### PR TITLE
Oppdater plassering av knapper og forhåndsvisningsknapp for brev

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -23,6 +23,7 @@ import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { useFagsakRessurser } from '../../../context/FagsakContext';
 import { VedtakBegrunnelserProvider } from '../../../context/VedtakBegrunnelserContext';
+import { DokumentIkon } from '../../../ikoner/DokumentIkon';
 import {
     BehandlerRolle,
     BehandlingStatus,
@@ -35,6 +36,7 @@ import { IFagsak } from '../../../typer/fagsak';
 import { ToggleNavn } from '../../../typer/toggles';
 import { IRestVedtakBegrunnelse } from '../../../typer/vedtak';
 import { hentAktivVedtakPåBehandlig } from '../../../utils/fagsak';
+import IkonKnapp from '../../Felleskomponenter/IkonKnapp/IkonKnapp';
 import UIModalWrapper from '../../Felleskomponenter/Modal/UIModalWrapper';
 import PdfVisningModal from '../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
@@ -48,6 +50,13 @@ interface IVedtakProps {
 
 const StyledFeilmelding = styled(Feilmelding)`
     margin-top: 1rem;
+`;
+
+const Container = styled.div`
+    max-width: 49rem;
+    #forhandsvis-vedtaksbrev {
+        float: right;
+    }
 `;
 
 const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åpenBehandling }) => {
@@ -198,16 +207,23 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                         }}
                         pdfdata={vedtaksbrev}
                     />
-                    <VedtakBegrunnelserProvider fagsak={fagsak} aktivVedtak={aktivVedtak}>
-                        <BegrunnelseTabell åpenBehandling={åpenBehandling} />
-                        <AvslagTabell åpenBehandling={åpenBehandling} />
-                    </VedtakBegrunnelserProvider>
-                    <Knapp
-                        mini={true}
-                        onClick={() => settVisVedtaksbrev(!visVedtaksbrev)}
-                        children={'Vis vedtaksbrev'}
-                    />
-                    {submitFeil !== '' && <StyledFeilmelding>{submitFeil}</StyledFeilmelding>}
+                    <Container>
+                        <VedtakBegrunnelserProvider fagsak={fagsak} aktivVedtak={aktivVedtak}>
+                            <BegrunnelseTabell åpenBehandling={åpenBehandling} />
+                            <AvslagTabell åpenBehandling={åpenBehandling} />
+                        </VedtakBegrunnelserProvider>
+                        <IkonKnapp
+                            id={'forhandsvis-vedtaksbrev'}
+                            erLesevisning={false}
+                            label={'Vis vedtaksbrev'}
+                            ikon={<DokumentIkon />}
+                            onClick={() => settVisVedtaksbrev(!visVedtaksbrev)}
+                            spinner={vedtaksbrev.status === RessursStatus.HENTER}
+                            knappPosisjon={'venstre'}
+                            mini={true}
+                        />
+                        {submitFeil !== '' && <StyledFeilmelding>{submitFeil}</StyledFeilmelding>}
+                    </Container>
                     {visModal && (
                         <UIModalWrapper
                             modal={{

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Felles/EkspanderbartBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Felles/EkspanderbartBegrunnelsePanel.tsx
@@ -15,8 +15,7 @@ import { formaterBeløp, isoStringToDayjs } from '../../../../../utils/formatter
 import { sisteDagInneværendeMåned } from '../../../../../utils/tid';
 
 const StyledEkspanderbartpanelBase = styled(EkspanderbartpanelBase)`
-    margin-bottom: 1.5rem;
-    max-width: 49rem;
+    margin-bottom: 1rem;
 
     .ekspanderbartPanel__hode {
         padding: 0 1rem 0 1.6rem;

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -35,10 +35,10 @@ const StyledInnholdstittel = styled(Innholdstittel)`
 const Navigering = styled.div`
     margin: 4rem 0 1rem;
     display: flex;
-    flex-direction: row;
-    justify-content: start;
+    flex-direction: row-reverse;
+    justify-content: end;
     button:not(:first-child) {
-        margin-left: 1rem;
+        margin-right: 1rem;
     }
 `;
 
@@ -78,15 +78,6 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
             {children}
 
             <Navigering>
-                {forrigeOnClick && skalViseForrigeKnapp && (
-                    <Knapp
-                        onClick={() => {
-                            forrigeOnClick();
-                        }}
-                        mini={true}
-                        children={forrigeKnappTittel ?? 'Forrige'}
-                    />
-                )}
                 {nesteOnClick && skalViseNesteKnapp && (
                     <Knapp
                         type={'hoved'}
@@ -99,6 +90,15 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
                         }}
                         mini={true}
                         children={nesteKnappTittel ?? 'Neste'}
+                    />
+                )}
+                {forrigeOnClick && skalViseForrigeKnapp && (
+                    <Knapp
+                        onClick={() => {
+                            forrigeOnClick();
+                        }}
+                        mini={true}
+                        children={forrigeKnappTittel ?? 'Forrige'}
                     />
                 )}
             </Navigering>

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -38,7 +38,7 @@ const StyledInnholdstittel = styled(Innholdstittel)`
 const Navigering = styled.div`
     padding: 1rem 0;
     display: flex;
-    flex-direction: row-reverse;
+    flex-direction: row;
     justify-content: space-between;
 `;
 
@@ -85,22 +85,6 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
             {children}
 
             <Navigering>
-                {nesteOnClick && skalViseNesteKnapp ? (
-                    <Knapp
-                        type={'hoved'}
-                        spinner={senderInn}
-                        disabled={senderInn}
-                        onClick={() => {
-                            if (!senderInn) {
-                                nesteOnClick();
-                            }
-                        }}
-                        mini={true}
-                        children={nesteKnappTittel ?? 'Neste'}
-                    />
-                ) : (
-                    <div />
-                )}
                 <div>
                     {forrigeOnClick && skalViseForrigeKnapp ? (
                         <Knapp
@@ -125,6 +109,22 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
                         <div />
                     )}
                 </div>
+                {nesteOnClick && skalViseNesteKnapp ? (
+                    <Knapp
+                        type={'hoved'}
+                        spinner={senderInn}
+                        disabled={senderInn}
+                        onClick={() => {
+                            if (!senderInn) {
+                                nesteOnClick();
+                            }
+                        }}
+                        mini={true}
+                        children={nesteKnappTittel ?? 'Neste'}
+                    />
+                ) : (
+                    <div />
+                )}
             </Navigering>
         </Container>
     );

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -33,10 +33,13 @@ const StyledInnholdstittel = styled(Innholdstittel)`
 `;
 
 const Navigering = styled.div`
-    padding: 1rem 0;
+    margin: 4rem 0 1rem;
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: start;
+    button:not(:first-child) {
+        margin-left: 1rem;
+    }
 `;
 
 const Skjemasteg: React.FunctionComponent<IProps> = ({
@@ -75,7 +78,7 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
             {children}
 
             <Navigering>
-                {forrigeOnClick && skalViseForrigeKnapp ? (
+                {forrigeOnClick && skalViseForrigeKnapp && (
                     <Knapp
                         onClick={() => {
                             forrigeOnClick();
@@ -83,10 +86,8 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
                         mini={true}
                         children={forrigeKnappTittel ?? 'Forrige'}
                     />
-                ) : (
-                    <div />
                 )}
-                {nesteOnClick && skalViseNesteKnapp ? (
+                {nesteOnClick && skalViseNesteKnapp && (
                     <Knapp
                         type={'hoved'}
                         spinner={senderInn}
@@ -99,8 +100,6 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
                         mini={true}
                         children={nesteKnappTittel ?? 'Neste'}
                     />
-                ) : (
-                    <div />
                 )}
             </Navigering>
         </Container>

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
-import { Flatknapp, Knapp } from 'nav-frontend-knapper';
+import { Knapp } from 'nav-frontend-knapper';
 import { Innholdstittel } from 'nav-frontend-typografi';
 
 import { useBehandling } from '../../../context/BehandlingContext';
@@ -16,13 +16,10 @@ interface IProps {
     forrigeOnClick?: () => void;
     nesteKnappTittel?: string;
     nesteOnClick?: () => void;
-    tilbakestillOnClick?: () => void;
-    tilbakestillKnappTittel?: string;
     senderInn: boolean;
     tittel: string;
     maxWidthStyle?: string;
     skalViseNesteKnapp?: boolean;
-    skalViseTilbakestillKnapp?: boolean;
     skalViseForrigeKnapp?: boolean;
 }
 
@@ -42,10 +39,6 @@ const Navigering = styled.div`
     justify-content: space-between;
 `;
 
-const TilbakestillKnapp = styled(Flatknapp)`
-    margin-left: 20px;
-`;
-
 const Skjemasteg: React.FunctionComponent<IProps> = ({
     children,
     className,
@@ -53,13 +46,10 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
     forrigeOnClick,
     nesteKnappTittel,
     nesteOnClick,
-    tilbakestillOnClick,
-    tilbakestillKnappTittel,
     senderInn,
     tittel,
     maxWidthStyle = '40rem',
     skalViseNesteKnapp = true,
-    skalViseTilbakestillKnapp,
     skalViseForrigeKnapp = true,
 }) => {
     const history = useHistory();
@@ -85,30 +75,17 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
             {children}
 
             <Navigering>
-                <div>
-                    {forrigeOnClick && skalViseForrigeKnapp ? (
-                        <Knapp
-                            onClick={() => {
-                                forrigeOnClick();
-                            }}
-                            mini={true}
-                            children={forrigeKnappTittel ?? 'Forrige'}
-                        />
-                    ) : (
-                        <div />
-                    )}
-                    {tilbakestillOnClick && skalViseTilbakestillKnapp ? (
-                        <TilbakestillKnapp
-                            onClick={() => {
-                                tilbakestillOnClick();
-                            }}
-                            mini={true}
-                            children={tilbakestillKnappTittel ?? 'Tilbakestill'}
-                        />
-                    ) : (
-                        <div />
-                    )}
-                </div>
+                {forrigeOnClick && skalViseForrigeKnapp ? (
+                    <Knapp
+                        onClick={() => {
+                            forrigeOnClick();
+                        }}
+                        mini={true}
+                        children={forrigeKnappTittel ?? 'Forrige'}
+                    />
+                ) : (
+                    <div />
+                )}
                 {nesteOnClick && skalViseNesteKnapp ? (
                     <Knapp
                         type={'hoved'}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro: Endre knappetype og plassering av forhåndsvisning](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3573)
- Navigeringsknapper plasseres til venstre 
- Oppdater posisjon og type knapp ved forhåndsvisning av brev
- Fjerner litt deprecated props (avklart med Meng)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Før
![Skjermbilde 2021-05-03 kl  16 10 15](https://user-images.githubusercontent.com/5719550/116887597-c645d000-ac2a-11eb-95cb-bb3e2134bd95.png)
Etter
![Skjermbilde 2021-05-03 kl  16 07 48](https://user-images.githubusercontent.com/5719550/116887663-d78edc80-ac2a-11eb-8615-3a729bf732d9.png)

