### PR TITLE
BUG: feilhåndtering behandlingsresultatsteg

### DIFF
--- a/src/frontend/context/behandlingContext/BehandlingContext.ts
+++ b/src/frontend/context/behandlingContext/BehandlingContext.ts
@@ -45,12 +45,15 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
             hentMinimalFagsak(fagsakId, false);
         }
         privatSettÅpenBehandling(behandling);
+        settBehandlingsstegSubmitressurs(byggTomRessurs());
     };
+
     const {
         submitRessurs: behandlingsstegSubmitressurs,
         vilkårsvurderingNesteOnClick,
         behandlingresultatNesteOnClick,
         sendTilBeslutterNesteOnClick,
+        settSubmitRessurs: settBehandlingsstegSubmitressurs,
     } = useBehandlingssteg(settÅpenBehandling, hentDataFraRessurs(åpenBehandling));
 
     const { opprettBehandling, logg, hentLogg, oppdaterRegisteropplysninger } = useBehandlingApi(

--- a/src/frontend/context/behandlingContext/useBehandlingssteg.ts
+++ b/src/frontend/context/behandlingContext/useBehandlingssteg.ts
@@ -135,6 +135,7 @@ const useBehandlingssteg = (
         vilkårsvurderingNesteOnClick,
         behandlingresultatNesteOnClick,
         sendTilBeslutterNesteOnClick,
+        settSubmitRessurs,
     };
 };
 

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelRad.tsx
@@ -25,7 +25,6 @@ import EndretUtbetalingAndelSkjema from './EndretUtbetalingAndelSkjema';
 interface IEndretUtbetalingAndelRadProps {
     endretUtbetalingAndel: IRestEndretUtbetalingAndel;
     åpenBehandling: IBehandling;
-    settFeilmelding: (feilmelding: string) => void;
 }
 
 const StyledCollapseIkon = styled(Collapse)`
@@ -50,7 +49,6 @@ const PersonCelle = styled.div`
 const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRadProps> = ({
     endretUtbetalingAndel,
     åpenBehandling,
-    settFeilmelding,
 }) => {
     const [åpenUtbetalingsAndel, settÅpenUtbetalingsAndel] = useState<boolean>(
         endretUtbetalingAndel.personIdent === null
@@ -168,7 +166,6 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
                             avbrytEndringAvUtbetalingsperiode={() => {
                                 settÅpenUtbetalingsAndel(false);
                             }}
-                            settFeilmelding={settFeilmelding}
                         />
                     </td>
                 </tr>

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelSkjema.tsx
@@ -80,13 +80,11 @@ const StyledFamilieTextarea = styled(FamilieTextarea)`
 interface IEndretUtbetalingAndelSkjemaProps {
     åpenBehandling: IBehandling;
     avbrytEndringAvUtbetalingsperiode: () => void;
-    settFeilmelding: (feilmelding: string) => void;
 }
 
 const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAndelSkjemaProps> = ({
     åpenBehandling,
     avbrytEndringAvUtbetalingsperiode,
-    settFeilmelding,
 }) => {
     const { request } = useHttp();
     const { erLesevisning, settÅpenBehandling } = useBehandling();
@@ -120,7 +118,6 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                     if (behandling.status === RessursStatus.SUKSESS) {
                         avbrytEndringAvUtbetalingsperiode();
                         settÅpenBehandling(behandling);
-                        settFeilmelding('');
                     }
                 }
             );

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/EndretUtbetalingAndelTabell.tsx
@@ -12,7 +12,6 @@ import EndretUtbetalingAndelRad from './EndretUtbetalingAndelRad';
 
 interface IEndretUtbetalingAndelTabellProps {
     åpenBehandling: IBehandling;
-    settFeilmelding: (feilmelding: string) => void;
 }
 
 const EndredePerioder = styled.div`
@@ -25,7 +24,6 @@ const Overskrift = styled(Element)`
 
 const EndretUtbetalingAndelTabell: React.FunctionComponent<IEndretUtbetalingAndelTabellProps> = ({
     åpenBehandling,
-    settFeilmelding,
 }) => {
     const endretUtbetalingAndeler = åpenBehandling.endretUtbetalingAndeler;
 
@@ -51,7 +49,6 @@ const EndretUtbetalingAndelTabell: React.FunctionComponent<IEndretUtbetalingAnde
                             <EndretUtbetalingAndelRad
                                 endretUtbetalingAndel={endretUtbetalingAndel}
                                 åpenBehandling={åpenBehandling}
-                                settFeilmelding={settFeilmelding}
                             />
                         </EndretUtbetalingAndelProvider>
                     ))}

--- a/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
+++ b/src/frontend/komponenter/Fagsak/TilkjentYtelse/TilkjentYtelse.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useState } from 'react';
 
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
@@ -20,6 +19,7 @@ import { ToggleNavn } from '../../../typer/toggles';
 import { IRestEndretUtbetalingAndel } from '../../../typer/utbetalingAndel';
 import { Utbetalingsperiode } from '../../../typer/vedtaksperiode';
 import { periodeOverlapperMedValgtDato } from '../../../utils/kalender';
+import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
 import EndretUtbetalingAndelTabell from './EndretUtbetalingAndelTabell';
 import { Oppsummeringsboks } from './Oppsummeringsboks';
@@ -61,7 +61,6 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ åpenBe
         settÅpenBehandling,
     } = useBehandling();
     const { toggles } = useApp();
-    const [feilmelding, settFeilmelding] = useState('');
 
     const forrigeOnClick = () => {
         history.push(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/vilkaarsvurdering`);
@@ -125,7 +124,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ åpenBe
                 }
             }}
             maxWidthStyle={'80rem'}
-            feilmelding={feilmelding}
+            feilmelding={hentFrontendFeilmelding(behandlingsstegSubmitressurs)}
         >
             <TilkjentYtelseTidslinje
                 grunnlagPersoner={grunnlagPersoner}
@@ -151,10 +150,7 @@ const TilkjentYtelse: React.FunctionComponent<ITilkjentYtelseProps> = ({ åpenBe
                 />
             )}
             {åpenBehandling.endretUtbetalingAndeler.length > 0 && (
-                <EndretUtbetalingAndelTabell
-                    åpenBehandling={åpenBehandling}
-                    settFeilmelding={settFeilmelding}
-                />
+                <EndretUtbetalingAndelTabell åpenBehandling={åpenBehandling} />
             )}
         </Skjemasteg>
     );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fjerner ubrukt feilmelding og bruker behandlingssteg submitressursen til å vise feilmelding. Rydder også opp i state når et kall går OK.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei
