### PR TITLE
Bugfix: Begrunnelsetekster og datodifferanse

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/useVedtakBegrunnelseMultiselect.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/useVedtakBegrunnelseMultiselect.test.ts
@@ -14,8 +14,8 @@ describe('useVedtakBegrunnelseMultiselect', () => {
         // Barn 2 har lovlig opphold april - november
         //
         // Det vil si:
-        // mai - juni: innvilget to barn pga BOR_MED_SØKER og LOVLIG_OPPHOLD
-        // juli - nov: redusert pga BOR_MED_SØKER
+        // mai: innvilget to barn pga BOR_MED_SØKER og LOVLIG_OPPHOLD
+        // juni - nov: redusert pga BOR_MED_SØKER
         // des - : opphør pga LOVLIG_OPPHOLD
 
         const personResultater = [
@@ -41,7 +41,7 @@ describe('useVedtakBegrunnelseMultiselect', () => {
 
         const innvilgelseperiode: Vedtaksperiode = {
             periodeFom: '2010-05-01',
-            periodeTom: '2010-06-30',
+            periodeTom: '2010-05-31',
             vedtaksperiodetype: Vedtaksperiodetype.UTBETALING,
             utbetalingsperiodeDetaljer: [],
             ytelseTyper: [YtelseType.ORDINÆR_BARNETRYGD],
@@ -49,7 +49,7 @@ describe('useVedtakBegrunnelseMultiselect', () => {
             utbetaltPerMnd: 2108,
         };
         const reduksjonsperiode: Vedtaksperiode = {
-            periodeFom: '2010-07-01',
+            periodeFom: '2010-06-01',
             periodeTom: '2010-11-30',
             vedtaksperiodetype: Vedtaksperiodetype.UTBETALING,
             utbetalingsperiodeDetaljer: [],

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/useVedtakBegrunnelseMultiselect.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/useVedtakBegrunnelseMultiselect.ts
@@ -18,16 +18,14 @@ import {
     Resultat,
     VilkårType,
 } from '../../../../typer/vilkår';
-import { Dayjs, familieDayjsDiff } from '../../../../utils/familieDayjs';
 import { isoStringToDayjs } from '../../../../utils/formatter';
+import { erISammeMåned } from '../../../../utils/tid';
 
 export const hentUtgjørendeVilkårImpl = (
     begrunnelseType: VedtakBegrunnelseType,
     personResultater: IRestPersonResultat[],
     vedtaksperiode: Vedtaksperiode
 ): VilkårType[] => {
-    const erSammeMåned = (dato1: Dayjs, dato2: Dayjs) =>
-        familieDayjsDiff(dato1, dato2, 'month') === 0;
     return personResultater
         .flatMap(personResultat => personResultat.vilkårResultater)
         .filter((vilkårResultat: IRestVilkårResultat) => {
@@ -39,7 +37,7 @@ export const hentUtgjørendeVilkårImpl = (
 
             if (begrunnelseType === VedtakBegrunnelseType.INNVILGELSE) {
                 return (
-                    erSammeMåned(vilkårPeriodeFom, vedtakPeriodeFom.subtract(1, 'month')) &&
+                    erISammeMåned(vilkårPeriodeFom, vedtakPeriodeFom.subtract(1, 'month')) &&
                     vilkårResultat.resultat === Resultat.OPPFYLT
                 );
             } else if (
@@ -47,7 +45,7 @@ export const hentUtgjørendeVilkårImpl = (
                 begrunnelseType === VedtakBegrunnelseType.OPPHØR
             ) {
                 return (
-                    erSammeMåned(
+                    erISammeMåned(
                         vilkårPeriodeTom,
                         vedtakPeriodeFom.subtract(oppfyltTomMånedEtter, 'month')
                     ) && vilkårResultat.resultat === Resultat.OPPFYLT

--- a/src/frontend/utils/familieDayjs.ts
+++ b/src/frontend/utils/familieDayjs.ts
@@ -30,6 +30,8 @@ const familieDayjs = (config?: ConfigType, format?: string): Dayjs => {
     return config ? dayjs(config).tz() : dayjs().tz();
 };
 
+// Obs! Enhet velger kun størrelse på intervaller man sammenligner, og ikke ulikhet på enhet.
+// Det vil si at 17.05.1814 og 01.06.1814 vil få 0 i diff, selv om de ikke er i samme måned. Se tester for eksempler.
 export const familieDayjsDiff = (
     første: Dayjs,
     andre: Dayjs,

--- a/src/frontend/utils/test/familieDayjs.test.ts
+++ b/src/frontend/utils/test/familieDayjs.test.ts
@@ -24,4 +24,18 @@ describe('utils/familieDayjs', () => {
         expect(familieDayjsDiff(dato, differanseDato, 'month')).toEqual(12);
         expect(familieDayjsDiff(dato, differanseDato, 'day')).toEqual(366);
     });
+
+    test('familieDayjsDiff returnerer 0 måneders differanse hvis 30 dager eller mindre diff, tross ulike måneder', () => {
+        const dato = familieDayjs('2018-06-29');
+        const differanseDato = familieDayjs('2018-05-31');
+
+        expect(familieDayjsDiff(dato, differanseDato, 'year')).toEqual(0);
+    });
+
+    test('familieDayjsDiff returnerer 0 års differanse hvis 365 dager eller mindre diff, tross ulike årstall', () => {
+        const dato = familieDayjs('2019-06-30');
+        const differanseDato = familieDayjs('2020-05-17');
+
+        expect(familieDayjsDiff(dato, differanseDato, 'year')).toEqual(0);
+    });
 });

--- a/src/frontend/utils/test/tid.test.ts
+++ b/src/frontend/utils/test/tid.test.ts
@@ -5,6 +5,7 @@ import familieDayjs from '../familieDayjs';
 import { datoformat } from '../formatter';
 import {
     datoDagenFør,
+    erISammeMåned,
     hentFørsteDagIYearMonth,
     hentSisteDagIYearMonth,
     leggTilÅr,
@@ -83,6 +84,33 @@ describe('utils/tid', () => {
         });
         test('Legger til 4 år på dato 29. februar i et skuddår', () => {
             expect(leggTilÅr('2020-02-29', 4)).toStrictEqual(dayjs(new Date('2024-02-29')));
+        });
+    });
+
+    describe('Returnerer om datoer er innenfor samme måned', () => {
+        test('Datoer innenfor samme måned returnerer true', () => {
+            expect(
+                erISammeMåned(
+                    familieDayjs('2018-10-31', datoformat.ISO_DAG),
+                    familieDayjs('2018-10-01', datoformat.ISO_DAG)
+                )
+            ).toEqual(true);
+        });
+        test('Datoer i forskjellige måneder samme år returnerer false', () => {
+            expect(
+                erISammeMåned(
+                    familieDayjs('2018-10-31', datoformat.ISO_DAG),
+                    familieDayjs('2018-11-01', datoformat.ISO_DAG)
+                )
+            ).toEqual(false);
+        });
+        test('Datoer i samme måned ulike år returnerer false', () => {
+            expect(
+                erISammeMåned(
+                    familieDayjs('2018-10-31', datoformat.ISO_DAG),
+                    familieDayjs('2019-10-31', datoformat.ISO_DAG)
+                )
+            ).toEqual(false);
         });
     });
 });

--- a/src/frontend/utils/tid.ts
+++ b/src/frontend/utils/tid.ts
@@ -40,3 +40,7 @@ export const leggTilÅr = (dato: string, år: number) => {
 export const datoDagenFør = (dayjs: Dayjs): Dayjs => {
     return dayjs.subtract(1, 'day');
 };
+
+export const erISammeMåned = (dato1: Dayjs, dato2: Dayjs) => {
+    return dato1.get('month') === dato2.get('month') && dato1.get('year') === dato2.get('year');
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [Får ikke opp begrunnelsestekster ved vilkår oppfylt fra månedsskifte ](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4515)

Feil ved sjekk på om måned før utbetaling matchet vilkår. Inntraff i tilfeller hvor vilkåret var oppfylt fra og med siste dag i måned med 31 dager. Dette pga hvordan diff-funksjonen til dayjs funker (se tester og kommentar).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
UTC or not to. Bør det brukes her? Det som kan skje ved utc er at den 1. i en måned kl 00:00 blir til måneden før når man gjør om til utc, men så at vi [her](https://github.com/navikt/familie-ba-sak-frontend/pull/636/files) har lagt det til for å fikse lignende bug som fikses nå 🤷‍♀️ 

Vi bør nok ta en runde på utilfunksjoner og diverse frontend (notert litt [her](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4594))

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke fått testet caset lenket til i brukerhistorien enda siden jeg ikke får henta den opp for øyeblikket pga autentiseringsfeil, men validert at tilsvarende feil fikses lokalt.

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
Om man er interessert kan jeg ta en recap på feilen  