### PR TITLE
Fjerner forrigeknapp fra vilkårsvurderingssiden dersom søknad-steget …

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -7,7 +7,7 @@ import { Feilmelding } from 'nav-frontend-typografi';
 
 import { useBehandling } from '../../../context/BehandlingContext';
 import { useVilkårsvurdering } from '../../../context/Vilkårsvurdering/VilkårsvurderingContext';
-import { IBehandling } from '../../../typer/behandling';
+import { IBehandling, BehandlingÅrsak } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { IVilkårResultat } from '../../../typer/vilkår';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
@@ -43,6 +43,10 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ fagsak, åpenBehan
 
     return (
         <Skjemasteg
+            skalViseForrigeKnapp={
+                !åpenBehandling.skalBehandlesAutomatisk &&
+                åpenBehandling.årsak === BehandlingÅrsak.SØKNAD
+            }
             tittel={'Vilkårsvurdering'}
             forrigeOnClick={() => {
                 if (opplysningsplikt) {

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -23,6 +23,7 @@ interface IProps {
     maxWidthStyle?: string;
     skalViseNesteKnapp?: boolean;
     skalViseTilbakestillKnapp?: boolean;
+    skalViseForrigeKnapp?: boolean;
 }
 
 const Container = styled.div<{ maxWidthStyle: string }>`
@@ -59,6 +60,7 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
     maxWidthStyle = '40rem',
     skalViseNesteKnapp = true,
     skalViseTilbakestillKnapp,
+    skalViseForrigeKnapp = true,
 }) => {
     const history = useHistory();
     const { forrigeÅpneSide } = useBehandling();
@@ -100,7 +102,7 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
                     <div />
                 )}
                 <div>
-                    {forrigeOnClick ? (
+                    {forrigeOnClick && skalViseForrigeKnapp ? (
                         <Knapp
                             onClick={() => {
                                 forrigeOnClick();


### PR DESCRIPTION
…i venstremenyen også er skjult.

### 💰 Hva forsøker du å løse i denne PR'en
Rapportert bug: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3655

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Bruker samme logikk som brukes for å skjule "Registrer søknad" fra venstremenyen. Ref. "visSide" i filen:
src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Usikker på hvordan dette ville se ut.


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

