### PR TITLE
Feature/tilskrive bruker

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -1,7 +1,7 @@
 import createUseContext from 'constate';
 import React, { useEffect } from 'react';
 
-import { Behandlingstype, BehandlingÅrsak, hentStegNummer } from '../typer/behandling';
+import { Behandlingstype, BehandlingÅrsak } from '../typer/behandling';
 import { RessursStatus } from '@navikt/familie-typer';
 import { useBehandling } from './BehandlingContext';
 import { IFagsak } from '../typer/fagsak';
@@ -122,10 +122,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
     const hentMuligeBrevMaler = () => {
         const brevMaler = [];
         if (åpenBehandling.status === RessursStatus.SUKSESS) {
-            if (
-                hentStegNummer(åpenBehandling.data.steg) >= 2 &&
-                åpenBehandling.data.årsak === BehandlingÅrsak.SØKNAD
-            ) {
+            if (åpenBehandling.data.årsak === BehandlingÅrsak.SØKNAD) {
                 brevMaler.push(Brevmal.INNHENTE_OPPLYSNINGER);
             }
 

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -29,6 +29,7 @@ import navFarger from 'nav-frontend-core';
 import SkjultLegend from '../../SkjultLegend';
 import { Felt } from '../../../../familie-skjema/typer';
 import useForhåndsvisning from '../../PdfVisningModal/useForhåndsvisning';
+import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
 
 interface IProps {
     brevMaler: Brevmal[];
@@ -201,8 +202,12 @@ const Brevskjema = ({ brevMaler, onSubmitSuccess }: IProps) => {
                     disabled={skjemaErLåst}
                     onClick={() => {
                         if (åpenBehandling.status === RessursStatus.SUKSESS) {
+                            const harRegistrertSøknad =
+                                hentStegNummer(åpenBehandling.data.steg) >
+                                hentStegNummer(BehandlingSteg.REGISTRERE_SØKNAD);
                             settNavigerTilOpplysningsplikt(
-                                skjema.felter.brevmal.verdi === Brevmal.INNHENTE_OPPLYSNINGER
+                                harRegistrertSøknad &&
+                                    skjema.felter.brevmal.verdi === Brevmal.INNHENTE_OPPLYSNINGER
                             );
                             onSubmit(
                                 {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter å ha tilskrevet bruker (sendt brev av typen "innhente opplysninger) skal man redirectes til opplysningsplikt-steget kun dersom man allerede har registrert søknad. Dersom man ikke enda har registrert søknad skal bruker bli stående på registrer søknad-steget.

Det nye menypunktet "Opplysningsplikt" vil i begge tilfeller dukke opp i vesntremenyen.

[Bakgrunn (fra favro)](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3062):
I forbindelse med at vi nå tillater å tilskrive bruker fra registrer-søknad-steget blir den opprinnelige flyten tiltenkt opplysningsplikt forvirrende. En foreslått løsning var at vi la opplysningsplikt-steget før registrering av søknad, men i og med at det på sikt vil oppstå en avhengighet til registrering av søknad fra opplysningsplikt (fordi man skal kunne velge hvilket av de registrerte barna som man fortsetter med) beholder vi flyt og velger kun å sende saksbehandler til opplysningsplikt-steget dersom registrer søknad er utfylt. Dersom det ikke er det kan vi anta at det er mangelfull søknad. Se akseptansekriterier.  

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Liten pr

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Liten endring, testet flyt funksjonelt

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Tidligere flyt dersom man sendte fra registrer søknad - ble uansett sendt til opplysningsplikt: 
![Skjermbilde 2020-11-27 kl  12 09 05](https://user-images.githubusercontent.com/5719550/100735869-362d0180-33d2-11eb-86af-4e2aad4772e6.png)

Ny flyt dersom man sender fra registrer søknad - blir værende på registrer søknad:
![Skjermbilde 2020-12-01 kl  12 40 49](https://user-images.githubusercontent.com/5719550/100736023-77251600-33d2-11eb-9980-8b699b95be30.png)

Ny flyt dersom man underveis i behandlingen får behov for å tilskrive - blir sendt tilbake til opplysningsplikt: 
![Skjermbilde 2020-12-01 kl  12 41 34](https://user-images.githubusercontent.com/5719550/100736138-9e7be300-33d2-11eb-8778-d11d66875e24.png)
