### PR TITLE
Bugfix: Reduksjonsbegrunnelse for 18 år dukker ikke opp

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/useVedtakBegrunnelseMultiselect.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/useVedtakBegrunnelseMultiselect.ts
@@ -20,8 +20,10 @@ import {
 import {
     DagMånedÅr,
     erISammeMåned,
+    erSamme,
     kalenderDatoMedFallback,
     KalenderEnhet,
+    sisteDagIMåned,
     TIDENES_ENDE,
     TIDENES_MORGEN,
     trekkFra,
@@ -48,7 +50,10 @@ export const hentUtgjørendeVilkårImpl = (
                 TIDENES_MORGEN
             );
             const oppfyltTomMånedEtter =
-                vilkårResultat.vilkårType !== VilkårType.UNDER_18_ÅR ? 1 : 0;
+                vilkårResultat.vilkårType !== VilkårType.UNDER_18_ÅR ||
+                erSamme(vilkårPeriodeTom, sisteDagIMåned(vilkårPeriodeTom))
+                    ? 1
+                    : 0;
 
             if (begrunnelseType === VedtakBegrunnelseType.INNVILGELSE) {
                 return (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4634

Logikken som henter utgjørende vilkår basert på utbetalingsperiode justerer måned basert på om det er 18 årsvilkår eller ikke, da 18 årsvilkåret påvirker utbetaling samme måned og ikke måneden etter som ellers.

Det som ikke har blitt tatt høyde for er tilfellene hvor barnet fyller første dag i mnd og 18 årsvilkåret er oppfylt til og med siste dag foregående måned. Da påvirker vilkåret faktisk måneden etterpå, slik som andre vilkår.

- Tar høyde for tilfelle beskrevet ovenfor i hentUtgjørendeVilkår
- Legger til test av edgecase

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Jeg antar dette har fungert tidligere fordi man satte feil dato på 18årsvilkåret og satte _til 18 årsdag_ i stedet for _til og med dagen før 18 årsdag_.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Bugscreenshot fra favrooppgave
![Skjermbilde 2021-05-10 kl  15 50 29](https://user-images.githubusercontent.com/5719550/117669770-8d1bdb80-b1a7-11eb-9c5d-64e80a9111db.png)

