### PR TITLE
Bugfix: tomme opphørsperioder ble vist i lesevisning

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelser.tsx
@@ -4,7 +4,7 @@ import { useBehandling } from '../../../../context/BehandlingContext';
 import { FritekstVedtakBegrunnelserProvider } from '../../../../context/FritekstVedtakBegrunnelserContext';
 import { useVedtakBegrunnelser } from '../../../../context/VedtakBegrunnelserContext';
 import { IBehandling } from '../../../../typer/behandling';
-import { IRestVedtakBegrunnelse } from '../../../../typer/vedtak';
+import { IRestVedtakBegrunnelse, VedtakBegrunnelseType } from '../../../../typer/vedtak';
 import { Vedtaksperiode, Vedtaksperiodetype } from '../../../../typer/vedtaksperiode';
 import familieDayjs, { familieDayjsDiff } from '../../../../utils/familieDayjs';
 import { datoformat } from '../../../../utils/formatter';
@@ -19,11 +19,11 @@ const VedtakBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({ åpenBehandli
     const { erLesevisning } = useBehandling();
     const { vedtakBegrunnelser } = useVedtakBegrunnelser();
 
-    const harVedtaksperioder =
-        åpenBehandling.vedtaksperioder.filter(
-            (periode: Vedtaksperiode) => periode.vedtaksperiodetype !== Vedtaksperiodetype.AVSLAG
-        ).length > 0;
-    const vedtaksperioderMedBegrunnelseBehov = åpenBehandling.vedtaksperioder
+    const utbetalingsperioder = åpenBehandling.vedtaksperioder.filter(
+        (periode: Vedtaksperiode) => periode.vedtaksperiodetype !== Vedtaksperiodetype.AVSLAG
+    );
+    const harVedtaksperioder = utbetalingsperioder.length > 0;
+    const vedtaksperioderMedBegrunnelseBehov = utbetalingsperioder
         .slice()
         .sort((a, b) =>
             familieDayjsDiff(
@@ -35,22 +35,26 @@ const VedtakBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({ åpenBehandli
             const vedtakBegrunnelserForPeriode = vedtakBegrunnelser.filter(
                 (vedtakBegrunnelse: IRestVedtakBegrunnelse) => {
                     return (
+                        vedtakBegrunnelse.begrunnelseType !== VedtakBegrunnelseType.AVSLAG &&
                         vedtakBegrunnelse.fom === vedtaksperiode.periodeFom &&
                         vedtakBegrunnelse.tom === vedtaksperiode.periodeTom
                     );
                 }
             );
 
-            // Viser kun perioder som har begrunnelse dersom man er i lesemodus.
             if (erLesevisning()) {
-                return vedtakBegrunnelserForPeriode.length !== 0;
+                // Viser kun perioder som har begrunnelse dersom man er i lesemodus.
+                return !!vedtakBegrunnelserForPeriode.length;
+            } else {
+                // Fjern perioder hvor fom er mer enn 2 måneder frem i tid.
+                return (
+                    familieDayjsDiff(
+                        familieDayjs(vedtaksperiode.periodeFom),
+                        familieDayjs(),
+                        'month'
+                    ) < 2
+                );
             }
-
-            // Fjern perioder hvor fom er mer enn 2 måneder frem i tid.
-            return (
-                familieDayjsDiff(familieDayjs(vedtaksperiode.periodeFom), familieDayjs(), 'month') <
-                2
-            );
         });
 
     return harVedtaksperioder ? (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4280 ved å ekskludere avslagsbegrunnelser ved rendering av utbetaling- og opphørsperioder

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
validert visning på bug-sak i dev
  
### 👀 Screen shots
Behandling det gjelder før og etter fix
![Skjermbilde 2021-04-14 kl  12 24 38](https://user-images.githubusercontent.com/5719550/114695925-6ee3cc80-9d1c-11eb-8898-f2bc34a0f112.png)

![Skjermbilde 2021-04-14 kl  12 24 47](https://user-images.githubusercontent.com/5719550/114695930-7014f980-9d1c-11eb-9bb9-ced3fba09b47.png)