### PR TITLE
Navigering / hovedside for saksbehandlingsløsningen TEA-936

### DIFF
--- a/src/frontend/context/OppgaverContext.tsx
+++ b/src/frontend/context/OppgaverContext.tsx
@@ -66,7 +66,7 @@ const [OppgaverProvider, useOppgaver] = createUseContext(() => {
         saksbehandler?: string
     ): Promise<Ressurs<IOppgave[]>> => {
         interface LooseObject {
-            [key: string]: any;
+            [key: string]: string;
         }
         const searchParams: LooseObject = {};
 

--- a/src/frontend/komponenter/Container.tsx
+++ b/src/frontend/komponenter/Container.tsx
@@ -35,7 +35,7 @@ const Container: React.FC<IProps> = ({ innloggetSaksbehandler }) => {
                                     exact={true}
                                     path={'/'}
                                     render={() => {
-                                        return <Redirect from="/" to="/fagsak/ny-fagsak" />;
+                                        return <Redirect from={'/'} to={'/oppgaver'} />;
                                     }}
                                 />
                                 <Route

--- a/src/frontend/komponenter/Oppgaver/FilterSkjema.tsx
+++ b/src/frontend/komponenter/Oppgaver/FilterSkjema.tsx
@@ -61,7 +61,9 @@ const initialFiltre = (innloggetSaksbehandler?: ISaksbehandler): IOppgaverFiltre
                       .map(v => v.toString())
                       .concat(innloggetSaksbehandler.displayName)
                 : Object.values(SaksbehandlerFilter).map(v => v.toString()),
-            selectedValue: SaksbehandlerFilter.Alle,
+            selectedValue: innloggetSaksbehandler
+                ? innloggetSaksbehandler.displayName
+                : SaksbehandlerFilter.Alle,
         },
     };
 };
@@ -120,6 +122,9 @@ const FilterSkjema: React.FunctionComponent<IFilterSkjemaProps> = ({ innloggetSa
                           .map(v => v.toString())
                           .concat(innloggetSaksbehandler.displayName)
                     : Object.values(SaksbehandlerFilter).map(v => v.toString()),
+                selectedValue: innloggetSaksbehandler
+                    ? innloggetSaksbehandler.displayName
+                    : SaksbehandlerFilter.Alle,
             },
         });
     }, [innloggetSaksbehandler]);

--- a/src/frontend/komponenter/Oppgaver/OppgaveHeader.tsx
+++ b/src/frontend/komponenter/Oppgaver/OppgaveHeader.tsx
@@ -1,0 +1,49 @@
+import { Systemtittel, Feilmelding } from 'nav-frontend-typografi';
+import React from 'react';
+import { Input } from 'nav-frontend-skjema';
+import { Knapp } from 'nav-frontend-knapper';
+import useFagsakApi from '../Fagsak/useFagsakApi';
+
+const OppgaveHeader: React.FunctionComponent = props => {
+    const [personIdent, settPersonIdent] = React.useState('');
+    const [visFeilmeldinger, settVisFeilmeldinger] = React.useState(false);
+    const [opprettelseFeilmelding, settOpprettelseFeilmelding] = React.useState('');
+
+    const { opprettEllerHentFagsak, senderInn } = useFagsakApi(
+        settVisFeilmeldinger,
+        settOpprettelseFeilmelding
+    );
+
+    return (
+        <div>
+            <div className={'oppgaveHeader'}>
+                <Systemtittel className={'oppgaveHeader__tittel'}>Oppgavebenken</Systemtittel>
+                <Input
+                    label={'Opprett eller hent fagsak'}
+                    value={personIdent}
+                    placeholder={'Skriv inn fnr/dnr 11 siffer'}
+                    onChange={event => {
+                        settPersonIdent(event.target.value);
+                    }}
+                    className={'oppgaveHeader__fnrInput'}
+                />
+                <Knapp
+                    type={'hoved'}
+                    onClick={() => {
+                        opprettEllerHentFagsak({
+                            personIdent,
+                        });
+                    }}
+                    children={'Fortsett'}
+                    className={'oppgaveHeader__opprettFagsakKnapp'}
+                    spinner={senderInn}
+                />
+            </div>
+            {visFeilmeldinger && (
+                <Feilmelding children={opprettelseFeilmelding} className={'feilmelding'} />
+            )}
+        </div>
+    );
+};
+
+export default OppgaveHeader;

--- a/src/frontend/komponenter/Oppgaver/VisOppgaver.tsx
+++ b/src/frontend/komponenter/Oppgaver/VisOppgaver.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FilterSkjema from './FilterSkjema';
 import OppgaveList from './OppgaveList';
 import { ISaksbehandler } from '../../typer/saksbehandler';
-import { Systemtittel } from 'nav-frontend-typografi';
+import OppgaveHeader from './OppgaveHeader';
 
 interface IVisOppgaverProps {
     innloggetSaksbehandler?: ISaksbehandler;
@@ -11,7 +11,8 @@ interface IVisOppgaverProps {
 const VisOppgaver: React.FunctionComponent<IVisOppgaverProps> = props => {
     return (
         <div className="visoppgaver">
-            <Systemtittel>Oppgavebenk</Systemtittel>
+            <OppgaveHeader>Oppgavebenk</OppgaveHeader>
+            <hr className={'visoppgaver__hr'} />
             <FilterSkjema innloggetSaksbehandler={props.innloggetSaksbehandler} />
             <OppgaveList />
         </div>

--- a/src/frontend/komponenter/Oppgaver/visoppgave.less
+++ b/src/frontend/komponenter/Oppgaver/visoppgave.less
@@ -1,5 +1,8 @@
 .visoppgaver {
     padding: 1rem;
+    &__hr{
+        margin-top: 2rem;
+    }
 }
 
 .filterskjema {
@@ -107,4 +110,28 @@ table.tabell th, table.tabell td{
     color: #0067c5;
     text-decoration: none;
     padding-right: 15px;
+}
+
+.oppgaveHeader{
+    display: flex;
+    flex-direction: row;
+
+    &__tittel{
+        flex: 1 0 0px;
+    }
+    
+    &__fnrInput{
+        width: 200px;
+    }
+
+    &__opprettFagsakKnapp{
+        margin-left: 1rem;
+        margin-top: auto;
+        align-self:flex-start;
+    }
+}
+
+.feilmelding{
+    margin-top: 10px;
+    float: right;
 }

--- a/src/frontend/komponenter/Oppgaver/visoppgave.less
+++ b/src/frontend/komponenter/Oppgaver/visoppgave.less
@@ -117,6 +117,8 @@ table.tabell th, table.tabell td{
     flex-direction: row;
 
     &__tittel{
+        margin-top:auto;
+        margin-bottom: auto;
         flex: 1 0 0px;
     }
     


### PR DESCRIPTION
Ref. favrokort med samme navn.

Funksjonalitet:
- gjør en redirect fra "/" til "/oppgaver" (mao. oppgavebenken blir forsiden, og blir også tilgjengelig fra "NAV Barnetrygd" øverst til venstre)
- kopierer "ny fagsak / gå til fagsak"-funksjonaliteten fra den tidligere forsiden ihht designspek
- saksbehandler er automatisk valgt som filter

Vi kan vurdere å slette OpprettFagsak-siden i samme PR, hvis ikke den skal brukes til noe annet senere.