### PR TITLE
Fjern unødvendig bredde på personinfo som gjør at ting brekker rart

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
@@ -51,7 +51,6 @@ const VilkårsvurderingSkjema: React.FunctionComponent<IVilkårsvurderingSkjema>
                                 person={personResultat.person}
                                 tag={'h3'}
                                 tekstType={'UNDERTITTEL'}
-                                width={'35rem'}
                             />
                             <IkonKnapp
                                 erLesevisning={false}

--- a/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -19,12 +19,11 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
     person,
     tag,
     tekstType = 'NORMALTEKST',
-    width = '30rem',
 }) => {
     const alder = hentAlder(person.fødselsdato);
 
     return (
-        <div className={'personinformasjon'} style={{ width }}>
+        <div className={'personinformasjon'}>
             {tekstType === 'UNDERTITTEL' && (
                 <>
                     <FamilieIkonVelger


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Denne fikser slik at personnummer ikke knekker unødvendig tidlig når man skalererer.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Fjerner width, og har lagt ved skjermbilder av der den brukes i vilkårsvurdering også for å vise at den ikke gjorde noen visuelle endringer der. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
ingenting å teste

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før:
![Screenshot 2020-12-08 at 09 37 34](https://user-images.githubusercontent.com/8656966/101459917-2618a300-3939-11eb-93d7-41fec488f16b.png)

![Screenshot 2020-12-08 at 09 37 48](https://user-images.githubusercontent.com/8656966/101459918-2749d000-3939-11eb-9675-51fe1c913991.png)

Etter: 
![Screenshot 2020-12-08 at 09 36 27](https://user-images.githubusercontent.com/8656966/101459942-33ce2880-3939-11eb-82cd-7011cbbb2f3e.png)
![Screenshot 2020-12-08 at 09 36 54](https://user-images.githubusercontent.com/8656966/101459945-34ff5580-3939-11eb-8826-fa47cdb8d881.png)


