### PR TITLE
Bugfix: Tillat fritekstbegrunnelse uten fom

### DIFF
--- a/src/frontend/context/FritekstVedtakBegrunnelserContext.tsx
+++ b/src/frontend/context/FritekstVedtakBegrunnelserContext.tsx
@@ -136,9 +136,6 @@ const [FritekstVedtakBegrunnelserProvider, useFritekstVedtakBegrunnelser] = cons
         };
 
         const onSubmit = () => {
-            if (!vedtaksperiode.periodeFom) {
-                throw new Error('Prøver å legge til en begrunnelse på en periode uten fom');
-            }
             settFritekstSubmit(FritekstSubmit.POST);
 
             if (fagsak.status === RessursStatus.SUKSESS) {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -25,7 +25,7 @@ export interface IRestPostVedtakBegrunnelse {
 }
 
 export interface IRestPostFritekstVedtakBegrunnelser {
-    fom: string;
+    fom?: string;
     tom?: string;
     fritekster: string[];
     vedtaksperiodetype: Vedtaksperiodetype;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
"Prøver å legge til en begrunnelse på en periode uten fom" trigges feilaktig frontend på sak i prod. Antar saksbehandler prøver å legge til fritekst på avslag uten periode.
(se slack https://nav-it.slack.com/archives/GS8JFPNTH/p1621510244002300)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Restobjekt backend har allerede nullable fom.