### PR TITLE
Minifix: Trim spaces

### DIFF
--- a/src/frontend/komponenter/Oppgaver/OppgaveHeader.tsx
+++ b/src/frontend/komponenter/Oppgaver/OppgaveHeader.tsx
@@ -23,7 +23,7 @@ const OppgaveHeader: React.FunctionComponent = () => {
                     value={personIdent}
                     placeholder={'Skriv inn fnr/dnr 11 siffer'}
                     onChange={event => {
-                        settPersonIdent(event.target.value);
+                        settPersonIdent(event.target.value.trim());
                     }}
                     className={'oppgave-header__fnrInput'}
                 />


### PR DESCRIPTION
Under testing fikk vi feil ved "Opprett eller hent fagsak" fra oppgavebenk. Feilmeldinga var av sorten "en feil har oppstått" og dette kom i loggene: 
![Skjermbilde 2020-06-09 kl  12 07 26](https://user-images.githubusercontent.com/5719550/84135861-c6edda80-aa4a-11ea-8723-8b7c2d43d5fc.png)

Viste seg å være at det var kommet med et space på slutten ved copy pasting av fødselsnummer. Dette fikser det (tok ikke lenger tid enn å utdype bug i favrokort).