### PR TITLE
Fjern perioder hvor fom er mer enn 2 måneder frem i tid fra vedtakssiden

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/UtbetalingBegrunnelseTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/UtbetalingBegrunnelseTabell.tsx
@@ -35,11 +35,12 @@ const UtbetalingBegrunnelseTabell: React.FC<IUtbetalingBegrunnelseTabell> = ({
     const utbetalingsperioderMedBegrunnelseBehov = åpenBehandling.utbetalingsperioder
         .slice()
         .sort((a, b) =>
-            dayjs(a.periodeFom, datoformat.ISO_DAG).diff(
-                dayjs(b.periodeFom, datoformat.ISO_DAG),
-                'day'
-            )
-        );
+            dayjs(a.periodeFom, datoformat.ISO_DAG).diff(dayjs(b.periodeFom, datoformat.ISO_DAG))
+        )
+        .filter((utbetalingsperiode: IUtbetalingsperiode) => {
+            // Fjern perioder hvor fom er mer enn 2 måneder frem i tid
+            return dayjs(utbetalingsperiode.periodeFom).diff(dayjs(), 'month') < 2;
+        });
 
     const slutterSenereEnnInneværendeMåned = (dato: string) =>
         stringToMoment(dato, TIDENES_MORGEN).isAfter(sisteDagInneværendeMåned());


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
SB ønsker kun å se nåværende perioder. For å filtrere bort de fleste av de fremtidige periodene setter vi en cut på 2 måneder frem i tid. F.eks. er vi i november så skal periodene hvor fom er november, desember og januar vises på vedtakssiden.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Bare fjernet perioder som går over 2 måneder frem i tid.
