### PR TITLE
Sett vis modal true ved innsending av dokument. 

### DIFF
--- a/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
@@ -39,6 +39,7 @@ const RegistrerSøknad: React.FC = () => {
             tittel={'Registrer opplysninger fra søknaden'}
             nesteOnClick={() => {
                 nesteAction(false);
+                settVisModal(true);
             }}
             nesteKnappTittel={erLesevisning() ? 'Neste' : 'Bekreft og fortsett'}
             senderInn={skjema.submitRessurs.status === RessursStatus.HENTER}
@@ -75,7 +76,7 @@ const RegistrerSøknad: React.FC = () => {
                 />
             )}
 
-            {visModal && (
+            {skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL && (
                 <UIModalWrapper
                     modal={{
                         className: 'søknad-modal',
@@ -100,16 +101,12 @@ const RegistrerSøknad: React.FC = () => {
                                     nesteAction(true);
                                 }}
                                 children={'Ja'}
-                                spinner={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             />,
                         ],
                     }}
                 >
                     <FjernVilkårAdvarsel>
-                        {skjema.submitRessurs.status === RessursStatus.FEILET ||
-                            (skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL &&
-                                skjema.submitRessurs.frontendFeilmelding)}
+                        {skjema.submitRessurs.frontendFeilmelding}
                     </FjernVilkårAdvarsel>
                 </UIModalWrapper>
             )}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Hører til denne:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4463
Når man skal fjerne et barn fra vilkårsvurderingen må man bekrefte valget, men modalen som lar deg bekrefte dette blir ikke vist. 
Denne PRen viser modalen når man trykker på neste og det er en funksjonell feil. 


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Tar gjerne en diskusjon på om vi burde bruke funksjonell feil for å formidle data fra backend til frontend. Burde det være en egen ressursstatus når man ønsker at noe skal bekreftes? 

Nå kommer denne modalen til å dukke opp hver gang det vi får funskjonell feil fra backend på dette stedet. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/17828446/116077634-fa068000-a695-11eb-8faa-3dc8db91cc89.png)
