### PR TITLE
Bugfix: Validering på fødselsdato

### DIFF
--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -64,7 +64,10 @@ const finnesDatoFørFødselsdato = (person: IGrunnlagPerson, fom: string, tom?: 
     const fomDato = familieDayjs(new Date(fom));
     const tomDato = tom ? familieDayjs(new Date(tom)) : undefined;
 
-    return fomDato.isBefore(fødselsdato) || (tomDato ? tomDato.isBefore(fødselsdato) : false);
+    return (
+        fomDato.isBefore(fødselsdato, 'day') ||
+        (tomDato ? tomDato.isBefore(fødselsdato, 'day') : false)
+    );
 };
 
 export const erPeriodeGyldig = (
@@ -95,7 +98,8 @@ export const erPeriodeGyldig = (
         }
         const fomDatoErGyldig = familieDayjs(fom).isValid();
         const fomDatoErFørTomDato = isoStringToDayjs(fom, TIDENES_MORGEN).isBefore(
-            isoStringToDayjs(tom, TIDENES_ENDE)
+            isoStringToDayjs(tom, TIDENES_ENDE),
+            'day'
         );
         return fomDatoErGyldig && fomDatoErFørTomDato ? ok(felt) : feil(felt, 'Ugyldig periode');
     } else {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -65,8 +65,8 @@ const finnesDatoFørFødselsdato = (person: IGrunnlagPerson, fom: string, tom?: 
     const tomDato = tom ? familieDayjs(new Date(tom)) : undefined;
 
     return (
-        fomDato.isBefore(fødselsdato, 'day') ||
-        (tomDato ? tomDato.isBefore(fødselsdato, 'day') : false)
+        fomDato.isBefore(fødselsdato, 'date') ||
+        (tomDato ? tomDato.isBefore(fødselsdato, 'date') : false)
     );
 };
 
@@ -99,7 +99,7 @@ export const erPeriodeGyldig = (
         const fomDatoErGyldig = familieDayjs(fom).isValid();
         const fomDatoErFørTomDato = isoStringToDayjs(fom, TIDENES_MORGEN).isBefore(
             isoStringToDayjs(tom, TIDENES_ENDE),
-            'day'
+            'date'
         );
         return fomDatoErGyldig && fomDatoErFørTomDato ? ok(felt) : feil(felt, 'Ugyldig periode');
     } else {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser bug: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4253
" Vilkår som er vurdert automatisk(under 18år og ugift) feiler på validering, men kun når behandling er opprettet som via journalføring. "

Usikker på hvorfor det skjedde akkurat ved journalføringsopprettelseer, men mulig det er tilfeldig? isBefore sammenligner by default på milliseconds. Både fødselsdato og fom-dato som trigga feilvalidering var `2015-11-15T00:00:00.000Z`, men mulig det er en diff som hadde vistes hvis man logga flere desimaler.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

