### PR TITLE
Visning av tilkjent ytelse

### DIFF
--- a/dev-server/mock-routes.js
+++ b/dev-server/mock-routes.js
@@ -54,6 +54,11 @@ app.get('/familie-ba-sak/api/logg/2', (req, res) => {
     setTimeout(() => res.send(lesMockFil(`logg-2.json`)), delayMs);
 });
 
+app.get('/familie-ba-sak/api/vedtak/oversikt/2', (req, res) => {
+    console.log('Truffet mock-endepunkt for beregning-oversikt');
+    setTimeout(() => res.send(lesMockFil(`beregning-oversikt-1.json`)), delayMs);
+});
+
 app.post('/familie-ba-sak/api/fagsaker/sok', (req, res) => {
     const søkparam = req.body;
     if (søkparam.personIdent === '17058018783') {

--- a/dev-server/mock/beregning-oversikt-1.json
+++ b/dev-server/mock/beregning-oversikt-1.json
@@ -1,0 +1,89 @@
+{
+  "data": [
+    {
+      "periodeFom": "2020-04-01",
+      "periodeTom": "2036-04-30",
+      "sakstype": "NASJONAL",
+      "beregningDetaljer": [
+        {
+          "person": {
+            "type": "BARN",
+            "fødselsdato": "2018-05-01",
+            "personIdent": "01101800033",
+            "navn": "Jenta Barnesen",
+            "kjønn": "KVINNE"
+          },
+          "stønadstype": "ORDINÆR_BARNETRYGD",
+          "utbetaltPerMnd": 1054
+        },
+        {
+          "person": {
+            "type": "BARN",
+            "fødselsdato": "2019-05-01",
+            "personIdent": "01101900033",
+            "navn": "Gutten Barnesen",
+            "kjønn": "MANN"
+          },
+          "stønadstype": "ORDINÆR_BARNETRYGD",
+          "utbetaltPerMnd": 1054
+        },
+        {
+          "person": {
+            "type": "SØKER",
+            "fødselsdato": "1990-05-01",
+            "personIdent": "12345678910",
+            "navn": "Mor Moresen",
+            "kjønn": "KVINNE"
+          },
+          "stønadstype": "UTVIDET_BARNETRYGD",
+          "utbetaltPerMnd": 1054
+        },
+        {
+          "person": {
+            "type": "SØKER",
+            "fødselsdato": "1990-05-01",
+            "personIdent": "12345678910",
+            "navn": "Mor Moresen",
+            "kjønn": "KVINNE"
+          },
+          "stønadstype": "SMÅBARNSTILLEGG",
+          "utbetaltPerMnd": 660
+        }
+      ],
+      "stønadstype": [
+        "ORDINÆR_BARNETRYGD",
+        "ORDINÆR_BARNETRYGD",
+        "UTVIDET_BARNETRYGD",
+        "SMÅBARNSTILLEGG"
+      ],
+      "antallBarn": 2,
+      "utbetaltPerMnd": 3162
+    },
+    {
+      "periodeFom": "2036-05-01",
+      "periodeTom": "2037-04-30",
+      "sakstype": "NASJONAL",
+      "beregningDetaljer": [
+        {
+          "person": {
+            "type": "BARN",
+            "fødselsdato": "2019-05-01",
+            "personIdent": "01101900033",
+            "navn": "Gutten Barnesen",
+            "kjønn": "MANN"
+          },
+          "stønadstype": "ORDINÆR_BARNETRYGD",
+          "utbetaltPerMnd": 1054
+        }
+      ],
+      "stønadstype": [
+        "ORDINÆR_BARNETRYGD"
+      ],
+      "antallBarn": 1,
+      "utbetaltPerMnd": 1054
+    }
+  ],
+  "status": "SUKSESS",
+  "melding": "Innhenting av data var vellykket",
+  "stacktrace": null
+}

--- a/src/frontend/api/fagsak.ts
+++ b/src/frontend/api/fagsak.ts
@@ -1,4 +1,4 @@
-import { IPersonBeregning } from '../typer/behandle';
+import { IPersonBeregning } from '../typer/beregning';
 import { BehandlingKategori, Behandlingstype, BehandlingUnderkategori } from '../typer/behandling';
 import { IFagsak } from '../typer/fagsak';
 import { IRestPersonResultat } from '../typer/vilkår';

--- a/src/frontend/index.less
+++ b/src/frontend/index.less
@@ -26,3 +26,4 @@
 @import "./komponenter/Felleskomponenter/HentPerson/hentperson.less";
 @import "./komponenter/Felleskomponenter/Modal/uimodalwrapper.less";
 @import "./komponenter/Felleskomponenter/SystemetLaster/systemet-laster.less";
+@import "./komponenter/Felleskomponenter/PersonInformasjon/personinformasjon.less";

--- a/src/frontend/index.less
+++ b/src/frontend/index.less
@@ -9,6 +9,7 @@
 @import "./komponenter/Fagsak/Beregning/beregning.less";
 @import "./komponenter/Fagsak/Vedtak/oppsummeringvedtak.less";
 @import "./komponenter/Fagsak/Søknad/registrersøknad.less";
+@import "./komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less";
 
 @import "./komponenter/Fagsak/Høyremeny/høyremeny.less";
 

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -8,6 +8,7 @@ import { AppContainer } from 'react-hot-loader';
 import { init } from '@sentry/browser';
 
 import App from './komponenter/App';
+import moment from 'moment';
 
 /* tslint:disable */
 const packageConfig = require('../../package.json');
@@ -24,6 +25,7 @@ init({
 if (process.env.NODE_ENV !== 'production') {
     axe(React, ReactDOM, 1000);
 }
+moment.locale('nb');
 
 const rootElement = document.getElementById('app');
 const renderApp = (Component: React.ComponentType<{}>): void => {

--- a/src/frontend/komponenter/Fagsak/Beregning/BeregningProvider.tsx
+++ b/src/frontend/komponenter/Fagsak/Beregning/BeregningProvider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { IBehandling } from '../../../typer/behandling';
-import { IPersonBeregning, ordinærBeløp, YtelseType } from '../../../typer/behandle';
+import { IPersonBeregning, ordinærBeløp, YtelseType } from '../../../typer/beregning';
 import { IFagsak } from '../../../typer/fagsak';
 import { IFelt } from '../../../typer/felt';
 import { erGyldigMånedDato, lagInitiellFelt } from '../../../utils/validators';

--- a/src/frontend/komponenter/Fagsak/Beregning/BeregningSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Beregning/BeregningSkjema.tsx
@@ -6,7 +6,7 @@ import { IFelt, Valideringsstatus } from '../../../typer/felt';
 import { IState, actions, useBeregningContext, useBeregningDispatch } from './BeregningProvider';
 
 import { IVedtakForBehandling } from '../../../typer/vedtak';
-import { IPersonBeregning, YtelseType, ytelsetype } from '../../../typer/behandle';
+import { IPersonBeregning, YtelseType, ytelsetype } from '../../../typer/beregning';
 import InputMedLabelTilVenstre from '../../Felleskomponenter/InputMedLabelTilVenstre/InputMedLabelTilVenstre';
 import { Panel } from 'nav-frontend-paneler';
 import { Checkbox, Select, SkjemaGruppe } from 'nav-frontend-skjema';

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -121,7 +121,7 @@ const FagsakContainer: React.FunctionComponent = () => {
                                         />
                                         <Route
                                             exact={true}
-                                            path="/fagsak/:fagsakId/oppsummeringberegning"
+                                            path="/fagsak/:fagsakId/tilkjent-ytelse"
                                             render={() => {
                                                 return <TilkjentYtelse fagsak={fagsak.data} />;
                                             }}

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -21,6 +21,7 @@ import { SøknadProvider } from '../../context/SøknadContext';
 import { hentAlder } from '../../utils/formatter';
 import { useFagsakRessurser } from '../../context/FagsakContext';
 import SystemetLaster from '../Felleskomponenter/SystemetLaster/SystemetLaster';
+import TilkjentYtelse from './TilkjentYtelse/TilkjentYtelse';
 
 const FagsakContainer: React.FunctionComponent = () => {
     const { fagsakId } = useParams();
@@ -116,6 +117,13 @@ const FagsakContainer: React.FunctionComponent = () => {
                                                         <Beregning fagsak={fagsak.data} />
                                                     </BeregningProvider>
                                                 );
+                                            }}
+                                        />
+                                        <Route
+                                            exact={true}
+                                            path="/fagsak/:fagsakId/oppsummeringberegning"
+                                            render={() => {
+                                                return <TilkjentYtelse fagsak={fagsak.data} />;
                                             }}
                                         />
                                         <Route

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -21,7 +21,7 @@ import { IVedtakForBehandling } from '../../../typer/vedtak';
 import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
-import { IPersonBeregning } from '../../../typer/behandle';
+import { IPersonBeregning } from '../../../typer/beregning';
 import { useApp } from '../../../context/AppContext';
 
 interface IProps {

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
@@ -1,19 +1,13 @@
 import * as React from 'react';
 import { IBeregningDetalj, ytelsetype } from '../../../typer/beregning';
-import { FamilieIkonVelger } from '@navikt/familie-ikoner';
-import { formaterBeløp, hentAlder } from '../../../utils/formatter';
+import { formaterBeløp } from '../../../utils/formatter';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { PersonType } from '../../../typer/person';
 import classNames from 'classnames';
+import PersonInformasjon from '../../Felleskomponenter/PersonInformasjon/PersonInformasjon';
 
 interface IProps {
     beregningDetaljer: IBeregningDetalj[];
-}
-
-interface IDetaljRadProps {
-    detalj: IBeregningDetalj;
-    skalVisePersonalia: boolean;
-    skalViseStipletLinje: boolean;
 }
 
 const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer }) => {
@@ -22,7 +16,7 @@ const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer })
         .map((detalj, index, alle) => {
             return (
                 <DetaljRad
-                    detalj={detalj}
+                    beregningDetalj={detalj}
                     skalVisePersonalia={index === 0}
                     skalViseStipletLinje={index === alle.length - 1}
                     key={index}
@@ -37,7 +31,7 @@ const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer })
                 .map((detalj, index) => {
                     return (
                         <DetaljRad
-                            detalj={detalj}
+                            beregningDetalj={detalj}
                             skalVisePersonalia={true}
                             skalViseStipletLinje={false}
                             key={index}
@@ -48,38 +42,31 @@ const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer })
     );
 };
 
+interface IDetaljRadProps {
+    beregningDetalj: IBeregningDetalj;
+    skalVisePersonalia: boolean;
+    skalViseStipletLinje: boolean;
+}
+
 const DetaljRad: React.FunctionComponent<IDetaljRadProps> = ({
-    detalj,
+    beregningDetalj,
     skalVisePersonalia,
     skalViseStipletLinje,
 }) => {
-    const alder = hentAlder(detalj.person.fødselsdato);
     const kolonneClassnames = classNames('tilkjentytelse-detaljer-kolonne', {
         'familierelasjon-separator': skalViseStipletLinje,
     });
     return (
-        <div className="tilkjentytelse-detaljer-rad">
-            <div className="tilkjentytelse-detaljer-kolonne" />
-            <div className={kolonneClassnames}>
-                {skalVisePersonalia && (
-                    <div className="detaljer-personalia">
-                        <FamilieIkonVelger
-                            className="familie-ikon"
-                            alder={alder}
-                            kjønn={detalj.person.kjønn}
-                        />
-                        <Normaltekst>
-                            {detalj.person.navn} ({alder} år) | {detalj.person.personIdent} |{' '}
-                            {detalj.person.type}
-                        </Normaltekst>
-                    </div>
-                )}
+        <div className="tilkjentytelse-detaljer-rad" role="row">
+            <div className="tilkjentytelse-detaljer-kolonne" role="cell" />
+            <div className={kolonneClassnames} role="cell">
+                {skalVisePersonalia && <PersonInformasjon person={beregningDetalj.person} />}
             </div>
-            <div className={kolonneClassnames}>
-                <Normaltekst>{ytelsetype[detalj.stønadstype].navn}</Normaltekst>
+            <div className={kolonneClassnames} role="cell">
+                <Normaltekst>{ytelsetype[beregningDetalj.stønadstype].navn}</Normaltekst>
             </div>
-            <div className={kolonneClassnames}>
-                <Normaltekst>{formaterBeløp(detalj.utbetaltPerMnd)}</Normaltekst>
+            <div className={kolonneClassnames} role="cell">
+                <Normaltekst>{formaterBeløp(beregningDetalj.utbetaltPerMnd)}</Normaltekst>
             </div>
         </div>
     );

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
@@ -3,42 +3,85 @@ import { IBeregningDetalj, ytelsetype } from '../../../typer/beregning';
 import { FamilieIkonVelger } from '@navikt/familie-ikoner';
 import { formaterBeløp, hentAlder } from '../../../utils/formatter';
 import { Normaltekst } from 'nav-frontend-typografi';
+import { PersonType } from '../../../typer/person';
+import classNames from 'classnames';
 
 interface IProps {
     beregningDetaljer: IBeregningDetalj[];
 }
 
+interface IDetaljRadProps {
+    detalj: IBeregningDetalj;
+    skalVisePersonalia: boolean;
+    skalViseStipletLinje: boolean;
+}
+
 const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer }) => {
+    const detaljerForSøker = beregningDetaljer
+        .filter(detalj => detalj.person.type === PersonType.SØKER)
+        .map((detalj, index, alle) => {
+            return (
+                <DetaljRad
+                    detalj={detalj}
+                    skalVisePersonalia={index === 0}
+                    skalViseStipletLinje={index === alle.length - 1}
+                    key={index}
+                />
+            );
+        });
     return (
         <>
-            {beregningDetaljer.map((detalj, index) => {
-                const alder = hentAlder(detalj.person.fødselsdato);
-                return (
-                    <div className="tilkjentytelse-detaljer-rad" key={index}>
-                        <div className="tilkjentytelse-detaljer-kolonne" />
-                        <div className="tilkjentytelse-detaljer-kolonne">
-                            <div className="detaljer-personalia">
-                                <FamilieIkonVelger
-                                    className="familie-ikon"
-                                    alder={alder}
-                                    kjønn={detalj.person.kjønn}
-                                />
-                                <Normaltekst>
-                                    {detalj.person.navn} ({alder} år) | {detalj.person.personIdent}{' '}
-                                    | {detalj.person.type}
-                                </Normaltekst>
-                            </div>
-                        </div>
-                        <div className="tilkjentytelse-detaljer-kolonne">
-                            <Normaltekst>{ytelsetype[detalj.stønadstype].navn}</Normaltekst>
-                        </div>
-                        <div className="tilkjentytelse-detaljer-kolonne">
-                            <Normaltekst>{formaterBeløp(detalj.utbetaltPerMnd)}</Normaltekst>
-                        </div>
-                    </div>
-                );
-            })}
+            {detaljerForSøker}
+            {beregningDetaljer
+                .filter(detalj => detalj.person.type !== PersonType.SØKER)
+                .map((detalj, index) => {
+                    return (
+                        <DetaljRad
+                            detalj={detalj}
+                            skalVisePersonalia={true}
+                            skalViseStipletLinje={false}
+                            key={index}
+                        />
+                    );
+                })}
         </>
+    );
+};
+
+const DetaljRad: React.FunctionComponent<IDetaljRadProps> = ({
+    detalj,
+    skalVisePersonalia,
+    skalViseStipletLinje,
+}) => {
+    const alder = hentAlder(detalj.person.fødselsdato);
+    const kolonneClassnames = classNames('tilkjentytelse-detaljer-kolonne', {
+        'familierelasjon-separator': skalViseStipletLinje,
+    });
+    return (
+        <div className="tilkjentytelse-detaljer-rad">
+            <div className="tilkjentytelse-detaljer-kolonne" />
+            <div className={kolonneClassnames}>
+                {skalVisePersonalia && (
+                    <div className="detaljer-personalia">
+                        <FamilieIkonVelger
+                            className="familie-ikon"
+                            alder={alder}
+                            kjønn={detalj.person.kjønn}
+                        />
+                        <Normaltekst>
+                            {detalj.person.navn} ({alder} år) | {detalj.person.personIdent} |{' '}
+                            {detalj.person.type}
+                        </Normaltekst>
+                    </div>
+                )}
+            </div>
+            <div className={kolonneClassnames}>
+                <Normaltekst>{ytelsetype[detalj.stønadstype].navn}</Normaltekst>
+            </div>
+            <div className={kolonneClassnames}>
+                <Normaltekst>{formaterBeløp(detalj.utbetaltPerMnd)}</Normaltekst>
+            </div>
+        </div>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
@@ -7,22 +7,27 @@ import { Normaltekst } from 'nav-frontend-typografi';
 interface IProps {
     beregningDetaljer: IBeregningDetalj[];
 }
+
 const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer }) => {
     return (
         <>
             {beregningDetaljer.map((detalj, index) => {
+                const alder = hentAlder(detalj.person.fødselsdato);
                 return (
                     <div className="tilkjentytelse-detaljer-rad" key={index}>
+                        <div className="tilkjentytelse-detaljer-kolonne" />
                         <div className="tilkjentytelse-detaljer-kolonne">
-                            <Normaltekst>
+                            <div className="detaljer-personalia">
                                 <FamilieIkonVelger
                                     className="familie-ikon"
-                                    alder={hentAlder(detalj.person.fødselsdato)}
+                                    alder={alder}
                                     kjønn={detalj.person.kjønn}
-                                />{' '}
-                                {detalj.person.navn} | {detalj.person.personIdent} |{' '}
-                                {detalj.person.type}
-                            </Normaltekst>
+                                />
+                                <Normaltekst>
+                                    {detalj.person.navn} ({alder} år) | {detalj.person.personIdent}{' '}
+                                    | {detalj.person.type}
+                                </Normaltekst>
+                            </div>
                         </div>
                         <div className="tilkjentytelse-detaljer-kolonne">
                             <Normaltekst>{ytelsetype[detalj.stønadstype].navn}</Normaltekst>

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { IBeregningDetalj } from '../../../typer/beregning';
+import { IBeregningDetalj, ytelsetype } from '../../../typer/beregning';
+import { FamilieIkonVelger } from '@navikt/familie-ikoner';
+import { formaterBeløp, hentAlder } from '../../../utils/formatter';
+import { Normaltekst } from 'nav-frontend-typografi';
 
 interface IProps {
     beregningDetaljer: IBeregningDetalj[];
@@ -11,11 +14,21 @@ const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer })
                 return (
                     <div className="tilkjentytelse-detaljer-rad" key={index}>
                         <div className="tilkjentytelse-detaljer-kolonne">
-                            {detalj.person.navn}|{detalj.person.personIdent}|{detalj.person.type}
+                            <Normaltekst>
+                                <FamilieIkonVelger
+                                    className="familie-ikon"
+                                    alder={hentAlder(detalj.person.fødselsdato)}
+                                    kjønn={detalj.person.kjønn}
+                                />{' '}
+                                {detalj.person.navn} | {detalj.person.personIdent} |{' '}
+                                {detalj.person.type}
+                            </Normaltekst>
                         </div>
-                        <div className="tilkjentytelse-detaljer-kolonne">{detalj.stønadstype}</div>
                         <div className="tilkjentytelse-detaljer-kolonne">
-                            {detalj.utbetaltPerMnd}
+                            <Normaltekst>{ytelsetype[detalj.stønadstype].navn}</Normaltekst>
+                        </div>
+                        <div className="tilkjentytelse-detaljer-kolonne">
+                            <Normaltekst>{formaterBeløp(detalj.utbetaltPerMnd)}</Normaltekst>
                         </div>
                     </div>
                 );

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/BeregningDetalj.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { IBeregningDetalj } from '../../../typer/beregning';
+
+interface IProps {
+    beregningDetaljer: IBeregningDetalj[];
+}
+const BeregningDetalj: React.FunctionComponent<IProps> = ({ beregningDetaljer }) => {
+    return (
+        <>
+            {beregningDetaljer.map((detalj, index) => {
+                return (
+                    <div className="tilkjentytelse-detaljer-rad" key={index}>
+                        <div className="tilkjentytelse-detaljer-kolonne">
+                            {detalj.person.navn}|{detalj.person.personIdent}|{detalj.person.type}
+                        </div>
+                        <div className="tilkjentytelse-detaljer-kolonne">{detalj.stønadstype}</div>
+                        <div className="tilkjentytelse-detaljer-kolonne">
+                            {detalj.utbetaltPerMnd}
+                        </div>
+                    </div>
+                );
+            })}
+        </>
+    );
+};
+
+export default BeregningDetalj;

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { IOppsummeringBeregning, ytelsetype } from '../../../typer/beregning';
 import Chevron from 'nav-datovelger/lib/elementer/ChevronSvg';
-import { datoformat, formaterBeløp, formaterIsoDato } from '../../../utils/formatter';
+import { datoformat, formaterBeløp } from '../../../utils/formatter';
 import BeregningDetalj from './BeregningDetalj';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 import classNames from 'classnames';
 import { kategorier } from '../../../typer/behandling';
+import { nyPeriode, periodeToString } from '../../../typer/periode';
 
 interface IProps {
     beregning: IOppsummeringBeregning;
@@ -21,31 +22,29 @@ const Oppsummeringsrad: React.FunctionComponent<IProps> = ({ beregning }) => {
     const kolonneClassnames = classNames('tilkjentytelse-kolonne', { åpen: åpentElement });
     const radClassnames = classNames('tilkjentytelse-rad', { åpen: åpentElement });
     const distinkteStønadstyper = [...new Set(beregning.stønadstype)];
+
     return (
-        <div className={radClassnames} onClick={() => oppdaterÅpentElement()} role="button">
-            <div className={kolonneClassnames}>
+        <div
+            className={radClassnames}
+            onClick={() => oppdaterÅpentElement()}
+            role="row"
+            aria-expanded={åpentElement}
+        >
+            <Kolonne classes={kolonneClassnames}>
                 <Chevron retning={åpentElement ? 'opp' : 'ned'} />
-            </div>
-            <div className={kolonneClassnames}>
-                <Normaltekst>
-                    {formaterIsoDato(beregning.periodeFom, datoformat.DATO_FORKORTTET)} -{' '}
-                    {formaterIsoDato(beregning.periodeTom, datoformat.DATO_FORKORTTET)}
-                </Normaltekst>
-            </div>
-            <div className={kolonneClassnames}>
-                <Normaltekst>{kategorier[beregning.sakstype].navn}</Normaltekst>
-            </div>
-            <div className={kolonneClassnames}>
-                <Normaltekst>
-                    {distinkteStønadstyper.map(stønad => ytelsetype[stønad].navn).join(' + ')}
-                </Normaltekst>
-            </div>
-            <div className={kolonneClassnames}>
-                <Normaltekst>{beregning.antallBarn}</Normaltekst>
-            </div>
-            <div className={kolonneClassnames}>
-                <Normaltekst>{formaterBeløp(beregning.utbetaltPerMnd)}</Normaltekst>
-            </div>
+            </Kolonne>
+            <Kolonne classes={kolonneClassnames}>
+                {periodeToString(
+                    nyPeriode(beregning.periodeFom, beregning.periodeTom),
+                    datoformat.DATO_FORKORTTET
+                )}
+            </Kolonne>
+            <Kolonne classes={kolonneClassnames}>{kategorier[beregning.sakstype].navn}</Kolonne>
+            <Kolonne classes={kolonneClassnames}>
+                {distinkteStønadstyper.map(stønad => ytelsetype[stønad].navn).join(' + ')}
+            </Kolonne>
+            <Kolonne classes={kolonneClassnames}>{beregning.antallBarn}</Kolonne>
+            <Kolonne classes={kolonneClassnames}>{formaterBeløp(beregning.utbetaltPerMnd)}</Kolonne>
             {åpentElement && <BeregningDetalj beregningDetaljer={beregning.beregningDetaljer} />}
         </div>
     );
@@ -53,23 +52,33 @@ const Oppsummeringsrad: React.FunctionComponent<IProps> = ({ beregning }) => {
 
 const OppsummeringsradHeader: React.FunctionComponent = () => {
     return (
-        <div className="tilkjentytelse-rad tilkjentytelse-header-rad">
-            <div className="tilkjentytelse-kolonne" />
-            <div className="tilkjentytelse-kolonne">
-                <Element>Periode</Element>
-            </div>
-            <div className="tilkjentytelse-kolonne">
-                <Element>Sakstype</Element>
-            </div>
-            <div className="tilkjentytelse-kolonne">
-                <Element>Satser</Element>
-            </div>
-            <div className="tilkjentytelse-kolonne">
-                <Element>Ant. barn</Element>
-            </div>
-            <div className="tilkjentytelse-kolonne">
-                <Element>Utbet./md.</Element>
-            </div>
+        <div className="tilkjentytelse-rad tilkjentytelse-header-rad" role="row">
+            <KolonneHeader />
+            <KolonneHeader>Periode</KolonneHeader>
+            <KolonneHeader>Sakstype</KolonneHeader>
+            <KolonneHeader>Satser</KolonneHeader>
+            <KolonneHeader>Ant. barn</KolonneHeader>
+            <KolonneHeader>Utbet./md.</KolonneHeader>
+        </div>
+    );
+};
+
+interface IKolonneProps {
+    classes: string;
+}
+
+const Kolonne: React.FunctionComponent<IKolonneProps> = ({ classes, children }) => {
+    return (
+        <div className={classes} role="cell">
+            <Normaltekst>{children}</Normaltekst>
+        </div>
+    );
+};
+
+const KolonneHeader: React.FunctionComponent = ({ children }) => {
+    return (
+        <div className="tilkjentytelse-kolonne" role="columnheader">
+            {children && <Element>{children}</Element>}
         </div>
     );
 };

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
@@ -6,9 +6,11 @@ import BeregningDetalj from './BeregningDetalj';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 import classNames from 'classnames';
 import { kategorier } from '../../../typer/behandling';
+
 interface IProps {
     beregning: IOppsummeringBeregning;
 }
+
 const Oppsummeringsrad: React.FunctionComponent<IProps> = ({ beregning }) => {
     const [åpentElement, setÅpentElement] = React.useState<boolean>(false);
 

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { IOppsummeringBeregning, ytelsetype } from '../../../typer/beregning';
+import Chevron from 'nav-datovelger/lib/elementer/ChevronSvg';
+import { datoformat, formaterBeløp, formaterIsoDato } from '../../../utils/formatter';
+import BeregningDetalj from './BeregningDetalj';
+import { Element, Normaltekst } from 'nav-frontend-typografi';
+import classNames from 'classnames';
+import { kategorier } from '../../../typer/behandling';
+interface IProps {
+    beregning: IOppsummeringBeregning;
+}
+const Oppsummeringsrad: React.FunctionComponent<IProps> = ({ beregning }) => {
+    const [åpentElement, setÅpentElement] = React.useState<boolean>(false);
+
+    const oppdaterÅpentElement = () => {
+        setÅpentElement(!åpentElement);
+    };
+
+    const kolonneClassnames = classNames(
+        'tilkjentytelse-kolonne',
+        åpentElement ? 'tilkjentytelse-rad-åpen' : ''
+    );
+    return (
+        <div className="tilkjentytelse-rad" onClick={() => oppdaterÅpentElement()} role="button">
+            <div className={kolonneClassnames}>
+                <Chevron retning={åpentElement ? 'opp' : 'ned'} />
+            </div>
+            <div className={kolonneClassnames}>
+                <Normaltekst>
+                    {formaterIsoDato(beregning.periodeFom, datoformat.DATO_FORKORTTET)} -{' '}
+                    {formaterIsoDato(beregning.periodeTom, datoformat.DATO_FORKORTTET)}
+                </Normaltekst>
+            </div>
+            <div className={kolonneClassnames}>
+                <Normaltekst>{kategorier[beregning.sakstype].navn}</Normaltekst>
+            </div>
+            <div className={kolonneClassnames}>
+                <Normaltekst>
+                    {beregning.stønadstype.map(stønad => ytelsetype[stønad].navn).join(' + ')}
+                </Normaltekst>
+            </div>
+            <div className={kolonneClassnames}>
+                <Normaltekst>{beregning.antallBarn}</Normaltekst>
+            </div>
+            <div className={kolonneClassnames}>
+                <Normaltekst>{formaterBeløp(beregning.utbetaltPerMnd)}</Normaltekst>
+            </div>
+            {åpentElement && <BeregningDetalj beregningDetaljer={beregning.beregningDetaljer} />}
+        </div>
+    );
+};
+
+const OppsummeringsradHeader: React.FunctionComponent = () => {
+    return (
+        <div className="tilkjentytelse-rad tilkjentytelse-header-rad">
+            <div className="tilkjentytelse-kolonne" />
+            <div className="tilkjentytelse-kolonne">
+                <Element>Periode</Element>
+            </div>
+            <div className="tilkjentytelse-kolonne">
+                <Element>Sakstype</Element>
+            </div>
+            <div className="tilkjentytelse-kolonne">
+                <Element>Satser</Element>
+            </div>
+            <div className="tilkjentytelse-kolonne">
+                <Element>Ant. barn</Element>
+            </div>
+            <div className="tilkjentytelse-kolonne">
+                <Element>Utbet./md.</Element>
+            </div>
+        </div>
+    );
+};
+
+export { Oppsummeringsrad, OppsummeringsradHeader };

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsrad.tsx
@@ -16,12 +16,11 @@ const Oppsummeringsrad: React.FunctionComponent<IProps> = ({ beregning }) => {
         setÅpentElement(!åpentElement);
     };
 
-    const kolonneClassnames = classNames(
-        'tilkjentytelse-kolonne',
-        åpentElement ? 'tilkjentytelse-rad-åpen' : ''
-    );
+    const kolonneClassnames = classNames('tilkjentytelse-kolonne', { åpen: åpentElement });
+    const radClassnames = classNames('tilkjentytelse-rad', { åpen: åpentElement });
+    const distinkteStønadstyper = [...new Set(beregning.stønadstype)];
     return (
-        <div className="tilkjentytelse-rad" onClick={() => oppdaterÅpentElement()} role="button">
+        <div className={radClassnames} onClick={() => oppdaterÅpentElement()} role="button">
             <div className={kolonneClassnames}>
                 <Chevron retning={åpentElement ? 'opp' : 'ned'} />
             </div>
@@ -36,7 +35,7 @@ const Oppsummeringsrad: React.FunctionComponent<IProps> = ({ beregning }) => {
             </div>
             <div className={kolonneClassnames}>
                 <Normaltekst>
-                    {beregning.stønadstype.map(stønad => ytelsetype[stønad].navn).join(' + ')}
+                    {distinkteStønadstyper.map(stønad => ytelsetype[stønad].navn).join(' + ')}
                 </Normaltekst>
             </div>
             <div className={kolonneClassnames}>

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -45,7 +45,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
             });
     }, []);
     const startdato = oppsummeringBeregning[0]
-        ? formaterIsoDato(oppsummeringBeregning[0].periodeFom, datoformat.DATO)
+        ? formaterIsoDato(oppsummeringBeregning[0].periodeFom, datoformat.DATO_FORLENGET)
         : '';
     return (
         <div className="tilkjentytelse">
@@ -60,7 +60,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
                     <br />
                     <div>
                         <OppsummeringsradHeader />
-                        {oppsummeringBeregning.map((beregning, index) => {
+                        {oppsummeringBeregning.reverse().map((beregning, index) => {
                             return <Oppsummeringsrad beregning={beregning} key={index} />;
                         })}
                     </div>
@@ -70,13 +70,13 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
             )}
             <div className={'tilkjentytelse__navigering'}>
                 <Knapp
-                    type={'hoved'}
+                    type={'standard'}
                     onClick={() => {
                         aktivBehandling?.type === Behandlingstype.REVURDERING
                             ? history.push(`/fagsak/${fagsak.id}/vilkår`)
                             : history.push(`/fagsak/${fagsak.id}/beregning`);
                     }}
-                    children={'Tilbake'}
+                    children={'Forrige'}
                 />
                 <Knapp
                     type={'hoved'}

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -1,5 +1,5 @@
 import { IFagsak } from '../../../typer/fagsak';
-import { Systemtittel } from 'nav-frontend-typografi';
+import { Ingress, Innholdstittel, Undertittel } from 'nav-frontend-typografi';
 import AlertStripe from 'nav-frontend-alertstriper';
 import * as React from 'react';
 import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
@@ -11,6 +11,7 @@ import { Behandlingstype } from '../../../typer/behandling';
 import { useHistory } from 'react-router';
 import { IOppsummeringBeregning } from '../../../typer/beregning';
 import { Oppsummeringsrad, OppsummeringsradHeader } from './Oppsummeringsrad';
+import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 
 interface ITilkjentYtelseProps {
     fagsak: IFagsak;
@@ -43,11 +44,19 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
                 setErrorMessage('Ukjent feil, Kunne ikke generere forhåndsvisning.');
             });
     }, []);
+    const startdato = oppsummeringBeregning[0]
+        ? formaterIsoDato(oppsummeringBeregning[0].periodeFom, datoformat.DATO)
+        : '';
     return (
-        <div>
+        <div className="tilkjentytelse">
             {errorMessage === undefined ? (
                 <div>
-                    <Systemtittel children={'Tilkjent ytelse'} />
+                    <Innholdstittel children={'Behandlingsresultat'} />
+                    <br />
+                    <Undertittel>
+                        Vilkårene for barnetrygd er oppfylt f.o.m. {startdato}
+                    </Undertittel>
+                    <Ingress>Se detaljer under periode.</Ingress>
                     <br />
                     <div>
                         <OppsummeringsradHeader />
@@ -59,7 +68,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
             ) : (
                 <AlertStripe type="feil">{errorMessage}</AlertStripe>
             )}
-            <div className={'oppsummering__navigering'}>
+            <div className={'tilkjentytelse__navigering'}>
                 <Knapp
                     type={'hoved'}
                     onClick={() => {

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -1,0 +1,79 @@
+import { IFagsak } from '../../../typer/fagsak';
+import { Systemtittel } from 'nav-frontend-typografi';
+import AlertStripe from 'nav-frontend-alertstriper';
+import * as React from 'react';
+import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
+import { useApp } from '../../../context/AppContext';
+import { Ressurs, RessursStatus } from '../../../typer/ressurs';
+import { AxiosError } from 'axios';
+import { Knapp } from 'nav-frontend-knapper';
+import { Behandlingstype } from '../../../typer/behandling';
+import { useHistory } from 'react-router';
+
+interface ITilkjentYtelseProps {
+    fagsak: IFagsak;
+}
+
+interface IOppsummeringBeregning {}
+
+interface IPersonDetalj {}
+
+const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak }) => {
+    const { axiosRequest } = useApp();
+    const history = useHistory();
+    const [oppsummeringBeregning, setOppsummeringBeregning] = React.useState<string>('');
+    const [errorMessage, setErrorMessage] = React.useState<string | undefined>(undefined);
+    const aktivBehandling = hentAktivBehandlingPåFagsak(fagsak);
+    React.useEffect(
+        axiosRequest<string, void>({
+            method: 'GET',
+            url: `/familie-ba-sak/api/vedtak/oppsummering/${aktivBehandling?.behandlingId}`,
+        })
+            .then((response: Ressurs<string>) => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    setOppsummeringBeregning(response.data);
+                    setErrorMessage(undefined);
+                } else if (response.status === RessursStatus.FEILET) {
+                    setErrorMessage(response.melding);
+                } else {
+                    setErrorMessage('Ukjent feil, kunne ikke vise tilkjent ytelse.');
+                }
+            })
+            .catch((_error: AxiosError) => {
+                setErrorMessage('Ukjent feil, Kunne ikke generere forhåndsvisning.');
+            })
+    );
+    console.log(oppsummeringBeregning);
+    return (
+        <div>
+            {errorMessage === undefined ? (
+                <div>
+                    <Systemtittel children={'Tilkjent ytelse'} />
+                    <br />
+                </div>
+            ) : (
+                <AlertStripe type="feil">{errorMessage}</AlertStripe>
+            )}
+            <div className={'oppsummering__navigering'}>
+                <Knapp
+                    type={'hoved'}
+                    onClick={() => {
+                        aktivBehandling?.type === Behandlingstype.REVURDERING
+                            ? history.push(`/fagsak/${fagsak.id}/vilkår`)
+                            : history.push(`/fagsak/${fagsak.id}/beregning`);
+                    }}
+                    children={'Tilbake'}
+                />
+                <Knapp
+                    type={'hoved'}
+                    children={'Neste'}
+                    onClick={() => {
+                        history.push(`/fagsak/${fagsak.id}/vedtak`);
+                    }}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default TilkjentYtelse;

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -1,17 +1,18 @@
 import { IFagsak } from '../../../typer/fagsak';
-import { Ingress, Innholdstittel, Undertittel } from 'nav-frontend-typografi';
+import { Ingress, Undertittel } from 'nav-frontend-typografi';
 import AlertStripe from 'nav-frontend-alertstriper';
 import * as React from 'react';
 import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
 import { useApp } from '../../../context/AppContext';
-import { Ressurs, RessursStatus } from '../../../typer/ressurs';
+import { byggFeiletRessurs, Ressurs, RessursStatus } from '../../../typer/ressurs';
 import { AxiosError } from 'axios';
-import { Knapp } from 'nav-frontend-knapper';
 import { Behandlingstype } from '../../../typer/behandling';
 import { useHistory } from 'react-router';
 import { IOppsummeringBeregning } from '../../../typer/beregning';
 import { Oppsummeringsrad, OppsummeringsradHeader } from './Oppsummeringsrad';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
+import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
+import SystemetLaster from '../../Felleskomponenter/SystemetLaster/SystemetLaster';
 
 interface ITilkjentYtelseProps {
     fagsak: IFagsak;
@@ -20,74 +21,83 @@ interface ITilkjentYtelseProps {
 const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak }) => {
     const { axiosRequest } = useApp();
     const history = useHistory();
-    const [oppsummeringBeregning, setOppsummeringBeregning] = React.useState<
-        IOppsummeringBeregning[]
-    >([]);
-    const [errorMessage, setErrorMessage] = React.useState<string | undefined>(undefined);
+    const [tilkjentYtelseRessurs, setTilkjentYtelseRessurs] = React.useState<
+        Ressurs<IOppsummeringBeregning[]>
+    >({ status: RessursStatus.IKKE_HENTET });
     const aktivBehandling = hentAktivBehandlingPåFagsak(fagsak);
+
     React.useEffect(() => {
+        setTilkjentYtelseRessurs({ status: RessursStatus.HENTER });
         axiosRequest<IOppsummeringBeregning[], void>({
             method: 'GET',
             url: `/familie-ba-sak/api/vedtak/oversikt/${aktivBehandling?.behandlingId}`,
         })
             .then((response: Ressurs<IOppsummeringBeregning[]>) => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    setOppsummeringBeregning(response.data);
-                    setErrorMessage(undefined);
-                } else if (response.status === RessursStatus.FEILET) {
-                    setErrorMessage(response.melding);
-                } else {
-                    setErrorMessage('Ukjent feil, kunne ikke vise tilkjent ytelse.');
-                }
+                setTilkjentYtelseRessurs(response);
             })
             .catch((_error: AxiosError) => {
-                setErrorMessage('Ukjent feil, Kunne ikke generere forhåndsvisning.');
+                setTilkjentYtelseRessurs(
+                    byggFeiletRessurs('Ukjent feil, Kunne ikke generere forhåndsvisning.', _error)
+                );
             });
     }, []);
-    const startdato = oppsummeringBeregning[0]
-        ? formaterIsoDato(oppsummeringBeregning[0].periodeFom, datoformat.DATO_FORLENGET)
-        : '';
-    return (
-        <div className="tilkjentytelse">
-            {errorMessage === undefined ? (
-                <div>
-                    <Innholdstittel children={'Behandlingsresultat'} />
-                    <br />
-                    <Undertittel>
-                        Vilkårene for barnetrygd er oppfylt f.o.m. {startdato}
-                    </Undertittel>
-                    <Ingress>Se detaljer under periode.</Ingress>
-                    <br />
-                    <div>
-                        <OppsummeringsradHeader />
-                        {oppsummeringBeregning.reverse().map((beregning, index) => {
-                            return <Oppsummeringsrad beregning={beregning} key={index} />;
-                        })}
-                    </div>
-                </div>
-            ) : (
-                <AlertStripe type="feil">{errorMessage}</AlertStripe>
-            )}
-            <div className={'tilkjentytelse__navigering'}>
-                <Knapp
-                    type={'standard'}
-                    onClick={() => {
-                        aktivBehandling?.type === Behandlingstype.REVURDERING
-                            ? history.push(`/fagsak/${fagsak.id}/vilkår`)
-                            : history.push(`/fagsak/${fagsak.id}/beregning`);
-                    }}
-                    children={'Forrige'}
-                />
-                <Knapp
-                    type={'hoved'}
-                    children={'Neste'}
-                    onClick={() => {
-                        history.push(`/fagsak/${fagsak.id}/vedtak`);
-                    }}
-                />
-            </div>
-        </div>
-    );
-};
 
+    const startdato = (oppsummeringBeregninger: IOppsummeringBeregning[]) => {
+        return oppsummeringBeregninger[0]
+            ? formaterIsoDato(oppsummeringBeregninger[0].periodeFom, datoformat.DATO_FORLENGET)
+            : '';
+    };
+
+    const nesteOnClick = () => {
+        history.push(`/fagsak/${fagsak.id}/vedtak`);
+    };
+
+    const forrigeOnClick = () => {
+        aktivBehandling?.type === Behandlingstype.REVURDERING
+            ? history.push(`/fagsak/${fagsak.id}/vilkaarsvurdering`)
+            : history.push(`/fagsak/${fagsak.id}/beregning`);
+    };
+    switch (tilkjentYtelseRessurs.status) {
+        case RessursStatus.HENTER:
+        case RessursStatus.IKKE_HENTET:
+            return <SystemetLaster />;
+        case RessursStatus.FEILET:
+            return <AlertStripe children={tilkjentYtelseRessurs.melding} type={'feil'} />;
+        case RessursStatus.IKKE_TILGANG:
+            return (
+                <AlertStripe
+                    children={'Du har ikke tilgang til å se behandlingsresultat for denne saken'}
+                    type={'advarsel'}
+                />
+            );
+        case RessursStatus.SUKSESS:
+            return (
+                <div className="tilkjentytelse">
+                    <Skjemasteg
+                        senderInn={false}
+                        tittel="Behandlingsresultat"
+                        forrigeOnClick={forrigeOnClick}
+                        nesteOnClick={nesteOnClick}
+                        maxWidthStyle={'80rem'}
+                    >
+                        <div className="tilkjentytelse-informasjon">
+                            <Undertittel>
+                                Vilkårene for barnetrygd er oppfylt f.o.m.{' '}
+                                {startdato(tilkjentYtelseRessurs.data)}
+                            </Undertittel>
+                            <Ingress>Se detaljer under periode.</Ingress>
+                        </div>
+                        <div role="table">
+                            <OppsummeringsradHeader />
+                            {tilkjentYtelseRessurs.data.reverse().map((beregning, index) => {
+                                return <Oppsummeringsrad beregning={beregning} key={index} />;
+                            })}
+                        </div>
+                    </Skjemasteg>
+                </div>
+            );
+        default:
+            return <AlertStripe children={'En ukjent feil oppstod'} type={'advarsel'} />;
+    }
+};
 export default TilkjentYtelse;

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -10,9 +10,7 @@ import { Knapp } from 'nav-frontend-knapper';
 import { Behandlingstype } from '../../../typer/behandling';
 import { useHistory } from 'react-router';
 import { IOppsummeringBeregning } from '../../../typer/beregning';
-import Chevron from 'nav-datovelger/lib/elementer/ChevronSvg';
-import BeregningDetalj from './BeregningDetalj';
-import { datoformat, formaterIsoDato } from '../../../utils/formatter';
+import { Oppsummeringsrad, OppsummeringsradHeader } from './Oppsummeringsrad';
 
 interface ITilkjentYtelseProps {
     fagsak: IFagsak;
@@ -25,7 +23,6 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
         IOppsummeringBeregning[]
     >([]);
     const [errorMessage, setErrorMessage] = React.useState<string | undefined>(undefined);
-    const [åpneElementer, setÅpneElementer] = React.useState<number[]>([]);
     const aktivBehandling = hentAktivBehandlingPåFagsak(fagsak);
     React.useEffect(() => {
         axiosRequest<IOppsummeringBeregning[], void>({
@@ -46,19 +43,6 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
                 setErrorMessage('Ukjent feil, Kunne ikke generere forhåndsvisning.');
             });
     }, []);
-
-    const oppdaterÅpneElementer = (index: number) => {
-        if (åpneElementer.includes(index)) {
-            setÅpneElementer(åpneElementer.filter(element => element !== index));
-        } else {
-            setÅpneElementer([...åpneElementer, index]);
-        }
-    };
-
-    const erElementÅpen = (index: number) => {
-        return åpneElementer.includes(index);
-    };
-
     return (
         <div>
             {errorMessage === undefined ? (
@@ -66,47 +50,9 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ fagsak 
                     <Systemtittel children={'Tilkjent ytelse'} />
                     <br />
                     <div>
-                        <div className="tilkjentytelse-rad">
-                            <div className="tilkjentytelse-kolonne" />
-                            <div className="tilkjentytelse-kolonne">Periode</div>
-                            <div className="tilkjentytelse-kolonne">Sakstype</div>
-                            <div className="tilkjentytelse-kolonne">Satser</div>
-                            <div className="tilkjentytelse-kolonne">Ant. barn</div>
-                            <div className="tilkjentytelse-kolonne">Utbet./md.</div>
-                        </div>
+                        <OppsummeringsradHeader />
                         {oppsummeringBeregning.map((beregning, index) => {
-                            return (
-                                <div className="tilkjentytelse-rad" key={index}>
-                                    <div className="tilkjentytelse-kolonne">
-                                        <button onClick={() => oppdaterÅpneElementer(index)}>
-                                            <Chevron
-                                                retning={erElementÅpen(index) ? 'opp' : 'ned'}
-                                            />
-                                        </button>
-                                    </div>
-                                    <div className="tilkjentytelse-kolonne">
-                                        {formaterIsoDato(beregning.periodeFom, datoformat.DATO)} -{' '}
-                                        {formaterIsoDato(beregning.periodeTom, datoformat.DATO)}
-                                    </div>
-                                    <div className="tilkjentytelse-kolonne">
-                                        {beregning.sakstype}
-                                    </div>
-                                    <div className="tilkjentytelse-kolonne">
-                                        {beregning.stønadstype.join(',')}
-                                    </div>
-                                    <div className="tilkjentytelse-kolonne">
-                                        {beregning.antallBarn}
-                                    </div>
-                                    <div className="tilkjentytelse-kolonne">
-                                        {beregning.utbetaltPerMnd}
-                                    </div>
-                                    {erElementÅpen(index) && (
-                                        <BeregningDetalj
-                                            beregningDetaljer={beregning.beregningDetaljer}
-                                        />
-                                    )}
-                                </div>
-                            );
+                            return <Oppsummeringsrad beregning={beregning} key={index} />;
                         })}
                     </div>
                 </div>

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -4,7 +4,7 @@
 }
 
 .tilkjentytelse-informasjon {
-  padding: 0.8em 0;
+  padding: 0.8rem 0;
 }
 
 .tilkjentytelse-rad {
@@ -26,8 +26,8 @@
 
   & .tilkjentytelse-kolonne:nth-child(1) {
     max-width: 40px;
-    padding-left: 0.8em;
-    padding-right: 1.2em;
+    padding-left: 0.8rem;
+    padding-right: 1.2rem;
   }
 
   & .tilkjentytelse-kolonne:nth-child(2) {
@@ -36,7 +36,7 @@
 
   & .tilkjentytelse-kolonne:nth-child(3) {
     flex: 3;
-    padding-right: 1.2em;
+    padding-right: 1.2rem;
   }
 
   & .tilkjentytelse-kolonne:nth-child(4) {
@@ -46,12 +46,12 @@
   & .tilkjentytelse-kolonne:nth-child(5) {
     flex: 2;
     text-align: center;
-    padding-right: 1.2em;
+    padding-right: 1.2rem;
   }
 
   & .tilkjentytelse-kolonne:nth-child(6) {
     flex: 2;
-    padding-right: 1.2em;
+    padding-right: 1.2rem;
     text-align: right;
     white-space: nowrap;
   }
@@ -59,8 +59,8 @@
   & .tilkjentytelse-kolonne {
     box-sizing: border-box;
     flex-grow: 1;
-    padding-top: 0.8em;
-    padding-bottom: 0.8em;
+    padding-top: 0.8rem;
+    padding-bottom: 0.8rem;
     overflow: visible;
     list-style: none;
 
@@ -79,20 +79,20 @@
 
     & .tilkjentytelse-detaljer-kolonne:nth-child(1) {
       max-width: 40px;
-      padding-left: 0.8em;
-      padding-right: 1.2em;
+      padding-left: 0.8rem;
+      padding-right: 1.2rem;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(2) {
       flex: 7;
-      padding-right: 1.2em;
+      padding-right: 1.2rem;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(3) {
       flex: 10;
-      padding-right: 1.2em;
+      padding-right: 1.2rem;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(4) {
       flex: 2;
-      padding-right: 1.2em;
+      padding-right: 1.2rem;
       text-align: right;
       white-space: nowrap;
     }
@@ -101,8 +101,8 @@
   & .tilkjentytelse-detaljer-kolonne {
     box-sizing: border-box;
     flex-grow: 1;
-    padding-top: 0.8em;
-    padding-bottom: 0.8em;
+    padding-top: 0.8rem;
+    padding-bottom: 0.8rem;
     overflow: hidden;
     list-style: none;
 

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -1,13 +1,12 @@
 .tilkjentytelse {
-  margin-left: 6rem;
-  margin-right: 6rem;
-
-  &__navigering {
-    margin-top: 2rem;
-    display: flex;
-    justify-content: space-between;
-  }
+  margin-left: 3rem;
+  margin-right: 3rem;
 }
+
+.tilkjentytelse-informasjon {
+  padding: 0.8em 0;
+}
+
 .tilkjentytelse-rad {
   display: flex;
   flex-wrap: wrap;
@@ -15,6 +14,7 @@
   padding: 0;
   width: 100%;
   border-bottom: 1px solid @navGra20;
+  cursor: pointer;
 
   &.åpen {
     border: 2px solid @navDypBlaLighten20;
@@ -69,6 +69,7 @@
     }
 
   }
+
   & .tilkjentytelse-detaljer-rad {
     display: flex;
     flex-wrap: wrap;
@@ -96,6 +97,7 @@
       white-space: nowrap;
     }
   }
+
   & .tilkjentytelse-detaljer-kolonne {
     box-sizing: border-box;
     flex-grow: 1;

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -1,4 +1,13 @@
+.tilkjentytelse {
+  margin-left: 6rem;
+  margin-right: 6rem;
 
+  &__navigering {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: space-between;
+  }
+}
 .tilkjentytelse-rad {
   display: flex;
   flex-wrap: wrap;
@@ -49,6 +58,19 @@
     margin: 0;
     padding: 0;
     width: 100%;
+
+    & .tilkjentytelse-detaljer-kolonne:nth-child(1) {
+      width: 5%;
+    }
+    & .tilkjentytelse-detaljer-kolonne:nth-child(2) {
+      width: 35%;
+    }
+    & .tilkjentytelse-detaljer-kolonne:nth-child(3) {
+      width: 50%;
+    }
+    & .tilkjentytelse-detaljer-kolonne:nth-child(4) {
+      width: 10%;
+    }
   }
   & .tilkjentytelse-detaljer-kolonne {
     box-sizing: border-box;
@@ -58,9 +80,15 @@
     overflow: hidden; // Or flex might break
     list-style: none;
 
+    & .detaljer-personalia {
+      display: flex;
+      align-items: center;
+    }
+
     & .familie-ikon {
       height: 20px;
       width: 20px;
+      margin-right: 0.5rem;
     }
   }
 }

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -16,6 +16,10 @@
   width: 100%;
   border-bottom: 1px solid @navGra20;
 
+  &.åpen {
+    border: 2px solid @navDypBlaLighten20;
+  }
+
   &.tilkjentytelse-header-rad {
     border-bottom: 1px solid @navGra80;
   }
@@ -23,20 +27,28 @@
   & .tilkjentytelse-kolonne:nth-child(1) {
     width: 5%;
   }
+
   & .tilkjentytelse-kolonne:nth-child(2) {
     width: 20%;
   }
+
   & .tilkjentytelse-kolonne:nth-child(3) {
     width: 15%;
   }
+
   & .tilkjentytelse-kolonne:nth-child(4) {
     width: 40%;
   }
+
   & .tilkjentytelse-kolonne:nth-child(5) {
     width: 10%;
+    text-align: center;
   }
+
   & .tilkjentytelse-kolonne:nth-child(6) {
     width: 10%;
+    text-align: right;
+    white-space: nowrap;
   }
 
   & .tilkjentytelse-kolonne {
@@ -47,7 +59,7 @@
     overflow: visible; // Or flex might break
     list-style: none;
 
-    &.tilkjentytelse-rad-åpen {
+    &.åpen {
       background-color: @navBlaLighten80;
     }
 
@@ -70,6 +82,8 @@
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(4) {
       width: 10%;
+      text-align: right;
+      white-space: nowrap;
     }
   }
   & .tilkjentytelse-detaljer-kolonne {
@@ -79,6 +93,10 @@
     padding: 0.8em 1.2em;
     overflow: hidden; // Or flex might break
     list-style: none;
+
+    &.familierelasjon-separator {
+      border-bottom: 1px dashed @navGra20;
+    }
 
     & .detaljer-personalia {
       display: flex;

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -1,0 +1,50 @@
+.tilkjentytelse-rad {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  & .tilkjentytelse-kolonne:nth-child(1) {
+    width: 5%;
+  }
+  & .tilkjentytelse-kolonne:nth-child(2) {
+    width: 20%;
+  }
+  & .tilkjentytelse-kolonne:nth-child(3) {
+    width: 20%;
+  }
+  & .tilkjentytelse-kolonne:nth-child(4) {
+    width: 40%;
+  }
+  & .tilkjentytelse-kolonne:nth-child(5) {
+    width: 5%;
+  }
+  & .tilkjentytelse-kolonne:nth-child(6) {
+    width: 10%;
+  }
+
+  & .tilkjentytelse-kolonne {
+    box-sizing: border-box;
+    flex-grow: 1;
+    //width: 20%; // 5kolonner
+    padding: 0.8em 1.2em;
+    overflow: hidden; // Or flex might break
+    list-style: none;
+    border-bottom: 1px solid red;
+  }
+  & .tilkjentytelse-detaljer-rad {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+  }
+  & .tilkjentytelse-detaljer-kolonne {
+    box-sizing: border-box;
+    flex-grow: 1;
+    //width: 20%; // 5kolonner
+    padding: 0.8em 1.2em;
+    overflow: hidden; // Or flex might break
+    list-style: none;
+  }
+}

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -25,37 +25,31 @@
   }
 
   & .tilkjentytelse-kolonne:nth-child(1) {
-    //width: 5%;
     max-width: 40px;
     padding-left: 0.8em;
     padding-right: 1.2em;
   }
 
   & .tilkjentytelse-kolonne:nth-child(2) {
-    //width: 20%;
     flex: 4;
   }
 
   & .tilkjentytelse-kolonne:nth-child(3) {
-    //width: 15%;
     flex: 3;
     padding-right: 1.2em;
   }
 
   & .tilkjentytelse-kolonne:nth-child(4) {
-    //width: 40%;
     flex: 8;
   }
 
   & .tilkjentytelse-kolonne:nth-child(5) {
-    //width: 10%;
     flex: 2;
     text-align: center;
     padding-right: 1.2em;
   }
 
   & .tilkjentytelse-kolonne:nth-child(6) {
-    //width: 10%;
     flex: 2;
     padding-right: 1.2em;
     text-align: right;
@@ -65,10 +59,9 @@
   & .tilkjentytelse-kolonne {
     box-sizing: border-box;
     flex-grow: 1;
-    //width: 20%; // 5kolonner
     padding-top: 0.8em;
     padding-bottom: 0.8em;
-    overflow: visible; // Or flex might break
+    overflow: visible;
     list-style: none;
 
     &.åpen {
@@ -84,23 +77,19 @@
     width: 100%;
 
     & .tilkjentytelse-detaljer-kolonne:nth-child(1) {
-      //width: 5%;
       max-width: 40px;
       padding-left: 0.8em;
       padding-right: 1.2em;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(2) {
-      //width: 35%;
       flex: 7;
       padding-right: 1.2em;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(3) {
-      //width: 50%;
       flex: 10;
       padding-right: 1.2em;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(4) {
-      //width: 10%;
       flex: 2;
       padding-right: 1.2em;
       text-align: right;
@@ -110,11 +99,9 @@
   & .tilkjentytelse-detaljer-kolonne {
     box-sizing: border-box;
     flex-grow: 1;
-    //width: 20%; // 5kolonner
-    //padding: 0.8em 1.2em;
     padding-top: 0.8em;
     padding-bottom: 0.8em;
-    overflow: hidden; // Or flex might break
+    overflow: hidden;
     list-style: none;
 
     &.familierelasjon-separator {

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -1,9 +1,16 @@
+
 .tilkjentytelse-rad {
   display: flex;
   flex-wrap: wrap;
   margin: 0;
   padding: 0;
   width: 100%;
+  border-bottom: 1px solid @navGra20;
+
+  &.tilkjentytelse-header-rad {
+    border-bottom: 1px solid @navGra80;
+  }
+
   & .tilkjentytelse-kolonne:nth-child(1) {
     width: 5%;
   }
@@ -11,13 +18,13 @@
     width: 20%;
   }
   & .tilkjentytelse-kolonne:nth-child(3) {
-    width: 20%;
+    width: 15%;
   }
   & .tilkjentytelse-kolonne:nth-child(4) {
     width: 40%;
   }
   & .tilkjentytelse-kolonne:nth-child(5) {
-    width: 5%;
+    width: 10%;
   }
   & .tilkjentytelse-kolonne:nth-child(6) {
     width: 10%;
@@ -28,9 +35,13 @@
     flex-grow: 1;
     //width: 20%; // 5kolonner
     padding: 0.8em 1.2em;
-    overflow: hidden; // Or flex might break
+    overflow: visible; // Or flex might break
     list-style: none;
-    border-bottom: 1px solid red;
+
+    &.tilkjentytelse-rad-åpen {
+      background-color: @navBlaLighten80;
+    }
+
   }
   & .tilkjentytelse-detaljer-rad {
     display: flex;
@@ -46,5 +57,10 @@
     padding: 0.8em 1.2em;
     overflow: hidden; // Or flex might break
     list-style: none;
+
+    & .familie-ikon {
+      height: 20px;
+      width: 20px;
+    }
   }
 }

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/tilkjentytelse.less
@@ -25,28 +25,39 @@
   }
 
   & .tilkjentytelse-kolonne:nth-child(1) {
-    width: 5%;
+    //width: 5%;
+    max-width: 40px;
+    padding-left: 0.8em;
+    padding-right: 1.2em;
   }
 
   & .tilkjentytelse-kolonne:nth-child(2) {
-    width: 20%;
+    //width: 20%;
+    flex: 4;
   }
 
   & .tilkjentytelse-kolonne:nth-child(3) {
-    width: 15%;
+    //width: 15%;
+    flex: 3;
+    padding-right: 1.2em;
   }
 
   & .tilkjentytelse-kolonne:nth-child(4) {
-    width: 40%;
+    //width: 40%;
+    flex: 8;
   }
 
   & .tilkjentytelse-kolonne:nth-child(5) {
-    width: 10%;
+    //width: 10%;
+    flex: 2;
     text-align: center;
+    padding-right: 1.2em;
   }
 
   & .tilkjentytelse-kolonne:nth-child(6) {
-    width: 10%;
+    //width: 10%;
+    flex: 2;
+    padding-right: 1.2em;
     text-align: right;
     white-space: nowrap;
   }
@@ -55,7 +66,8 @@
     box-sizing: border-box;
     flex-grow: 1;
     //width: 20%; // 5kolonner
-    padding: 0.8em 1.2em;
+    padding-top: 0.8em;
+    padding-bottom: 0.8em;
     overflow: visible; // Or flex might break
     list-style: none;
 
@@ -72,16 +84,25 @@
     width: 100%;
 
     & .tilkjentytelse-detaljer-kolonne:nth-child(1) {
-      width: 5%;
+      //width: 5%;
+      max-width: 40px;
+      padding-left: 0.8em;
+      padding-right: 1.2em;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(2) {
-      width: 35%;
+      //width: 35%;
+      flex: 7;
+      padding-right: 1.2em;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(3) {
-      width: 50%;
+      //width: 50%;
+      flex: 10;
+      padding-right: 1.2em;
     }
     & .tilkjentytelse-detaljer-kolonne:nth-child(4) {
-      width: 10%;
+      //width: 10%;
+      flex: 2;
+      padding-right: 1.2em;
       text-align: right;
       white-space: nowrap;
     }
@@ -90,7 +111,9 @@
     box-sizing: border-box;
     flex-grow: 1;
     //width: 20%; // 5kolonner
-    padding: 0.8em 1.2em;
+    //padding: 0.8em 1.2em;
+    padding-top: 0.8em;
+    padding-bottom: 0.8em;
     overflow: hidden; // Or flex might break
     list-style: none;
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -80,7 +80,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak }) =
             <div className={'oppsummering__navigering'}>
                 <Knapp
                     type={'hoved'}
-                    onClick={() => history.push(`/fagsak/${fagsak.id}/oppsummeringberegning`)}
+                    onClick={() => history.push(`/fagsak/${fagsak.id}/tilkjent-ytelse`)}
                     children={'Tilbake'}
                 />
                 {errorMessage === undefined && visSubmitKnapp && (

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import Confetti from 'react-confetti';
 import { useHistory } from 'react-router';
 
-import { BehandlingStatus, Behandlingstype } from '../../../typer/behandling';
+import { BehandlingStatus } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { Ressurs, RessursStatus } from '../../../typer/ressurs';
 import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
@@ -80,11 +80,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak }) =
             <div className={'oppsummering__navigering'}>
                 <Knapp
                     type={'hoved'}
-                    onClick={() => {
-                        aktivBehandling?.type === Behandlingstype.REVURDERING
-                            ? history.push(`/fagsak/${fagsak.id}/vilkår`)
-                            : history.push(`/fagsak/${fagsak.id}/beregning`);
-                    }}
+                    onClick={() => history.push(`/fagsak/${fagsak.id}/oppsummeringberegning`)}
                     children={'Tilbake'}
                 />
                 {errorMessage === undefined && visSubmitKnapp && (

--- a/src/frontend/komponenter/Fagsak/useFagsakApi.ts
+++ b/src/frontend/komponenter/Fagsak/useFagsakApi.ts
@@ -15,7 +15,7 @@ import { IFelt, Valideringsstatus } from '../../typer/felt';
 import { Ressurs, RessursStatus } from '../../typer/ressurs';
 import { datoformat, formaterIsoDato } from '../../utils/formatter';
 import { IState as IBereningState } from './Beregning/BeregningProvider';
-import { IPersonBeregning } from '../../typer/behandle';
+import { IPersonBeregning } from '../../typer/beregning';
 import { hentAktivBehandlingPåFagsak, erBehandlingenInnvilget } from '../../utils/fagsak';
 import { useFagsakRessurser } from '../../context/FagsakContext';
 import { useApp } from '../../context/AppContext';
@@ -251,7 +251,7 @@ const useFagsakApi = (
                         if (response.status === RessursStatus.SUKSESS) {
                             settFagsak(response);
 
-                            history.push(`/fagsak/${fagsak.id}/vedtak`);
+                            history.push(`/fagsak/${fagsak.id}/oppsummeringberegning`);
                         } else if (response.status === RessursStatus.FEILET) {
                             settFeilmelding(response.melding);
                             settVisFeilmeldinger(true);
@@ -265,7 +265,7 @@ const useFagsakApi = (
                         settFeilmelding('Opprettelse av vedtak feilet');
                     });
             } else {
-                history.push(`/fagsak/${fagsak.id}/vedtak`);
+                history.push(`/fagsak/${fagsak.id}/oppsummeringberegning`);
             }
         } else {
             settVisFeilmeldinger(true);

--- a/src/frontend/komponenter/Fagsak/useFagsakApi.ts
+++ b/src/frontend/komponenter/Fagsak/useFagsakApi.ts
@@ -251,7 +251,7 @@ const useFagsakApi = (
                         if (response.status === RessursStatus.SUKSESS) {
                             settFagsak(response);
 
-                            history.push(`/fagsak/${fagsak.id}/oppsummeringberegning`);
+                            history.push(`/fagsak/${fagsak.id}/tilkjent-ytelse`);
                         } else if (response.status === RessursStatus.FEILET) {
                             settFeilmelding(response.melding);
                             settVisFeilmeldinger(true);
@@ -265,7 +265,7 @@ const useFagsakApi = (
                         settFeilmelding('Opprettelse av vedtak feilet');
                     });
             } else {
-                history.push(`/fagsak/${fagsak.id}/oppsummeringberegning`);
+                history.push(`/fagsak/${fagsak.id}/tilkjent-ytelse`);
             }
         } else {
             settVisFeilmeldinger(true);

--- a/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { IPerson } from '../../../typer/person';
+import { FamilieIkonVelger } from '@navikt/familie-ikoner';
+import { Normaltekst } from 'nav-frontend-typografi';
+import { hentAlder } from '../../../utils/formatter';
+
+interface IProps {
+    person: IPerson;
+}
+
+const PersonInformasjon: React.FunctionComponent<IProps> = ({ person }) => {
+    const alder = hentAlder(person.fødselsdato);
+    return (
+        <div className="personinformasjon">
+            <FamilieIkonVelger className="familie-ikon" alder={alder} kjønn={person.kjønn} />
+            <Normaltekst>{`${person.navn} (${alder} år) | ${person.personIdent} | ${person.type} `}</Normaltekst>
+        </div>
+    );
+};
+
+export default PersonInformasjon;

--- a/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/personinformasjon.less
+++ b/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/personinformasjon.less
@@ -1,0 +1,4 @@
+.personinformasjon {
+    display: flex;
+    align-items: center;
+}

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -8,6 +8,7 @@ interface IProps {
     nesteOnClick?: () => void;
     senderInn: boolean;
     tittel: string;
+    maxWidthStyle: string | undefined;
 }
 
 const Skjemasteg: React.FunctionComponent<IProps> = ({
@@ -17,9 +18,10 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
     nesteOnClick,
     senderInn,
     tittel,
+    maxWidthStyle = '40rem',
 }) => {
     return (
-        <div className={'skjemasteg'}>
+        <div className={'skjemasteg'} style={{ maxWidth: maxWidthStyle }}>
             <Systemtittel children={tittel} />
 
             {children}

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/skjemasteg.less
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/skjemasteg.less
@@ -1,5 +1,4 @@
 .skjemasteg {
-    max-width: 40rem;
     margin: 0 auto;
 
     &__navigering {

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -27,6 +27,12 @@ export const sider: ISide[] = [
         navn: 'Beregning',
         steg: BehandlingSteg.VILKÅRSVURDERING,
     },
+    {
+        id: 'BEHANDLINGRESULTAT',
+        href: 'oppsummeringberegning',
+        navn: 'Behandlingsresultat',
+        steg: BehandlingSteg.VILKÅRSVURDERING,
+    },
     { id: 'VEDTAK', href: 'vedtak', navn: 'Vedtak', steg: BehandlingSteg.SEND_TIL_BESLUTTER },
 ];
 

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -29,7 +29,7 @@ export const sider: ISide[] = [
     },
     {
         id: 'BEHANDLINGRESULTAT',
-        href: 'oppsummeringberegning',
+        href: 'tilkjent-ytelse',
         navn: 'Behandlingsresultat',
         steg: BehandlingSteg.VILKÅRSVURDERING,
     },

--- a/src/frontend/typer/beregning.ts
+++ b/src/frontend/typer/beregning.ts
@@ -1,4 +1,22 @@
 import { INøkkelPar } from './common';
+import { BehandlingKategori } from './behandling';
+import { IPerson } from './person';
+
+export interface IOppsummeringBeregning {
+    periodeFom: string;
+    periodeTom: string;
+    sakstype: BehandlingKategori;
+    beregningDetaljer: IBeregningDetalj[];
+    stønadstype: YtelseType[];
+    antallBarn: number;
+    utbetaltPerMnd: number;
+}
+
+export interface IBeregningDetalj {
+    person: IPerson;
+    stønadstype: YtelseType;
+    utbetaltPerMnd: number;
+}
 
 export interface IPersonBeregning {
     personident: string;

--- a/src/frontend/typer/periode.ts
+++ b/src/frontend/typer/periode.ts
@@ -22,12 +22,12 @@ export const nyMoment = (dato: string | undefined) => {
     return moment(dato, datoformat.ISO_DAG);
 };
 
-export const periodeToString = (periode: IPeriode) => {
+export const periodeToString = (periode: IPeriode, format: datoformat = datoformat.DATO) => {
     return `${formaterIsoDato(
         periode.fom,
-        datoformat.DATO,
+        format,
         datoformatNorsk.DATO.toLowerCase()
-    )} - ${formaterIsoDato(periode.tom, datoformat.DATO)}`;
+    )} - ${formaterIsoDato(periode.tom, format)}`;
 };
 
 export const formaterMomentTilStringDato = (dato: Moment): string => {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -1,4 +1,4 @@
-import { IPersonBeregning } from './behandle';
+import { IPersonBeregning } from './beregning';
 
 export interface IVedtakForBehandling {
     aktiv: boolean;

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -3,6 +3,7 @@ import moment, { Moment } from 'moment';
 export enum datoformat {
     MÅNED = 'MM.YY',
     DATO = 'DD.MM.YYYY',
+    DATO_FORKORTTET = 'DD.MM.YY',
     ISO_MÅNED = 'YYYY-MM',
     ISO_DAG = 'YYYY-MM-DD',
     DATO_TID = 'DD.MM.YY HH:mm',
@@ -25,4 +26,8 @@ export const formaterDato = (dato: Moment, tilFormat: datoformat) => {
 export const hentAlder = (dato: string): number => {
     const momentDato = moment(dato);
     return momentDato.isValid() ? momentDato.diff(moment(), 'years') : 0;
+};
+
+export const formaterBeløp = (beløp: number): string => {
+    return `${beløp.toLocaleString('no-NO')} kr`;
 };

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -20,7 +20,6 @@ export const formaterIsoDato = (
     tilFormat: datoformat,
     defaultString?: string
 ) => {
-    moment.locale('nb');
     const momentDato = moment(dato);
     return momentDato.isValid() && dato
         ? momentDato.format(tilFormat)

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -25,7 +25,7 @@ export const formaterDato = (dato: Moment, tilFormat: datoformat) => {
 
 export const hentAlder = (dato: string): number => {
     const momentDato = moment(dato);
-    return momentDato.isValid() ? momentDato.diff(moment(), 'years') : 0;
+    return momentDato.isValid() ? moment().diff(momentDato, 'years') : 0;
 };
 
 export const formaterBeløp = (beløp: number): string => {

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -4,6 +4,7 @@ export enum datoformat {
     MÅNED = 'MM.YY',
     DATO = 'DD.MM.YYYY',
     DATO_FORKORTTET = 'DD.MM.YY',
+    DATO_FORLENGET = 'LL',
     ISO_MÅNED = 'YYYY-MM',
     ISO_DAG = 'YYYY-MM-DD',
     DATO_TID = 'DD.MM.YY HH:mm',
@@ -15,6 +16,7 @@ export enum datoformatNorsk {
 }
 
 export const formaterIsoDato = (dato: string | undefined, tilFormat: datoformat) => {
+    moment.locale('nb');
     const momentDato = moment(dato);
     return momentDato.isValid() ? momentDato.format(tilFormat) : dato ? dato : '';
 };

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import { IPersonBeregning } from '../typer/behandle';
+import { IPersonBeregning } from '../typer/beregning';
 import { feil, IFelt, ok, Valideringsstatus, ValiderIFelt } from '../typer/felt';
 import { datoformat } from './formatter';
 import { IPeriode, stringToMoment, TIDENES_MORGEN, TIDENES_ENDE } from '../typer/periode';


### PR DESCRIPTION
Eget skjermbilde med tabellvisning av tilkjent ytelse/oppsummering av beregning. Hver rad kan klikkes på, da ekspanderes den og viser detaljer om hver person sin andel. 

Skisser her: https://share.goabstract.com/a1b3bc95-e752-4148-a165-48f27b948ac6

Denne PR-en inkluderer visning av utvidet barnetrygd/småbarnstillegg på søker iht skisser, men ikke tekst/ikoner for institusjon/verge eller delt stønad. Vi har også hatt en gjennomgang med Gunn og Eivind og blitt enige om å ikke vise sum under detaljvisning. 