### PR TITLE
Visning og multiselect for opphørsperioder

### DIFF
--- a/src/frontend/context/VedtakBegrunnelseContext.tsx
+++ b/src/frontend/context/VedtakBegrunnelseContext.tsx
@@ -8,9 +8,11 @@ import { byggTomRessurs, Ressurs, RessursStatus } from '@navikt/familie-typer';
 import { IFagsak } from '../typer/fagsak';
 import { IPeriode, lagPeriodeId } from '../typer/periode';
 import {
+    IRestDeleteVedtakBegrunnelser,
     IRestPostVedtakBegrunnelse,
     IRestVedtakBegrunnelse,
     IVedtakForBehandling,
+    VedtakBegrunnelseType,
 } from '../typer/vedtak';
 import { Vilkårsbegrunnelser } from '../typer/vilkår';
 import { useFagsakRessurser } from './FagsakContext';
@@ -122,6 +124,25 @@ const [VedtakBegrunnelserProvider, useVedtakBegrunnelser] = constate(
             );
         };
 
+        const slettVedtakBegrunnelserForPeriodeOgVedtakbegrunnelseTyper = (
+            fom: string,
+            vedtakbegrunnelseTyper: VedtakBegrunnelseType[],
+            tom?: string
+        ) => {
+            håndterEndringerPåVedtakBegrunnelser(
+                request<IRestDeleteVedtakBegrunnelser, IFagsak>({
+                    method: 'DELETE',
+                    url: `/familie-ba-sak/api/fagsaker/${fagsak.id}/vedtak/begrunnelser/perioder-vedtaksbegrunnelsetyper`,
+                    data: {
+                        fom,
+                        tom,
+                        vedtakbegrunnelseTyper,
+                    },
+                }),
+                lagPeriodeId({ fom, tom })
+            );
+        };
+
         const slettVedtakBegrunnelserForPeriode = (fom: string, tom?: string) => {
             håndterEndringerPåVedtakBegrunnelser(
                 request<IPeriode, IFagsak>({
@@ -141,6 +162,7 @@ const [VedtakBegrunnelserProvider, useVedtakBegrunnelser] = constate(
             leggTilVedtakBegrunnelse,
             slettVedtakBegrunnelse,
             slettVedtakBegrunnelserForPeriode,
+            slettVedtakBegrunnelserForPeriodeOgVedtakbegrunnelseTyper,
             vedtakBegrunnelseSubmit,
             vedtakBegrunnelser,
             vilkårBegrunnelser,

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -2,12 +2,8 @@ import React from 'react';
 
 import { Normaltekst } from 'nav-frontend-typografi';
 
-import {
-    IUtbetalingsperiodeDetalj,
-    satsBeløp,
-    YtelseType,
-    ytelsetype,
-} from '../../../typer/beregning';
+import { satsBeløp, YtelseType, ytelsetype } from '../../../typer/beregning';
+import { IUtbetalingsperiodeDetalj } from '../../../typer/vedtaksperiode';
 import { formaterBeløp } from '../../../utils/formatter';
 import DashedHr from '../../Felleskomponenter/DashedHr/DashedHr';
 import PersonInformasjon from '../../Felleskomponenter/PersonInformasjon/PersonInformasjon';

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -16,6 +16,7 @@ import {
     underkategorier,
 } from '../../../typer/behandling';
 import { FagsakStatus, IFagsak } from '../../../typer/fagsak';
+import { hentUtbetalingsperioder, Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import { hentAktivBehandlingPåFagsak } from '../../../utils/fagsak';
 import familieDayjs, { familieDayjsDiff } from '../../../utils/familieDayjs';
 import { datoformat, formaterDato } from '../../../utils/formatter';
@@ -62,7 +63,7 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ fagsak }) => {
         gjeldendeBehandling = aktivBehandling;
     }
 
-    const utbetalingsperioder = gjeldendeBehandling?.utbetalingsperioder ?? [];
+    const utbetalingsperioder = hentUtbetalingsperioder(gjeldendeBehandling);
     const utbetalingsperiodeInneværendeMåned = utbetalingsperioder.find(periode =>
         periodeOverlapperMedValgtDato(periode.periodeFom, periode.periodeTom, new Date())
     );
@@ -81,7 +82,10 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ fagsak }) => {
     };
 
     const løpendeMånedligUtbetaling = () => {
-        if (utbetalingsperiodeInneværendeMåned) {
+        if (
+            utbetalingsperiodeInneværendeMåned &&
+            utbetalingsperiodeInneværendeMåned.vedtaksperiodetype === Vedtaksperiodetype.UTBETALING
+        ) {
             return utbetalingsperiodeInneværendeMåned.utbetaltPerMnd < 1 &&
                 gjeldendeBehandling?.kategori === BehandlingKategori.EØS ? (
                 <AlertStripe className={'saksoversikt__alert'} type={'info'}>
@@ -101,7 +105,7 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ fagsak }) => {
                                 </FlexSpaceBetween>
                             </AlertStripe>
                         )}
-                    <Utbetalinger utbetalingsperiode={utbetalingsperiodeInneværendeMåned} />
+                    <Utbetalinger vedtaksperiode={utbetalingsperiodeInneværendeMåned} />
                 </>
             );
         } else if (utbetalingsperiodeNesteMåned) {

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Utbetalinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Utbetalinger.tsx
@@ -2,17 +2,23 @@ import React from 'react';
 
 import { Normaltekst } from 'nav-frontend-typografi';
 
-import { IUtbetalingsperiodeDetalj, IUtbetalingsperiode } from '../../../typer/beregning';
+import {
+    IUtbetalingsperiodeDetalj,
+    Vedtaksperiode,
+    Vedtaksperiodetype,
+} from '../../../typer/vedtaksperiode';
 import { formaterBeløp, sorterFødselsdato } from '../../../utils/formatter';
 import PersonUtbetaling from './PersonUtbetaling';
 
 interface IUtbetalingerProps {
-    utbetalingsperiode?: IUtbetalingsperiode;
+    vedtaksperiode?: Vedtaksperiode;
 }
 
-const Utbetalinger: React.FC<IUtbetalingerProps> = ({ utbetalingsperiode }) => {
+const Utbetalinger: React.FC<IUtbetalingerProps> = ({ vedtaksperiode }) => {
+    if (vedtaksperiode?.vedtaksperiodetype !== Vedtaksperiodetype.UTBETALING) return null;
+
     const utbetalingsperiodeDetaljerGruppertPåPerson =
-        utbetalingsperiode?.utbetalingsperiodeDetaljer
+        vedtaksperiode?.utbetalingsperiodeDetaljer
             .sort((detaljA, detaljB) =>
                 sorterFødselsdato(detaljA.person.fødselsdato, detaljB.person.fødselsdato)
             )
@@ -48,9 +54,7 @@ const Utbetalinger: React.FC<IUtbetalingerProps> = ({ utbetalingsperiode }) => {
                 <li className={'saksoversikt__utbetalinger__totallinje'}>
                     <Normaltekst>Totalt utbetalt/mnd</Normaltekst>
                     <Normaltekst>
-                        {utbetalingsperiode
-                            ? formaterBeløp(utbetalingsperiode.utbetaltPerMnd)
-                            : '-'}
+                        {vedtaksperiode ? formaterBeløp(vedtaksperiode.utbetaltPerMnd) : '-'}
                     </Normaltekst>
                 </li>
                 <hr />

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/Oppsummeringsboks.tsx
@@ -6,7 +6,8 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 import { Skalaetikett } from '@navikt/helse-frontend-tidslinje/lib/src/components/types.internal';
 
 import { useTidslinje } from '../../../context/TidslinjeContext';
-import { IUtbetalingsperiode, ytelsetype } from '../../../typer/beregning';
+import { ytelsetype } from '../../../typer/beregning';
+import { Vedtaksperiode, Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import familieDayjs from '../../../utils/familieDayjs';
 import {
     datoformat,
@@ -18,18 +19,17 @@ import {
 } from '../../../utils/formatter';
 
 interface IProps {
-    utbetalingsperioder: IUtbetalingsperiode[];
+    vedtaksperioder: Vedtaksperiode[];
     aktivEtikett: Skalaetikett;
 }
 
-const summerTotalbeløpForPeriode = (sum: number, periode: IUtbetalingsperiode) => {
-    return sum + periode.utbetaltPerMnd;
+const summerTotalbeløpForPeriode = (sum: number, vedtaksperiode: Vedtaksperiode) => {
+    if (vedtaksperiode.vedtaksperiodetype !== Vedtaksperiodetype.UTBETALING) return sum;
+
+    return sum + vedtaksperiode.utbetaltPerMnd;
 };
 
-const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
-    utbetalingsperioder,
-    aktivEtikett,
-}) => {
+const Oppsummeringsboks: React.FunctionComponent<IProps> = ({ vedtaksperioder, aktivEtikett }) => {
     const { settAktivEtikett } = useTidslinje();
 
     const månedNavnOgÅr = () => {
@@ -43,7 +43,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                 <div className={'tilkjentytelse-informasjonsboks__header__info'}>
                     <Element>{månedNavnOgÅr()}</Element>
 
-                    {utbetalingsperioder.length > 0 ? (
+                    {vedtaksperioder.length > 0 ? (
                         <Normaltekst>
                             Totalt utbetalt i mnd
                             <span
@@ -52,7 +52,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                 }
                             >
                                 {formaterBeløp(
-                                    utbetalingsperioder.reduce(summerTotalbeløpForPeriode, 0)
+                                    vedtaksperioder.reduce(summerTotalbeløpForPeriode, 0)
                                 )}
                             </span>
                         </Normaltekst>
@@ -66,7 +66,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                     }}
                 />
             </div>
-            {utbetalingsperioder.length !== 0 && (
+            {vedtaksperioder.length > 0 && (
                 <table>
                     <thead>
                         <tr>
@@ -82,8 +82,11 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                         </tr>
                     </thead>
                     <tbody>
-                        {utbetalingsperioder.map((utbetalingsperiode: IUtbetalingsperiode) => {
-                            return utbetalingsperiode.utbetalingsperiodeDetaljer
+                        {vedtaksperioder.map((vedtaksperiode: Vedtaksperiode) => {
+                            if (vedtaksperiode.vedtaksperiodetype !== Vedtaksperiodetype.UTBETALING)
+                                return null;
+
+                            return vedtaksperiode.utbetalingsperiodeDetaljer
                                 .sort((detaljA, detaljB) =>
                                     sorterFødselsdato(
                                         detaljA.person.fødselsdato,

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -4,8 +4,8 @@ import { useHistory } from 'react-router';
 
 import { useTidslinje } from '../../../context/TidslinjeContext';
 import { IBehandling } from '../../../typer/behandling';
-import { IUtbetalingsperiode } from '../../../typer/beregning';
 import { IFagsak } from '../../../typer/fagsak';
+import { hentUtbetalingsperioder, Vedtaksperiode } from '../../../typer/vedtaksperiode';
 import { periodeOverlapperMedValgtDato } from '../../../utils/tid';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
 import { Oppsummeringsboks } from './Oppsummeringsboks';
@@ -31,13 +31,13 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
     };
 
     const filtrerPerioderForAktivEtikett = (
-        utbetalingsperioder: IUtbetalingsperiode[]
-    ): IUtbetalingsperiode[] => {
+        utbetalingsperioder: Vedtaksperiode[]
+    ): Vedtaksperiode[] => {
         return aktivEtikett
-            ? utbetalingsperioder.filter((utbetalingsperioder: IUtbetalingsperiode) =>
+            ? utbetalingsperioder.filter((utbetalingsperiode: Vedtaksperiode) =>
                   periodeOverlapperMedValgtDato(
-                      utbetalingsperioder.periodeFom,
-                      utbetalingsperioder.periodeTom,
+                      utbetalingsperiode.periodeFom,
+                      utbetalingsperiode.periodeTom,
                       aktivEtikett.dato
                   )
               )
@@ -56,8 +56,8 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
             <TilkjentYtelseTidslinje />
             {aktivEtikett && (
                 <Oppsummeringsboks
-                    utbetalingsperioder={filtrerPerioderForAktivEtikett(
-                        åpenBehandling.utbetalingsperioder
+                    vedtaksperioder={filtrerPerioderForAktivEtikett(
+                        hentUtbetalingsperioder(åpenBehandling)
                     )}
                     aktivEtikett={aktivEtikett}
                 />

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelserMultiselect.tsx
@@ -20,7 +20,7 @@ import {
     IVedtakBegrunnelseSubmit,
     useVedtakBegrunnelser,
 } from '../../../../context/VedtakBegrunnelseContext';
-import { IPeriode, lagPeriodeId } from '../../../../typer/periode';
+import { lagPeriodeId } from '../../../../typer/periode';
 import {
     finnVedtakBegrunnelseType,
     hentBakgrunnsfarge,
@@ -29,12 +29,13 @@ import {
     VedtakBegrunnelseType,
     vedtakBegrunnelseTyper,
 } from '../../../../typer/vedtak';
+import { Vedtaksperiode } from '../../../../typer/vedtaksperiode';
 import { IRestPersonResultat } from '../../../../typer/vilkår';
 import useVedtakBegrunnelseMultiselect from './useVedtakBegrunnelseMultiselect';
 
 interface IVedtakBegrunnelseMultiselect {
     erLesevisning: boolean;
-    periode: IPeriode;
+    vedtaksperiode: Vedtaksperiode;
     personResultater: IRestPersonResultat[];
 }
 
@@ -44,16 +45,20 @@ const GroupLabel = styled.div`
 
 const VedtakBegrunnelserMultiselect: React.FC<IVedtakBegrunnelseMultiselect> = ({
     erLesevisning,
-    periode,
+    vedtaksperiode,
     personResultater,
 }) => {
+    const periode = {
+        fom: vedtaksperiode.periodeFom,
+        tom: vedtaksperiode.periodeTom,
+    };
     const { vedtakBegrunnelseSubmit, vilkårBegrunnelser } = useVedtakBegrunnelser();
     const {
-        gruppertBegrunnelser,
+        grupperteBegrunnelser,
         onChangeBegrunnelse,
         valgteBegrunnelser,
         vedtakBegrunnelserForPeriode,
-    } = useVedtakBegrunnelseMultiselect(personResultater, periode);
+    } = useVedtakBegrunnelseMultiselect(personResultater, vedtaksperiode);
 
     const submitForPeriode: IVedtakBegrunnelseSubmit | undefined =
         lagPeriodeId(periode) === vedtakBegrunnelseSubmit.periodeId
@@ -143,7 +148,7 @@ const VedtakBegrunnelserMultiselect: React.FC<IVedtakBegrunnelseMultiselect> = (
                     </GroupLabel>
                 );
             }}
-            options={gruppertBegrunnelser}
+            options={grupperteBegrunnelser}
         />
     );
 };

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksBegrunnelsePanel.tsx
@@ -7,8 +7,13 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { Behandlingstype } from '../../../../typer/behandling';
-import { IUtbetalingsperiode, IUtbetalingsperiodeDetalj } from '../../../../typer/beregning';
 import { periodeToString, TIDENES_MORGEN } from '../../../../typer/periode';
+import {
+    hentVedtaksperiodeTittel,
+    IUtbetalingsperiodeDetalj,
+    Vedtaksperiode,
+    Vedtaksperiodetype,
+} from '../../../../typer/vedtaksperiode';
 import { IRestPersonResultat } from '../../../../typer/vilkår';
 import { formaterBeløp, formaterPersonIdent, isoStringToDayjs } from '../../../../utils/formatter';
 import { sisteDagInneværendeMåned } from '../../../../utils/tid';
@@ -16,7 +21,7 @@ import Hjelpetekst44px from './Hjelpetekst44px';
 import VedtakBegrunnelserMultiselect from './VedtakBegrunnelserMultiselect';
 
 interface IVedtakBegrunnelserTabell {
-    utbetalingsperiode: IUtbetalingsperiode;
+    vedtaksperiode: Vedtaksperiode;
     personResultater: IRestPersonResultat[];
     behandlingsType: Behandlingstype;
 }
@@ -60,7 +65,7 @@ const UtbetalingsperiodeDetalj = styled.div`
 `;
 
 const VedtakBegrunnelsePanel: React.FC<IVedtakBegrunnelserTabell> = ({
-    utbetalingsperiode,
+    vedtaksperiode,
     personResultater,
     behandlingsType,
 }) => {
@@ -71,7 +76,7 @@ const VedtakBegrunnelsePanel: React.FC<IVedtakBegrunnelserTabell> = ({
 
     return (
         <StyledEkspanderbartpanel
-            key={utbetalingsperiode.periodeFom}
+            key={vedtaksperiode.periodeFom}
             apen={behandlingsType === Behandlingstype.FØRSTEGANGSBEHANDLING}
             tittel={
                 <UtbetalingsperiodepanelTittel>
@@ -84,41 +89,46 @@ const VedtakBegrunnelsePanel: React.FC<IVedtakBegrunnelserTabell> = ({
                     )}
                     <Element>
                         {periodeToString({
-                            fom: utbetalingsperiode.periodeFom,
-                            tom: slutterSenereEnnInneværendeMåned(utbetalingsperiode.periodeTom)
+                            fom: vedtaksperiode.periodeFom,
+                            tom: slutterSenereEnnInneværendeMåned(vedtaksperiode.periodeTom)
                                 ? ''
-                                : utbetalingsperiode.periodeTom,
+                                : vedtaksperiode.periodeTom,
                         })}
                     </Element>
-                    <Normaltekst>Ordinær</Normaltekst>
-                    <Normaltekst>{formaterBeløp(utbetalingsperiode.utbetaltPerMnd)}</Normaltekst>
+                    <Normaltekst>{hentVedtaksperiodeTittel(vedtaksperiode)}</Normaltekst>
+                    {vedtaksperiode.vedtaksperiodetype === Vedtaksperiodetype.UTBETALING && (
+                        <Normaltekst>{formaterBeløp(vedtaksperiode.utbetaltPerMnd)}</Normaltekst>
+                    )}
                 </UtbetalingsperiodepanelTittel>
             }
         >
             <UtbetalingsperiodepanelBody>
-                <div>
-                    <Element>Resultat</Element>
+                {vedtaksperiode.vedtaksperiodetype === Vedtaksperiodetype.UTBETALING ? (
+                    <div>
+                        <Element>Resultat</Element>
 
-                    {utbetalingsperiode.utbetalingsperiodeDetaljer.map(
-                        (detalj: IUtbetalingsperiodeDetalj) => (
-                            <UtbetalingsperiodeDetalj key={detalj.person.personIdent}>
-                                <Normaltekst title={detalj.person.navn}>
-                                    {formaterPersonIdent(detalj.person.personIdent)}
-                                </Normaltekst>
+                        {vedtaksperiode.utbetalingsperiodeDetaljer.map(
+                            (detalj: IUtbetalingsperiodeDetalj) => (
+                                <UtbetalingsperiodeDetalj key={detalj.person.personIdent}>
+                                    <Normaltekst title={detalj.person.navn}>
+                                        {formaterPersonIdent(detalj.person.personIdent)}
+                                    </Normaltekst>
 
-                                <Normaltekst>{formaterBeløp(detalj.utbetaltPerMnd)}</Normaltekst>
-                            </UtbetalingsperiodeDetalj>
-                        )
-                    )}
-                </div>
+                                    <Normaltekst>
+                                        {formaterBeløp(detalj.utbetaltPerMnd)}
+                                    </Normaltekst>
+                                </UtbetalingsperiodeDetalj>
+                            )
+                        )}
+                    </div>
+                ) : (
+                    <div />
+                )}
                 <div>
                     <VedtakBegrunnelserMultiselect
                         erLesevisning={erLesevisning()}
                         personResultater={personResultater}
-                        periode={{
-                            fom: utbetalingsperiode.periodeFom,
-                            tom: utbetalingsperiode.periodeTom,
-                        }}
+                        vedtaksperiode={vedtaksperiode}
                     />
                 </div>
             </UtbetalingsperiodepanelBody>

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -1,9 +1,10 @@
-import { IPersonMedAndelerTilkjentYtelse, IUtbetalingsperiode } from './beregning';
+import { IPersonMedAndelerTilkjentYtelse } from './beregning';
 import { INøkkelPar } from './common';
 import { IOpplysningsplikt } from './opplysningsplikt';
 import { IGrunnlagPerson } from './person';
 import { ITotrinnskontroll } from './totrinnskontroll';
 import { IVedtakForBehandling } from './vedtak';
+import { Vedtaksperiode } from './vedtaksperiode';
 import { IRestPersonResultat, IRestStegTilstand } from './vilkår';
 
 export enum BehandlingKategori {
@@ -163,7 +164,7 @@ export interface IBehandling {
     type: Behandlingstype;
     underkategori: BehandlingUnderkategori;
     vedtakForBehandling: IVedtakForBehandling[];
-    utbetalingsperioder: IUtbetalingsperiode[];
+    vedtaksperioder: Vedtaksperiode[];
     personerMedAndelerTilkjentYtelse: IPersonMedAndelerTilkjentYtelse[];
     årsak: BehandlingÅrsak;
     skalBehandlesAutomatisk: boolean;

--- a/src/frontend/typer/beregning.ts
+++ b/src/frontend/typer/beregning.ts
@@ -1,21 +1,5 @@
 import { INøkkelPar } from './common';
-import { IGrunnlagPerson } from './person';
 import { YearMonth } from './tid';
-
-export interface IUtbetalingsperiode {
-    periodeFom: string;
-    periodeTom: string;
-    utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
-    ytelseTyper: YtelseType[];
-    antallBarn: number;
-    utbetaltPerMnd: number;
-}
-
-export interface IUtbetalingsperiodeDetalj {
-    person: IGrunnlagPerson;
-    ytelseType: YtelseType;
-    utbetaltPerMnd: number;
-}
 
 export interface IPersonMedAndelerTilkjentYtelse {
     personIdent: string;

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -5,6 +5,7 @@ export interface IToggles {
 export enum ToggleNavn {
     visTekniskOpphør = 'familie-ba-sak.behandling.vis-teknisk-opphoer',
     visAvslag = 'familie-ba-sak.behandling.vis-avslag',
+    visOpphørsperioder = 'familie-ba-sak.behandling.vis-opphørsperioder',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -5,7 +5,7 @@ export interface IToggles {
 export enum ToggleNavn {
     visTekniskOpphør = 'familie-ba-sak.behandling.vis-teknisk-opphoer',
     visAvslag = 'familie-ba-sak.behandling.vis-avslag',
-    visOpphørsperioder = 'familie-ba-sak.behandling.vis-opphørsperioder',
+    visOpphørsperioder = 'familie-ba-sak.behandling.vis-opphoersperioder',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -12,17 +12,23 @@ export interface IVedtakForBehandling {
 }
 
 export interface IRestVedtakBegrunnelse {
-    id?: number;
-    fom: string;
-    tom?: string;
-    begrunnelseType?: VedtakBegrunnelseType;
     begrunnelse?: VedtakBegrunnelse;
+    begrunnelseType?: VedtakBegrunnelseType;
+    fom: string;
+    id?: number;
+    tom?: string;
 }
 
 export interface IRestPostVedtakBegrunnelse {
     fom: string;
     tom?: string;
     vedtakBegrunnelse: VedtakBegrunnelse;
+}
+
+export interface IRestDeleteVedtakBegrunnelser {
+    fom: string;
+    tom?: string;
+    vedtakbegrunnelseTyper: VedtakBegrunnelseType[];
 }
 
 export interface IRestVedtakBegrunnelseTilknyttetVilkår {

--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -1,0 +1,47 @@
+import { IBehandling } from './behandling';
+import { ytelsetype, YtelseType } from './beregning';
+import { IGrunnlagPerson } from './person';
+
+export enum Vedtaksperiodetype {
+    UTBETALING = 'UTBETALING',
+    OPPHØR = 'OPPHØR',
+    AVSLAG = 'AVSLAG',
+}
+
+export type Vedtaksperiode =
+    | {
+          periodeFom: string;
+          periodeTom: string;
+          vedtaksperiodetype: Vedtaksperiodetype.UTBETALING;
+          utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
+          ytelseTyper: YtelseType[];
+          antallBarn: number;
+          utbetaltPerMnd: number;
+      }
+    | {
+          periodeFom: string;
+          periodeTom: string;
+          vedtaksperiodetype: Vedtaksperiodetype.OPPHØR;
+      };
+
+export interface IUtbetalingsperiodeDetalj {
+    person: IGrunnlagPerson;
+    ytelseType: YtelseType;
+    utbetaltPerMnd: number;
+}
+
+export const hentUtbetalingsperioder = (behandling: IBehandling | undefined) =>
+    behandling?.vedtaksperioder.filter(
+        periode => periode.vedtaksperiodetype === Vedtaksperiodetype.UTBETALING
+    ) ?? [];
+
+export const hentVedtaksperiodeTittel = (vedtaksperiode: Vedtaksperiode) => {
+    switch (vedtaksperiode.vedtaksperiodetype) {
+        case Vedtaksperiodetype.UTBETALING:
+            return ytelsetype[vedtaksperiode.ytelseTyper[0]].navn;
+        case Vedtaksperiodetype.OPPHØR:
+            return 'Opphør';
+        default:
+            return '';
+    }
+};

--- a/src/mock-server/mock/fagsak.ts
+++ b/src/mock-server/mock/fagsak.ts
@@ -198,7 +198,7 @@ export const mockBehandling = (behandlingId: number, aktiv: boolean, steg: strin
             godkjent: true,
             opprettetTidspunkt: '2020-03-19T10:08:56.8',
         },
-        utbetalingsperioder: [],
+        vedtaksperioder: [],
         personerMedAndelerTilkjentYtelse: [],
         årsak: BehandlingÅrsak.SØKNAD,
         skalBehandlesAutomatisk: false,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Skrevet om fra å bruke utbetalingsperioder til vedtaksperioder. Lagt til støtte for å begrunne opphørsperioder. Endret på sletting av begrunnelser på en periode da vi trenger å spesifisere begrunnelsestypene siden disse nå er skilt ut i egne paneler.
Det er ikke sikkert dette hadde vært strengt nødvendig nå siden ingen av periodene nå overlapper, men vi vil få overlappende perioder når vi begynner å se på avslag.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Venter til enhetstest-gjeld er forbedret slik at vi får en helhetlig testrigg.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Etter:
![Skjermbilde 2021-02-26 kl  09 45 37](https://user-images.githubusercontent.com/11041674/109277256-62acba00-7817-11eb-9333-0b0acbe8d5bc.png)

Før er helt likt bortsett fra at opphørsbegrunnelsene er plassert i utbetalingsperiodene.
