### PR TITLE
Fikser 2 ui bugs. Se melding for favrokort

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
@@ -5,8 +5,9 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 import Visittkort from '@navikt/familie-visittkort';
 
-import { fagsakStatus, IFagsak } from '../../../typer/fagsak';
+import { IFagsak } from '../../../typer/fagsak';
 import { IPersonInfo } from '../../../typer/person';
+import { hentFagsakStatusVisning } from '../../../utils/fagsak';
 import { formaterPersonIdent, hentAlder } from '../../../utils/formatter';
 import Behandlingsmeny from './Behandlingsmeny/Behandlingsmeny';
 
@@ -25,12 +26,7 @@ const Personlinje: React.FC<IProps> = ({ bruker, fagsak }) => {
         >
             <div style={{ flex: 1 }}></div>
             <Normaltekst children={'Status på sak '} />
-            <Element
-                className={'visittkort__status'}
-                children={
-                    fagsak.underBehandling ? 'Under behandling' : fagsakStatus[fagsak.status].navn
-                }
-            />
+            <Element className={'visittkort__status'} children={hentFagsakStatusVisning(fagsak)} />
             <Lenke className={'visittkort__lenke'} href={`/fagsak/${fagsak.id}/saksoversikt`}>
                 <Normaltekst>Gå til saksoversikt</Normaltekst>
             </Lenke>

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -12,8 +12,8 @@ import {
     kategorier,
     underkategorier,
 } from '../../../typer/behandling';
-import { fagsakStatus, IFagsak } from '../../../typer/fagsak';
-import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
+import { IFagsak } from '../../../typer/fagsak';
+import { hentAktivBehandlingPåFagsak, hentFagsakStatusVisning } from '../../../utils/fagsak';
 
 interface IBehandlingLenkepanel {
     fagsak: IFagsak;
@@ -53,7 +53,7 @@ const Innholdstabell: React.FC<IInnholdstabell> = ({ fagsak, behandling }) => {
                         </Normaltekst>
                     </td>
                     <td>
-                        <Normaltekst>{fagsakStatus[fagsak.status].navn}</Normaltekst>
+                        <Normaltekst>{hentFagsakStatusVisning(fagsak)}</Normaltekst>
                     </td>
                 </tr>
             </tbody>

--- a/src/frontend/komponenter/Fagsak/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -75,29 +75,29 @@ const Totrinnskontrollskjema: React.FunctionComponent<IProps> = ({
                         />
                     </div>
                 )}
-                <Knapp
-                    type={'hoved'}
-                    spinner={senderInn}
-                    disabled={senderInn}
-                    mini={true}
-                    onClick={() => {
-                        if (!senderInn) {
-                            sendInnVedtak({
-                                beslutning: totrinnskontrollStatus,
-                                begrunnelse:
-                                    totrinnskontrollStatus === TotrinnskontrollBeslutning.UNDERKJENT
-                                        ? totrinnskontrollBegrunnelse
-                                        : '',
-                            });
-                        }
-                    }}
-                    children={
-                        totrinnskontrollStatus === TotrinnskontrollBeslutning.UNDERKJENT
-                            ? 'Send til saksbehandler'
-                            : 'Godkjenn vedtaket'
-                    }
-                />
             </SkjemaGruppe>
+            <Knapp
+                type={'hoved'}
+                spinner={senderInn}
+                disabled={senderInn}
+                mini={true}
+                onClick={() => {
+                    if (!senderInn) {
+                        sendInnVedtak({
+                            beslutning: totrinnskontrollStatus,
+                            begrunnelse:
+                                totrinnskontrollStatus === TotrinnskontrollBeslutning.UNDERKJENT
+                                    ? totrinnskontrollBegrunnelse
+                                    : '',
+                        });
+                    }
+                }}
+                children={
+                    totrinnskontrollStatus === TotrinnskontrollBeslutning.UNDERKJENT
+                        ? 'Send til saksbehandler'
+                        : 'Godkjenn vedtaket'
+                }
+            />
         </div>
     );
 };

--- a/src/frontend/utils/fagsak.ts
+++ b/src/frontend/utils/fagsak.ts
@@ -1,9 +1,12 @@
 import { FeltState } from '../familie-skjema/typer';
 import { IBehandling } from '../typer/behandling';
-import { IFagsak } from '../typer/fagsak';
+import { fagsakStatus, IFagsak } from '../typer/fagsak';
 import { IVedtakForBehandling } from '../typer/vedtak';
 import { IPersonResultat, IVilkårResultat, Resultat } from '../typer/vilkår';
 import familieDayjs from './familieDayjs';
+
+export const hentFagsakStatusVisning = (fagsak: IFagsak): string =>
+    fagsak.underBehandling ? 'Under behandling' : fagsakStatus[fagsak.status].navn;
 
 export const hentSisteBehandlingPåFagsak = (fagsak: IFagsak): IBehandling | undefined => {
     if (fagsak.behandlinger.length === 0) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Flytter knapp slik at feilmelding kommer over knappen. Retter opp visning av status på fagsak slik at denne er lik.
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-2693
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-2879

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før:
![Skjermbilde 2020-12-11 kl  10 21 27](https://user-images.githubusercontent.com/11041674/101885883-ff59a700-3b9a-11eb-9c17-dd9577af53c2.png)

![Skjermbilde 2020-12-11 kl  10 22 48](https://user-images.githubusercontent.com/11041674/101885795-e2bd6f00-3b9a-11eb-871e-c70830108ee7.png)

Etter:
![Skjermbilde 2020-12-11 kl  10 21 12](https://user-images.githubusercontent.com/11041674/101885902-054f8800-3b9b-11eb-8eb1-8f707a478d49.png)

![Skjermbilde 2020-12-11 kl  10 21 59](https://user-images.githubusercontent.com/11041674/101885813-ea7d1380-3b9a-11eb-9e86-72d01a3b822e.png)

