### PR TITLE
Vis feilmelding ved submit på vedtaksside

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -139,7 +139,10 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                 if (response.status === RessursStatus.SUKSESS) {
                     settVisModal(true);
                     settFagsak(response);
-                } else if (response.status === RessursStatus.FEILET) {
+                } else if (
+                    response.status === RessursStatus.FEILET ||
+                    response.status === RessursStatus.FUNKSJONELL_FEIL
+                ) {
                     settSubmitFeil(response.frontendFeilmelding);
                 }
             });


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vis feilmelding når validering feiler på ved sending til beslutter. Må sjekke på ny type feilstatus slik at den blir fanget opp. 

Oppdaget i forbindelse med endring av flyt på opplysningsplikt, hvor "Opplysningsplikt må tas stilling til før behandling kan sendes til beslutter." mangler, som Eivind skriver her:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3062