### PR TITLE
Støtt fritekster for vedtaksperioder

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -227,13 +227,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                             </Alertstripe>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>
-                                {brukNyeVedtaksperioder ? (
-                                    <VedtaksperioderMedBegrunnelser
-                                        fagsak={fagsak}
-                                        åpenBehandling={åpenBehandling}
-                                        erLesevisning={erLesevisning()}
-                                    />
-                                ) : (
+                                {brukNyeVedtaksperioder && ( // TODO: Husk å switche toggle før merge
                                     <VedtakBegrunnelserProvider
                                         fagsak={fagsak}
                                         aktivVedtak={aktivVedtak}
@@ -242,6 +236,11 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                                         <AvslagBegrunnelser åpenBehandling={åpenBehandling} />
                                     </VedtakBegrunnelserProvider>
                                 )}
+                                <VedtaksperioderMedBegrunnelser
+                                    fagsak={fagsak}
+                                    åpenBehandling={åpenBehandling}
+                                    erLesevisning={erLesevisning()}
+                                />
                             </VedtaksbegrunnelseTeksterProvider>
                         )}
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -227,7 +227,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                             </Alertstripe>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>
-                                {!brukNyeVedtaksperioder && (
+                                {brukNyeVedtaksperioder && (
                                     <VedtakBegrunnelserProvider
                                         fagsak={fagsak}
                                         aktivVedtak={aktivVedtak}

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -227,7 +227,13 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                             </Alertstripe>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>
-                                {brukNyeVedtaksperioder && ( // TODO: Husk å switche toggle før merge
+                                {brukNyeVedtaksperioder ? (
+                                    <VedtaksperioderMedBegrunnelser
+                                        fagsak={fagsak}
+                                        åpenBehandling={åpenBehandling}
+                                        erLesevisning={erLesevisning()}
+                                    />
+                                ) : (
                                     <VedtakBegrunnelserProvider
                                         fagsak={fagsak}
                                         aktivVedtak={aktivVedtak}
@@ -236,11 +242,6 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                                         <AvslagBegrunnelser åpenBehandling={åpenBehandling} />
                                     </VedtakBegrunnelserProvider>
                                 )}
-                                <VedtaksperioderMedBegrunnelser
-                                    fagsak={fagsak}
-                                    åpenBehandling={åpenBehandling}
-                                    erLesevisning={erLesevisning()}
-                                />
                             </VedtaksbegrunnelseTeksterProvider>
                         )}
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -227,7 +227,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                             </Alertstripe>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>
-                                {brukNyeVedtaksperioder && ( // TODO: Husk å switche toggle før merge
+                                {!brukNyeVedtaksperioder && (
                                     <VedtakBegrunnelserProvider
                                         fagsak={fagsak}
                                         aktivVedtak={aktivVedtak}

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -227,7 +227,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ fagsak, åp
                             </Alertstripe>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>
-                                {brukNyeVedtaksperioder && (
+                                {brukNyeVedtaksperioder && ( // TODO: Husk å switche toggle før merge
                                     <VedtakBegrunnelserProvider
                                         fagsak={fagsak}
                                         aktivVedtak={aktivVedtak}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -277,6 +277,7 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
                     },
                     (fagsak: Ressurs<IFagsak>) => {
                         settFagsak(fagsak);
+                        onPanelClose(false);
                     }
                 );
             }

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -206,7 +206,16 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
 
                     break;
                 case 'clear':
-                    skjema.felter.begrunnelser.validerOgSettFelt([]);
+                    if (
+                        skjema.felter.fritekster.verdi.length > 0 &&
+                        vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.FORTSATT_INNVILGET
+                    ) {
+                        alert(
+                            'Fritekst kan kun brukes i kombinasjon med en eller flere begrunnelser. Legg først til en ny begrunnelse eller fjern friteksten(e).'
+                        );
+                    } else {
+                        skjema.felter.begrunnelser.validerOgSettFelt([]);
+                    }
 
                     break;
                 default:

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -40,7 +40,9 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
     ({ åpenBehandling, vedtaksperiodeMedBegrunnelser }: IProps) => {
         const { settFagsak } = useFagsakRessurser();
         const [erPanelEkspandert, settErPanelEkspandert] = useState(
-            åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING
+            åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING &&
+                vedtaksperiodeMedBegrunnelser.begrunnelser.length === 0 &&
+                vedtaksperiodeMedBegrunnelser.fritekster.length === 0
         );
 
         const maksAntallKulepunkter =

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelsePanel.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Element } from 'nav-frontend-typografi';
-
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { IBehandling } from '../../../../typer/behandling';
 import { IRestVedtakBegrunnelse, VedtakBegrunnelseType } from '../../../../typer/vedtak';
@@ -62,7 +60,6 @@ const VedtakBegrunnelsePanel: React.FC<IVedtakBegrunnelserTabell> = ({
                     <div />
                 )}
                 <div>
-                    <Element style={{ marginBottom: '0.5rem' }}>Begrunnelser i brev</Element>
                     <VedtakBegrunnelserMultiselect
                         erLesevisning={erLesevisning()}
                         personResultater={åpenBehandling.personResultater}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelserMultiselect.tsx
@@ -2,7 +2,6 @@ import React, { CSSProperties } from 'react';
 
 import styled from 'styled-components';
 
-import navFarger from 'nav-frontend-core';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 import {
@@ -103,14 +102,6 @@ const VedtakBegrunnelserMultiselect: React.FC<IVedtakBegrunnelseMultiselect> = (
                     whiteSpace: 'pre-wrap',
                     textOverflow: 'hidden',
                     overflow: 'hidden',
-                }),
-                multiValueRemove: (provided: CSSProperties) => ({
-                    ...provided,
-                    ':hover': {
-                        backgroundColor: navFarger.navBla,
-                        color: 'white',
-                        borderRadius: '0 .4rem .4rem 0',
-                    },
                 }),
             }}
             placeholder={'Velg begrunnelse(r)'}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtakBegrunnelserMultiselect.tsx
@@ -117,7 +117,7 @@ const VedtakBegrunnelserMultiselect: React.FC<IVedtakBegrunnelseMultiselect> = (
             isLoading={vedtakBegrunnelseSubmit.status === RessursStatus.HENTER}
             isDisabled={erLesevisning || vedtakBegrunnelseSubmit.status === RessursStatus.HENTER}
             feil={submitForPeriode?.feilmelding}
-            label="Velg standardtekst"
+            label="Velg standardtekst i brev"
             creatable={false}
             erLesevisning={erLesevisning}
             isMulti={true}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -2,7 +2,6 @@ import React, { CSSProperties, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import navFarger from 'nav-frontend-core';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 import {
@@ -88,14 +87,6 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
                     whiteSpace: 'pre-wrap',
                     textOverflow: 'hidden',
                     overflow: 'hidden',
-                }),
-                multiValueRemove: (provided: CSSProperties) => ({
-                    ...provided,
-                    ':hover': {
-                        backgroundColor: navFarger.navBla,
-                        color: 'white',
-                        borderRadius: '0 .4rem .4rem 0',
-                    },
                 }),
             }}
             placeholder={'Velg begrunnelse(r)'}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -101,7 +101,7 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
             placeholder={'Velg begrunnelse(r)'}
             isDisabled={skalIkkeEditeres || skjema.submitRessurs.status === RessursStatus.HENTER}
             feil={skjema.visFeilmeldinger ? begrunnelser.feilmelding : undefined}
-            label="Velg standardtekst"
+            label="Velg standardtekst i brev"
             creatable={false}
             erLesevisning={skalIkkeEditeres}
             isMulti={true}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -35,6 +35,11 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
         putVedtaksperiodeMedBegrunnelser,
     } = useVedtaksperiodeMedBegrunnelser();
 
+    const visFritekster = () =>
+        vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.FORTSATT_INNVILGET ||
+        (vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.UTBETALING &&
+            skjema.felter.begrunnelser.verdi.length > 0);
+
     return (
         <EkspanderbartBegrunnelsePanel
             vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
@@ -50,9 +55,7 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
             <SkjemaGruppe feil={skjema.visFeilmeldinger && skjemaFeilmelding()}>
                 <Element style={{ marginBottom: '0.5rem' }}>Begrunnelser i brev</Element>
                 <BegrunnelserMultiselect vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type} />
-                {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.UTBETALING && (
-                    <FritekstVedtakbegrunnelser />
-                )}
+                {visFritekster() && <FritekstVedtakbegrunnelser />}
             </SkjemaGruppe>
 
             <Knapperekke>

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { SkjemaGruppe } from 'nav-frontend-skjema';
-import { Element } from 'nav-frontend-typografi';
 
 import { FamilieKnapp } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -53,7 +52,6 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
             )}
 
             <SkjemaGruppe feil={skjema.visFeilmeldinger && skjemaFeilmelding()}>
-                <Element style={{ marginBottom: '0.5rem' }}>Begrunnelser i brev</Element>
                 <BegrunnelserMultiselect vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type} />
                 {visFritekster() && <FritekstVedtakbegrunnelser />}
             </SkjemaGruppe>

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -69,12 +69,14 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
                 )
             )}
 
-            <OverskriftMedHjelpetekst
-                overskrift={'Begrunnelser for avslag i vedtaksbrev'}
-                hjelpetekst={
-                    'Her har vi hentet begrunnelsestekster for avslag som du har satt i vilkårsvurderingen.'
-                }
-            />
+            {avslagOgResterende[0].length > 0 && (
+                <OverskriftMedHjelpetekst
+                    overskrift={'Begrunnelser for avslag i vedtaksbrev'}
+                    hjelpetekst={
+                        'Her har vi hentet begrunnelsestekster for avslag som du har satt i vilkårsvurderingen.'
+                    }
+                />
+            )}
             {avslagOgResterende[0].map(
                 (vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (
                     <VedtaksperiodeMedBegrunnelserProvider

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -68,8 +68,7 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
                     </VedtaksperiodeMedBegrunnelserProvider>
                 )
             )}
-
-            {avslagOgResterende[0].length > 0 && (
+            {avslagOgResterende[0] && (
                 <OverskriftMedHjelpetekst
                     overskrift={'Begrunnelser for avslag i vedtaksbrev'}
                     hjelpetekst={

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -101,7 +101,7 @@ const AvslagBegrunnelseMultiselect: React.FC<IProps> = ({
     return (
         <FamilieReactSelect
             value={valgteBegrunnlser}
-            label={'Velg standardtekst'}
+            label={'Velg standardtekst i brev'}
             creatable={false}
             placeholder={'Velg begrunnelse(r)'}
             isLoading={vilkårSubmit !== VilkårSubmit.NONE}


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5347
Fikser logikk og validering for fritekstbegrunnelser med nytt format for vedtaksperioder
- lukk panel ved lagre
- feilmelding om man prøver å slette multiselectbegrunnelser når fritekster finnes
- mulighet for å legge til tre fritekster når ikke fortsatt_innvilget 
- 
I tillegg: 
- mindre tekstjusteringer etter gjennomgang med CAmilla
- gjenbruk av gammel logikk for å hente ut korrekte begrunnelser til multiselect
- styling av multiselect i lesevisning, slik at ikke knapper synes da 

Beklager glissen pr-beskrivelse og favrokort. 