### PR TITLE
Bugfix/ingen opplysninger

### DIFF
--- a/src/frontend/komponenter/Fagsak/Søknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/BarnMedOpplysninger.tsx
@@ -12,14 +12,14 @@ interface IProps {
 const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
     const { settBarn } = useSøknad();
     const alder = barn.fødselsdato
-        ? moment().diff(moment(barn.fødselsdato, 'YYYY-MM-DD'), 'years')
-        : 'ukjent';
+        ? moment().diff(moment(barn.fødselsdato, 'YYYY-MM-DD'), 'years') + 'år'
+        : 'Alder ukjent';
 
     return (
         <div className={'søknad__panel--gruppebarn'}>
             <FamilieCheckbox
                 id={`barn-${barn.ident}`}
-                label={`${barn.navn ?? 'ukjent'} (${alder} år) ${barn.ident}`}
+                label={`${barn.navn ?? 'Navn ukjent'} (${alder}) ${barn.ident}`}
                 checked={barn.inkludertISøknaden}
                 onChange={() => {
                     settBarn({

--- a/src/frontend/komponenter/Felleskomponenter/InputMedLesevisning/IngenOpplysningerValgt.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/InputMedLesevisning/IngenOpplysningerValgt.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
+import { useFagsakRessurser } from '../../../context/FagsakContext';
 
 interface IProps {
     minimumOpplysning: boolean[];
@@ -9,7 +10,9 @@ class IngenOpplysningerValgt extends Component<IProps> {
     render() {
         const { minimumOpplysning } = this.props;
         const harOpplysningerÅVise = minimumOpplysning.filter(Boolean);
+        const { erLesevisning } = useFagsakRessurser();
         return (
+            erLesevisning() &&
             harOpplysningerÅVise.length === 0 && (
                 <Normaltekst className={'skjemaelement'} children={'Ingen opplysninger valgt.'} />
             )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5719550/80969687-4a982400-8e1a-11ea-932b-cb9604cc4dcc.png)


- "Ingen opplysninger valgt" ble også vist når ingen var valgt under behandling. Ikke kritisk, men skal kun vises under lesevisning. 
- Litt mer utfyllende tilbakemelding når man ikke klarer å hente data på barn