### PR TITLE
Filtere etter hva backend har sendt, ikke etter strengverdi

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Hooks/useVedtaksbegrunnelser.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Hooks/useVedtaksbegrunnelser.ts
@@ -51,11 +51,6 @@ export const useVilkårBegrunnelser = ({
                       )
                   )
                   .reduce((acc: GroupType<ISelectOption>[], vedtakBegrunnelseType: string) => {
-                      const vedtaksbegrunnelsetype =
-                          vedtakBegrunnelseType === 'INNVILGELSE'
-                              ? 'INNVILGET'
-                              : vedtakBegrunnelseType;
-
                       return [
                           ...acc,
                           {
@@ -63,9 +58,15 @@ export const useVilkårBegrunnelser = ({
                                   vedtakBegrunnelseType as VedtakBegrunnelseType
                               ],
                               options: vedtaksperiodeMedBegrunnelser.gyldigeBegrunnelser
-                                  .filter((vedtakBegrunnelse: VedtakBegrunnelse) =>
-                                      vedtakBegrunnelse.includes(vedtaksbegrunnelsetype)
-                                  )
+                                  .filter((vedtakBegrunnelse: VedtakBegrunnelse) => {
+                                      return (
+                                          vedtaksbegrunnelseTekster.data[
+                                              vedtakBegrunnelseType as VedtakBegrunnelseType
+                                          ].find(
+                                              begrunnelse => begrunnelse.id === vedtakBegrunnelse
+                                          ) !== undefined
+                                      );
+                                  })
                                   .map((vedtakBegrunnelse: VedtakBegrunnelse) => ({
                                       label:
                                           vedtaksbegrunnelseTekster.data[


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bugfix: Begrunnelser med feil navn i enumet, altså ikke for elksempel INNVILGET som en del av strengen i enumet dukket ikke opp. 

Denne fiksen bruker enumene gitt fra backend til å filtrere i stedet. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
