### PR TITLE
Bug på vedtakssiden - begrunnelser

### DIFF
--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -37,7 +37,7 @@ import {
 } from '../typer/manuell-journalføring';
 import { Adressebeskyttelsegradering, IPersonInfo, PersonType } from '../typer/person';
 import { hentAktivBehandlingPåFagsak } from '../utils/fagsak';
-import familieDayjs from '../utils/familieDayjs';
+import familieDayjs, { familieDayjsDiff } from '../utils/familieDayjs';
 import { useApp } from './AppContext';
 
 const tomPerson: IPersonInfo = {
@@ -448,7 +448,10 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         return oppdatertData.status === RessursStatus.SUKSESS &&
             oppdatertData.data.fagsak?.behandlinger.length
             ? oppdatertData.data.fagsak.behandlinger.sort((a, b) =>
-                  familieDayjs(b.opprettetTidspunkt).diff(familieDayjs(a.opprettetTidspunkt))
+                  familieDayjsDiff(
+                      familieDayjs(b.opprettetTidspunkt),
+                      familieDayjs(a.opprettetTidspunkt)
+                  )
               )
             : [];
     };

--- a/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
+++ b/src/frontend/context/Vilkårsvurdering/vilkårsvurdering.ts
@@ -8,7 +8,7 @@ import {
     IRestVilkårResultat,
     IVilkårResultat,
 } from '../../typer/vilkår';
-import familieDayjs from '../../utils/familieDayjs';
+import familieDayjs, { familieDayjsDiff } from '../../utils/familieDayjs';
 import { datoformat } from '../../utils/formatter';
 import {
     erPeriodeGyldig,
@@ -108,7 +108,8 @@ export const mapFraRestPersonResultatTilPersonResultat = (
                 return -1;
             }
 
-            return familieDayjs(b.person.fødselsdato, datoformat.ISO_DAG).diff(
+            return familieDayjsDiff(
+                familieDayjs(b.person.fødselsdato, datoformat.ISO_DAG),
                 familieDayjs(a.person.fødselsdato, datoformat.ISO_DAG)
             );
         });

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { IVedtakForBehandling } from '../../../typer/vedtak';
-import familieDayjs from '../../../utils/familieDayjs';
+import familieDayjs, { familieDayjsDiff } from '../../../utils/familieDayjs';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 
 interface IBehandlingshistorikkProps {
@@ -47,7 +47,10 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ fagsak }) => {
                     <tbody>
                         {fagsak.behandlinger
                             .sort((a, b) =>
-                                familieDayjs(b.opprettetTidspunkt).diff(a.opprettetTidspunkt)
+                                familieDayjsDiff(
+                                    familieDayjs(b.opprettetTidspunkt),
+                                    familieDayjs(a.opprettetTidspunkt)
+                                )
                             )
                             .map((behandling: IBehandling) => {
                                 const aktivVedtakForBehandling = behandling.vedtakForBehandling.find(

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../../typer/behandling';
 import { FagsakStatus, IFagsak } from '../../../typer/fagsak';
 import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
-import familieDayjs from '../../../utils/familieDayjs';
+import familieDayjs, { familieDayjsDiff } from '../../../utils/familieDayjs';
 import { datoformat, formaterDato } from '../../../utils/formatter';
 import { periodeOverlapperMedValgtDato } from '../../../utils/tid';
 import Behandlinger from './Behandlinger';
@@ -49,7 +49,10 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ fagsak }) => {
     let gjeldendeBehandling =
         iverksatteBehandlinger.length > 0
             ? iverksatteBehandlinger.sort((a, b) =>
-                  familieDayjs(b.opprettetTidspunkt).diff(a.opprettetTidspunkt)
+                  familieDayjsDiff(
+                      familieDayjs(b.opprettetTidspunkt),
+                      familieDayjs(a.opprettetTidspunkt)
+                  )
               )[0]
             : undefined;
 

--- a/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
@@ -16,7 +16,7 @@ import {
     IFamilierelasjonMaskert,
 } from '../../../typer/person';
 import { IBarnMedOpplysninger, ISøknadDTO } from '../../../typer/søknad';
-import familieDayjs from '../../../utils/familieDayjs';
+import familieDayjs, { familieDayjsDiff } from '../../../utils/familieDayjs';
 import { datoformat } from '../../../utils/formatter';
 import BarnMedOpplysninger from './BarnMedOpplysninger';
 import LeggTilBarn from './LeggTilBarn';
@@ -50,7 +50,8 @@ const Barna: React.FunctionComponent<IProps> = ({ settSøknadOgValider, søknad 
     const { bruker } = useFagsakRessurser();
     const sorterteBarnMedOpplysninger = søknad.barnaMedOpplysninger.sort(
         (a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
-            return familieDayjs(b.fødselsdato, datoformat.ISO_DAG).diff(
+            return familieDayjsDiff(
+                familieDayjs(b.fødselsdato, datoformat.ISO_DAG),
                 familieDayjs(a.fødselsdato, datoformat.ISO_DAG)
             );
         }

--- a/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/UtbetalingBegrunnelseTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/UtbetalingBegrunnelseTabell.tsx
@@ -53,7 +53,11 @@ const UtbetalingBegrunnelseTabell: React.FC<IUtbetalingBegrunnelseTabell> = ({
             }
 
             // Fjern perioder hvor fom er mer enn 2 måneder frem i tid.
-            return familieDayjs(utbetalingsperiode.periodeFom).diff(familieDayjs(), 'month') < 2;
+            return (
+                familieDayjs(utbetalingsperiode.periodeFom)
+                    .utc()
+                    .diff(familieDayjs().utc(), 'month') < 2
+            );
         });
 
     const slutterSenereEnnInneværendeMåned = (dato: string) =>

--- a/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/UtbetalingBegrunnelseTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/UtbetalingBegrunnelseTabell.tsx
@@ -9,7 +9,7 @@ import { IBehandling } from '../../../../typer/behandling';
 import { IUtbetalingsperiode } from '../../../../typer/beregning';
 import { periodeToString, TIDENES_MORGEN } from '../../../../typer/periode';
 import { IRestUtbetalingBegrunnelse } from '../../../../typer/vedtak';
-import familieDayjs from '../../../../utils/familieDayjs';
+import familieDayjs, { familieDayjsDiff } from '../../../../utils/familieDayjs';
 import { datoformat, isoStringToDayjs } from '../../../../utils/formatter';
 import { sisteDagInneværendeMåned } from '../../../../utils/tid';
 import IkonKnapp from '../../../Felleskomponenter/IkonKnapp/IkonKnapp';
@@ -33,7 +33,8 @@ const UtbetalingBegrunnelseTabell: React.FC<IUtbetalingBegrunnelseTabell> = ({
     const utbetalingsperioderMedBegrunnelseBehov = åpenBehandling.utbetalingsperioder
         .slice()
         .sort((a, b) =>
-            familieDayjs(a.periodeFom, datoformat.ISO_DAG).diff(
+            familieDayjsDiff(
+                familieDayjs(a.periodeFom, datoformat.ISO_DAG),
                 familieDayjs(b.periodeFom, datoformat.ISO_DAG)
             )
         )
@@ -54,9 +55,11 @@ const UtbetalingBegrunnelseTabell: React.FC<IUtbetalingBegrunnelseTabell> = ({
 
             // Fjern perioder hvor fom er mer enn 2 måneder frem i tid.
             return (
-                familieDayjs(utbetalingsperiode.periodeFom)
-                    .utc()
-                    .diff(familieDayjs().utc(), 'month') < 2
+                familieDayjsDiff(
+                    familieDayjs(utbetalingsperiode.periodeFom),
+                    familieDayjs(),
+                    'month'
+                ) < 2
             );
         });
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/useUtbetalingBegrunnelse.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/useUtbetalingBegrunnelse.ts
@@ -15,7 +15,7 @@ import {
     Resultat,
     VilkårType,
 } from '../../../../typer/vilkår';
-import familieDayjs, { sammenlignDatoer } from '../../../../utils/familieDayjs';
+import familieDayjs, { familieDayjsDiff } from '../../../../utils/familieDayjs';
 import { isoStringToDayjs } from '../../../../utils/formatter';
 
 const useUtbetalingBegrunnelse = (
@@ -63,21 +63,21 @@ const useUtbetalingBegrunnelse = (
             .filter((vilkårResultat: IRestVilkårResultat) => {
                 if (utbetalingBegrunnelse.begrunnelseType === VedtakBegrunnelseType.INNVILGELSE) {
                     return (
-                        sammenlignDatoer(
+                        familieDayjsDiff(
                             isoStringToDayjs(vilkårResultat.periodeFom, TIDENES_MORGEN),
                             familieDayjs(periode.fom).subtract(1, 'month'),
                             'month'
-                        ) && vilkårResultat.resultat === Resultat.OPPFYLT
+                        ) === 0 && vilkårResultat.resultat === Resultat.OPPFYLT
                     );
                 } else if (
                     utbetalingBegrunnelse.begrunnelseType === VedtakBegrunnelseType.REDUKSJON
                 ) {
                     return (
-                        sammenlignDatoer(
+                        familieDayjsDiff(
                             isoStringToDayjs(vilkårResultat.periodeTom, TIDENES_ENDE),
                             familieDayjs(periode.tom).subtract(1, 'month'),
                             'month'
-                        ) && vilkårResultat.resultat === Resultat.OPPFYLT
+                        ) === 0 && vilkårResultat.resultat === Resultat.OPPFYLT
                     );
                 } else {
                     return true;

--- a/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/useUtbetalingBegrunnelse.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/useUtbetalingBegrunnelse.ts
@@ -15,7 +15,7 @@ import {
     Resultat,
     VilkårType,
 } from '../../../../typer/vilkår';
-import familieDayjs from '../../../../utils/familieDayjs';
+import familieDayjs, { sammenlignDatoer } from '../../../../utils/familieDayjs';
 import { isoStringToDayjs } from '../../../../utils/formatter';
 
 const useUtbetalingBegrunnelse = (
@@ -63,19 +63,21 @@ const useUtbetalingBegrunnelse = (
             .filter((vilkårResultat: IRestVilkårResultat) => {
                 if (utbetalingBegrunnelse.begrunnelseType === VedtakBegrunnelseType.INNVILGELSE) {
                     return (
-                        isoStringToDayjs(vilkårResultat.periodeFom, TIDENES_MORGEN).diff(
+                        sammenlignDatoer(
+                            isoStringToDayjs(vilkårResultat.periodeFom, TIDENES_MORGEN),
                             familieDayjs(periode.fom).subtract(1, 'month'),
                             'month'
-                        ) === 0 && vilkårResultat.resultat === Resultat.OPPFYLT
+                        ) && vilkårResultat.resultat === Resultat.OPPFYLT
                     );
                 } else if (
                     utbetalingBegrunnelse.begrunnelseType === VedtakBegrunnelseType.REDUKSJON
                 ) {
                     return (
-                        isoStringToDayjs(vilkårResultat.periodeTom, TIDENES_ENDE).diff(
+                        sammenlignDatoer(
+                            isoStringToDayjs(vilkårResultat.periodeTom, TIDENES_ENDE),
                             familieDayjs(periode.tom).subtract(1, 'month'),
                             'month'
-                        ) === 0 && vilkårResultat.resultat === Resultat.OPPFYLT
+                        ) && vilkårResultat.resultat === Resultat.OPPFYLT
                     );
                 } else {
                     return true;

--- a/src/frontend/typer/periode.ts
+++ b/src/frontend/typer/periode.ts
@@ -1,8 +1,8 @@
-import familieDayjs, { Dayjs } from '../utils/familieDayjs';
+import familieDayjs, { Dayjs, sammenlignDatoer } from '../utils/familieDayjs';
 import { datoformat, datoformatNorsk, formaterIsoDato, isoStringToDayjs } from '../utils/formatter';
 
-export const TIDENES_MORGEN: Dayjs = familieDayjs(-8640000000000000);
-export const TIDENES_ENDE: Dayjs = familieDayjs(8640000000000000);
+export const TIDENES_MORGEN: Dayjs = familieDayjs().subtract(1000, 'year');
+export const TIDENES_ENDE: Dayjs = familieDayjs().add(1000, 'year');
 
 export interface IPeriode {
     // Format YYYY-MM-DD (ISO)
@@ -26,7 +26,8 @@ export const periodeToString = (periode: IPeriode, format: datoformat = datoform
 };
 
 export const periodeDiff = (første: IPeriode, annen: IPeriode) => {
-    return isoStringToDayjs(første.fom, TIDENES_ENDE).diff(
+    return sammenlignDatoer(
+        isoStringToDayjs(første.fom, TIDENES_ENDE),
         isoStringToDayjs(annen.fom, TIDENES_ENDE)
     );
 };

--- a/src/frontend/typer/periode.ts
+++ b/src/frontend/typer/periode.ts
@@ -1,4 +1,4 @@
-import familieDayjs, { Dayjs, sammenlignDatoer } from '../utils/familieDayjs';
+import familieDayjs, { Dayjs, familieDayjsDiff } from '../utils/familieDayjs';
 import { datoformat, datoformatNorsk, formaterIsoDato, isoStringToDayjs } from '../utils/formatter';
 
 export const TIDENES_MORGEN: Dayjs = familieDayjs().subtract(1000, 'year');
@@ -26,7 +26,7 @@ export const periodeToString = (periode: IPeriode, format: datoformat = datoform
 };
 
 export const periodeDiff = (første: IPeriode, annen: IPeriode) => {
-    return sammenlignDatoer(
+    return familieDayjsDiff(
         isoStringToDayjs(første.fom, TIDENES_ENDE),
         isoStringToDayjs(annen.fom, TIDENES_ENDE)
     );

--- a/src/frontend/utils/fagsak.ts
+++ b/src/frontend/utils/fagsak.ts
@@ -4,7 +4,7 @@ import { IBehandling } from '../typer/behandling';
 import { fagsakStatus, IFagsak } from '../typer/fagsak';
 import { IVedtakForBehandling } from '../typer/vedtak';
 import { IPersonResultat, IVilkårResultat, Resultat } from '../typer/vilkår';
-import familieDayjs from './familieDayjs';
+import familieDayjs, { familieDayjsDiff } from './familieDayjs';
 
 export const hentFagsakStatusVisning = (fagsak: IFagsak): string =>
     fagsak.underBehandling ? 'Under behandling' : fagsakStatus[fagsak.status].navn;
@@ -14,7 +14,7 @@ export const hentSisteBehandlingPåFagsak = (fagsak: IFagsak): IBehandling | und
         return undefined;
     } else {
         return fagsak.behandlinger.sort((a, b) =>
-            familieDayjs(b.opprettetTidspunkt).diff(a.opprettetTidspunkt)
+            familieDayjsDiff(familieDayjs(b.opprettetTidspunkt), familieDayjs(a.opprettetTidspunkt))
         )[0];
     }
 };

--- a/src/frontend/utils/familieDayjs.ts
+++ b/src/frontend/utils/familieDayjs.ts
@@ -1,4 +1,4 @@
-import dayjs, { ConfigType } from 'dayjs';
+import dayjs, { ConfigType, OpUnitType, QUnitType } from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
@@ -26,6 +26,14 @@ const familieDayjs = (config?: ConfigType, format?: string): Dayjs => {
         return dayjs.tz(config, format, norskTidssone);
     }
     return config ? dayjs.tz(config) : dayjs.tz(dayjs());
+};
+
+export const sammenlignDatoer = (
+    første: Dayjs,
+    andre: Dayjs,
+    unit?: QUnitType | OpUnitType
+): boolean => {
+    return første.utc().diff(andre.utc(), unit) === 0;
 };
 
 export default familieDayjs;

--- a/src/frontend/utils/familieDayjs.ts
+++ b/src/frontend/utils/familieDayjs.ts
@@ -28,12 +28,12 @@ const familieDayjs = (config?: ConfigType, format?: string): Dayjs => {
     return config ? dayjs.tz(config) : dayjs.tz(dayjs());
 };
 
-export const sammenlignDatoer = (
+export const familieDayjsDiff = (
     første: Dayjs,
     andre: Dayjs,
     unit?: QUnitType | OpUnitType
-): boolean => {
-    return første.utc().diff(andre.utc(), unit) === 0;
+): number => {
+    return første.utc().diff(andre.utc(), unit);
 };
 
 export default familieDayjs;

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -1,4 +1,4 @@
-import familieDayjs, { Dayjs } from './familieDayjs';
+import familieDayjs, { Dayjs, familieDayjsDiff } from './familieDayjs';
 
 export enum datoformat {
     MÅNED = 'MM.YY',
@@ -42,12 +42,12 @@ export const formaterIverksattDato = (dato: string | undefined) =>
 
 export const hentAlder = (dato: string): number => {
     const dayjsDato = familieDayjs(dato);
-    return dayjsDato.isValid() ? familieDayjs().diff(dayjsDato, 'year') : 0;
+    return dayjsDato.isValid() ? familieDayjsDiff(familieDayjs(), dayjsDato, 'year') : 0;
 };
 
 export const hentAlderSomString = (fødselsdato: string | undefined) => {
     return fødselsdato
-        ? familieDayjs().diff(familieDayjs(fødselsdato, 'YYYY-MM-DD'), 'year') + ' år'
+        ? familieDayjsDiff(familieDayjs(), familieDayjs(fødselsdato, 'YYYY-MM-DD'), 'year') + ' år'
         : 'Alder ukjent';
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser bug hvor begrunnelser ikke ble valgt pga feil ved sammenligning av datoer på grunn av tidssoner. Sammenligner nå på utc tid.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Bør vi skille på display-dayjs og "teknisk-dayjs"? Feilen kom på bakgrunn av ønsket om å ha datoer formatert til riktig tidssone.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke så lett å teste denne bugen pga tidssone-issues. Om du vet om en måte så si ifra :) 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer.
