### PR TITLE
Bug ved validering av periode med ugyldig string

### DIFF
--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -38,6 +38,26 @@ describe('utils/validators', () => {
         målform: Målform.NB,
     };
 
+    test('Periode med ugyldig fom gir feil', () => {
+        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('400220', undefined));
+        const valideringsresultat = erPeriodeGyldig(periode, {
+            person: mockBarn,
+            erEksplisittAvslagPåSøknad: false,
+        });
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual('Ugyldig f.o.m.');
+    });
+
+    test('Periode med ugyldig tom gir feil', () => {
+        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2020-06-17', '400220'));
+        const valideringsresultat = erPeriodeGyldig(periode, {
+            person: mockBarn,
+            erEksplisittAvslagPåSøknad: false,
+        });
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual('Ugyldig t.o.m.');
+    });
+
     test('Periode uten datoer gir feil hvis ikke avslag', () => {
         const periode: FeltState<IPeriode> = nyFeltState(nyPeriode(undefined, undefined));
         const valideringsresultat = erPeriodeGyldig(periode, {
@@ -69,24 +89,14 @@ describe('utils/validators', () => {
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 
-    test('Periode med fom-dato og ugyldig periode gir feil', () => {
+    test('Periode med fom-dato på oppfylt periode senere enn tom', () => {
         const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2010-06-17', '2010-01-17'));
         const valideringsresultat = erPeriodeGyldig(periode, {
             person: mockBarn,
             erEksplisittAvslagPåSøknad: true,
         });
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
-        expect(valideringsresultat.feilmelding).toEqual('Ugyldig periode');
-    });
-
-    test('Periode med fom-dato på oppfylt periode ', () => {
-        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2010-06-17', '2010-01-17'));
-        const valideringsresultat = erPeriodeGyldig(periode, {
-            person: mockBarn,
-            erEksplisittAvslagPåSøknad: true,
-        });
-        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
-        expect(valideringsresultat.feilmelding).toEqual('Ugyldig periode');
+        expect(valideringsresultat.feilmelding).toEqual('F.o.m må settes tidligere enn t.o.m');
     });
 
     test('Periode med fom-dato før barnets fødselsdato på oppfylt periode gir feil', () => {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -82,6 +82,12 @@ export const erPeriodeGyldig = (
     const er18ÅrsVilkår: boolean | undefined = avhengigheter?.er18ÅrsVilkår;
 
     if (fom) {
+        if (!erIsoStringGyldig(fom)) {
+            return feil(felt, 'Ugyldig f.o.m.');
+        } else if (tom && !erIsoStringGyldig(tom)) {
+            return feil(felt, 'Ugyldig t.o.m.');
+        }
+
         if (!erEksplisittAvslagPåSøknad) {
             if (person && person.type === PersonType.BARN) {
                 if (finnesDatoFørFødselsdato(person, fom, tom)) {
@@ -95,13 +101,12 @@ export const erPeriodeGyldig = (
                 }
             }
         }
-        const fomDatoErGyldig = erIsoStringGyldig(fom);
         const fomDatoErFørTomDato = erFør(
             kalenderDatoMedFallback(fom, TIDENES_MORGEN),
             kalenderDatoMedFallback(tom, TIDENES_ENDE)
         );
 
-        return fomDatoErGyldig && fomDatoErFørTomDato ? ok(felt) : feil(felt, 'Ugyldig periode');
+        return fomDatoErFørTomDato ? ok(felt) : feil(felt, 'F.o.m må settes tidligere enn t.o.m');
     } else {
         if (erEksplisittAvslagPåSøknad) {
             return !tom


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Endrer litt på logikken for validering på perioder på vilkår for å forhindre at kalender apiet kaster feil ved ugyldig datoer.

Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4835

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen
