### PR TITLE
Venstrestill knapper

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -36,7 +36,7 @@ const Navigering = styled.div`
     margin: 4rem 0 1rem;
     display: flex;
     flex-direction: row-reverse;
-    justify-content: end;
+    justify-content: flex-end;
     button:not(:first-child) {
         margin-right: 1rem;
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'e
Gjorde en row-reverse i siste liten på [forrige pr](https://github.com/navikt/familie-ba-sak-frontend/pull/996) for å fikse at man tabber først til "Neste"-knappen selv om den visuelt ligger sist. Holdt ikke med `end` for å venstrestille, men må sette `flex-end`. 


Før:
![Skjermbilde 2021-05-04 kl  12 05 44](https://user-images.githubusercontent.com/5719550/116988756-18d9c780-acd1-11eb-9b7d-5ceb31bf9cef.png)

Etter
![Skjermbilde 2021-05-04 kl  12 05 30](https://user-images.githubusercontent.com/5719550/116988764-1d9e7b80-acd1-11eb-9540-5c449466e125.png)
