### PR TITLE
Tatt bort validering på begrunnelse

### DIFF
--- a/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
+++ b/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
@@ -24,12 +24,13 @@ import {
 import { datoformat } from '../../utils/formatter';
 import { randomUUID } from '../../utils/commons';
 import { IPerson } from '../../typer/person';
-import { IFelt } from '../../typer/felt';
+import { IFelt, Valideringsstatus } from '../../typer/felt';
 import {
     lagInitiellFelt,
     erUtfylt,
     erPeriodeGyldig,
     erResultatGyldig,
+    ikkeValider,
 } from '../../utils/validators';
 import { validerVilkår, kjørValidering } from './validering';
 import { hentPeriode, hentResultat, hentBegrunnelse } from './utils';
@@ -422,10 +423,12 @@ export const mapFraRestVilkårsvurderingTilUi = (
                         personResultat.vilkårResultater.map((vilkårResultat: IRestVilkårResultat) =>
                             lagInitiellFelt(
                                 {
-                                    begrunnelse: lagInitiellFelt(
-                                        vilkårResultat.begrunnelse,
-                                        erUtfylt
-                                    ),
+                                    begrunnelse: {
+                                        feilmelding: '',
+                                        valideringsFunksjon: ikkeValider,
+                                        valideringsstatus: Valideringsstatus.OK,
+                                        verdi: vilkårResultat.begrunnelse,
+                                    },
                                     id: randomUUID(),
                                     periode: lagInitiellFelt(
                                         nyPeriode(

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -2,7 +2,7 @@ import { randomUUID } from '../utils/commons';
 import { IPeriode, nyPeriode } from './periode';
 import { IPerson, PersonType } from './person';
 import { IFelt, nyttFelt } from './felt';
-import { erUtfylt, erPeriodeGyldig, erResultatGyldig } from '../utils/validators';
+import { erPeriodeGyldig, erResultatGyldig, ikkeValider } from '../utils/validators';
 import { INøkkelPar } from './common';
 
 export enum Resultat {
@@ -48,7 +48,7 @@ export enum VilkårType {
 }
 
 export const lagTomtFeltMedVilkår = (vilkårType: VilkårType): IVilkårResultat => ({
-    begrunnelse: nyttFelt('', erUtfylt),
+    begrunnelse: nyttFelt('', ikkeValider),
     id: randomUUID(),
     periode: nyttFelt(nyPeriode(), erPeriodeGyldig),
     resultat: nyttFelt(Resultat.KANSKJE, erResultatGyldig),

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from '../utils/commons';
 import { IPeriode, nyPeriode } from './periode';
 import { IPerson, PersonType } from './person';
-import { IFelt, nyttFelt } from './felt';
+import { IFelt, nyttFelt, Valideringsstatus } from './felt';
 import { erPeriodeGyldig, erResultatGyldig, ikkeValider } from '../utils/validators';
 import { INøkkelPar } from './common';
 
@@ -48,7 +48,12 @@ export enum VilkårType {
 }
 
 export const lagTomtFeltMedVilkår = (vilkårType: VilkårType): IVilkårResultat => ({
-    begrunnelse: nyttFelt('', ikkeValider),
+    begrunnelse: {
+        feilmelding: '',
+        valideringsFunksjon: ikkeValider,
+        valideringsstatus: Valideringsstatus.OK,
+        verdi: '',
+    },
     id: randomUUID(),
     periode: nyttFelt(nyPeriode(), erPeriodeGyldig),
     resultat: nyttFelt(Resultat.KANSKJE, erResultatGyldig),

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -52,18 +52,8 @@ export const erResultatGyldig = (felt: IFelt<Resultat>): IFelt<Resultat> => {
     return felt.verdi !== Resultat.KANSKJE ? ok(felt) : feil(felt, 'Resultat er ikke satt');
 };
 
-export const erGyldigBegrunnelse = (felt: IFelt<string>): IFelt<string> => {
-    if (felt.verdi === '') {
-        return feil(felt, 'Begrunnelse er påkrevd. Vennligst fyll ut en begrunnelse til vedtaket.');
-    }
-    return ok(felt);
-};
-
 const ikkeUtfyltFelt = 'Feltet er påkrevd, men mangler input';
 export const erUtfylt = (felt: IFelt<string>): IFelt<string> => {
-    if (felt.verdi === '') {
-        return feil(felt, ikkeUtfyltFelt);
-    }
     return ok(felt);
 };
 

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -54,6 +54,9 @@ export const erResultatGyldig = (felt: IFelt<Resultat>): IFelt<Resultat> => {
 
 const ikkeUtfyltFelt = 'Feltet er påkrevd, men mangler input';
 export const erUtfylt = (felt: IFelt<string>): IFelt<string> => {
+    if (felt.verdi === '') {
+        return feil(felt, ikkeUtfyltFelt);
+    }
     return ok(felt);
 };
 
@@ -71,4 +74,8 @@ export const validerFelt = <T>(nyVerdi: T, felt: IFelt<T>): IFelt<T> => {
         ...felt,
         verdi: nyVerdi,
     });
+};
+
+export const ikkeValider = <T>(felt: IFelt<T>): IFelt<T> => {
+    return ok(felt);
 };


### PR DESCRIPTION
Kanskje ikke den mest korrekte måten å sette felte til optional på? Testet lokalt, og jeg får ikke lenger feilmelding når begrunnelse mangler.