### PR TITLE
Fix/diskresjonskode ved søk og tidslinje

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,6 @@
     "plugins": ["@typescript-eslint", "react-app", "prettier"],
     "rules": {
         "no-case-declarations": "off",
-
         "import/extensions": [
             "off",
             "ignorePackages",

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "plugins": ["@typescript-eslint", "react-app", "prettier"],
     "rules": {
         "no-case-declarations": "off",
+
         "import/extensions": [
             "off",
             "ignorePackages",
@@ -35,6 +36,7 @@
         "@typescript-eslint/interface-name-prefix": "off",
         "@typescript-eslint/no-var-requires": "warn",
         "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/no-unused-vars": ["warn", { "vars": "all","args": "all", "argsIgnorePattern": "^_" }],
         "react-app/react-hooks/exhaustive-deps": "off"
     },
     "settings": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css}": [
       "prettier --write",
-      "eslint --fix src/"
+      "eslint --fix src/ --max-warnings=0"
     ]
   },
   "dependencies": {

--- a/src/frontend/familie-react-select/FamilieReactSelect.tsx
+++ b/src/frontend/familie-react-select/FamilieReactSelect.tsx
@@ -12,6 +12,7 @@ interface IProps extends NamedProps {
     label: string | React.ReactNode;
     feil?: string;
     propSelectStyles?: StylesConfig;
+    //TODO: legg inn lesevisningsverdi når denne dras ut i felles
 }
 
 const Container = styled.div`

--- a/src/frontend/familie-react-select/FamilieReactSelect.tsx
+++ b/src/frontend/familie-react-select/FamilieReactSelect.tsx
@@ -10,7 +10,6 @@ interface IProps extends NamedProps {
     erLesevisning: boolean;
     creatable?: boolean;
     label: string | React.ReactNode;
-    lesevisningVerdi?: string;
     feil?: string;
     propSelectStyles?: StylesConfig;
 }
@@ -76,7 +75,6 @@ const FamilieReactSelect: React.FC<IProps> = ({
     erLesevisning,
     creatable = false,
     label,
-    lesevisningVerdi,
     value,
     feil,
     propSelectStyles,

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsboks.tsx
@@ -3,7 +3,7 @@ import { IUtbetalingsperiode, ytelsetype } from '../../../typer/beregning';
 import {
     datoformat,
     formaterBeløp,
-    formaterIsoDato,
+    formaterDato,
     formaterPersonIdent,
     hentAlderSomString,
     sorterFødselsdato,
@@ -12,6 +12,7 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 import { useTidslinje } from '../../../context/TidslinjeContext';
 import { Xknapp } from 'nav-frontend-ikonknapper';
 import { Skalaetikett } from '@navikt/helse-frontend-tidslinje/lib/src/components/types.internal';
+import familieDayjs from '../../../utils/familieDayjs';
 
 interface IProps {
     utbetalingsperioder: IUtbetalingsperiode[];
@@ -29,7 +30,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
     const { settAktivEtikett } = useTidslinje();
 
     const månedNavnOgÅr = () => {
-        const navn = formaterIsoDato(aktivEtikett.dato.toDateString(), datoformat.MÅNED_NAVN);
+        const navn = formaterDato(familieDayjs(aktivEtikett.dato), datoformat.MÅNED_NAVN);
         return navn[0].toUpperCase() + navn.substr(1);
     };
 

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -91,7 +91,8 @@ const FagsakDeltagerSøk: React.FC = () => {
                                         ? history.push(
                                               `/fagsak/${resultat[index].fagsakId}/saksoversikt`
                                           )
-                                        : settDeltagerForOpprettFagsak(deltager);
+                                        : deltager.harTilgang &&
+                                          settDeltagerForOpprettFagsak(deltager);
                                 }}
                             />
                         );

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,8 +13,6 @@
       "strictPropertyInitialization": true,
       "noImplicitThis": true,
       "alwaysStrict": true,
-      "noUnusedLocals": true,
-      "noUnusedParameters": true,
       "noImplicitReturns": false,
       "noFallthroughCasesInSwitch": true,
       "moduleResolution": "node",


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Denne fikser 3 ting:

1. Når man søker, og bruker har diskresjonskode, skal man ikke kunne trykke på personen
2. Oppsummeringsboksen som dukker opp når man trykker på en mdn i tidslinjen i behandlingsresultat viser riktig måned (viste måneden før, noe som er en bug)
3. Fjerner dobbel error/warning på ubrukte variabler i terminalen. Løsningen jeg gikk for er å disable errors for det i typescript, og heller legge til det i eslint. I tillegg er det satt en grense på 0 warnings i eslint når man comitter, dette for å unngå å pushe ubrukte variabler, noe som vil feile når den bygger.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer
