### PR TITLE
Oppdatert lesevisning på multiselect og avslagsbegrunnelser på nytt format

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@navikt/ds-icons": "^0.3.2",
     "@navikt/familie-backend": "^5.0.26",
     "@navikt/familie-clipboard": "^3.1.6",
-    "@navikt/familie-form-elements": "^3.0.2",
+    "@navikt/familie-form-elements": "^3.0.3",
     "@navikt/familie-header": "^3.0.17",
     "@navikt/familie-http": "^1.0.5",
     "@navikt/familie-ikoner": "^3.1.11",

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -21,6 +21,7 @@ import {
     VedtakBegrunnelseType,
     vedtakBegrunnelseTyper,
 } from '../../../../../typer/vedtak';
+import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import {
     finnVedtakBegrunnelseType,
     hentBakgrunnsfarge,
@@ -29,12 +30,17 @@ import {
 import { useVedtaksbegrunnelseTekster } from '../Context/VedtaksbegrunnelseTeksterContext';
 import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 
+interface IProps {
+    vedtaksperiodetype: Vedtaksperiodetype;
+}
+
 const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect: React.FC = () => {
+const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
     const { erLesevisning } = useBehandling();
+    const skalIkkeEditeres = erLesevisning() || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
     const {
         id,
         skjema,
@@ -92,12 +98,12 @@ const BegrunnelserMultiselect: React.FC = () => {
                     },
                 }),
             }}
-            placeholder={'Velg begrunnelse(r)'}
-            isDisabled={erLesevisning() || skjema.submitRessurs.status === RessursStatus.HENTER}
+            placeholder={'Valgt(e) begrunnelse(r)'}
+            isDisabled={skalIkkeEditeres || skjema.submitRessurs.status === RessursStatus.HENTER}
             feil={skjema.visFeilmeldinger ? begrunnelser.feilmelding : undefined}
             label="Begrunnelse(r) i brev"
             creatable={false}
-            erLesevisning={erLesevisning()}
+            erLesevisning={skalIkkeEditeres}
             isMulti={true}
             onChange={(_, action: ActionMeta<ISelectOption>) => {
                 onChangeBegrunnelse(action);

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -98,7 +98,7 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
                     },
                 }),
             }}
-            placeholder={'Valgt(e) begrunnelse(r)'}
+            placeholder={'Velg begrunnelse(r)'}
             isDisabled={skalIkkeEditeres || skjema.submitRessurs.status === RessursStatus.HENTER}
             feil={skjema.visFeilmeldinger ? begrunnelser.feilmelding : undefined}
             label="Begrunnelse(r) i brev"

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -44,7 +44,7 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
             )}
 
             <SkjemaGruppe feil={skjema.visFeilmeldinger && skjemaFeilmelding()}>
-                <BegrunnelserMultiselect />
+                <BegrunnelserMultiselect vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type} />
 
                 <FritekstVedtakbegrunnelser />
             </SkjemaGruppe>

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -6,7 +6,11 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { IBehandling } from '../../../../../typer/behandling';
 import { IFagsak } from '../../../../../typer/fagsak';
-import { IVedtaksperiodeMedBegrunnelser } from '../../../../../typer/vedtaksperiode';
+import {
+    IVedtaksperiodeMedBegrunnelser,
+    Vedtaksperiodetype,
+} from '../../../../../typer/vedtaksperiode';
+import { partition } from '../../../../../utils/commons';
 import { hentAktivVedtakPåBehandlig } from '../../../../../utils/fagsak';
 import { useVedtaksbegrunnelseTekster } from '../Context/VedtaksbegrunnelseTeksterContext';
 import { VedtaksperiodeMedBegrunnelserProvider } from '../Context/VedtaksperiodeMedBegrunnelserContext';
@@ -33,13 +37,39 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
         return <AlertStripeFeil>Klarte ikke å hente inn begrunnelser for vedtak.</AlertStripeFeil>;
     }
 
+    const avslagOgResterende = partition(
+        vedtaksperiode => vedtaksperiode.type === Vedtaksperiodetype.AVSLAG,
+        vedtaksperioderMedBegrunnelser
+    );
+
     return vedtaksperioderMedBegrunnelser.length > 0 ? (
         <>
             <OverskriftMedHjelpetekst
                 overskrift={'Begrunnelser i vedtaksbrev'}
                 hjelpetekst={'Her skal du sette begrunnelsestekster for fortsatt innvilgelse'}
             />
-            {vedtaksperioderMedBegrunnelser.map(
+            {avslagOgResterende[1].map(
+                (vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (
+                    <VedtaksperiodeMedBegrunnelserProvider
+                        key={vedtaksperiodeMedBegrunnelser.id}
+                        fagsak={fagsak}
+                        åpenBehandling={åpenBehandling}
+                        vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
+                    >
+                        <VedtaksperiodeMedBegrunnelserPanel
+                            vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
+                        />
+                    </VedtaksperiodeMedBegrunnelserProvider>
+                )
+            )}
+
+            <OverskriftMedHjelpetekst
+                overskrift={'Begrunnelser for avslag i vedtaksbrev'}
+                hjelpetekst={
+                    'Her har vi hentet begrunnelsestekster for avslag som du har satt i vilkårsvurderingen.'
+                }
+            />
+            {avslagOgResterende[0].map(
                 (vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (
                     <VedtaksperiodeMedBegrunnelserProvider
                         key={vedtaksperiodeMedBegrunnelser.id}

--- a/src/frontend/utils/commons.ts
+++ b/src/frontend/utils/commons.ts
@@ -28,3 +28,13 @@ export const sjekkTilgangTilPerson = (personRes: Ressurs<IPersonInfo>): Ressurs<
         return personRes;
     }
 };
+
+// Skamløst knabba herfra https://gist.github.com/zachlysobey/71ac85046d0d533287ed85e1caa64660
+export function partition<T>(predicate: (val: T) => boolean, arr: Array<T>): [Array<T>, Array<T>] {
+    const partitioned: [Array<T>, Array<T>] = [[], []];
+    arr.forEach((val: T) => {
+        const partitionIndex: 0 | 1 = predicate(val) ? 0 : 1;
+        partitioned[partitionIndex].push(val);
+    });
+    return partitioned;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,6 +1590,28 @@
     nav-frontend-typografi "^3.1.1"
     react-select "^4.0.13"
 
+"@navikt/familie-form-elements@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@navikt/familie-form-elements/-/familie-form-elements-3.0.3.tgz#4391f696ca54e491d142f6a8ca58bcb2a4c41c5d"
+  integrity sha512-mCL/Qg7m+deUZe6+OHy7TG26jOY4hQoQOXBUvCZXvs730gThJ5g3JFB7pgx7Wb98b6rZEBoNkEV8/ugj8g3E8Q==
+  dependencies:
+    "@navikt/fnrvalidator" "^1.1.3"
+    "@types/classnames" "^2.2.10"
+    "@types/react-select" "^3.0.28"
+    classnames "^2.2.6"
+    dayjs "^1.10.4"
+    nav-datovelger "^11.0.0"
+    nav-frontend-knapper "^2.1.2"
+    nav-frontend-knapper-style "^1.1.2"
+    nav-frontend-lenker "^1.1.1"
+    nav-frontend-lenker-style "^1.1.1"
+    nav-frontend-skjema "^3.2.1"
+    nav-frontend-skjema-style "^2.2.1"
+    nav-frontend-toggle "^1.1.2"
+    nav-frontend-toggle-style "^1.1.2"
+    nav-frontend-typografi "^3.1.1"
+    react-select "^4.0.13"
+
 "@navikt/familie-header@^3.0.17":
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/@navikt/familie-header/-/familie-header-3.0.17.tgz#727b26856540e2b6a396b4f9719275018b1c9e5c"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Inkluderer denne oppdateringa i mutliselectlesevisning: https://github.com/navikt/familie-felles-frontend/pull/402 
+ visning av avslagsbegrunnelser på denne måten 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Må gjøre en avsjekk med Gunn og Camilla.
Fjerner gammel funksjonalitet i egen pr. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
![Skjermbilde 2021-06-15 kl  15 55 27](https://user-images.githubusercontent.com/5719550/122085414-faeca000-ce02-11eb-8439-dfb184af57ca.png)
