### PR TITLE
Legg på tooltip med navn på hover på personinfo

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -21,6 +21,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
     tekstType = 'NORMALTEKST',
 }) => {
     const alder = hentAlder(person.fødselsdato);
+    const navnOgAlder = `${person.navn} (${alder} år)`;
 
     return (
         <div className={'personinformasjon'}>
@@ -31,10 +32,9 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
                         alder={alder}
                         kjønn={person.kjønn}
                     />
-                    <Undertittel
-                        className={'navn'}
-                        tag={tag}
-                    >{`${person.navn} (${alder} år)`}</Undertittel>
+                    <Undertittel className={'navn'} tag={tag} title={navnOgAlder}>
+                        {navnOgAlder}
+                    </Undertittel>
                     <Undertittel>&ensp;|&ensp;</Undertittel>
                     <Clipboard>
                         <Undertittel>{formaterPersonIdent(person.personIdent)}</Undertittel>
@@ -53,10 +53,9 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
                         alder={alder}
                         kjønn={person.kjønn}
                     />
-                    <Normaltekst
-                        className={'navn'}
-                        tag={tag}
-                    >{`${person.navn} (${alder} år)`}</Normaltekst>
+                    <Normaltekst className={'navn'} tag={tag} title={navnOgAlder}>
+                        {navnOgAlder}
+                    </Normaltekst>
                     <Normaltekst>&ensp;|&ensp;</Normaltekst>
                     <Clipboard>
                         <Normaltekst>{formaterPersonIdent(person.personIdent)}</Normaltekst>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når skjermen blir liten blir personinfoen forkortet med "...". Denne PR'n legger på en tooltip på hover, som viser hele navnet tilfelle man ikke kan se det pga. liten skjerm. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
