### PR TITLE
Sivilstandvisning registeropplysninger 

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger.tsx
@@ -9,6 +9,7 @@ import { Ingress, Undertekst } from 'nav-frontend-typografi';
 import { Globe, Heart, Home, Passport } from '@navikt/ds-icons';
 
 import { IRestRegisterhistorikk } from '../../../typer/person';
+import { Registeropplysning } from '../../../typer/registeropplysning';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 import RegisteropplysningerTabell from './RegisteropplysningerTabell';
 
@@ -45,7 +46,7 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ opplysning
                         }
                     />
                     <RegisteropplysningerTabell
-                        opplysningstype={'Sivilstand'}
+                        opplysningstype={Registeropplysning.SIVILSTAND}
                         ikon={
                             <Heart
                                 style={{ fontSize: '1.5rem' }}
@@ -57,7 +58,7 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ opplysning
                         historikk={opplysninger.sivilstand}
                     />
                     <RegisteropplysningerTabell
-                        opplysningstype={'Oppholdstillatelse'}
+                        opplysningstype={Registeropplysning.OPPHOLD}
                         ikon={
                             <Passport
                                 style={{ fontSize: '1.5rem' }}
@@ -69,7 +70,7 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ opplysning
                         historikk={opplysninger.oppholdstillatelse}
                     />
                     <RegisteropplysningerTabell
-                        opplysningstype={'Statsborgerskap'}
+                        opplysningstype={Registeropplysning.STATSBORGERSKAP}
                         ikon={
                             <Globe
                                 style={{ fontSize: '1.5rem' }}
@@ -81,7 +82,7 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ opplysning
                         historikk={opplysninger.statsborgerskap}
                     />
                     <RegisteropplysningerTabell
-                        opplysningstype={'Adresse'}
+                        opplysningstype={Registeropplysning.BOSTEDSADRESSE}
                         ikon={
                             <Home
                                 style={{ fontSize: '1.5rem' }}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/RegisteropplysningerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/RegisteropplysningerTabell.tsx
@@ -3,12 +3,15 @@ import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { IRestRegisteropplysning } from '../../../typer/person';
+import { Registeropplysning, registeropplysning } from '../../../typer/registeropplysning';
 import {
+    kalenderDato,
     kalenderDatoMedFallback,
     kalenderDatoTilDate,
     kalenderDiff,
     periodeToString,
     TIDENES_MORGEN,
+    tilVisning,
 } from '../../../utils/kalender';
 
 const Container = styled.div`
@@ -46,7 +49,7 @@ const OpplysningsIkon = styled.div`
 `;
 
 interface IRegisteropplysningerTabellProps {
-    opplysningstype: string;
+    opplysningstype: Registeropplysning;
     ikon: ReactNode;
     historikk: IRestRegisteropplysning[];
 }
@@ -62,12 +65,18 @@ const RegisteropplysningerTabell: React.FC<IRegisteropplysningerTabellProps> = (
                 <OpplysningsIkon children={ikon} />
                 <Tabell
                     className={'tabell'}
-                    aria-label={`Registeropplysninger for ${opplysningstype}`}
+                    aria-label={`Registeropplysninger for ${registeropplysning[opplysningstype]}`}
                 >
                     <thead>
                         <tr>
-                            <TabellHeader children={opplysningstype} />
-                            <TabellHeader children={'Periode'} />
+                            <TabellHeader children={registeropplysning[opplysningstype]} />
+                            <TabellHeader
+                                children={
+                                    opplysningstype === Registeropplysning.SIVILSTAND
+                                        ? 'Dato'
+                                        : 'Periode'
+                                }
+                            />
                         </tr>
                     </thead>
                     {historikk.length ? (
@@ -89,10 +98,18 @@ const RegisteropplysningerTabell: React.FC<IRegisteropplysningerTabellProps> = (
                                     >
                                         <td children={periode.verdi} />
                                         <td
-                                            children={periodeToString({
-                                                fom: periode.fom,
-                                                tom: periode.tom,
-                                            })}
+                                            children={
+                                                opplysningstype === Registeropplysning.SIVILSTAND
+                                                    ? tilVisning(
+                                                          periode.fom
+                                                              ? kalenderDato(periode.fom)
+                                                              : undefined
+                                                      )
+                                                    : periodeToString({
+                                                          fom: periode.fom,
+                                                          tom: periode.tom,
+                                                      })
+                                            }
                                         />
                                     </TabellRad>
                                 );

--- a/src/frontend/typer/registeropplysning.ts
+++ b/src/frontend/typer/registeropplysning.ts
@@ -1,0 +1,13 @@
+export enum Registeropplysning {
+    SIVILSTAND = 'SIVILSTAND',
+    OPPHOLD = 'OPPHOLD',
+    STATSBORGERSKAP = 'STATSBORGERSKAP',
+    BOSTEDSADRESSE = 'BOSTEDSADRESSE',
+}
+
+export const registeropplysning: Record<Registeropplysning, string> = {
+    SIVILSTAND: 'Sivilstand',
+    OPPHOLD: 'Oppholdstillatelse',
+    STATSBORGERSKAP: 'Statsborgerskap',
+    BOSTEDSADRESSE: 'Adresse',
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-4933 
- Legger til enum og record så man slipper å sjekke på string for å identifisere sivilstand
- Viser "Dato" i stedet for "Periode" som kolonnenavn ved sivilstand
- Viser ikke strek etter fom-dato på sivilstand