### PR TITLE
Fiks logikk på select for opprett behandling

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -12,7 +12,7 @@ import {
 import { FagsakStatus, IFagsak } from '../../../../../typer/fagsak';
 import { hentAktivBehandlingPåFagsak } from '../../../../../utils/fagsak';
 import useOpprettBehandling from './useOpprettBehandling';
-import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+import { RessursStatus } from '@navikt/familie-typer';
 import SkjultLegend from '../../../../Felleskomponenter/SkjultLegend';
 import { useApp } from '../../../../../context/AppContext';
 import { ToggleNavn } from '../../../../../typer/toggles';
@@ -45,14 +45,13 @@ const OpprettBehandling: React.FC<IProps> = ({ onListElementClick, fagsak }) => 
     const {
         fjernState,
         onBekreft,
-        settSelectedBehandlingstype,
         selectedBehandlingstype,
-        settSubmitRessurs,
         submitRessurs,
-        settSelectedBehandlingÅrsak,
         selectedBehandlingÅrsak,
         valideringsFeil,
-        settValideringsfeil,
+        behandlingstypeOnChange,
+        behandlingÅrsakOnChange,
+        visÅrsakerSelect,
     } = useOpprettBehandling(() => settVisModal(false));
 
     const lukkOpprettBehandlingModal = () => {
@@ -118,14 +117,7 @@ const OpprettBehandling: React.FC<IProps> = ({ onListElementClick, fagsak }) => 
                         name={'Behandling'}
                         label={'Velg type behandling'}
                         onChange={(event: React.ChangeEvent<BehandlingstypeSelect>): void => {
-                            settSubmitRessurs(byggTomRessurs());
-                            settValideringsfeil(valideringsFeil => {
-                                return {
-                                    ...valideringsFeil,
-                                    behandlingstype: '',
-                                };
-                            });
-                            settSelectedBehandlingstype(event.target.value);
+                            behandlingstypeOnChange(event.target.value);
                         }}
                     >
                         <option disabled={true} value={''}>
@@ -161,39 +153,26 @@ const OpprettBehandling: React.FC<IProps> = ({ onListElementClick, fagsak }) => 
                         )}
                     </FamilieSelect>
 
-                    <FamilieSelect
-                        feil={valideringsFeil.behandlingÅrsak}
-                        erLesevisning={false}
-                        value={selectedBehandlingÅrsak}
-                        name={'Behandlingsårsak'}
-                        label={'Velg årsak'}
-                        onChange={(event: React.ChangeEvent<BehandlingÅrsakSelect>): void => {
-                            settSubmitRessurs(byggTomRessurs());
-                            settValideringsfeil(valideringsFeil => {
-                                return {
-                                    ...valideringsFeil,
-                                    behandlingÅrsak: '',
-                                };
-                            });
-                            settSelectedBehandlingÅrsak(event.target.value);
-                        }}
-                    >
-                        <option disabled={true} value={''}>
-                            Velg
-                        </option>
-                        {selectedBehandlingstype === Behandlingstype.TEKNISK_OPPHØR ? (
-                            <option
-                                key={BehandlingÅrsak.TEKNISK_OPPHØR}
-                                aria-selected={
-                                    selectedBehandlingÅrsak === BehandlingÅrsak.TEKNISK_OPPHØR
-                                }
-                                value={BehandlingÅrsak.TEKNISK_OPPHØR}
-                            >
-                                {behandlingÅrsak[BehandlingÅrsak.TEKNISK_OPPHØR]}
+                    {visÅrsakerSelect && (
+                        <FamilieSelect
+                            feil={valideringsFeil.behandlingÅrsak}
+                            erLesevisning={false}
+                            value={selectedBehandlingÅrsak}
+                            name={'Behandlingsårsak'}
+                            label={'Velg årsak'}
+                            onChange={(event: React.ChangeEvent<BehandlingÅrsakSelect>): void => {
+                                behandlingÅrsakOnChange(event.target.value);
+                            }}
+                        >
+                            <option disabled={true} value={''}>
+                                Velg
                             </option>
-                        ) : (
-                            Object.values(BehandlingÅrsak)
-                                .filter(årsak => årsak !== BehandlingÅrsak.TEKNISK_OPPHØR)
+                            {Object.values(BehandlingÅrsak)
+                                .filter(
+                                    årsak =>
+                                        årsak !== BehandlingÅrsak.TEKNISK_OPPHØR &&
+                                        årsak !== BehandlingÅrsak.FØDSELSHENDELSE
+                                )
                                 .map(årsak => {
                                     return (
                                         <option
@@ -204,9 +183,9 @@ const OpprettBehandling: React.FC<IProps> = ({ onListElementClick, fagsak }) => 
                                             {behandlingÅrsak[årsak]}
                                         </option>
                                     );
-                                })
-                        )}
-                    </FamilieSelect>
+                                })}
+                        </FamilieSelect>
+                    )}
                 </SkjemaGruppe>
             </UIModalWrapper>
         </>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -153,7 +153,7 @@ const OpprettBehandling: React.FC<IProps> = ({ onListElementClick, fagsak }) => 
                         )}
                     </FamilieSelect>
 
-                    {visÅrsakerSelect && (
+                    {visÅrsakerSelect() && (
                         <FamilieSelect
                             feil={valideringsFeil.behandlingÅrsak}
                             erLesevisning={false}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -94,6 +94,7 @@ const useOpprettBehandling = (lukkModal: () => void) => {
                 settSelectedBehandlingÅrsak(BehandlingÅrsak.SØKNAD);
                 break;
             default:
+                settSelectedBehandlingÅrsak('');
                 break;
         }
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -27,7 +27,6 @@ const useOpprettBehandling = (lukkModal: () => void) => {
         behandlingstype: '',
         behandlingÅrsak: '',
     });
-    const [visÅrsakerSelect, settVisÅrsakerSelect] = useState(false);
 
     const { opprettBehandling } = useFagsakApi(
         _ => {
@@ -76,6 +75,8 @@ const useOpprettBehandling = (lukkModal: () => void) => {
         }
     };
 
+    const visÅrsakerSelect = () => selectedBehandlingstype === Behandlingstype.REVURDERING;
+
     const behandlingstypeOnChange = (behandlingstype: Behandlingstype | '') => {
         settSubmitRessurs(byggTomRessurs());
         settValideringsfeil(valideringsFeil => {
@@ -88,14 +89,12 @@ const useOpprettBehandling = (lukkModal: () => void) => {
         switch (behandlingstype) {
             case Behandlingstype.TEKNISK_OPPHØR:
                 settSelectedBehandlingÅrsak(BehandlingÅrsak.TEKNISK_OPPHØR);
-                settVisÅrsakerSelect(false);
                 break;
             case Behandlingstype.FØRSTEGANGSBEHANDLING:
                 settSelectedBehandlingÅrsak(BehandlingÅrsak.SØKNAD);
-                settVisÅrsakerSelect(false);
                 break;
             default:
-                settVisÅrsakerSelect(true);
+                break;
         }
 
         settSelectedBehandlingstype(behandlingstype);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -27,6 +27,7 @@ const useOpprettBehandling = (lukkModal: () => void) => {
         behandlingstype: '',
         behandlingÅrsak: '',
     });
+    const [visÅrsakerSelect, settVisÅrsakerSelect] = useState(false);
 
     const { opprettBehandling } = useFagsakApi(
         _ => {
@@ -75,17 +76,52 @@ const useOpprettBehandling = (lukkModal: () => void) => {
         }
     };
 
+    const behandlingstypeOnChange = (behandlingstype: Behandlingstype | '') => {
+        settSubmitRessurs(byggTomRessurs());
+        settValideringsfeil(valideringsFeil => {
+            return {
+                ...valideringsFeil,
+                behandlingstype: '',
+            };
+        });
+
+        switch (behandlingstype) {
+            case Behandlingstype.TEKNISK_OPPHØR:
+                settSelectedBehandlingÅrsak(BehandlingÅrsak.TEKNISK_OPPHØR);
+                settVisÅrsakerSelect(false);
+                break;
+            case Behandlingstype.FØRSTEGANGSBEHANDLING:
+                settSelectedBehandlingÅrsak(BehandlingÅrsak.SØKNAD);
+                settVisÅrsakerSelect(false);
+                break;
+            default:
+                settVisÅrsakerSelect(true);
+        }
+
+        settSelectedBehandlingstype(behandlingstype);
+    };
+
+    const behandlingÅrsakOnChange = (behandlingÅrsak: BehandlingÅrsak | '') => {
+        settSubmitRessurs(byggTomRessurs());
+        settValideringsfeil(valideringsFeil => {
+            return {
+                ...valideringsFeil,
+                behandlingÅrsak: '',
+            };
+        });
+        settSelectedBehandlingÅrsak(behandlingÅrsak);
+    };
+
     return {
         onBekreft,
         fjernState,
-        settSubmitRessurs,
         submitRessurs,
-        settSelectedBehandlingstype,
         selectedBehandlingstype,
         selectedBehandlingÅrsak,
-        settSelectedBehandlingÅrsak,
         valideringsFeil,
-        settValideringsfeil,
+        behandlingstypeOnChange,
+        behandlingÅrsakOnChange,
+        visÅrsakerSelect,
     };
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I opprett behandling-modalen skal man først kun få opp 1 select for behandlingstype. Dersom man velger revurdering i denne skal det komme opp en select til for å velge årsak. Dersom man velger behandlingstype teknisk opphør setter den årsaken til teknisk opphør automatisk, og ved førstegangsbehandling setter den søknad som årsak.
 
### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingenting spesielt. 

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_ Var ikke helt sikker på om jeg skulle skrive tester for onChange-metodene, vi har jo ikke helt sett på hvordan man mocker states ogsånn. 

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_ Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots

Før viste den alltid begge inputs
![Screenshot 2020-11-26 at 15 07 29](https://user-images.githubusercontent.com/8656966/100361069-02309580-2ffa-11eb-8c11-752c214f5af5.png)


Nå vises kun to inputs dersom revurdering er valgt som behandlinstype
![Screenshot 2020-11-26 at 15 07 02](https://user-images.githubusercontent.com/8656966/100361031-f3e27980-2ff9-11eb-9eb9-caf51a9f991a.png)

