### PR TITLE
Bugfix: Legg til spinner og disable knapp ved submit av henleggelse

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
@@ -134,6 +134,8 @@ const HenleggBehandling: React.FC<IProps> = ({ onListElementClick, fagsak, behan
                             type={'hoved'}
                             mini={true}
                             onClick={() => onBekreft(behandling.behandlingId)}
+                            spinner={skjema.submitRessurs.status === RessursStatus.HENTER}
+                            disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             children={
                                 skjema.felter.årsak.verdi === HenleggelseÅrsak.SØKNAD_TRUKKET
                                     ? 'Bekreft og send brev'


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4311
Disabler submitknapp og legger på spinner i henleggelse-modal

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Validert spin/disable frontend
