### PR TITLE
Dokumentoversikt/endre bredde på kolonner

### DIFF
--- a/src/frontend/komponenter/Fagsak/journalposter/JournalpostListe.tsx
+++ b/src/frontend/komponenter/Fagsak/journalposter/JournalpostListe.tsx
@@ -162,13 +162,13 @@ const JournalpostListe: React.FC<IProps> = ({ bruker }) => {
 
                 <StyledTabell className="tabell tabell--stripet">
                     <colgroup>
-                        <col style={{ width: '5%' }} />
-                        <col style={{ width: '5%', minWidth: '12rem' }} />
+                        <col style={{ width: '3rem' }} />
+                        <col style={{ width: '10rem' }} />
                         <col style={{ width: '25%' }} />
-                        <col style={{ width: '15%', minWidth: '12rem' }} />
+                        <col style={{ width: '15%' }} />
                         <col style={{ width: '20%' }} />
-                        <col style={{ width: '25%' }} />
-                        <col style={{ width: '5%', minWidth: '8rem' }} />
+                        <col style={{ width: '23%' }} />
+                        <col style={{ width: '7%' }} />
                     </colgroup>
                     <thead>
                         <tr>
@@ -295,7 +295,13 @@ const JournalpostListe: React.FC<IProps> = ({ bruker }) => {
                                             {journalpost.tittel}
                                         </EllipsisNormaltekst>
                                     </Td>
-                                    <Td>{journalpoststatus[journalpost.journalstatus]}</Td>
+                                    <Td>
+                                        <EllipsisNormaltekst
+                                            title={journalpoststatus[journalpost.journalstatus]}
+                                        >
+                                            {journalpoststatus[journalpost.journalstatus]}
+                                        </EllipsisNormaltekst>
+                                    </Td>
                                 </tr>
                             )
                         )}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Rette opp rar styling-bug hvor bredden på kolonnene i dokumentoversikten oppførte seg annerledes i Chrome SKSS. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
