### PR TITLE
Fritekstplaceholder for dokumenttittel

### DIFF
--- a/src/frontend/komponenter/ManuellJournalfør/Dokument/EndreDokumentInfoPanel.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/Dokument/EndreDokumentInfoPanel.tsx
@@ -81,12 +81,17 @@ export const EndreDokumentInfoPanel: React.FC<IProps> = ({ dokument, visFeilmeld
                 erLesevisning={erLesevisning()}
                 creatable={true}
                 isClearable
+                placeholder={'Skriv fritekst for å endre tittel...'}
                 isMulti={false}
                 options={tittelList}
-                value={{
-                    value: dokumentFraSkjema?.tittel ?? '',
-                    label: dokumentFraSkjema?.tittel ?? '',
-                }}
+                value={
+                    !dokumentFraSkjema?.tittel || dokumentFraSkjema.tittel === ''
+                        ? null
+                        : {
+                              value: dokumentFraSkjema.tittel,
+                              label: dokumentFraSkjema.tittel,
+                          }
+                }
                 feil={
                     visFeilmeldinger && dokumentFraSkjema?.tittel === ''
                         ? 'Tittel er ikke satt'


### PR DESCRIPTION
Samme endring som for journalposttittel
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-5785

<img width="617" alt="Skjermbilde 2021-09-01 kl  16 37 08" src="https://user-images.githubusercontent.com/5719550/131691132-654055bb-9545-44fe-8b2b-01b1cfc0f0a3.png">
<img width="625" alt="Skjermbilde 2021-09-01 kl  16 37 15" src="https://user-images.githubusercontent.com/5719550/131691137-f2eeeeb4-5ebb-4aae-8917-f0af8c6e7712.png">
<img width="613" alt="Skjermbilde 2021-09-01 kl  16 37 30" src="https://user-images.githubusercontent.com/5719550/131691141-51ccc599-4b48-4c01-877c-a0f927b03828.png">
