### PR TITLE
Reduskjonstekster vises ikke eftersom filter filtrerer på feil periode.

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/useUtbetalingBegrunnelse.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/UtbetalingBegrunnelserTabell/useUtbetalingBegrunnelse.ts
@@ -75,7 +75,7 @@ const useUtbetalingBegrunnelse = (
                     return (
                         familieDayjsDiff(
                             isoStringToDayjs(vilkårResultat.periodeTom, TIDENES_ENDE),
-                            familieDayjs(periode.tom).subtract(1, 'month'),
+                            familieDayjs(periode.tom).endOf('month'),
                             'month'
                         ) === 0 && vilkårResultat.resultat === Resultat.OPPFYLT
                     );


### PR DESCRIPTION
…eriode

### 💰 Hva forsøker du å løse i denne PR'en
Reduskjonstekster i dropdown-menu vises ikke i perioder di skal vises.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [-] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Finnes ikke tester fra før.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
