### PR TITLE
Legg til manglende behandlingstyper.

### DIFF
--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -150,6 +150,10 @@ export const behandlingstyper: INøkkelPar = {
         id: 'MIGRERING_FRA_INFOTRYGD',
         navn: 'Migrering fra infotrygd',
     },
+    MIGRERING_FRA_INFOTRYGD_OPPHØRT: {
+        id: 'MIGRERING_FRA_INFOTRYGD',
+        navn: 'Opphør migrering fra infotrygd',
+    },
     REVURDERING: {
         id: 'REVURDERING',
         navn: 'Revurdering',
@@ -157,6 +161,10 @@ export const behandlingstyper: INøkkelPar = {
     TEKNISK_OPPHØR: {
         id: 'TEKNISK_OPPHØR',
         navn: 'Teknisk opphør',
+    },
+    KLAGE: {
+        id: 'KLAGE',
+        navn: 'Klage',
     },
 };
 


### PR DESCRIPTION
Frontend tryna da man forsøkte å hente opphørt infotrygd-sak. Brukes på saksoversikt når man rendrer behandlinger. 
Legger også inn klage, som mangla. 

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-2380