### PR TITLE
Sorter perioder i tidslinjen

### DIFF
--- a/src/frontend/context/TidslinjeContext.ts
+++ b/src/frontend/context/TidslinjeContext.ts
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { IPersonBeregning, IYtelsePeriode } from '../typer/beregning';
 import { Periode } from '@navikt/helse-frontend-tidslinje';
 import { Skalaetikett } from '@navikt/helse-frontend-tidslinje/lib/src/components/types.internal';
+import { IPerson } from '../typer/person';
 
 export interface ITidslinjeVindu {
     id: number;
@@ -91,6 +92,49 @@ const [TidslinjeProvider, useTidslinje] = createUseContext(() => {
             : [[]];
     };
 
+    const mapPersonberegningerTilPersoner = (
+        personer: IPerson[],
+        personberegninger?: IPersonBeregning[]
+    ): IPerson[] => {
+        if (!personberegninger) {
+            return [];
+        }
+        return personberegninger
+            .map((personBeregning: IPersonBeregning) => {
+                return personer.find(
+                    (person: IPerson) => person.personIdent === personBeregning.personIdent
+                );
+            })
+            .reduce((acc: IPerson[], person) => {
+                if (person) {
+                    return [...acc, person];
+                }
+                return acc;
+            }, []);
+    };
+
+    const mapPersonerTilPersonberegninger = (
+        personer: IPerson[],
+        personberegninger?: IPersonBeregning[]
+    ): IPersonBeregning[] => {
+        if (!personberegninger) {
+            return [];
+        }
+        return personer
+            .map((person: IPerson) => {
+                return personberegninger.find(
+                    (personberegning: IPersonBeregning) =>
+                        person.personIdent === personberegning.personIdent
+                );
+            })
+            .reduce((acc: IPersonBeregning[], personberegning) => {
+                if (personberegning) {
+                    return [...acc, personberegning];
+                }
+                return acc;
+            }, []);
+    };
+
     return {
         aktivEtikett,
         settAktivEtikett,
@@ -102,6 +146,8 @@ const [TidslinjeProvider, useTidslinje] = createUseContext(() => {
         genererRader,
         initiellAktivEtikettErSatt,
         setInitiellAktivEtikettErSatt,
+        mapPersonberegningerTilPersoner,
+        mapPersonerTilPersonberegninger,
     };
 });
 


### PR DESCRIPTION
Bug: bare labels men ikke perioder var sortert i tidslinjen. Nå er er også periodene sortert. 