### PR TITLE
Legg til simulering. Alle simuleringer vises som tomme

### DIFF
--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -12,6 +12,7 @@ import { TidslinjeProvider } from '../../context/TidslinjeContext';
 import { VilkårsvurderingProvider } from '../../context/Vilkårsvurdering/VilkårsvurderingContext';
 import { IFagsak } from '../../typer/fagsak';
 import { useAmplitude } from '../../utils/amplitude';
+import Simulering from './Simulering/Simulering';
 import RegistrerSøknad from './Søknad/RegistrerSøknad';
 import TilkjentYtelse from './TilkjentYtelse/TilkjentYtelse';
 import OppsummeringVedtak from './Vedtak/OppsummeringVedtak';
@@ -78,6 +79,15 @@ const BehandlingContainer: React.FunctionComponent<IProps> = ({ fagsak }) => {
                                         åpenBehandling={åpenBehandling.data}
                                     />
                                 </TidslinjeProvider>
+                            );
+                        }}
+                    />
+                    <Route
+                        exact={true}
+                        path="/fagsak/:fagsakId/:behandlingId/simulering"
+                        render={() => {
+                            return (
+                                <Simulering fagsak={fagsak} åpenBehandling={åpenBehandling.data} />
                             );
                         }}
                     />

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -32,22 +32,21 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
 
     const nesteOnClick = async () => {
         settSenderInn(true);
-        const response = await request<IBehandling, any>({
+        request<IBehandling, any>({
             method: 'POST',
             url: `/familie-ba-sak/api/simulering/${aktivtVedtak?.id}/bekreft`,
-        });
-
-        if (response.status === RessursStatus.SUKSESS) {
-            history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vedtak`);
-        } else if (
-            response.status === RessursStatus.FEILET ||
-            response.status === RessursStatus.FUNKSJONELL_FEIL ||
-            response.status === RessursStatus.IKKE_TILGANG
-        ) {
-            settErFeilMedBekreft(response.frontendFeilmelding);
-        }
-
-        settSenderInn(false);
+        }).then((ressurs: IRessurs<IFagsak>) => {
+            settSenderInn(false);
+            if (response.status === RessursStatus.SUKSESS) {
+                history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vedtak`);
+            } else if (
+                response.status === RessursStatus.FEILET ||
+                response.status === RessursStatus.FUNKSJONELL_FEIL ||
+                response.status === RessursStatus.IKKE_TILGANG
+            ) {
+                settErFeilMedBekreft(response.frontendFeilmelding);
+            }
+        }); 
     };
 
     const forrigeOnClick = () => {

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -48,8 +48,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             maxWidthStyle={'80rem'}
         >
             <StyledAlertstripe type="info">
-                Det er ingen etterbetaling, feilutbetaling eller neste utbetaling (det er ikke
-                implementert enda.)
+                Det er ingen etterbetaling, feilutbetaling eller neste utbetaling (Visning av
+                simuleringen er ikke implementert enda)
             </StyledAlertstripe>
         </Skjemasteg>
     );

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+import { useHistory } from 'react-router';
+import styled from 'styled-components';
+
+import Alertstripe from 'nav-frontend-alertstriper';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { aktivVedtakPåBehandling } from '../../../api/fagsak';
+import { IBehandling } from '../../../typer/behandling';
+import { IFagsak } from '../../../typer/fagsak';
+import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
+
+interface ISimuleringProps {
+    fagsak: IFagsak;
+    åpenBehandling: IBehandling;
+}
+
+const StyledAlertstripe = styled(Alertstripe)`
+    margin-bottom: 2rem;
+`;
+
+const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling, fagsak }) => {
+    const { request } = useHttp();
+    const history = useHistory();
+    const aktivtVedtak = aktivVedtakPåBehandling(åpenBehandling);
+
+    const nesteOnClick = async () => {
+        await request<IBehandling, any>({
+            method: 'POST',
+            url: `/familie-ba-sak/api/simulering/${aktivtVedtak?.id}/bekreft`,
+        });
+        history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vedtak`);
+    };
+
+    const forrigeOnClick = () => {
+        history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/tilkjent-ytelse`);
+    };
+
+    return (
+        <Skjemasteg
+            senderInn={false}
+            tittel="Simulering"
+            className="simulering"
+            forrigeOnClick={forrigeOnClick}
+            nesteOnClick={nesteOnClick}
+            maxWidthStyle={'80rem'}
+        >
+            <StyledAlertstripe type="info">
+                Det er ingen etterbetaling, feilutbetaling eller neste utbetaling (det er ikke
+                implementert enda.)
+            </StyledAlertstripe>
+        </Skjemasteg>
+    );
+};
+
+export default Simulering;

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 
 import { useHistory } from 'react-router';
 
+import { useApp } from '../../../context/AppContext';
 import { useTidslinje } from '../../../context/TidslinjeContext';
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
+import { ToggleNavn } from '../../../typer/toggles';
 import { hentUtbetalingsperioder, Vedtaksperiode } from '../../../typer/vedtaksperiode';
 import { periodeOverlapperMedValgtDato } from '../../../utils/tid';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
@@ -22,8 +24,11 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
 }) => {
     const history = useHistory();
     const { aktivEtikett } = useTidslinje();
+    const { toggles } = useApp();
     const nesteOnClick = () => {
-        history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/simulering`);
+        toggles[ToggleNavn.visSimulering]
+            ? history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/simulering`)
+            : history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vedtak`);
     };
 
     const forrigeOnClick = () => {

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -23,7 +23,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
     const history = useHistory();
     const { aktivEtikett } = useTidslinje();
     const nesteOnClick = () => {
-        history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vedtak`);
+        history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/simulering`);
     };
 
     const forrigeOnClick = () => {

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -32,6 +32,7 @@ import {
     IBehandling,
 } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
+import { ToggleNavn } from '../../../typer/toggles';
 import { IRestVedtakBegrunnelse } from '../../../typer/vedtak';
 import { hentAktivVedtakPåBehandlig } from '../../../utils/fagsak';
 import UIModalWrapper from '../../Felleskomponenter/Modal/UIModalWrapper';
@@ -49,7 +50,7 @@ const StyledFeilmelding = styled(Feilmelding)`
 `;
 
 const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åpenBehandling }) => {
-    const { hentSaksbehandlerRolle, innloggetSaksbehandler } = useApp();
+    const { hentSaksbehandlerRolle, innloggetSaksbehandler, toggles } = useApp();
     const { request } = useHttp();
     const { settFagsak } = useFagsakRessurser();
     const { erLesevisning } = useBehandling();
@@ -167,7 +168,13 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
         <Skjemasteg
             tittel={'Vedtak'}
             forrigeOnClick={() =>
-                history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/simulering`)
+                toggles[ToggleNavn.visSimulering]
+                    ? history.push(
+                          `/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/simulering`
+                      )
+                    : history.push(
+                          `/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/tilkjent-ytelse`
+                      )
             }
             nesteOnClick={visSubmitKnapp ? sendInn : undefined}
             nesteKnappTittel={'Til godkjenning'}

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -167,7 +167,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
         <Skjemasteg
             tittel={'Vedtak'}
             forrigeOnClick={() =>
-                history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/tilkjent-ytelse`)
+                history.push(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/simulering`)
             }
             nesteOnClick={visSubmitKnapp ? sendInn : undefined}
             nesteKnappTittel={'Til godkjenning'}

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
@@ -6,8 +6,11 @@ import { Normaltekst } from 'nav-frontend-typografi';
 
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
+import { BehandlingSteg } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
+import { ToggleNavn } from '../../../typer/toggles';
 import Link from './Link';
 import { erSidenAktiv, IUnderside, sider, visSide } from './sider';
 
@@ -18,10 +21,21 @@ interface IProps {
 const Venstremeny: React.FunctionComponent<IProps> = ({ fagsak }) => {
     const { åpenBehandling } = useBehandling();
 
+    const { toggles } = useApp();
+
+    const { SIMULERING, ...utenSimulering } = sider;
+    const siderUtenSimulering = {
+        ...utenSimulering,
+        BEHANDLINGRESULTAT: {
+            ...utenSimulering.BEHANDLINGRESULTAT,
+            steg: BehandlingSteg.SEND_TIL_BESLUTTER,
+        },
+    };
+
     return (
         <nav className={'venstremeny'}>
             {åpenBehandling.status === RessursStatus.SUKSESS
-                ? Object.entries(sider)
+                ? Object.entries(toggles[ToggleNavn.visSimulering] ? sider : siderUtenSimulering)
                       .filter(([_, side]) => visSide(side, åpenBehandling.data))
                       .map(([sideId, side], index: number) => {
                           const tilPath = `/fagsak/${fagsak.id}/${åpenBehandling.data.behandlingId}/${side.href}`;

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
@@ -23,19 +23,24 @@ const Venstremeny: React.FunctionComponent<IProps> = ({ fagsak }) => {
 
     const { toggles } = useApp();
 
-    const { SIMULERING, ...utenSimulering } = sider;
-    const siderUtenSimulering = {
-        ...utenSimulering,
-        BEHANDLINGRESULTAT: {
-            ...utenSimulering.BEHANDLINGRESULTAT,
-            steg: BehandlingSteg.SEND_TIL_BESLUTTER,
-        },
+    const alleSiderUtenomSimulering = () => {
+        const { SIMULERING, ...allSiderUtenomSimulering } = sider;
+
+        return {
+            ...allSiderUtenomSimulering,
+            BEHANDLINGRESULTAT: {
+                ...allSiderUtenomSimulering.BEHANDLINGRESULTAT,
+                steg: BehandlingSteg.SEND_TIL_BESLUTTER,
+            },
+        };
     };
 
     return (
         <nav className={'venstremeny'}>
             {åpenBehandling.status === RessursStatus.SUKSESS
-                ? Object.entries(toggles[ToggleNavn.visSimulering] ? sider : siderUtenSimulering)
+                ? Object.entries(
+                      toggles[ToggleNavn.visSimulering] ? sider : alleSiderUtenomSimulering()
+                  )
                       .filter(([_, side]) => visSide(side, åpenBehandling.data))
                       .map(([sideId, side], index: number) => {
                           const tilPath = `/fagsak/${fagsak.id}/${åpenBehandling.data.behandlingId}/${side.href}`;

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -27,8 +27,8 @@ export interface IUnderside {
 export enum SideId {
     REGISTRERE_SØKNAD = 'REGISTRERE_SØKNAD',
     VILKÅRSVURDERING = 'VILKÅRSVURDERING',
-    SIMULERING = 'SIMULERING',
     BEHANDLINGRESULTAT = 'BEHANDLINGRESULTAT',
+    SIMULERING = 'SIMULERING',
     VEDTAK = 'VEDTAK',
 }
 
@@ -72,7 +72,7 @@ export const sider: Record<SideId, ISide> = {
     BEHANDLINGRESULTAT: {
         href: 'tilkjent-ytelse',
         navn: 'Behandlingsresultat',
-        steg: BehandlingSteg.SEND_TIL_BESLUTTER,
+        steg: BehandlingSteg.SIMULERING,
     },
     SIMULERING: {
         href: 'simulering',

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -27,6 +27,7 @@ export interface IUnderside {
 export enum SideId {
     REGISTRERE_SØKNAD = 'REGISTRERE_SØKNAD',
     VILKÅRSVURDERING = 'VILKÅRSVURDERING',
+    SIMULERING = 'SIMULERING',
     BEHANDLINGRESULTAT = 'BEHANDLINGRESULTAT',
     VEDTAK = 'VEDTAK',
 }
@@ -72,6 +73,11 @@ export const sider: Record<SideId, ISide> = {
         href: 'tilkjent-ytelse',
         navn: 'Behandlingsresultat',
         steg: BehandlingSteg.SEND_TIL_BESLUTTER,
+    },
+    SIMULERING: {
+        href: 'simulering',
+        navn: 'Simulering',
+        steg: BehandlingSteg.SIMULERING,
     },
     VEDTAK: {
         href: 'vedtak',

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -55,6 +55,7 @@ export enum BehandlingSteg {
     REGISTRERE_SØKNAD = 'REGISTRERE_SØKNAD',
     REGISTRERE_PERSONGRUNNLAG = 'REGISTRERE_PERSONGRUNNLAG',
     VILKÅRSVURDERING = 'VILKÅRSVURDERING',
+    SIMULERING = 'SIMULERING',
     SEND_TIL_BESLUTTER = 'SEND_TIL_BESLUTTER',
     BESLUTTE_VEDTAK = 'BESLUTTE_VEDTAK',
     IVERKSETT_MOT_OPPDRAG = 'IVERKSETT_MOT_OPPDRAG',
@@ -78,22 +79,24 @@ export const hentStegNummer = (steg: BehandlingSteg): number => {
             return 1;
         case BehandlingSteg.VILKÅRSVURDERING:
             return 2;
-        case BehandlingSteg.SEND_TIL_BESLUTTER:
+        case BehandlingSteg.SIMULERING:
             return 3;
-        case BehandlingSteg.BESLUTTE_VEDTAK:
+        case BehandlingSteg.SEND_TIL_BESLUTTER:
             return 4;
-        case BehandlingSteg.IVERKSETT_MOT_OPPDRAG:
+        case BehandlingSteg.BESLUTTE_VEDTAK:
             return 5;
-        case BehandlingSteg.VENTE_PÅ_STATUS_FRA_ØKONOMI:
+        case BehandlingSteg.IVERKSETT_MOT_OPPDRAG:
             return 6;
-        case BehandlingSteg.JOURNALFØR_VEDTAKSBREV:
+        case BehandlingSteg.VENTE_PÅ_STATUS_FRA_ØKONOMI:
             return 7;
-        case BehandlingSteg.DISTRIBUER_VEDTAKSBREV:
+        case BehandlingSteg.JOURNALFØR_VEDTAKSBREV:
             return 8;
-        case BehandlingSteg.FERDIGSTILLE_BEHANDLING:
+        case BehandlingSteg.DISTRIBUER_VEDTAKSBREV:
             return 9;
-        case BehandlingSteg.BEHANDLING_AVSLUTTET:
+        case BehandlingSteg.FERDIGSTILLE_BEHANDLING:
             return 10;
+        case BehandlingSteg.BEHANDLING_AVSLUTTET:
+            return 11;
         default:
             return 0;
     }

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -6,6 +6,7 @@ export enum ToggleNavn {
     visTekniskOpphør = 'familie-ba-sak.behandling.vis-teknisk-opphoer',
     visAvslag = 'familie-ba-sak.behandling.vis-avslag',
     visOpphørsperioder = 'familie-ba-sak.behandling.vis-opphoersperioder',
+    visSimulering = 'familie-ba-sak.behandling.vis-simulering',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Første skritt i å få inn simulering. Denne PRen legger til simuleringsteget, men alle simuleringer vises som tomme. 

Vi må ha dette for at [backend PRen](https://github.com/navikt/familie-ba-sak/pull/875) ikke skal brekke frontenden. 

Denne løsningen fungerer selv om simulering ikke er implementert backend. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_

![image](https://user-images.githubusercontent.com/17828446/111145324-674bcf00-8588-11eb-90e9-6bf730d0a085.png)


