### PR TITLE
Legg til varsel dersom det allerede er en tilbakekreving på fagsaken.

### DIFF
--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -88,6 +88,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                         {tilbakekrevingErToggletPå && erFeilutbetaling && (
                             <TilbakekrevingSkjema
                                 søkerMålform={hentSøkersMålform(åpenBehandling)}
+                                fagsakId={fagsak.id}
                             />
                         )}
                     </>


### PR DESCRIPTION
Legg til varsel dersom SB1 ikke har opprettet en tilbakekreving, men det er en feilutbetaling.

Denne oppgaven er knyttet til to favro-oppgaver: 

Allerede åpen tilbakekreving:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4320
Her viser vi en infotekst dersom det allerede finnes en åpen sak på fagsaken

Automatisk tilbakekreving dersom det har kommet en feilutbetaling etter at SB1 sendte til godkjenner
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4369
Her viser vi en infotekst som sier at tilbakekreving blir opprettet automatisk dersom det ikke er gjort noen valg om tilbakekreving når SB2 er på tilbakekrevingsteget