### PR TITLE
Setter spinner og system laster når man oppretter en fagsak

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
@@ -37,11 +37,13 @@ const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({ lukkModal, deltager
                         onClick={async () => {
                             settSenderInn(true);
                             if (deltager && (await sjekkTilgang(deltager.ident))) {
-                                opprettFagsak({
-                                    personIdent: deltager.ident,
-                                    aktørId: null,
-                                });
-                                lukkModal();
+                                opprettFagsak(
+                                    {
+                                        personIdent: deltager.ident,
+                                        aktørId: null,
+                                    },
+                                    lukkModal
+                                );
                             }
                         }}
                         children={'Ja, opprett fagsak'}

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/OpprettFagsakModal.tsx
@@ -21,7 +21,7 @@ const StyledUndertittel = styled(Undertittel)`
 `;
 
 const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({ lukkModal, deltager }) => {
-    const { opprettFagsak, feilmelding, senderInn } = useOpprettFagsak();
+    const { opprettFagsak, feilmelding, senderInn, settSenderInn } = useOpprettFagsak();
     const { sjekkTilgang } = useApp();
     const visModal = !!deltager;
 
@@ -35,6 +35,7 @@ const OpprettFagsakModal: React.FC<IOpprettFagsakModal> = ({ lukkModal, deltager
                         type={'hoved'}
                         mini={true}
                         onClick={async () => {
+                            settSenderInn(true);
                             if (deltager && (await sjekkTilgang(deltager.ident))) {
                                 opprettFagsak({
                                     personIdent: deltager.ident,

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
@@ -21,11 +21,11 @@ const useOpprettFagsak = () => {
     const [senderInn, settSenderInn] = useState(false);
 
     const opprettFagsak = (data: IOpprettFagsakData) => {
-        settSenderInn(true);
         axiosRequest<IFagsak, IOpprettFagsakData>({
             data,
             method: 'POST',
             url: `/familie-ba-sak/api/fagsaker`,
+            påvirkerSystemLaster: true,
         })
             .then((response: Ressurs<IFagsak>) => {
                 settSenderInn(false);
@@ -54,6 +54,7 @@ const useOpprettFagsak = () => {
         opprettFagsak,
         feilmelding,
         senderInn,
+        settSenderInn,
     };
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/useOpprettFagsak.ts
@@ -20,7 +20,7 @@ const useOpprettFagsak = () => {
     const [feilmelding, settFeilmelding] = useState('');
     const [senderInn, settSenderInn] = useState(false);
 
-    const opprettFagsak = (data: IOpprettFagsakData) => {
+    const opprettFagsak = (data: IOpprettFagsakData, onSuccess?: () => void) => {
         axiosRequest<IFagsak, IOpprettFagsakData>({
             data,
             method: 'POST',
@@ -30,6 +30,7 @@ const useOpprettFagsak = () => {
             .then((response: Ressurs<IFagsak>) => {
                 settSenderInn(false);
                 if (response.status === RessursStatus.SUKSESS) {
+                    onSuccess && onSuccess();
                     const aktivBehandling: IBehandling | undefined = hentAktivBehandlingPåFagsak(
                         response.data
                     );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når man oppretter fagsak og ting går litt tregt har man muligheten til å gjøre andre ting før den er ferdig sånn som navigere, opprette fagsak en gang til osv. Denne PR'en fikser slik at knappen opprett blir disablet, og man får beskjed om at systemet laster slik at man ikke kan gjøre noe annet før den er ferdig med å opprette. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke noe å teste

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer. 
