### PR TITLE
Legg til uthenting av høyeste rollenivå saksbehandler har

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@navikt/boxed-list-with-links": "^1.0.2",
-    "@navikt/familie-backend": "^5.0.2",
+    "@navikt/familie-backend": "^5.0.3",
     "@navikt/familie-header": "1.0.2",
     "@navikt/familie-ikoner": "^3.0.3",
     "@navikt/familie-typer": "^3.0.2",

--- a/src/frontend/api/axios.ts
+++ b/src/frontend/api/axios.ts
@@ -100,7 +100,3 @@ export const apiLoggFeil = (melding: string) => {
         melding,
     });
 };
-
-export const tilFeilside = () => {
-    return preferredAxios.get('/error');
-};

--- a/src/frontend/api/axios.ts
+++ b/src/frontend/api/axios.ts
@@ -100,3 +100,7 @@ export const apiLoggFeil = (melding: string) => {
         melding,
     });
 };
+
+export const tilFeilside = () => {
+    return preferredAxios.get('/error');
+};

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { håndterRessurs, loggFeil, preferredAxios } from '../api/axios';
 import { Ressurs } from '../typer/ressurs';
 import { ISaksbehandler } from '../typer/saksbehandler';
+import { BehandlerRolle } from '../typer/behandling';
 
 export interface IModal {
     content: string;
@@ -62,7 +63,38 @@ const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IPro
             });
     };
 
-    return { axiosRequest, autentisert, åpneModal, lukkModal, modal, settModal };
+    const gruppeIdTilRolle = (gruppeId: string) => {
+        switch (gruppeId) {
+            case '199c2b39-e535-4ae8-ac59-8ccbee7991ae':
+                return BehandlerRolle.VEILEDER;
+            case '847e3d72-9dc1-41c3-80ff-f5d4acdd5d46':
+                return BehandlerRolle.SAKSBEHANDLER;
+            case '7a271f87-39fb-468b-a9ee-6cf3c070f548':
+                return BehandlerRolle.BESLUTTER;
+            default:
+                return BehandlerRolle.SYSTEM;
+        }
+    };
+
+    const hentSaksbehandlerRolle = (): BehandlerRolle | undefined => {
+        let rolle = BehandlerRolle.SYSTEM;
+        if (innloggetSaksbehandler && innloggetSaksbehandler.groups) {
+            innloggetSaksbehandler.groups.forEach(id => {
+                rolle = rolle < gruppeIdTilRolle(id) ? gruppeIdTilRolle(id) : rolle;
+            });
+            return rolle;
+        }
+    };
+
+    return {
+        axiosRequest,
+        hentSaksbehandlerRolle,
+        autentisert,
+        åpneModal,
+        lukkModal,
+        modal,
+        settModal,
+    };
 });
 
 export { AppProvider, useApp };

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -7,7 +7,6 @@ import { Ressurs } from '../typer/ressurs';
 import { ISaksbehandler } from '../typer/saksbehandler';
 import { BehandlerRolle } from '../typer/behandling';
 import { gruppeIdTilRolle } from '../utils/behandling';
-import { useHistory } from 'react-router';
 
 export interface IModal {
     content: string;

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -77,6 +77,10 @@ const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IPro
             innloggetSaksbehandler,
             'Saksbehandler tilhører ingen av de definerte tilgangsgruppene.'
         );
+        axiosRequest<void, void>({
+            method: 'GET',
+            url: '/error',
+        });
     };
 
     return {

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -32,7 +32,6 @@ interface IProps {
 const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IProps) => {
     const [autentisert, settAutentisert] = React.useState(true);
     const [modal, settModal] = React.useState<IModal>(initalState);
-    const history = useHistory();
 
     const åpneModal = () => {
         settModal({
@@ -79,7 +78,6 @@ const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IPro
             innloggetSaksbehandler,
             'Saksbehandler tilhører ingen av de definerte tilgangsgruppene.'
         );
-        history.push(`/error`);
     };
 
     return {

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -6,6 +6,7 @@ import { håndterRessurs, loggFeil, preferredAxios } from '../api/axios';
 import { Ressurs } from '../typer/ressurs';
 import { ISaksbehandler } from '../typer/saksbehandler';
 import { BehandlerRolle } from '../typer/behandling';
+import { gruppeIdTilRolle } from '../utils/behandling';
 
 export interface IModal {
     content: string;
@@ -61,19 +62,6 @@ const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IPro
                 const responsRessurs: Ressurs<T> = error.response?.data;
                 return håndterRessurs(responsRessurs, innloggetSaksbehandler);
             });
-    };
-
-    const gruppeIdTilRolle = (gruppeId: string) => {
-        switch (gruppeId) {
-            case '199c2b39-e535-4ae8-ac59-8ccbee7991ae':
-                return BehandlerRolle.VEILEDER;
-            case '847e3d72-9dc1-41c3-80ff-f5d4acdd5d46':
-                return BehandlerRolle.SAKSBEHANDLER;
-            case '7a271f87-39fb-468b-a9ee-6cf3c070f548':
-                return BehandlerRolle.BESLUTTER;
-            default:
-                return BehandlerRolle.SYSTEM;
-        }
     };
 
     const hentSaksbehandlerRolle = (): BehandlerRolle | undefined => {

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -72,6 +72,11 @@ const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IPro
             });
             return rolle;
         }
+        loggFeil(
+            undefined,
+            innloggetSaksbehandler,
+            'Saksbehandler tilhører ingen av de definerte tilgangsgruppene.'
+        );
     };
 
     return {

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -7,6 +7,7 @@ import { Ressurs } from '../typer/ressurs';
 import { ISaksbehandler } from '../typer/saksbehandler';
 import { BehandlerRolle } from '../typer/behandling';
 import { gruppeIdTilRolle } from '../utils/behandling';
+import { useHistory } from 'react-router';
 
 export interface IModal {
     content: string;
@@ -31,6 +32,7 @@ interface IProps {
 const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IProps) => {
     const [autentisert, settAutentisert] = React.useState(true);
     const [modal, settModal] = React.useState<IModal>(initalState);
+    const history = useHistory();
 
     const åpneModal = () => {
         settModal({
@@ -77,10 +79,7 @@ const [AppProvider, useApp] = createUseContext(({ innloggetSaksbehandler }: IPro
             innloggetSaksbehandler,
             'Saksbehandler tilhører ingen av de definerte tilgangsgruppene.'
         );
-        axiosRequest<void, void>({
-            method: 'GET',
-            url: '/error',
-        });
+        history.push(`/error`);
     };
 
     return {

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/komponenter/HendelseItem.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/komponenter/HendelseItem.tsx
@@ -1,6 +1,7 @@
-import { BehandlerRolle, Hendelse } from '../typer';
+import { Hendelse } from '../typer';
 
 import React from 'react';
+import { BehandlerRolle } from '../../../../typer/behandling';
 
 interface IHendelseItemProps {
     hendelse: Hendelse;
@@ -12,7 +13,9 @@ const HendelseItem = ({ hendelse }: IHendelseItemProps) => (
         {hendelse.beskrivelse && <p className={'hendelsesbeskrivelse'}>{hendelse.beskrivelse}</p>}
         <p className={'hendelsesdato'}>{`${hendelse.dato}`}</p>
         <p className={'hendelsesdato'}>{`${hendelse.utførtAv} ${
-            hendelse.rolle !== BehandlerRolle.SYSTEM ? `(${hendelse.rolle.toLowerCase()})` : ''
+            hendelse.rolle !== BehandlerRolle.SYSTEM
+                ? `(${BehandlerRolle[hendelse.rolle].toLowerCase()})`
+                : ''
         }`}</p>
     </li>
 );

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/typer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/typer.ts
@@ -1,13 +1,9 @@
+import { BehandlerRolle } from '../../../typer/behandling';
+
 export enum Tabs {
     Historikk,
     Meldinger,
     Dokumenter,
-}
-
-export enum BehandlerRolle {
-    SYSTEM = 'SYSTEM',
-    SAKSBEHANDLER = 'SAKSBEHANDLER',
-    BESLUTTER = 'BESLUTTER',
 }
 
 export interface Hendelse {

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/typer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/typer.ts
@@ -1,9 +1,13 @@
-import { BehandlerRolle } from '../../../typer/behandling';
-
 export enum Tabs {
     Historikk,
     Meldinger,
     Dokumenter,
+}
+
+export enum BehandlerRolle {
+    SYSTEM = 'SYSTEM',
+    SAKSBEHANDLER = 'SAKSBEHANDLER',
+    BESLUTTER = 'BESLUTTER',
 }
 
 export interface Hendelse {

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/typer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/typer.ts
@@ -1,3 +1,5 @@
+import { BehandlerRolle } from '../../../typer/behandling';
+
 export enum Tabs {
     Historikk,
     Meldinger,
@@ -11,10 +13,4 @@ export interface Hendelse {
     utførtAv: string;
     rolle: BehandlerRolle;
     beskrivelse?: string;
-}
-
-export enum BehandlerRolle {
-    SYSTEM = 'SYSTEM',
-    SAKSBEHANDLER = 'SAKSBEHANDLER',
-    BESLUTTER = 'BESLUTTER',
 }

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -49,6 +49,7 @@ export enum BehandlingResultat {
 
 export enum BehandlerRolle {
     SYSTEM,
+    VEILEDER,
     SAKSBEHANDLER,
     BESLUTTER,
 }

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -48,10 +48,10 @@ export enum BehandlingResultat {
 }
 
 export enum BehandlerRolle {
-    SYSTEM,
-    VEILEDER,
-    SAKSBEHANDLER,
-    BESLUTTER,
+    SYSTEM = 0,
+    VEILEDER = 1,
+    SAKSBEHANDLER = 2,
+    BESLUTTER = 3,
 }
 
 export interface IBehandling {

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -1,0 +1,14 @@
+import { BehandlerRolle } from '../typer/behandling';
+
+export const gruppeIdTilRolle = (gruppeId: string) => {
+    switch (gruppeId) {
+        case '199c2b39-e535-4ae8-ac59-8ccbee7991ae':
+            return BehandlerRolle.VEILEDER;
+        case '847e3d72-9dc1-41c3-80ff-f5d4acdd5d46':
+            return BehandlerRolle.SAKSBEHANDLER;
+        case '7a271f87-39fb-468b-a9ee-6cf3c070f548':
+            return BehandlerRolle.BESLUTTER;
+        default:
+            return BehandlerRolle.SYSTEM;
+    }
+};


### PR DESCRIPTION
Arbeid i forbindelse med totrinnskontroll, hvor man har behov for å kontrollere hvilke roller innlogget bruker har. 

- Fjerne duplikat BehandlerRolle-enum 
- Legger til VEILEDER på nivå over system. Blir dette korrekt? 
- Oppdaterer til nyeste familie-backend, som returnerer groups på innlogget bruker
- Legger til funksjon som returnerer høyeste tilgangen til innlogget bruker. Tar gjerne i mot forslag hvis noen har en mer elegant måte å hente ut "max enum" fra lista. 