### PR TITLE
Endre logikk for om periode skal vises i simuleringstabellen

### DIFF
--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
@@ -98,9 +98,8 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
         erEtter(kalenderDato(periode.fom), kalenderDato(fomDatoNestePeriode));
 
     const periodeSkalVisesITabell = (periode: ISimuleringPeriode) =>
-        !erMerEnn12MånederISimulering ||
-        (!periodeErEtterNesteUtbetalingsPeriode(periode) &&
-            kalenderDato(periode.fom).år === aktueltÅr);
+        !periodeErEtterNesteUtbetalingsPeriode(periode) &&
+        (!erMerEnn12MånederISimulering || kalenderDato(periode.fom).år === aktueltÅr);
 
     const formaterBeløpUtenValutakode = (beløp?: number) =>
         beløp ? formaterBeløp(beløp).slice(0, -3) : '-';


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4754
Dersom det var mindre enn 12 måneder i simuleringen viste vi alle periodene. Endra det til å være alle periodene minus de som er etter neste periode


Før:
![image](https://user-images.githubusercontent.com/17828446/118658799-042b2280-b7ed-11eb-85be-a7e78510d08e.png)

Etter:
![image](https://user-images.githubusercontent.com/17828446/118658864-14430200-b7ed-11eb-959b-4b081e7623dd.png)

