### PR TITLE
retter type for tilbakekrevingsbehandlinger på minimalfagsak

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -14,9 +14,14 @@ import {
     behandlingstyper,
     behandlingÅrsak,
 } from '../../../typer/behandling';
-import { IBehandlingstema, tilBehandlingstema } from '../../../typer/behandlingstema';
+import {
+    hentKategorierHvisVisningBehandling,
+    IBehandlingstema,
+    tilBehandlingstema,
+} from '../../../typer/behandlingstema';
 import { IMinimalFagsak } from '../../../typer/fagsak';
 import {
+    ITilbakekrevingsbehandling,
     Tilbakekrevingsbehandlingstype,
     tilbakekrevingstyper,
 } from '../../../typer/tilbakekrevingsbehandling';
@@ -28,8 +33,11 @@ interface IBehandlingshistorikkProps {
     minimalFagsak: IMinimalFagsak;
 }
 
-const lagLenkePåType = (fagsakId: number, behandling: VisningBehandling): ReactNode => {
-    return behandling.status === BehandlingStatus.AVSLUTTET ? (
+const lagLenkePåType = (
+    fagsakId: number,
+    behandling: VisningBehandling | ITilbakekrevingsbehandling
+): ReactNode =>
+    behandling.status === BehandlingStatus.AVSLUTTET ? (
         behandlingstyper[behandling.type].navn
     ) : tilbakekrevingstyper.some(type => type === behandling.type) ? (
         <Lenke
@@ -45,13 +53,12 @@ const lagLenkePåType = (fagsakId: number, behandling: VisningBehandling): React
             {behandlingstyper[behandling.type].navn}
         </Lenke>
     );
-};
 
 const lagLenkePåResultat = (
     minimalFagsak: IMinimalFagsak,
-    behandling: VisningBehandling
-): ReactNode => {
-    return !behandling.resultat ? (
+    behandling: VisningBehandling | ITilbakekrevingsbehandling
+): ReactNode =>
+    !behandling.resultat ? (
         '-'
     ) : tilbakekrevingstyper.some(type => type === behandling.type) ? (
         <Lenke
@@ -69,18 +76,16 @@ const lagLenkePåResultat = (
     ) : (
         behandlingsresultater[behandling.resultat]
     );
-};
 
-const finnÅrsak = (behandling: VisningBehandling): ReactNode => {
-    return behandling.type === Tilbakekrevingsbehandlingstype.TILBAKEKREVING
+const finnÅrsak = (behandling: VisningBehandling | ITilbakekrevingsbehandling): ReactNode =>
+    behandling.type === Tilbakekrevingsbehandlingstype.TILBAKEKREVING
         ? 'Feilutbetaling'
         : behandling.årsak
         ? behandlingÅrsak[behandling.årsak]
         : '-';
-};
 
 const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) => {
-    const behandlinger: VisningBehandling[] = [
+    const behandlinger: (VisningBehandling | ITilbakekrevingsbehandling)[] = [
         ...minimalFagsak.behandlinger,
         ...minimalFagsak.tilbakekrevingsbehandlinger,
     ];
@@ -111,12 +116,15 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
                                     new Date(a.opprettetTidspunkt)
                                 )
                             )
-                            .map((behandling: VisningBehandling) => {
-                                const behandlingstema: IBehandlingstema | undefined =
-                                    tilBehandlingstema(
-                                        behandling.kategori,
-                                        behandling.underkategori
-                                    );
+                            .map((behandling: VisningBehandling | ITilbakekrevingsbehandling) => {
+                                const kategorier = hentKategorierHvisVisningBehandling(behandling);
+
+                                const behandlingstema: IBehandlingstema | undefined = kategorier
+                                    ? tilBehandlingstema(
+                                          kategorier.kategori,
+                                          kategorier.underkategori
+                                      )
+                                    : undefined;
                                 return (
                                     <tr key={behandling.behandlingId}>
                                         <td

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/visningBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/visningBehandling.ts
@@ -5,21 +5,16 @@ import {
     BehandlingÅrsak,
 } from '../../../typer/behandling';
 import { BehandlingKategori, BehandlingUnderkategori } from '../../../typer/behandlingstema';
-import {
-    TilbakekrevingsbehandlingResultat,
-    Tilbakekrevingsbehandlingstype,
-    TilbakekrevingsbehandlingÅrsak,
-} from '../../../typer/tilbakekrevingsbehandling';
 
 export interface VisningBehandling {
     aktiv: boolean;
     behandlingId: number | string;
-    kategori: BehandlingKategori;
     opprettetTidspunkt: string;
-    resultat?: BehandlingResultat | TilbakekrevingsbehandlingResultat;
+    resultat?: BehandlingResultat;
     status: BehandlingStatus;
-    type: Behandlingstype | Tilbakekrevingsbehandlingstype;
+    type: Behandlingstype;
+    kategori: BehandlingKategori;
     underkategori: BehandlingUnderkategori;
     vedtaksdato?: string;
-    årsak?: BehandlingÅrsak | TilbakekrevingsbehandlingÅrsak;
+    årsak?: BehandlingÅrsak;
 }

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -287,13 +287,14 @@ export const behandlingsresultater: Record<
     FORTSATT_INNVILGET: 'Fortsatt innvilget',
     HENLAGT_FEILAKTIG_OPPRETTET: 'Henlagt (feilaktig opprettet)',
     HENLAGT_SØKNAD_TRUKKET: 'Henlagt (søknad trukket)',
+    HENLAGT_AUTOMATISK_FØDSELSHENDELSE: 'Henlagt automatisk fødselshendelse',
     IKKE_VURDERT: 'Ikke vurdert',
     /** De neste er resultat for tilbakekrevingsbehandlinger **/
+    IKKE_FASTSATT: 'Ikke fastsatt',
     INGEN_TILBAKEBETALING: 'Ingen tilbakebetaling',
     DELVIS_TILBAKEBETALING: 'Delvis tilbakebetaling',
     FULL_TILBAKEBETALING: 'Full tilbakebetaling',
     HENLAGT: 'Henlagt',
-    HENLAGT_AUTOMATISK_FØDSELSHENDELSE: 'Henlagt automatisk fødselshendelse',
 };
 
 export const behandlingsstatuser: Record<BehandlingStatus, string> = {

--- a/src/frontend/typer/behandlingstema.ts
+++ b/src/frontend/typer/behandlingstema.ts
@@ -1,4 +1,6 @@
+import { VisningBehandling } from '../komponenter/Fagsak/Saksoversikt/visningBehandling';
 import { IOppgave } from './oppgave';
+import { ITilbakekrevingsbehandling } from './tilbakekrevingsbehandling';
 
 export enum BehandlingKategori {
     NASJONAL = 'NASJONAL',
@@ -67,11 +69,11 @@ export const behandlingstemaer: Record<Behandlingstema, IBehandlingstema> = {
 export const tilBehandlingstema = (
     kategori: BehandlingKategori,
     underkategori: BehandlingUnderkategori
-): IBehandlingstema => {
+): IBehandlingstema | undefined => {
     return Object.values(behandlingstemaer).find(
         (tema: IBehandlingstema) =>
             tema.kategori === kategori && tema.underkategori === underkategori
-    ) as IBehandlingstema;
+    );
 };
 
 export const kodeTilBehandlingUnderkategoriMap: Record<string, BehandlingUnderkategori> = {
@@ -93,4 +95,14 @@ export const utredBehandlingstemaFraOppgave = (oppgave: IOppgave): IBehandlingst
               kodeTilBehandlingUnderkategoriMap[gjelder]
           )
         : undefined;
+};
+
+export const hentKategorierHvisVisningBehandling = (
+    behandling?: VisningBehandling | ITilbakekrevingsbehandling
+) => {
+    const kategori: BehandlingKategori | undefined = (behandling as VisningBehandling)?.kategori;
+    const underkategori: BehandlingUnderkategori | undefined = (behandling as VisningBehandling)
+        ?.underkategori;
+
+    return kategori && underkategori ? { kategori, underkategori } : undefined;
 };

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -1,5 +1,6 @@
 import { VisningBehandling } from '../komponenter/Fagsak/Saksoversikt/visningBehandling';
 import { INøkkelPar } from './common';
+import { ITilbakekrevingsbehandling } from './tilbakekrevingsbehandling';
 import { Utbetalingsperiode } from './vedtaksperiode';
 
 // Enum
@@ -21,7 +22,7 @@ export interface IBaseFagsak {
 
 export interface IMinimalFagsak extends IBaseFagsak {
     behandlinger: VisningBehandling[];
-    tilbakekrevingsbehandlinger: VisningBehandling[];
+    tilbakekrevingsbehandlinger: ITilbakekrevingsbehandling[];
     gjeldendeUtbetalingsperioder: Utbetalingsperiode[];
 }
 

--- a/src/frontend/typer/tilbakekrevingsbehandling.ts
+++ b/src/frontend/typer/tilbakekrevingsbehandling.ts
@@ -1,3 +1,30 @@
+export interface ITilbakekrevingsbehandling {
+    behandlingId: number | string;
+    opprettetTidspunkt: string;
+    aktiv: boolean;
+    årsak?: TilbakekrevingsbehandlingÅrsak;
+    type: Tilbakekrevingsbehandlingstype;
+    status: Behandlingsstatus;
+    resultat?: Behandlingsresultatstype;
+    vedtaksdato?: string;
+}
+
+export enum Behandlingsresultatstype {
+    IKKE_FASTSATT = 'IKKE_FASTSATT',
+    INGEN_TILBAKEBETALING = 'INGEN_TILBAKEBETALING',
+    DELVIS_TILBAKEBETALING = 'DELVIS_TILBAKEBETALING',
+    FULL_TILBAKEBETALING = 'FULL_TILBAKEBETALING',
+    HENLAGT = 'HENLAGT',
+}
+
+export enum Behandlingsstatus {
+    AVSLUTTET = 'AVSLUTTET',
+    FATTER_VEDTAK = 'FATTER_VEDTAK',
+    IVERKSETTER_VEDTAK = 'IVERKSETTER_VEDTAK',
+    OPPRETTET = 'OPPRETTET',
+    UTREDES = 'UTREDES',
+}
+
 export enum Tilbakekrevingsbehandlingstype {
     TILBAKEKREVING = 'TILBAKEKREVING',
     REVURDERING_TILBAKEKREVING = 'REVURDERING_TILBAKEKREVING',
@@ -17,6 +44,7 @@ export enum TilbakekrevingsbehandlingÅrsak {
 }
 
 export enum TilbakekrevingsbehandlingResultat {
+    IKKE_FASTSATT = 'IKKE_FASTSATT',
     INGEN_TILBAKEBETALING = 'INGEN_TILBAKEBETALING',
     DELVIS_TILBAKEBETALING = 'DELVIS_TILBAKEBETALING',
     FULL_TILBAKEBETALING = 'FULL_TILBAKEBETALING',


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Visningbehandling og Tilbakekrevingsbehandling har små forskjeller. Foreslår å ikke bruke VisningBehandling for tilbakekrevingsbehandlinger på minimalfagsak, men heller ha en egen type for det