### PR TITLE
Ekspandert person er default på vilkårsvurdering ved lesevisning

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingSkjema.tsx
@@ -4,6 +4,7 @@ import { Collapse } from 'react-collapse';
 
 import { FeltState } from '@navikt/familie-skjema';
 
+import { useBehandling } from '../../../context/BehandlingContext';
 import { useVilkårsvurdering } from '../../../context/Vilkårsvurdering/VilkårsvurderingContext';
 import FamilieChevron from '../../../ikoner/FamilieChevron';
 import {
@@ -25,11 +26,13 @@ const VilkårsvurderingSkjema: React.FunctionComponent<IVilkårsvurderingSkjema>
     visFeilmeldinger,
 }) => {
     const { vilkårsvurdering } = useVilkårsvurdering();
+    const { erLesevisning } = useBehandling();
     const [personErEkspandert, settPersonErEkspandert] = useState<{ [key: string]: boolean }>(
         vilkårsvurdering.reduce((personMapEkspandert, personResultat) => {
             return {
                 ...personMapEkspandert,
                 [personResultat.personIdent]:
+                    erLesevisning() ||
                     personResultat.vilkårResultater.filter(
                         (vilkårResultat: FeltState<IVilkårResultat>) =>
                             vilkårResultat.verdi.resultat.verdi === Resultat.IKKE_VURDERT


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Alle personer er by default ekspandert under lesevisning. Fra mobdesign. 

Se https://barnetrygd.dev.adeo.no/fagsak/1048901/1051151/vilkaarsvurdering

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![Skjermbilde 2021-02-03 kl  13 30 29](https://user-images.githubusercontent.com/5719550/106747302-01346980-6624-11eb-96f1-07a74cb383a2.png)
