### PR TITLE
Satte periode til ikke utbetalt vis forfallsdato ikke er passert

### DIFF
--- a/src/frontend/typer/simulering.ts
+++ b/src/frontend/typer/simulering.ts
@@ -4,6 +4,7 @@ export interface ISimuleringDTO {
     etterbetaling: number;
     feilutbetaling: number;
     fom: string;
+    tidSimuleringHentet?: string;
     tomDatoNestePeriode?: string;
     tomSisteUtbetaling?: string;
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Simuleringsresultatet blir feil i følgende tilfelle:
* Revurdering hvor siste måned ikke gir endring i utbetaling.
* Dato etter økonomis batch-kjøring (vanligvis etter 20 i måneden) men før forfallsdato (vanligvis 29 i måneden)

Følgende blir feil:
* Neste utbetaling som er inneværende måned viser at 0kr utbetales.
* Tidligere utbetalt viser at full beløp er utbetalt.

Riktig er: 
* Neste utbetaling viser at full beløp.
*  Tidligere utbetalt viser at 0kr.


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 🤷‍♀ ️Hvor er det lurt å starte?
Fiksen kan bare testes mellom batch kjøringsdato (vanligvis etter 20 i måneden) og før forfallsdato (vanligvis 29 i måneden)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
