### PR TITLE
Visning av infoboks for "eldre" behandlinger

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger.tsx
@@ -8,7 +8,7 @@ import { Ingress, Undertekst } from 'nav-frontend-typografi';
 
 import { Globe, Heart, Home, Passport } from '@navikt/ds-icons';
 
-import { IRestRegisterhistorikk, IRestRegisteropplysning } from '../../../typer/person';
+import { IRestRegisterhistorikk } from '../../../typer/person';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 import RegisteropplysningerTabell from './RegisteropplysningerTabell';
 
@@ -26,20 +26,12 @@ interface IRegisteropplysningerProps {
 }
 
 const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ opplysninger }) => {
-    const finnesTomPeriode = (opplysninger: IRestRegisteropplysning[]): boolean =>
-        !!opplysninger.find(opplysning => !opplysning.fom && !opplysning.tom);
-    const finnesTomPeriodePåPerson =
-        finnesTomPeriode(opplysninger.oppholdstillatelse) ||
-        opplysninger.oppholdstillatelse.length === 0 ||
-        finnesTomPeriode(opplysninger.statsborgerskap) ||
-        opplysninger.statsborgerskap.length === 0 ||
-        finnesTomPeriode(opplysninger.bostedsadresse) ||
-        opplysninger.bostedsadresse.length === 0;
+    const bleOpprettetUtenRegisteropplysninger = opplysninger.statsborgerskap.length === 0;
 
     return (
         <>
             <Ingress children={'Registeropplysninger'} />
-            {finnesTomPeriodePåPerson ? (
+            {bleOpprettetUtenRegisteropplysninger ? (
                 <Alertstripe type="info" style={{ marginTop: '1rem' }}>
                     Behandlingen ble gjort før registeropplysninger ble lagret i systemet og mangler
                     derfor opplysninger.


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser bool som avgjør om man skal vise infoboks for eldre behandlinger ved å sjekke manglende statsborgerskap, som kun skal være tilfellet på disse behandlingene. hvorfor 👇

### 🔎️ Er det noe spesielt du ønsker å fremheve?
**De "eldre" behandlingene vi ønsker å trigge boksen på har:**
- ikke lagret datoer på sivilstand, men kan ikke sjekke på dette fordi det er varierende om dette finnes på nyere behandlinger også
- ikke lagret bostedsadresse og opphold, men kan ikke sjekke på dette fordi også nyere behandlinger kan mangle dette (selv om _flertallet_ har bostedsadresse)
- ikke lagret statsborgerskap og vi kan sjekke på dette fordi dette skal være tilgjengelig på alle vi spør for selv om man ikke vet stat (ukjent XUK eller statsløs XXX)

### 👀 Screen shots
Gjelder visningen av denne
![Skjermbilde 2021-05-31 kl  10 22 49](https://user-images.githubusercontent.com/5719550/120164467-e7361c80-c1fa-11eb-9a6e-6a1051e396cd.png)

Av og til vil vi vise selv om data mangler
![Skjermbilde 2021-05-31 kl  10 29 25](https://user-images.githubusercontent.com/5719550/120164686-1c426f00-c1fb-11eb-8aca-4e6e4a34a30d.png)
![Skjermbilde 2021-05-31 kl  10 22 57](https://user-images.githubusercontent.com/5719550/120164504-f0bf8480-c1fa-11eb-9a0b-975dae5eadb4.png)
