### PR TITLE
Forhåndsvis brevbegrunnelser

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -55,7 +55,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
         ? false
         : fagsak.behandlinger.length > 0 && kanOppretteBehandling;
     const visTekniskOpphør = revurderingEnabled && toggles[ToggleNavn.visTekniskOpphør];
-    const visManuellSatsendring = revurderingEnabled && toggles[ToggleNavn.manuellSatsendring];
     const kanOppretteTilbakekreving = !manuellJournalfør && toggles[ToggleNavn.tilbakekreving];
 
     return (
@@ -128,7 +127,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                             årsak =>
                                 årsak !== BehandlingÅrsak.TEKNISK_OPPHØR &&
                                 årsak !== BehandlingÅrsak.FØDSELSHENDELSE &&
-                                (visManuellSatsendring || årsak !== BehandlingÅrsak.SATSENDRING)
+                                årsak !== BehandlingÅrsak.SATSENDRING
                         )
                         .map(årsak => {
                             return (

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -49,6 +49,9 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
                 vedtaksperiodeMedBegrunnelser.fritekster.length === 0
         );
         const [standardBegrunnelserPut, settStandardBegrunnelserPut] = useState(byggTomRessurs());
+        const [genererteBrevbegrunnelser, settGenererteBrevbegrunnelser] = useState<
+            Ressurs<string[]>
+        >(byggTomRessurs());
 
         const maksAntallKulepunkter =
             vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.FORTSATT_INNVILGET ? 1 : 3;
@@ -125,6 +128,7 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
         useEffect(() => {
             if (vedtaksbegrunnelseTekster.status === RessursStatus.SUKSESS) {
                 populerSkjemaFraBackend();
+                genererOgSettBegrunnelserForForhåndsvisning(vedtaksperiodeMedBegrunnelser.id);
             }
         }, [vedtaksbegrunnelseTekster, vedtaksperiodeMedBegrunnelser]);
 
@@ -220,6 +224,28 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
             });
         };
 
+        const genererOgSettBegrunnelserForForhåndsvisning = (vedtaksperiodeId: number) => {
+            settGenererteBrevbegrunnelser(byggHenterRessurs());
+            request<void, string[]>({
+                method: 'GET',
+                url: `/familie-ba-sak/api/vedtaksperioder/brevbegrunnelser/${vedtaksperiodeId}`,
+            }).then((hentedeBegrunnelser: Ressurs<string[]>) => {
+                if (hentedeBegrunnelser.status === RessursStatus.SUKSESS) {
+                    settGenererteBrevbegrunnelser(hentedeBegrunnelser);
+                } else if (hentedeBegrunnelser.status === RessursStatus.FUNKSJONELL_FEIL) {
+                    settGenererteBrevbegrunnelser(
+                        byggFeiletRessurs(hentedeBegrunnelser.frontendFeilmelding)
+                    );
+                } else {
+                    settGenererteBrevbegrunnelser(
+                        byggFeiletRessurs(
+                            'Klarte ikke generere forhåndsvisning av brevbegrunnelser'
+                        )
+                    );
+                }
+            });
+        };
+
         const leggTilFritekst = () => {
             skjema.felter.fritekster.validerOgSettFelt([
                 ...skjema.felter.fritekster.verdi,
@@ -279,6 +305,7 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
             utbetalingsperiode,
             åpenBehandling,
             standardBegrunnelserPut,
+            genererteBrevbegrunnelser,
         };
     }
 );

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -14,9 +14,11 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { useApp } from '../../../../../context/AppContext';
 import { useFagsakRessurser } from '../../../../../context/FagsakContext';
 import { Behandlingstype, IBehandling } from '../../../../../typer/behandling';
 import { IFagsak } from '../../../../../typer/fagsak';
+import { ToggleNavn } from '../../../../../typer/toggles';
 import { VedtakBegrunnelse } from '../../../../../typer/vedtak';
 import {
     hentGjeldendeUtbetalingsperiodePåBehandlingOgPeriode,
@@ -42,6 +44,7 @@ export interface IFritekstFelt {
 const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] = constate(
     ({ åpenBehandling, vedtaksperiodeMedBegrunnelser }: IProps) => {
         const { settFagsak } = useFagsakRessurser();
+        const { toggles } = useApp();
         const { request } = useHttp();
         const [erPanelEkspandert, settErPanelEkspandert] = useState(
             åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING &&
@@ -128,7 +131,12 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
         useEffect(() => {
             if (vedtaksbegrunnelseTekster.status === RessursStatus.SUKSESS) {
                 populerSkjemaFraBackend();
-                genererOgSettBegrunnelserForForhåndsvisning(vedtaksperiodeMedBegrunnelser.id);
+                if (
+                    vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.AVSLAG ||
+                    toggles[ToggleNavn.forhåndsvisAlleBrevbegrunnelser]
+                ) {
+                    genererOgSettBegrunnelserForForhåndsvisning(vedtaksperiodeMedBegrunnelser.id);
+                }
             }
         }, [vedtaksbegrunnelseTekster, vedtaksperiodeMedBegrunnelser]);
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+import { Element, Normaltekst } from 'nav-frontend-typografi';
+
+import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
+
 import { VedtakBegrunnelseType } from '../../../../../typer/vedtak';
 import {
     IVedtaksperiodeMedBegrunnelser,
@@ -22,6 +26,7 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
         erPanelEkspandert,
         onPanelClose,
         utbetalingsperiode,
+        genererteBrevbegrunnelser,
     } = useVedtaksperiodeMedBegrunnelser();
 
     const visFritekster = () =>
@@ -42,9 +47,20 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
                 />
             )}
             <BegrunnelserMultiselect vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type} />
+            {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS && (
+                <>
+                    <Element>Begrunnelse(r)</Element>
+                    <ul>
+                        {genererteBrevbegrunnelser.data.map((begrunnelse: string) => (
+                            <li>
+                                <Normaltekst children={begrunnelse} />
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
             {visFritekster() && <FritekstVedtakbegrunnelser />}
         </EkspanderbartBegrunnelsePanel>
     );
 };
-
 export default VedtaksperiodeMedBegrunnelserPanel;

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -4,6 +4,8 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
 
+import { useApp } from '../../../../../context/AppContext';
+import { ToggleNavn } from '../../../../../typer/toggles';
 import { VedtakBegrunnelseType } from '../../../../../typer/vedtak';
 import {
     IVedtaksperiodeMedBegrunnelser,
@@ -28,6 +30,10 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
         utbetalingsperiode,
         genererteBrevbegrunnelser,
     } = useVedtaksperiodeMedBegrunnelser();
+    const { toggles } = useApp();
+    const forhåndvisBegrunnelsetekster =
+        vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.AVSLAG ||
+        toggles[ToggleNavn.forhåndsvisAlleBrevbegrunnelser];
 
     const visFritekster = () =>
         vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.UTBETALING ||
@@ -47,18 +53,19 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
                 />
             )}
             <BegrunnelserMultiselect vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type} />
-            {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS && (
-                <>
-                    <Element>Begrunnelse(r)</Element>
-                    <ul>
-                        {genererteBrevbegrunnelser.data.map((begrunnelse: string) => (
-                            <li>
-                                <Normaltekst children={begrunnelse} />
-                            </li>
-                        ))}
-                    </ul>
-                </>
-            )}
+            {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS &&
+                forhåndvisBegrunnelsetekster && (
+                    <>
+                        <Element>Begrunnelse(r)</Element>
+                        <ul>
+                            {genererteBrevbegrunnelser.data.map((begrunnelse: string) => (
+                                <li>
+                                    <Normaltekst children={begrunnelse} />
+                                </li>
+                            ))}
+                        </ul>
+                    </>
+                )}
             {visFritekster() && <FritekstVedtakbegrunnelser />}
         </EkspanderbartBegrunnelsePanel>
     );

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -9,7 +9,7 @@ export enum ToggleNavn {
     journalpostliste = 'familie-ba-sak.behandling.journalpostliste',
     brukNyeVedtaksperioder = 'familie-ba-sak.behandling.vedtakstype-med-begrunnelser',
     brukErDeltBosted = 'familie-ba-sak.behandling.delt_bosted',
-    manuellSatsendring = 'familie-ba-sak.manuell-satsendring',
+    forhåndsvisAlleBrevbegrunnelser = 'familie-ba-sak.forhaandsvis-alle-brevbegrunnelser',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5566
Backend: https://github.com/navikt/familie-ba-sak/pull/1225 

Legger til forhåndsvisning av begrunnelser. For avslag vises alltid, slik som tidligere, så da trenger vi ikke varsle om tap av funksjonalitet her @MarcusGustafson74 . 

I tillegg er det bare å slå på toggle for å få forhåndsvisning for alle andre vedtakstyper.


### 🔎️ Er det noe spesielt du ønsker å fremheve?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Eksempel når alt er slått på 

https://user-images.githubusercontent.com/5719550/124754433-82bd5a00-df2a-11eb-8cb8-352c706dadf9.mov

