### PR TITLE
Kun vise tittelen "Begrunnelse(r)" når det er satt minst 1 begrunnelse og ikke vis multiselect for avslag

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -4,8 +4,6 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 
 import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
 
-import { useApp } from '../../../../../context/AppContext';
-import { ToggleNavn } from '../../../../../typer/toggles';
 import { VedtakBegrunnelseType } from '../../../../../typer/vedtak';
 import {
     IVedtaksperiodeMedBegrunnelser,
@@ -26,10 +24,6 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
 }) => {
     const { erPanelEkspandert, onPanelClose, utbetalingsperiode, genererteBrevbegrunnelser } =
         useVedtaksperiodeMedBegrunnelser();
-    const { toggles } = useApp();
-    const forhåndvisBegrunnelsetekster =
-        vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.AVSLAG ||
-        toggles[ToggleNavn.forhåndsvisAlleBrevbegrunnelser];
 
     const visFritekster = () =>
         (vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.UTBETALING &&
@@ -66,7 +60,6 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
                     />
                 )}
             {genererteBrevbegrunnelser.status === RessursStatus.SUKSESS &&
-                forhåndvisBegrunnelsetekster &&
                 genererteBrevbegrunnelser.data.length > 0 && (
                     <>
                         <Element>Begrunnelse(r)</Element>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
- Kun vise tittelen "Begrunnelse(r)" når det er satt minst 1 begrunnelse.
- Ikke vise multiselect for avslagsperioder og endrede perioder

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening å teste

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ikke vise tittel når listen med begrunnelser er tom:
![image](https://user-images.githubusercontent.com/25459913/137344300-ea96c172-810b-41a2-b932-8fb70c8c99df.png)
![image](https://user-images.githubusercontent.com/25459913/137344340-9aa1e91d-fd38-49e8-8951-dcbfe41a09bf.png)

Fjerne multiselect:
<img width="819" alt="Skjermbilde 2021-10-15 kl  08 07 50" src="https://user-images.githubusercontent.com/25459913/137440385-a25881da-0afa-46d6-9fa5-a7015a11b6e4.png">
![image](https://user-images.githubusercontent.com/25459913/137440404-c88d8dde-a3f5-4a9f-b8ec-eb8e37c07a91.png)


