### PR TITLE
Bug/validering på begrunnelse

### DIFF
--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -96,6 +96,8 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 }),
                 begrunnelse: useFelt<string | undefined>({
                     verdi: endretUtbetalingAndel.begrunnelse,
+                    valideringsfunksjon: felt =>
+                        felt.verdi ? ok(felt) : feil(felt, 'Du må oppgi en begrunnelse.'),
                 }),
             },
             skjemanavn: 'Endre utbetalingsperiode',

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelRad.tsx
@@ -23,6 +23,8 @@ interface IEndretUtbetalingAndelRadProps {
     åpenBehandling: IBehandling;
     settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
     settFeilmelding: (feilmelding: string) => void;
+    visFeilmeldinger: boolean;
+    opprettelseFeilmelding?: string;
 }
 
 const StyledCollapseIkon = styled(Collapse)`
@@ -38,6 +40,8 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
     åpenBehandling,
     settVisFeilmeldinger,
     settFeilmelding,
+    visFeilmeldinger,
+    opprettelseFeilmelding = '',
 }) => {
     const [åpenUtbetalingsAndel, settÅpenUtbetalingsAndel] = useState<boolean>(
         endretUtbetalingAndel.personIdent === null
@@ -96,7 +100,8 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
             <tr>
                 <td>
                     {formaterIdent(
-                        endretUtbetalingAndel.personIdent ? endretUtbetalingAndel.personIdent : ''
+                        endretUtbetalingAndel.personIdent ? endretUtbetalingAndel.personIdent : '',
+                        'Ikke satt'
                     )}
                 </td>
                 <td>
@@ -143,6 +148,8 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
                             }}
                             settVisFeilmeldinger={settVisFeilmeldinger}
                             settFeilmelding={settFeilmelding}
+                            visFeilmeldinger={visFeilmeldinger}
+                            opprettelseFeilmelding={opprettelseFeilmelding}
                         />
                     </td>
                 </tr>

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelRad.tsx
@@ -22,10 +22,6 @@ import EndretUtbetalingAndelSkjema from './EndretUtbetalingAndelSkjema';
 interface IEndretUtbetalingAndelRadProps {
     endretUtbetalingAndel: IRestEndretUtbetalingAndel;
     åpenBehandling: IBehandling;
-    settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
-    settFeilmelding: (feilmelding: string) => void;
-    visFeilmeldinger: boolean;
-    opprettelseFeilmelding?: string;
 }
 
 const StyledCollapseIkon = styled(Collapse)`
@@ -43,10 +39,6 @@ const TdUtenUnderstrek = styled.td<{ erÅpen: boolean }>`
 const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRadProps> = ({
     endretUtbetalingAndel,
     åpenBehandling,
-    settVisFeilmeldinger,
-    settFeilmelding,
-    visFeilmeldinger,
-    opprettelseFeilmelding = '',
 }) => {
     const [åpenUtbetalingsAndel, settÅpenUtbetalingsAndel] = useState<boolean>(
         endretUtbetalingAndel.personIdent === null
@@ -138,10 +130,6 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
                             avbrytEndringAvUtbetalingsperiode={() => {
                                 settÅpenUtbetalingsAndel(false);
                             }}
-                            settVisFeilmeldinger={settVisFeilmeldinger}
-                            settFeilmelding={settFeilmelding}
-                            visFeilmeldinger={visFeilmeldinger}
-                            opprettelseFeilmelding={opprettelseFeilmelding}
                         />
                     </td>
                 </tr>

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelSkjema.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { Flatknapp, Knapp } from 'nav-frontend-knapper';
 import { Radio, SkjemaGruppe } from 'nav-frontend-skjema';
-import { Element, Normaltekst } from 'nav-frontend-typografi';
+import { Element, Feilmelding, Normaltekst } from 'nav-frontend-typografi';
 
 import { Delete } from '@navikt/ds-icons';
 import {
@@ -86,6 +86,8 @@ interface IEndretUtbetalingAndelSkjemaProps {
     avbrytEndringAvUtbetalingsperiode: () => void;
     settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
     settFeilmelding: (feilmelding: string) => void;
+    visFeilmeldinger: boolean;
+    opprettelseFeilmelding?: string;
 }
 
 const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAndelSkjemaProps> = ({
@@ -93,6 +95,8 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
     avbrytEndringAvUtbetalingsperiode,
     settVisFeilmeldinger,
     settFeilmelding,
+    visFeilmeldinger,
+    opprettelseFeilmelding = '',
 }) => {
     const { request } = useHttp();
     const { erLesevisning } = useBehandling();
@@ -382,8 +386,12 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
                         skjema.felter.begrunnelse.validerOgSettFelt(event.target.value);
                     }}
+                    feil={skjema.visFeilmeldinger && skjema.felter.begrunnelse.feilmelding}
                 />
             </Feltmargin>
+            {visFeilmeldinger && opprettelseFeilmelding !== '' && (
+                <Feilmelding>{opprettelseFeilmelding}</Feilmelding>
+            )}
             <Knapperekke>
                 <Knapperad>
                     <StyledFerdigKnapp

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelSkjema.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { Flatknapp, Knapp } from 'nav-frontend-knapper';
 import { Radio, SkjemaGruppe } from 'nav-frontend-skjema';
-import { Element, Feilmelding, Normaltekst } from 'nav-frontend-typografi';
+import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 import { Delete } from '@navikt/ds-icons';
 import {
@@ -35,6 +35,7 @@ import {
 } from '../../../typer/utbetalingAndel';
 import { datoformatNorsk } from '../../../utils/formatter';
 import { YearMonth } from '../../../utils/kalender';
+import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import IkonKnapp from '../../Felleskomponenter/IkonKnapp/IkonKnapp';
 import Knapperekke from '../../Felleskomponenter/Knapperekke';
 import MånedÅrVelger from '../../Felleskomponenter/MånedÅrInput/MånedÅrVelger';
@@ -82,19 +83,11 @@ const StyledFamilieTextarea = styled(FamilieTextarea)`
 interface IEndretUtbetalingAndelSkjemaProps {
     åpenBehandling: IBehandling;
     avbrytEndringAvUtbetalingsperiode: () => void;
-    settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
-    settFeilmelding: (feilmelding: string) => void;
-    visFeilmeldinger: boolean;
-    opprettelseFeilmelding?: string;
 }
 
 const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAndelSkjemaProps> = ({
     åpenBehandling,
     avbrytEndringAvUtbetalingsperiode,
-    settVisFeilmeldinger,
-    settFeilmelding,
-    visFeilmeldinger,
-    opprettelseFeilmelding = '',
 }) => {
     const { request } = useHttp();
     const { erLesevisning } = useBehandling();
@@ -130,18 +123,8 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 },
                 (fagsak: Ressurs<IFagsak>) => {
                     if (fagsak.status === RessursStatus.SUKSESS) {
-                        settVisFeilmeldinger(false);
                         avbrytEndringAvUtbetalingsperiode();
                         settFagsak(fagsak);
-                    }
-                },
-                (fagsak: Ressurs<IFagsak>) => {
-                    if (
-                        fagsak.status === RessursStatus.FUNKSJONELL_FEIL ||
-                        fagsak.status === RessursStatus.FEILET
-                    ) {
-                        settVisFeilmeldinger(true);
-                        settFeilmelding(fagsak.frontendFeilmelding);
                     }
                 }
             );
@@ -182,197 +165,202 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
     };
 
     return (
-        <StyledSkjemaGruppe>
-            <Feltmargin>
-                <StyledPersonvelger
-                    {...skjema.felter.person.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    label={<Element>Velg hvem det gjelder</Element>}
-                    value={tilOptionType(skjema.felter.person.verdi)}
-                    placeholder={'Velg person'}
-                    isMulti={false}
-                    onChange={(valg): void => {
-                        skjema.felter.person.validerOgSettFelt((valg as OptionType).value);
-                    }}
-                    options={åpenBehandling.personer.map(person => ({
-                        value: person.personIdent,
-                        label: person.personIdent,
-                    }))}
-                />
-            </Feltmargin>
-
-            <Feltmargin>
-                <Element>Fastsett andelsperiode</Element>
-                <MånedÅrVelger
-                    {...skjema.felter.fom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    label={
-                        <>
-                            <SkjultLegend>Fastsett andelsperiode </SkjultLegend>
-                            <Normaltekst>F.o.m</Normaltekst>
-                        </>
-                    }
-                    antallÅrFrem={finnÅrFremTilStønadTom()}
-                    antallÅrTilbake={finnÅrTilbakeTilStønadFra()}
-                    onEndret={(dato: YearMonth | undefined) =>
-                        skjema.felter.fom.validerOgSettFelt(dato)
-                    }
-                    lesevisning={erLesevisning()}
-                />
-                <MånedÅrVelger
-                    {...skjema.felter.tom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    label={
-                        <>
-                            <SkjultLegend>Fastsett andelsperiode </SkjultLegend>
-                            <Normaltekst>T.o.m</Normaltekst>
-                        </>
-                    }
-                    antallÅrFrem={finnÅrFremTilStønadTom()}
-                    antallÅrTilbake={finnÅrTilbakeTilStønadFra()}
-                    onEndret={(dato: YearMonth | undefined) => {
-                        skjema.felter.tom.validerOgSettFelt(dato);
-                    }}
-                    lesevisning={erLesevisning()}
-                />
-            </Feltmargin>
-
-            <Feltmargin>
-                <FamilieRadioGruppe
-                    legend={<Element>Skal perioden utbetales til søker?</Element>}
-                    erLesevisning={erLesevisning()}
-                >
-                    <Radio
-                        label={'Ja'}
-                        name={'skal perioden utbetales til søker?'}
-                        checked={skjema.felter.periodeSkalUtbetalesTilSøker.verdi}
-                        onChange={() =>
-                            skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(true)
-                        }
-                        id={'ja-perioden-utbetales-til-søker'}
+        <>
+            <StyledSkjemaGruppe feil={hentFrontendFeilmelding(skjema.submitRessurs)}>
+                <Feltmargin>
+                    <StyledPersonvelger
+                        {...skjema.felter.person.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                        label={<Element>Velg hvem det gjelder</Element>}
+                        value={tilOptionType(skjema.felter.person.verdi)}
+                        placeholder={'Velg person'}
+                        isMulti={false}
+                        onChange={(valg): void => {
+                            skjema.felter.person.validerOgSettFelt((valg as OptionType).value);
+                        }}
+                        options={åpenBehandling.personer.map(person => ({
+                            value: person.personIdent,
+                            label: person.personIdent,
+                        }))}
                     />
-                    <Radio
-                        label={'Nei'}
-                        name={'skal perioden utbetales til søker?'}
-                        checked={!skjema.felter.periodeSkalUtbetalesTilSøker.verdi}
-                        onChange={() =>
-                            skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(false)
+                </Feltmargin>
+
+                <Feltmargin>
+                    <Element>Fastsett andelsperiode</Element>
+                    <MånedÅrVelger
+                        {...skjema.felter.fom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                        label={
+                            <>
+                                <SkjultLegend>Fastsett andelsperiode </SkjultLegend>
+                                <Normaltekst>F.o.m</Normaltekst>
+                            </>
                         }
-                        id={'nei-perioden-skal-ikke-utbetales-til-søker'}
+                        antallÅrFrem={finnÅrFremTilStønadTom()}
+                        antallÅrTilbake={finnÅrTilbakeTilStønadFra()}
+                        onEndret={(dato: YearMonth | undefined) =>
+                            skjema.felter.fom.validerOgSettFelt(dato)
+                        }
+                        lesevisning={erLesevisning()}
                     />
-                </FamilieRadioGruppe>
-            </Feltmargin>
+                    <MånedÅrVelger
+                        {...skjema.felter.tom.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                        label={
+                            <>
+                                <SkjultLegend>Fastsett andelsperiode </SkjultLegend>
+                                <Normaltekst>T.o.m</Normaltekst>
+                            </>
+                        }
+                        antallÅrFrem={finnÅrFremTilStønadTom()}
+                        antallÅrTilbake={finnÅrTilbakeTilStønadFra()}
+                        onEndret={(dato: YearMonth | undefined) => {
+                            skjema.felter.tom.validerOgSettFelt(dato);
+                        }}
+                        lesevisning={erLesevisning()}
+                    />
+                </Feltmargin>
 
-            <Feltmargin>
-                <FamilieReactSelect
-                    {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    value={
-                        skjema.felter.årsak.verdi
-                            ? årsakTilOption(skjema.felter.årsak.verdi)
-                            : undefined
-                    }
-                    label={<Element>Årsak</Element>}
-                    placeholder={'Velg årsak'}
-                    isMulti={false}
-                    onChange={(valg): void => {
-                        skjema.felter.årsak.validerOgSettFelt((valg as ÅrsakOption).årsak);
-                    }}
-                    options={årsaker.map(årsak => årsakTilOption(årsak))}
-                />
-            </Feltmargin>
+                <Feltmargin>
+                    <FamilieRadioGruppe
+                        legend={<Element>Skal perioden utbetales til søker?</Element>}
+                        erLesevisning={erLesevisning()}
+                    >
+                        <Radio
+                            label={'Ja'}
+                            name={'skal perioden utbetales til søker?'}
+                            checked={skjema.felter.periodeSkalUtbetalesTilSøker.verdi}
+                            onChange={() =>
+                                skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(true)
+                            }
+                            id={'ja-perioden-utbetales-til-søker'}
+                        />
+                        <Radio
+                            label={'Nei'}
+                            name={'skal perioden utbetales til søker?'}
+                            checked={!skjema.felter.periodeSkalUtbetalesTilSøker.verdi}
+                            onChange={() =>
+                                skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(false)
+                            }
+                            id={'nei-perioden-skal-ikke-utbetales-til-søker'}
+                        />
+                    </FamilieRadioGruppe>
+                </Feltmargin>
 
-            <Feltmargin>
-                <StyledFamilieDatovelger
-                    {...skjema.felter.søknadstidspunkt.hentNavBaseSkjemaProps(
-                        skjema.visFeilmeldinger
-                    )}
-                    feil={!!skjema.felter.søknadstidspunkt.feilmelding && skjema.visFeilmeldinger}
-                    valgtDato={
-                        skjema.felter.søknadstidspunkt.verdi !== null
-                            ? skjema.felter.søknadstidspunkt.verdi
-                            : undefined
-                    }
-                    label={<Element>Søknadstidspunkt</Element>}
-                    placeholder={datoformatNorsk.DATO}
-                    onChange={(dato?: ISODateString) =>
-                        skjema.felter.søknadstidspunkt.validerOgSettFelt(dato)
-                    }
-                />
-                {skjema.felter.søknadstidspunkt.feilmelding && skjema.visFeilmeldinger && (
-                    <StyledFeilmelding>
-                        {skjema.felter.søknadstidspunkt.feilmelding}
-                    </StyledFeilmelding>
-                )}
-            </Feltmargin>
+                <Feltmargin>
+                    <FamilieReactSelect
+                        {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                        value={
+                            skjema.felter.årsak.verdi
+                                ? årsakTilOption(skjema.felter.årsak.verdi)
+                                : undefined
+                        }
+                        label={<Element>Årsak</Element>}
+                        placeholder={'Velg årsak'}
+                        isMulti={false}
+                        onChange={(valg): void => {
+                            skjema.felter.årsak.validerOgSettFelt((valg as ÅrsakOption).årsak);
+                        }}
+                        options={årsaker.map(årsak => årsakTilOption(årsak))}
+                    />
+                </Feltmargin>
 
-            {skjema.felter.avtaletidspunktDeltBosted.erSynlig && (
                 <Feltmargin>
                     <StyledFamilieDatovelger
-                        {...skjema.felter.avtaletidspunktDeltBosted.hentNavBaseSkjemaProps(
+                        {...skjema.felter.søknadstidspunkt.hentNavBaseSkjemaProps(
                             skjema.visFeilmeldinger
                         )}
                         feil={
-                            !!skjema.felter.avtaletidspunktDeltBosted.feilmelding &&
-                            skjema.visFeilmeldinger
+                            !!skjema.felter.søknadstidspunkt.feilmelding && skjema.visFeilmeldinger
                         }
                         valgtDato={
-                            skjema.felter.avtaletidspunktDeltBosted.verdi !== null
-                                ? skjema.felter.avtaletidspunktDeltBosted.verdi
+                            skjema.felter.søknadstidspunkt.verdi !== null
+                                ? skjema.felter.søknadstidspunkt.verdi
                                 : undefined
                         }
-                        label={<Element>Avtale om delt bosted</Element>}
+                        label={<Element>Søknadstidspunkt</Element>}
                         placeholder={datoformatNorsk.DATO}
                         onChange={(dato?: ISODateString) =>
-                            skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(dato)
+                            skjema.felter.søknadstidspunkt.validerOgSettFelt(dato)
                         }
                     />
-                    {skjema.felter.avtaletidspunktDeltBosted.feilmelding &&
-                        skjema.visFeilmeldinger && (
-                            <StyledFeilmelding>
-                                {skjema.felter.avtaletidspunktDeltBosted.feilmelding}
-                            </StyledFeilmelding>
-                        )}
+                    {skjema.felter.søknadstidspunkt.feilmelding && skjema.visFeilmeldinger && (
+                        <StyledFeilmelding>
+                            {skjema.felter.søknadstidspunkt.feilmelding}
+                        </StyledFeilmelding>
+                    )}
                 </Feltmargin>
-            )}
-            {skjema.felter.fullSats.erSynlig && (
-                <Feltmargin>
-                    <StyledSatsvelger
-                        {...skjema.felter.fullSats.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        label={<Element>Sats</Element>}
-                        value={
-                            skjema.felter.fullSats.verdi !== undefined
-                                ? satsTilOption(skjema.felter.fullSats.verdi)
-                                : undefined
-                        }
-                        placeholder={'Velg sats'}
-                        isMulti={false}
-                        onChange={(valg): void => {
-                            skjema.felter.fullSats.validerOgSettFelt((valg as SatsOption).fullSats);
-                        }}
-                        options={satser.map(sats =>
-                            satsTilOption(sats === IEndretUtbetalingAndelFullSats.FULL_SATS)
-                        )}
-                    />
-                </Feltmargin>
-            )}
 
-            <Feltmargin>
-                <StyledFamilieTextarea
-                    erLesevisning={erLesevisning()}
-                    placeholder={'Begrunn hvorfor det er gjort endringer på vilkåret.'}
-                    label={'Begrunnelse'}
-                    value={
-                        skjema.felter.begrunnelse.verdi !== null &&
-                        skjema.felter.begrunnelse.verdi !== undefined
-                            ? skjema.felter.begrunnelse.verdi
-                            : ''
-                    }
-                    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-                        skjema.felter.begrunnelse.validerOgSettFelt(event.target.value);
-                    }}
-                    feil={skjema.visFeilmeldinger && skjema.felter.begrunnelse.feilmelding}
-                />
-            </Feltmargin>
-            {visFeilmeldinger && opprettelseFeilmelding !== '' && (
-                <Feilmelding>{opprettelseFeilmelding}</Feilmelding>
-            )}
+                {skjema.felter.avtaletidspunktDeltBosted.erSynlig && (
+                    <Feltmargin>
+                        <StyledFamilieDatovelger
+                            {...skjema.felter.avtaletidspunktDeltBosted.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            feil={
+                                !!skjema.felter.avtaletidspunktDeltBosted.feilmelding &&
+                                skjema.visFeilmeldinger
+                            }
+                            valgtDato={
+                                skjema.felter.avtaletidspunktDeltBosted.verdi !== null
+                                    ? skjema.felter.avtaletidspunktDeltBosted.verdi
+                                    : undefined
+                            }
+                            label={<Element>Avtale om delt bosted</Element>}
+                            placeholder={datoformatNorsk.DATO}
+                            onChange={(dato?: ISODateString) =>
+                                skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(dato)
+                            }
+                        />
+                        {skjema.felter.avtaletidspunktDeltBosted.feilmelding &&
+                            skjema.visFeilmeldinger && (
+                                <StyledFeilmelding>
+                                    {skjema.felter.avtaletidspunktDeltBosted.feilmelding}
+                                </StyledFeilmelding>
+                            )}
+                    </Feltmargin>
+                )}
+                {skjema.felter.fullSats.erSynlig && (
+                    <Feltmargin>
+                        <StyledSatsvelger
+                            {...skjema.felter.fullSats.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            label={<Element>Sats</Element>}
+                            value={
+                                skjema.felter.fullSats.verdi !== undefined
+                                    ? satsTilOption(skjema.felter.fullSats.verdi)
+                                    : undefined
+                            }
+                            placeholder={'Velg sats'}
+                            isMulti={false}
+                            onChange={(valg): void => {
+                                skjema.felter.fullSats.validerOgSettFelt(
+                                    (valg as SatsOption).fullSats
+                                );
+                            }}
+                            options={satser.map(sats =>
+                                satsTilOption(sats === IEndretUtbetalingAndelFullSats.FULL_SATS)
+                            )}
+                        />
+                    </Feltmargin>
+                )}
+
+                <Feltmargin>
+                    <StyledFamilieTextarea
+                        {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
+                        erLesevisning={erLesevisning()}
+                        placeholder={'Begrunn hvorfor det er gjort endringer på vilkåret.'}
+                        label={'Begrunnelse'}
+                        value={
+                            skjema.felter.begrunnelse.verdi !== null &&
+                            skjema.felter.begrunnelse.verdi !== undefined
+                                ? skjema.felter.begrunnelse.verdi
+                                : ''
+                        }
+                        onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                            skjema.felter.begrunnelse.validerOgSettFelt(event.target.value);
+                        }}
+                    />
+                </Feltmargin>
+            </StyledSkjemaGruppe>
             <Knapperekke>
                 <Knapperad>
                     <StyledFerdigKnapp
@@ -395,7 +383,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     ikon={<Delete />}
                 />
             </Knapperekke>
-        </StyledSkjemaGruppe>
+        </>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelTabell.tsx
@@ -12,10 +12,6 @@ import EndretUtbetalingAndelRad from './EndretUtbetalingAndelRad';
 
 interface IEndretUtbetalingAndelTabellProps {
     åpenBehandling: IBehandling;
-    settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
-    settFeilmelding: (feilmelding: string) => void;
-    visFeilmeldinger: boolean;
-    opprettelseFeilmelding?: string;
 }
 
 const EndredePerioder = styled.div`
@@ -28,10 +24,6 @@ const Overskrift = styled(Element)`
 
 const EndretUtbetalingAndelTabell: React.FunctionComponent<IEndretUtbetalingAndelTabellProps> = ({
     åpenBehandling,
-    settVisFeilmeldinger,
-    settFeilmelding,
-    visFeilmeldinger,
-    opprettelseFeilmelding = '',
 }) => {
     const endretUtbetalingAndeler = åpenBehandling.endretUtbetalingAndeler;
 
@@ -57,10 +49,6 @@ const EndretUtbetalingAndelTabell: React.FunctionComponent<IEndretUtbetalingAnde
                             <EndretUtbetalingAndelRad
                                 endretUtbetalingAndel={endretUtbetalingAndel}
                                 åpenBehandling={åpenBehandling}
-                                settVisFeilmeldinger={settVisFeilmeldinger}
-                                settFeilmelding={settFeilmelding}
-                                visFeilmeldinger={visFeilmeldinger}
-                                opprettelseFeilmelding={opprettelseFeilmelding}
                             />
                         </EndretUtbetalingAndelProvider>
                     ))}

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelTabell.tsx
@@ -14,6 +14,8 @@ interface IEndretUtbetalingAndelTabellProps {
     åpenBehandling: IBehandling;
     settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
     settFeilmelding: (feilmelding: string) => void;
+    visFeilmeldinger: boolean;
+    opprettelseFeilmelding?: string;
 }
 
 const EndredePerioder = styled.div`
@@ -28,6 +30,8 @@ const EndretUtbetalingAndelTabell: React.FunctionComponent<IEndretUtbetalingAnde
     åpenBehandling,
     settVisFeilmeldinger,
     settFeilmelding,
+    visFeilmeldinger,
+    opprettelseFeilmelding = '',
 }) => {
     const endretUtbetalingAndeler = åpenBehandling.endretUtbetalingAndeler;
 
@@ -55,6 +59,8 @@ const EndretUtbetalingAndelTabell: React.FunctionComponent<IEndretUtbetalingAnde
                                 åpenBehandling={åpenBehandling}
                                 settVisFeilmeldinger={settVisFeilmeldinger}
                                 settFeilmelding={settFeilmelding}
+                                visFeilmeldinger={visFeilmeldinger}
+                                opprettelseFeilmelding={opprettelseFeilmelding}
                             />
                         </EndretUtbetalingAndelProvider>
                     ))}

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
 import { Flatknapp } from 'nav-frontend-knapper';
-import { Element } from 'nav-frontend-typografi';
+import { Element, Feilmelding } from 'nav-frontend-typografi';
 
 import { Edit } from '@navikt/ds-icons';
 import { useHttp } from '@navikt/familie-http';
@@ -138,6 +138,9 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
                         <StyledEditIkon />
                         <Element>Endre utbetalingsperiode</Element>
                     </Flatknapp>
+                    {visFeilmeldinger && opprettelseFeilmelding !== '' && (
+                        <Feilmelding>{opprettelseFeilmelding}</Feilmelding>
+                    )}
                 </EndretUtbetalingAndel>
             )}
             {aktivEtikett && (
@@ -149,13 +152,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
                 />
             )}
             {åpenBehandling.endretUtbetalingAndeler.length > 0 && (
-                <EndretUtbetalingAndelTabell
-                    åpenBehandling={åpenBehandling}
-                    settVisFeilmeldinger={settVisFeilmeldinger}
-                    settFeilmelding={settOpprettelseFeilmelding}
-                    visFeilmeldinger={visFeilmeldinger}
-                    opprettelseFeilmelding={opprettelseFeilmelding}
-                />
+                <EndretUtbetalingAndelTabell åpenBehandling={åpenBehandling} />
             )}
         </Skjemasteg>
     );

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
 import { Flatknapp } from 'nav-frontend-knapper';
-import { Element, Feilmelding } from 'nav-frontend-typografi';
+import { Element } from 'nav-frontend-typografi';
 
 import { Edit } from '@navikt/ds-icons';
 import { useHttp } from '@navikt/familie-http';
@@ -153,10 +153,9 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({
                     åpenBehandling={åpenBehandling}
                     settVisFeilmeldinger={settVisFeilmeldinger}
                     settFeilmelding={settOpprettelseFeilmelding}
+                    visFeilmeldinger={visFeilmeldinger}
+                    opprettelseFeilmelding={opprettelseFeilmelding}
                 />
-            )}
-            {visFeilmeldinger && opprettelseFeilmelding !== '' && (
-                <Feilmelding>{opprettelseFeilmelding}</Feilmelding>
             )}
         </Skjemasteg>
     );

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -69,16 +69,16 @@ const erOrgNr = (orgNr: string) => {
     return kunSiffer(orgNr) && orgNr.length === 9;
 };
 
-export const formaterIdent = (personIdent: string) => {
+export const formaterIdent = (personIdent: string, ukjentTekst = 'Ukjent id') => {
     if (personIdent === '') {
-        return 'Ukjent id';
+        return ukjentTekst;
     }
 
     return erPersonId(personIdent)
         ? `${personIdent.slice(0, 6)} ${personIdent.slice(6, personIdent.length)}`
         : erOrgNr(personIdent)
         ? `${personIdent.slice(0, 3)} ${personIdent.slice(3, 6)} ${personIdent.slice(6, 9)}`
-        : 'Ukjent id';
+        : ukjentTekst;
 };
 
 export const sorterFødselsdato = (fødselsDatoA: string, fødselsDatoB: string) =>


### PR DESCRIPTION
Tre mindre endringer:

1. Lagt til validering på begrunnelse av endret periode (må være oppgitt)
2. Fyttet visning av feilmeldinger til å ligge over knapperaden og ikke helt i bunnen av siden.
3. Endret fra "Ukjent id" -> "Ikke satt" på personfeltet når det ligger en tom endring i tabellen. Endringen skal ikke påvirke andre steder der `formaterIdent` blir brukt, "Ukjent id" vil fremdeles være default.