### PR TITLE
Bugfix: tidslinjesortering

### DIFF
--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -6,7 +6,6 @@ import { useTidslinje } from '../../../context/TidslinjeContext';
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { Vedtaksperiode } from '../../../typer/vedtaksperiode';
-import { sorterFødselsdato } from '../../../utils/formatter';
 import { periodeOverlapperMedValgtDato } from '../../../utils/kalender';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
 import { Oppsummeringsboks } from './Oppsummeringsboks';
@@ -50,7 +49,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
     const grunnlagPersoner = filterGrunnlagPersonerMedAndeler(
         åpenBehandling.personer,
         åpenBehandling.personerMedAndelerTilkjentYtelse
-    ).sort((personA, personB) => sorterFødselsdato(personA.fødselsdato, personB.fødselsdato));
+    );
 
     const tidslinjePersoner = filterAndelPersonerIGrunnlag(
         grunnlagPersoner,


### PR DESCRIPTION
Fikser sortering på tidslinja i prod: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-6310

I et forsøk på å forenkle og tydeliggjøre litt (https://github.com/navikt/familie-ba-sak-frontend/pull/1403) forsvant sortering i en av funksjonene, da man var prisgitt at sorteringa på den **ene** lista som kom inn ble bevart i output. Det bør kun påvirke `filterOgSorterAndelPersonerIGrunnlag`, men legger også til sortering i `filterOgSorterGrunnlagPersonerMedAndeler` slik at det blir tydelig at sorteringa er vesentlig og man alltid får samme rekkefølge. 