### PR TITLE
Bugfix: TEA2741

### DIFF
--- a/src/frontend/context/FagsakContext.tsx
+++ b/src/frontend/context/FagsakContext.tsx
@@ -33,7 +33,6 @@ const [FagsakProvider, useFagsakRessurser] = createUseContext(() => {
     const { axiosRequest } = useApp();
 
     React.useEffect(() => {
-        console.log(fagsakRessurser);
         if (
             fagsakRessurser.fagsak.status === RessursStatus.SUKSESS &&
             (fagsakRessurser.bruker.status === RessursStatus.IKKE_HENTET ||

--- a/src/frontend/context/FagsakContext.tsx
+++ b/src/frontend/context/FagsakContext.tsx
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import createUseContext from 'constate';
 import React from 'react';
-import { fagsakStatus, IFagsak } from '../typer/fagsak';
+import { IFagsak } from '../typer/fagsak';
 import { ILogg } from '../typer/logg';
 import { IPersonInfo } from '../typer/person';
 import {
@@ -12,7 +12,6 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 import { useApp } from './AppContext';
-import { Bruker } from '@navikt/familie-header';
 
 interface IHovedRessurser {
     bruker: Ressurs<IPersonInfo>;

--- a/src/frontend/context/FagsakContext.tsx
+++ b/src/frontend/context/FagsakContext.tsx
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import createUseContext from 'constate';
 import React from 'react';
-import { IFagsak } from '../typer/fagsak';
+import { fagsakStatus, IFagsak } from '../typer/fagsak';
 import { ILogg } from '../typer/logg';
 import { IPersonInfo } from '../typer/person';
 import {
@@ -12,6 +12,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 import { useApp } from './AppContext';
+import { Bruker } from '@navikt/familie-header';
 
 interface IHovedRessurser {
     bruker: Ressurs<IPersonInfo>;
@@ -33,7 +34,14 @@ const [FagsakProvider, useFagsakRessurser] = createUseContext(() => {
     const { axiosRequest } = useApp();
 
     React.useEffect(() => {
-        if (fagsakRessurser.fagsak.status === RessursStatus.SUKSESS) {
+        console.log(fagsakRessurser);
+        if (
+            fagsakRessurser.fagsak.status === RessursStatus.SUKSESS &&
+            (fagsakRessurser.bruker.status === RessursStatus.IKKE_HENTET ||
+                (fagsakRessurser.bruker.status === RessursStatus.SUKSESS &&
+                    fagsakRessurser.fagsak.data.søkerFødselsnummer !==
+                        fagsakRessurser.bruker.data.personIdent))
+        ) {
             settFagsakRessurser({
                 ...fagsakRessurser,
                 bruker: {
@@ -54,7 +62,7 @@ const [FagsakProvider, useFagsakRessurser] = createUseContext(() => {
                 });
             });
         }
-    }, [fagsakRessurser.fagsak.status]);
+    }, [fagsakRessurser.fagsak]);
 
     const hentFagsak = (fagsakId: string): void => {
         settFagsakRessurser({

--- a/src/frontend/context/FagsakContext.tsx
+++ b/src/frontend/context/FagsakContext.tsx
@@ -32,9 +32,7 @@ const [FagsakProvider, useFagsakRessurser] = createUseContext(() => {
     }, [fagsak]);
 
     const hentFagsak = (fagsakId: string): void => {
-        settFagsak({
-            status: RessursStatus.HENTER,
-        });
+        settFagsak(byggHenterRessurs());
         axiosRequest<IFagsak, void>({
             method: 'GET',
             url: `/familie-ba-sak/api/fagsaker/${fagsakId}`,
@@ -61,9 +59,7 @@ const [FagsakProvider, useFagsakRessurser] = createUseContext(() => {
     };
 
     const hentBruker = (personIdent: string): void => {
-        settBruker({
-            status: RessursStatus.HENTER,
-        });
+        settBruker(byggHenterRessurs());
         axiosRequest<IPersonInfo, void>({
             method: 'GET',
             url: '/familie-ba-sak/api/person',


### PR DESCRIPTION
See: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-2741

In FagsakContext, the logic for updating user information was that when hentFagsak() is called, it will first change the fagsakRessurser.fagsak.status, and then call backend to get fagsak. The change of fagsakRessurser.fagsak.status will trigger another call to backend to get user information.
However, in the scenario with the bug, hentFagsak() was not called, instead, settFagsak() was called to update the fagsak, which could not trigger the call to get user information.
With this bugfix, FagsakContext updates user information when either 1) fagsak status is changed, or 2) the person ident of fagsak is no longer equal to the person ident of user information