### PR TITLE
Filtrerer vekk henlagte behandlinger.

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useBehandling } from '../../../context/BehandlingContext';
 import {
     BehandlingKategori,
+    BehandlingResultat,
     BehandlingStatus,
     IBehandling,
     kategorier,
@@ -36,7 +37,10 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ fagsak }) => {
     }, [fagsak.status]);
 
     const behandlingshistorikk = fagsak.behandlinger.filter(
-        (behandling: IBehandling) => behandling.status === BehandlingStatus.AVSLUTTET
+        (behandling: IBehandling) =>
+            behandling.status === BehandlingStatus.AVSLUTTET &&
+            behandling.samletResultat !== BehandlingResultat.HENLAGT_FEILAKTIG_OPPRETTET &&
+            behandling.samletResultat !== BehandlingResultat.HENLAGT_SØKNAD_TRUKKET
     );
 
     let gjeldendeBehandling =

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -36,7 +36,7 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ fagsak }) => {
         bestemÅpenBehandling(undefined);
     }, [fagsak.status]);
 
-    const behandlingshistorikk = fagsak.behandlinger.filter(
+    const iverksatteBehandlinger = fagsak.behandlinger.filter(
         (behandling: IBehandling) =>
             behandling.status === BehandlingStatus.AVSLUTTET &&
             behandling.samletResultat !== BehandlingResultat.HENLAGT_FEILAKTIG_OPPRETTET &&
@@ -44,8 +44,8 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ fagsak }) => {
     );
 
     let gjeldendeBehandling =
-        behandlingshistorikk.length > 0
-            ? behandlingshistorikk.sort((a, b) =>
+        iverksatteBehandlinger.length > 0
+            ? iverksatteBehandlinger.sort((a, b) =>
                   moment(b.opprettetTidspunkt).diff(a.opprettetTidspunkt)
               )[0]
             : undefined;


### PR DESCRIPTION
Dersom det kom til en revurdering som ble henlagt på en løpende behandling så feilet visning av "Løpende månedlig utbetaling" ettersom det var den henlagte behandlingen som ble plukket ut. Fikk da visning av feiltekst "Noe gikk galt ved henting av utbetalinger. Prøv igjen eller...".