### PR TITLE
Filtrer bort valg (legg til barn og behandlingstype)

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -81,7 +81,8 @@ const Behandlingsmeny: React.FC<IProps> = ({ fagsak }) => {
                     )}
                     {åpenBehandling.status === RessursStatus.SUKSESS &&
                         !erLesevisning() &&
-                        åpenBehandling.data.årsak !== BehandlingÅrsak.SØKNAD &&
+                        (åpenBehandling.data.årsak === BehandlingÅrsak.NYE_OPPLYSNINGER ||
+                            åpenBehandling.data.årsak === BehandlingÅrsak.KLAGE) &&
                         toggles[ToggleNavn.brukLeggTilBarnPåBehandling] && (
                             <li>
                                 <LeggTilBarnPBehandling

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -55,7 +55,8 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
         ? false
         : fagsak.behandlinger.length > 0 && kanOppretteBehandling;
     const visTekniskOpphør = revurderingEnabled && toggles[ToggleNavn.visTekniskOpphør];
-    const kanOppretteTilbakekreving = !manuellJournalfør && toggles[ToggleNavn.tilbakekreving];
+    const kanOppretteTilbakekreving =
+        revurderingEnabled && !manuellJournalfør && toggles[ToggleNavn.tilbakekreving];
 
     return (
         <>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
- ikke mulig å legge til barn på andre behandlingstyper enn NYE_OPPLYSNINGER og KLAGE
- ikke mulig å opprette tilbakekreving hvis det ikke finnes behandling fra før
