### PR TITLE
Test sortering og filtrering av vedtaksbegrunnelser 

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelser.tsx
@@ -4,62 +4,14 @@ import { useBehandling } from '../../../../context/BehandlingContext';
 import { FritekstVedtakBegrunnelserProvider } from '../../../../context/FritekstVedtakBegrunnelserContext';
 import { useVedtakBegrunnelser } from '../../../../context/VedtakBegrunnelserContext';
 import { IBehandling } from '../../../../typer/behandling';
-import { IRestVedtakBegrunnelse, VedtakBegrunnelseType } from '../../../../typer/vedtak';
 import { Vedtaksperiode, Vedtaksperiodetype } from '../../../../typer/vedtaksperiode';
-import familieDayjs, { familieDayjsDiff } from '../../../../utils/familieDayjs';
-import { datoformat } from '../../../../utils/formatter';
+import { filtrerOgSorterPerioderMedBegrunnelseBehov } from '../../../../utils/vedtakUtils';
 import OverskriftMedHjelpetekst from './Felles/OverskriftMedHjelpetekst';
 import VedtakBegrunnelsePanel from './VedtakBegrunnelsePanel';
 
 interface IVedtakBegrunnelserTabell {
     åpenBehandling: IBehandling;
 }
-
-export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
-    utbetalingsperioder: Vedtaksperiode[],
-    vedtakBegrunnelser: IRestVedtakBegrunnelse[],
-    erLesevisning: boolean
-): Vedtaksperiode[] => {
-    return utbetalingsperioder
-        .slice()
-        .sort((a, b) =>
-            familieDayjsDiff(
-                familieDayjs(a.periodeFom, datoformat.ISO_DAG),
-                familieDayjs(b.periodeFom, datoformat.ISO_DAG)
-            )
-        )
-        .filter((vedtaksperiode: Vedtaksperiode) => {
-            return (
-                vedtaksperiode.vedtaksperiodetype === Vedtaksperiodetype.UTBETALING ||
-                vedtaksperiode.vedtaksperiodetype === Vedtaksperiodetype.OPPHØR
-            );
-        })
-        .filter((vedtaksperiode: Vedtaksperiode) => {
-            const vedtakBegrunnelserForPeriode = vedtakBegrunnelser.filter(
-                (vedtakBegrunnelse: IRestVedtakBegrunnelse) => {
-                    return (
-                        vedtakBegrunnelse.begrunnelseType !== VedtakBegrunnelseType.AVSLAG &&
-                        vedtakBegrunnelse.fom === vedtaksperiode.periodeFom &&
-                        vedtakBegrunnelse.tom === vedtaksperiode.periodeTom
-                    );
-                }
-            );
-
-            if (erLesevisning) {
-                // Viser kun perioder som har begrunnelse dersom man er i lesemodus.
-                return !!vedtakBegrunnelserForPeriode.length;
-            } else {
-                // Fjern perioder hvor fom er mer enn 2 måneder frem i tid.
-                return (
-                    familieDayjsDiff(
-                        familieDayjs(vedtaksperiode.periodeFom),
-                        familieDayjs(),
-                        'month'
-                    ) < 2
-                );
-            }
-        });
-};
 
 const VedtakBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({ åpenBehandling }) => {
     const { erLesevisning } = useBehandling();

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -1,0 +1,109 @@
+import { VedtakBegrunnelse, VedtakBegrunnelseType } from '../../../../../typer/vedtak';
+import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
+import familieDayjs from '../../../../../utils/familieDayjs';
+import { datoformat } from '../../../../../utils/formatter';
+import { mockVedtakbegrunnelse } from '../../../../../utils/test/vedtak/vedtakbegrunnelse.mock';
+import {
+    mockAvslagssperiode,
+    mockOpphørsperiode,
+    mockUtbetalingsperiode,
+} from '../../../../../utils/test/vedtak/vedtaksperiode.mock';
+import { filtrerOgSorterPerioderMedBegrunnelseBehov } from '../../../../../utils/vedtakUtils';
+
+describe('VedtakBegrunnelserContext', () => {
+    describe('Test filtrerOgSorterPerioderMedBegrunnelseBehov', () => {
+        const fom = '2020-01-01';
+        const tom = '2020-02-28';
+        const opphørFom = '2020-03-01';
+
+        const vedtaksperioder = [
+            mockOpphørsperiode({ periodeFom: opphørFom }),
+            mockUtbetalingsperiode({ periodeFom: fom, periodeTom: tom }),
+            mockAvslagssperiode({ periodeFom: fom, periodeTom: tom }),
+        ];
+
+        test(`Test at kun vedtaksperioder av typen OPPHØR og UTBETALING returneres`, () => {
+            const periodeTyper = filtrerOgSorterPerioderMedBegrunnelseBehov(
+                vedtaksperioder,
+                [],
+                false
+            ).map(p => p.vedtaksperiodetype);
+            expect(periodeTyper.length).toBe(2);
+            expect(periodeTyper).toContain(Vedtaksperiodetype.OPPHØR);
+            expect(periodeTyper).toContain(Vedtaksperiodetype.UTBETALING);
+        });
+
+        test(`Test at returnerte perioder er sortert på fom-dato.`, () => {
+            const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(vedtaksperioder, [], false);
+            expect(perioder.length).toBe(2);
+            expect(perioder[0].vedtaksperiodetype).toBe(Vedtaksperiodetype.UTBETALING);
+            expect(perioder[1].vedtaksperiodetype).toBe(Vedtaksperiodetype.OPPHØR);
+        });
+
+        describe('Test lesevisning', () => {
+            const erLesevisning = true;
+            test(`Test at ubegrunnede perioder ikke returneres ved lesevisning`, () => {
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
+                    vedtaksperioder,
+                    [
+                        mockVedtakbegrunnelse({
+                            begrunnelse: VedtakBegrunnelse.OPPHØR_BARN_FLYTTET_FRA_SØKER,
+                            begrunnelseType: VedtakBegrunnelseType.OPPHØR,
+                            fom: opphørFom,
+                            tom: '',
+                        }),
+                    ],
+                    erLesevisning
+                );
+                expect(perioder.length).toBe(1);
+                expect(perioder[0].vedtaksperiodetype).toEqual(Vedtaksperiodetype.OPPHØR);
+            });
+            test(`Test at perioder med kun avslagsbegrunnelse ikke returneres ved lesevisning`, () => {
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
+                    vedtaksperioder,
+                    [
+                        mockVedtakbegrunnelse({
+                            begrunnelse: VedtakBegrunnelse.AVSLAG_MEDLEM_I_FOLKETRYGDEN,
+                            begrunnelseType: VedtakBegrunnelseType.AVSLAG,
+                            fom: fom,
+                            tom: tom,
+                        }),
+                    ],
+                    erLesevisning
+                );
+                expect(perioder.length).toBe(0);
+            });
+        });
+
+        describe('Test filtrering av perioder frem i tid', () => {
+            test(`Test at perioder med fom-dato før 2 mnd frem i tid returneres`, () => {
+                const enMndFremITid = familieDayjs().add(1, 'month');
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
+                    [
+                        mockUtbetalingsperiode({
+                            periodeFom: enMndFremITid.startOf('month').format(datoformat.ISO_DAG),
+                            periodeTom: enMndFremITid.endOf('month').format(datoformat.ISO_DAG),
+                        }),
+                    ],
+                    [],
+                    false
+                );
+                expect(perioder.length).toBe(1);
+            });
+            test(`Test at perioder med fom-dato fra og med 2 mnd frem i tid ikke returneres`, () => {
+                const enMndFremITid = familieDayjs().add(2, 'month');
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
+                    [
+                        mockUtbetalingsperiode({
+                            periodeFom: enMndFremITid.startOf('month').format(datoformat.ISO_DAG),
+                            periodeTom: enMndFremITid.endOf('month').format(datoformat.ISO_DAG),
+                        }),
+                    ],
+                    [],
+                    false
+                );
+                expect(perioder.length).toBe(0);
+            });
+        });
+    });
+});

--- a/src/frontend/utils/test/vedtak/vedtakbegrunnelse.mock.ts
+++ b/src/frontend/utils/test/vedtak/vedtakbegrunnelse.mock.ts
@@ -1,0 +1,28 @@
+import {
+    IRestVedtakBegrunnelse,
+    VedtakBegrunnelse,
+    VedtakBegrunnelseType,
+} from '../../../typer/vedtak';
+
+interface IMockRestVedtakBegrunnelse {
+    begrunnelse?: VedtakBegrunnelse;
+    begrunnelseType?: VedtakBegrunnelseType;
+    fom?: string;
+    tom?: string;
+}
+
+export const mockVedtakbegrunnelse = ({
+    begrunnelse = VedtakBegrunnelse.INNVILGET_BOR_HOS_SØKER,
+    begrunnelseType = VedtakBegrunnelseType.INNVILGELSE,
+    fom = '2020-01-01',
+    tom = '2020-02-28',
+}: IMockRestVedtakBegrunnelse = {}): IRestVedtakBegrunnelse => {
+    return {
+        id: 1,
+        begrunnelse,
+        begrunnelseType,
+        brevBegrunnelse: 'Eksempel brevbegrunnelse',
+        fom,
+        tom,
+    };
+};

--- a/src/frontend/utils/test/vedtak/vedtaksperiode.mock.ts
+++ b/src/frontend/utils/test/vedtak/vedtaksperiode.mock.ts
@@ -1,0 +1,44 @@
+import { YtelseType } from '../../../typer/beregning';
+import { Vedtaksperiode, Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
+
+interface IMockVedtaksperiode {
+    periodeFom?: string;
+    periodeTom?: string;
+}
+
+export const mockUtbetalingsperiode = ({
+    periodeFom = '2020-01-01',
+    periodeTom = '2020-02-28',
+}: IMockVedtaksperiode = {}): Vedtaksperiode => {
+    return {
+        periodeFom,
+        periodeTom,
+        vedtaksperiodetype: Vedtaksperiodetype.UTBETALING,
+        utbetalingsperiodeDetaljer: [],
+        ytelseTyper: [YtelseType.ORDINÆR_BARNETRYGD],
+        antallBarn: 1,
+        utbetaltPerMnd: 1054,
+    };
+};
+
+export const mockOpphørsperiode = ({
+    periodeFom = '2020-03-01',
+    periodeTom = '',
+}: IMockVedtaksperiode = {}): Vedtaksperiode => {
+    return {
+        periodeFom,
+        periodeTom,
+        vedtaksperiodetype: Vedtaksperiodetype.OPPHØR,
+    };
+};
+
+export const mockAvslagssperiode = ({
+    periodeFom = '2019-06-01',
+    periodeTom = '2019-06-30',
+}: IMockVedtaksperiode = {}): Vedtaksperiode => {
+    return {
+        periodeFom,
+        periodeTom,
+        vedtaksperiodetype: Vedtaksperiodetype.AVSLAG,
+    };
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4425
- Trekker ut logikk som filtrerer og sorterer vedtaksperioder med begrunnelsebehov til utilfunksjon
- Skriver tester for dette
- En liten logikkjustering som gjør at man filtrerer bort/skjuler perioder som er 2 mnd senere enn den 1. i inneværende måned, siden periodene alltid har fom-dato første i måneden

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
