### PR TITLE
Fiks etter funksjonell test: Fjern intern scroll i komponenten ved lang brev-tekst

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Hendelsesoversikt.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Hendelsesoversikt.tsx
@@ -39,12 +39,12 @@ const Hendelsesoversikt = ({ hendelser, className }: IHendelsesoversiktProps) =>
                     onClick={() => settAktivTab(Tabs.Dokumenter)}
                 />
             </div>
-            <div className={'hendelsesoversikt__content'}>
-                {aktivTab === Tabs.Historikk && hendelser.length > 0 && (
+            {aktivTab === Tabs.Historikk && hendelser.length > 0 && (
+                <div className={'historikk'}>
                     <ul className={'hendelsesoversikt__list'}>{hendelser?.map(tilHendelseItem)}</ul>
-                )}
-                {aktivTab === Tabs.Meldinger && <Brev />}
-            </div>
+                </div>
+            )}
+            {aktivTab === Tabs.Meldinger && <Brev />}
         </div>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/hendelsesoversikt.less
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/hendelsesoversikt.less
@@ -12,11 +12,6 @@
     @listPadding: 1.25rem;
     @itemPadding: 0.75rem;
     @tekstMargin: 2px;
-
-    &__content {
-        overflow: auto;
-        height: 35rem;
-    }
     
     &__list {
         min-height: 3.125rem;
@@ -82,5 +77,10 @@
 
     .brev {
         margin: 0 1.25rem;
+    }
+
+    .historikk {
+        overflow: auto;
+        height: 35rem;
     }
 }


### PR DESCRIPTION
Følger nå vinduets hovedscroll hvis teksten blir veldig lang.

Historikk beholder egen scroll og maks-høyde.