### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,4 @@
 version: 2
-registries:
-  npm-registry-npm-pkg-github-com-navikt-data-catalog-components:
-    type: npm-registry
-    url: https://npm.pkg.github.com/@navikt/data-catalog-components
-    token: "${{secrets.NPM_REGISTRY_NPM_PKG_GITHUB_COM_NAVIKT_DATA_CATALOG_COMPONENTS_TOKEN}}"
-  npm-registry-npm-pkg-github-com-deetly-plotly-view:
-    type: npm-registry
-    url: https://npm.pkg.github.com/@deetly/plotly-view
-    token: "${{secrets.NPM_REGISTRY_NPM_PKG_GITHUB_COM_DEETLY_PLOTLY_VIEW_TOKEN}}"
 
 updates:
 - package-ecosystem: npm
@@ -255,6 +246,3 @@ updates:
   - dependency-name: constate
     versions:
     - 3.2.0
-  registries:
-  - npm-registry-npm-pkg-github-com-navikt-data-catalog-components
-  - npm-registry-npm-pkg-github-com-deetly-plotly-view


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Siden den gamle dependabot ble skrudd av 3.august må vi oppgradere til å bruke github-native dependabot. 
Følger det EF har gjort https://github.com/navikt/familie-ef-sak-frontend/commit/f6211d99b1dd7a195fe93e60cc6a945cf5db61d1

