### PR TITLE
Fjern søknadsbilde i urelevante tilfeller

### DIFF
--- a/src/frontend/komponenter/Fagsak/useFagsakApi.ts
+++ b/src/frontend/komponenter/Fagsak/useFagsakApi.ts
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router';
 import { IOpprettBehandlingData, IOpprettEllerHentFagsakData } from '../../api/fagsak';
 import { useApp } from '../../context/AppContext';
 import { useFagsakRessurser } from '../../context/FagsakContext';
-import { Behandlingstype, IBehandling } from '../../typer/behandling';
+import { BehandlingÅrsak, IBehandling } from '../../typer/behandling';
 import { IFagsak } from '../../typer/fagsak';
 import { byggFeiletRessurs, Ressurs, RessursStatus } from '@navikt/familie-typer';
 import { IPersonResultat } from '../../typer/vilkår';
@@ -73,16 +73,13 @@ const useFagsakApi = (
                     if (!aktivBehandling) {
                         settVisFeilmeldinger(true);
                         settFeilmelding('Opprettelse av behandling feilet');
-                    } else if (
-                        aktivBehandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD ||
-                        aktivBehandling.type === Behandlingstype.TEKNISK_OPPHØR
-                    ) {
+                    } else if (aktivBehandling.årsak === BehandlingÅrsak.SØKNAD) {
                         history.push(
-                            `/fagsak/${response.data.id}/${aktivBehandling?.behandlingId}/vilkaarsvurdering`
+                            `/fagsak/${response.data.id}/${aktivBehandling?.behandlingId}/registrer-soknad`
                         );
                     } else {
                         history.push(
-                            `/fagsak/${response.data.id}/${aktivBehandling?.behandlingId}/registrer-soknad`
+                            `/fagsak/${response.data.id}/${aktivBehandling?.behandlingId}/vilkaarsvurdering`
                         );
                     }
                 } else if (response.status === RessursStatus.FEILET) {

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -1,7 +1,7 @@
 import {
     BehandlingSteg,
     BehandlingStegStatus,
-    Behandlingstype,
+    BehandlingÅrsak,
     hentStegNummer,
     IBehandling,
 } from '../../../typer/behandling';
@@ -105,8 +105,7 @@ export const visSide = (side: ISide, åpenBehandling: IBehandling, harOpplysning
         return harOpplysningsplikt;
     } else if (
         åpenBehandling.skalBehandlesAutomatisk ||
-        åpenBehandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD ||
-        åpenBehandling.type === Behandlingstype.TEKNISK_OPPHØR
+        åpenBehandling.årsak !== BehandlingÅrsak.SØKNAD
     ) {
         return side.steg !== BehandlingSteg.REGISTRERE_SØKNAD;
     } else {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Denne fjerner registrer søknad-siden i alle andre tilfeller enn når årsaken til en behandling er søknad.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ingen utils å teste. Mangler litt oppsett for mock for å skrive test for f.eks. visSider med en mock på åpenBehandling.


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen endringer, bare flyt, enten vises søknaden eller så vises den ikke.