### PR TITLE
Juster opp igjen z-index fordi nedtrekk forsvinner bak datepicker

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
@@ -28,7 +28,7 @@ const MarginSkjemaGruppe = styled(SkjemaGruppe)`
         margin: 0.5rem 0 0 0;
         & > div {
             max-width: 100%;
-            z-index: 1;
+            z-index: 999;
         }
     }
 `;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ivrige datepickers igjen etter z-index-justering. Øker derfor avslagskjema igjen. Avklart med @halvorbmundal .

### 👀 Screen shots
<img width="430" alt="Skjermbilde 2021-04-07 kl  11 32 32" src="https://user-images.githubusercontent.com/5719550/113844660-02edeb00-9795-11eb-8463-fe89a8067919.png">
