### PR TITLE
Fjern "sakstype" på IUtbetalingsperiode

### DIFF
--- a/src/frontend/typer/beregning.ts
+++ b/src/frontend/typer/beregning.ts
@@ -1,4 +1,3 @@
-import { BehandlingKategori } from './behandling';
 import { INøkkelPar } from './common';
 import { IGrunnlagPerson } from './person';
 import { YearMonth } from './tid';
@@ -6,7 +5,6 @@ import { YearMonth } from './tid';
 export interface IUtbetalingsperiode {
     periodeFom: string;
     periodeTom: string;
-    sakstype: BehandlingKategori;
     utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
     ytelseTyper: YtelseType[];
     antallBarn: number;


### PR DESCRIPTION
- Fjern felt som ikke brukes. Kommer pr som fjerner dette fra backend også. BehandlingKategori-data ligger fortsatt tilgjengelig på behandlingsnivå. 

- Det vil fortsatt eksistere en komponent som heter Sakstype. Denne sammenstiller både kategori og underkategori, så lar den få hete det. 

- Må merges før tilhørende backend-pr som fjerner felt 

### 💰 Hva forsøker du å løse i denne PR'en
I forbindelse med rydding backend (https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3003)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Felt brukes ikke

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
 
