### PR TITLE
Sidefiltrering i venstremeny og redirect

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -52,6 +52,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
         ? false
         : fagsak.behandlinger.length > 0 && kanOppretteBehandling;
     const visTekniskOpphør = revurderingEnabled && toggles[ToggleNavn.visTekniskOpphør];
+    const visManuellSatsendring = revurderingEnabled && toggles[ToggleNavn.manuellSatsendring];
 
     return (
         <>
@@ -110,7 +111,8 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                         .filter(
                             årsak =>
                                 årsak !== BehandlingÅrsak.TEKNISK_OPPHØR &&
-                                årsak !== BehandlingÅrsak.FØDSELSHENDELSE
+                                årsak !== BehandlingÅrsak.FØDSELSHENDELSE &&
+                                (visManuellSatsendring || årsak !== BehandlingÅrsak.SATSENDRING)
                         )
                         .map(årsak => {
                             return (

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -101,10 +101,15 @@ export const erSidenAktiv = (side: ISide, behandling: IBehandling): boolean => {
 };
 
 export const visSide = (side: ISide, åpenBehandling: IBehandling) => {
-    if (åpenBehandling.skalBehandlesAutomatisk || åpenBehandling.årsak !== BehandlingÅrsak.SØKNAD) {
-        return side.steg !== BehandlingSteg.REGISTRERE_SØKNAD;
-    } else {
-        return true;
+    switch (side) {
+        case sider.REGISTRERE_SØKNAD:
+            return åpenBehandling.årsak === BehandlingÅrsak.SØKNAD;
+        case sider.SIMULERING:
+            return !åpenBehandling.skalBehandlesAutomatisk;
+        case sider.VEDTAK:
+            return åpenBehandling.årsak !== BehandlingÅrsak.SATSENDRING;
+        default:
+            return true;
     }
 };
 

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -9,6 +9,7 @@ export enum ToggleNavn {
     journalpostliste = 'familie-ba-sak.behandling.journalpostliste',
     brukNyeVedtaksperioder = 'familie-ba-sak.behandling.vedtakstype-med-begrunnelser',
     brukErDeltBosted = 'familie-ba-sak.behandling.delt_bosted',
+    manuellSatsendring = 'familie-ba-sak.manuell-satsendring',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
- Ikke vis simulering i sidemeny ved automatiske behandlinger 
- Ikke vis vedtak ved satsendring hvor ikke brev er generert
- Fiks redirect fra saksoversikten når ikek vedtakside skal vises 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Relevant for denne, men steg for behandlingene backend må uansett gjennomgås: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5555 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
![Skjermbilde 2021-06-29 kl  15 01 12](https://user-images.githubusercontent.com/5719550/123801829-ede3ac80-d8ea-11eb-80bf-269fb460289f.png)
