### PR TITLE
behandlingstema i saksoversikt tabell

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -14,7 +14,7 @@ import {
     behandlingstyper,
     behandlingÅrsak,
 } from '../../../typer/behandling';
-import { behandlingKategori, behandlingUnderkategori } from '../../../typer/behandlingstema';
+import { tilBehandlingstema } from '../../../typer/behandlingstema';
 import { IMinimalFagsak } from '../../../typer/fagsak';
 import {
     Tilbakekrevingsbehandlingstype,
@@ -97,8 +97,7 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
                             <th children={'Opprettet'} />
                             <th children={'Årsak'} />
                             <th children={'Type'} />
-                            <th children={'Fagsaktype'} />
-                            <th children={'Gjelder'} />
+                            <th children={'Behandlingstema'} />
                             <th children={'Status'} />
                             <th children={'Vedtaksdato'} />
                             <th children={'Resultat'} />
@@ -124,14 +123,12 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
                                         <td>{finnÅrsak(behandling)}</td>
                                         <td>{lagLenkePåType(minimalFagsak.id, behandling)}</td>
                                         <td>
-                                            {behandling.kategori
-                                                ? behandlingKategori[behandling.kategori]
-                                                : '-'}
-                                        </td>
-                                        <td>
-                                            {behandling.underkategori
-                                                ? behandlingUnderkategori[behandling.underkategori]
-                                                : '-'}
+                                            {
+                                                tilBehandlingstema(
+                                                    behandling.kategori,
+                                                    behandling.underkategori
+                                                ).navn
+                                            }
                                         </td>
                                         <td>{behandlingsstatuser[behandling.status]}</td>
                                         <td

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -7,7 +7,7 @@ import Panel from 'nav-frontend-paneler';
 import { Normaltekst } from 'nav-frontend-typografi';
 
 import { BehandlingStatus } from '../../../typer/behandling';
-import { behandlingKategori, behandlingUnderkategori } from '../../../typer/behandlingstema';
+import { tilBehandlingstema } from '../../../typer/behandlingstema';
 import { IMinimalFagsak } from '../../../typer/fagsak';
 import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '../../../utils/fagsak';
 import { VisningBehandling } from './visningBehandling';
@@ -27,10 +27,7 @@ const Innholdstabell: React.FC<IInnholdstabell> = ({ minimalFagsak, behandling }
             <thead>
                 <tr>
                     <th>
-                        <Normaltekst>Fagsaktype</Normaltekst>
-                    </th>
-                    <th>
-                        <Normaltekst>Gjelder</Normaltekst>
+                        <Normaltekst>Behandlingstema</Normaltekst>
                     </th>
                     <th>
                         <Normaltekst>Status</Normaltekst>
@@ -41,15 +38,9 @@ const Innholdstabell: React.FC<IInnholdstabell> = ({ minimalFagsak, behandling }
                 <tr>
                     <td>
                         <Normaltekst>
-                            {behandling && behandling.kategori
-                                ? behandlingKategori[behandling.kategori]
-                                : '-'}
-                        </Normaltekst>
-                    </td>
-                    <td>
-                        <Normaltekst>
-                            {behandling && behandling.underkategori
-                                ? behandlingUnderkategori[behandling.underkategori]
+                            {behandling
+                                ? tilBehandlingstema(behandling.kategori, behandling.underkategori)
+                                      .navn
                                 : '-'}
                         </Normaltekst>
                     </td>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bytter visning av kategori og underkategori til behandlingstema på saksoversikt-siden

### 👀 Screen shots

Før:
<img width="1003" alt="Screenshot 2021-11-10 at 08 35 11" src="https://user-images.githubusercontent.com/17552002/141069741-8096c14e-0534-46cb-aa67-d6f623507e90.png">

Etter:
<img width="993" alt="Screenshot 2021-11-10 at 08 34 23" src="https://user-images.githubusercontent.com/17552002/141069639-f1356211-d611-4ade-ac3d-5d4b656ac342.png">


