### PR TITLE
Skal gi feil også på 18årsdag på 18årsvilkår

### DIFF
--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -92,7 +92,7 @@ describe('utils/validators', () => {
     });
 
     test('Periode med etter barnets fødselsdato gir feil på 18 årsvilkåret', () => {
-        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2000-05-17', '2018-05-18'));
+        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2000-05-17', '2018-05-17'));
         const valideringsresultat = erPeriodeGyldig(periode, {
             person: mockBarn,
             erEksplisittAvslagPåSøknad: false,

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -54,8 +54,8 @@ const finnesDatoEtterFødselsdatoPluss18 = (person: IGrunnlagPerson, fom: string
     const fomDato = familieDayjs(new Date(fom));
     const tomDato = tom ? familieDayjs(new Date(tom)) : undefined;
     return (
-        fomDato.isAfter(fødselsdatoPluss18) ||
-        (tomDato ? tomDato.isAfter(fødselsdatoPluss18) : false)
+        fomDato.isSameOrAfter(fødselsdatoPluss18) ||
+        (tomDato ? tomDato.isSameOrAfter(fødselsdatoPluss18) : false)
     );
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://github.com/navikt/familie-ba-sak-frontend/pull/882: Sjekket en dag for sent. Skal ikke tillate å sette tom-dato på 18 årsdag på 18årsvilkår. 

Grensetilfelle i valideringstest oppdatert og validering oppdatert. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇