### PR TITLE
Bugfix/frontend warnings

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Felles/EkspanderbartBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Felles/EkspanderbartBegrunnelsePanel.tsx
@@ -26,7 +26,7 @@ const StyledEkspanderbartpanelBase = styled(EkspanderbartpanelBase)`
     }
 `;
 
-const PanelTittel = styled.p`
+const PanelTittel = styled.div`
     width: 100%;
     display: grid;
     grid-template-columns: 12rem 7.5rem auto;

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/FritekstVedtakbegrunnelser.tsx
@@ -164,12 +164,11 @@ const FritekstVedtakbegrunnelser: React.FC<IProps> = () => {
                     </StyledElement>
                     {Object.keys(redigerbarefritekster).map((fritekstId: string) => {
                         return (
-                            <StyledFamilieFritekstFelt>
+                            <StyledFamilieFritekstFelt key={`fritekst-${fritekstId}`}>
                                 <SkjultLegend>{`Kulepunkt ${fritekstId}`}</SkjultLegend>
                                 <FamilieTextareaBegrunnelseFritekst
                                     feil={feilMelding[fritekstId]}
                                     erLesevisning={erLesevisning()}
-                                    defaultValue={redigerbarefritekster[fritekstId].verdi}
                                     key={`fritekst-${fritekstId}`}
                                     id={`${fritekstId}`}
                                     textareaClass={'fritekst-textarea'}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/FritekstVedtakbegrunnelser.tsx
@@ -98,6 +98,10 @@ const StyledHjelpetekst44px = styled(Hjelpetekst44px)`
     }
 `;
 
+const ItalicText = styled(Normaltekst)`
+    font-style: italic;
+`;
+
 const FritekstVedtakbegrunnelser: React.FC<IProps> = () => {
     const { erLesevisning } = useBehandling();
     const {
@@ -138,26 +142,25 @@ const FritekstVedtakbegrunnelser: React.FC<IProps> = () => {
                                     <Normaltekst>
                                         Brev som sendes ut bør være så kortfattede og presise som
                                         mulig.{' '}
+                                        <Lenke
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            href="https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Spr%C3%A5k.aspx"
+                                        >
+                                            Se retningslinjer for klarspråk.
+                                        </Lenke>
                                     </Normaltekst>
-                                    <Lenke
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        href="https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Spr%C3%A5k.aspx"
-                                    >
-                                        Se retningslinjer for klarspråk.
-                                    </Lenke>
-                                    <br />
                                     <br />
                                     <Element>Eksempler på formulering:</Element>
-                                    <Normaltekst style={{ fontStyle: 'italic' }}>
+                                    <ItalicText>
                                         Barnevernet har bekreftet at de overtok omsorgen for barnet
                                         mars 2021
-                                    </Normaltekst>
+                                    </ItalicText>
                                     <br />
-                                    <Normaltekst style={{ fontStyle: 'italic' }}>
+                                    <ItalicText>
                                         Opplysningene fra Folkeregisteret viser at barnet ikke bor
                                         sammen med deg
-                                    </Normaltekst>
+                                    </ItalicText>
                                 </div>
                             }
                         />

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/FritekstVedtakbegrunnelser.tsx
@@ -7,7 +7,7 @@ import { EtikettInfo } from 'nav-frontend-etiketter';
 import Lenke from 'nav-frontend-lenker';
 import { PopoverOrientering } from 'nav-frontend-popover';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
-import { Element } from 'nav-frontend-typografi';
+import { Element, Normaltekst } from 'nav-frontend-typografi';
 import { Feilmelding } from 'nav-frontend-typografi';
 
 import { FamilieKnapp, FamilieTextarea } from '@navikt/familie-form-elements';
@@ -55,7 +55,7 @@ const StyledFamilieFritekstFelt = styled.div`
     }
 `;
 
-const StyledElement = styled(Element)`
+const InfoBoks = styled.div`
     margin: 0 2.8rem 0 0;
     display: flex;
     align-items: center;
@@ -129,13 +129,16 @@ const FritekstVedtakbegrunnelser: React.FC<IProps> = () => {
             {harFritekster ? (
                 <StyledSkjemaGruppe>
                     <SkjultLegend>Fritekst til kulepunkt i brev</SkjultLegend>
-                    <StyledElement>
+                    <InfoBoks>
                         Fritekst til kulepunkt i brev (valgfri)
                         <StyledHjelpetekst44px
                             type={PopoverOrientering.OverVenstre}
                             innhold={
                                 <div>
-                                    Brev som sendes ut bør være så kortfattede og presise som mulig.{' '}
+                                    <Normaltekst>
+                                        Brev som sendes ut bør være så kortfattede og presise som
+                                        mulig.{' '}
+                                    </Normaltekst>
                                     <Lenke
                                         target="_blank"
                                         rel="noopener noreferrer"
@@ -143,25 +146,25 @@ const FritekstVedtakbegrunnelser: React.FC<IProps> = () => {
                                     >
                                         Se retningslinjer for klarspråk.
                                     </Lenke>
-                                    <p />
-                                    <b>Eksempler på formulering:</b>
                                     <br />
-                                    <text style={{ fontStyle: 'italic' }}>
+                                    <br />
+                                    <Element>Eksempler på formulering:</Element>
+                                    <Normaltekst style={{ fontStyle: 'italic' }}>
                                         Barnevernet har bekreftet at de overtok omsorgen for barnet
                                         mars 2021
-                                    </text>
-                                    <p />
-                                    <text style={{ fontStyle: 'italic' }}>
+                                    </Normaltekst>
+                                    <br />
+                                    <Normaltekst style={{ fontStyle: 'italic' }}>
                                         Opplysningene fra Folkeregisteret viser at barnet ikke bor
                                         sammen med deg
-                                    </text>
+                                    </Normaltekst>
                                 </div>
                             }
                         />
                         <StyledEtikettInfo mini={true}>
                             Skriv {målform[søkersMålform()]}
                         </StyledEtikettInfo>
-                    </StyledElement>
+                    </InfoBoks>
                     {Object.keys(redigerbarefritekster).map((fritekstId: string) => {
                         return (
                             <StyledFamilieFritekstFelt key={`fritekst-${fritekstId}`}>
@@ -225,7 +228,7 @@ const FritekstVedtakbegrunnelser: React.FC<IProps> = () => {
                         mini={true}
                     />
                     <Feilmelding style={{ paddingLeft: '0rem' }}>
-                        {feilMelding[`legg-til-fritekst`]}
+                        {feilMelding[`legg-til-fritekst`] ?? ''}
                     </Feilmelding>
                     <Knapperad>
                         <FamilieKnapp

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelsePanel.tsx
@@ -71,7 +71,7 @@ const VedtakBegrunnelsePanel: React.FC<IVedtakBegrunnelserTabell> = ({
         >
             <UtbetalingsperiodepanelBody>
                 {vedtaksperiode.vedtaksperiodetype === Vedtaksperiodetype.UTBETALING ? (
-                    <div>
+                    <div style={{ marginBottom: '1rem' }}>
                         <Element>Resultat</Element>
 
                         {vedtaksperiode.utbetalingsperiodeDetaljer

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelser.tsx
@@ -79,6 +79,7 @@ const VedtakBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({ åpenBehandli
                     <FritekstVedtakBegrunnelserProvider
                         vedtaksperiode={vedtaksperiode}
                         behandlingstype={åpenBehandling.type}
+                        key={vedtaksperiode.periodeFom}
                     >
                         <VedtakBegrunnelsePanel
                             vedtaksperiode={vedtaksperiode}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikset div warningar fra frontend consolet som oppsto som følge av implementasjonen av fritekst.
Og øket spacet mellom Resultat og begrunnelse i vedtakspanelet.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [-] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant med tester.

### 💬 Ønsker du en muntlig gjennomgang?
- [] Ja
- [X] Nei
  