### PR TITLE
Forbedre fritekstfeltet i innhentingsbrev og varsel om revurdering

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -121,7 +121,10 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
             return ok(felt);
         },
         skalFeltetVises: (avhengigheter: Avhengigheter) => {
-            return avhengigheter?.brevmal.valideringsstatus === Valideringsstatus.OK;
+            return (
+                avhengigheter?.brevmal.valideringsstatus === Valideringsstatus.OK &&
+                avhengigheter?.brevmal.verdi !== Brevmal.VARSEL_OM_REVURDERING
+            );
         },
         avhengigheter: { brevmal },
     });
@@ -190,6 +193,15 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
             lagInitiellFritekst('', genererIdBasertPåAndreFritekster(fritekster)),
         ]);
     };
+
+    /**
+     * Legger til initielt fritekstpunkt hvis brevmal er "Varsel om revurdering"
+     */
+    useEffect(() => {
+        if (fritekster.verdi.length === 0 && brevmal.verdi === Brevmal.VARSEL_OM_REVURDERING) {
+            leggTilFritekst();
+        }
+    }, [brevmal, fritekster]);
 
     const hentSkjemaData = (): IManueltBrevRequestPåBehandling => ({
         mottakerIdent: skjema.felter.mottakerIdent.verdi,

--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -4,14 +4,14 @@ import createUseContext from 'constate';
 
 import {
     Avhengigheter,
-    FeltState,
-    Valideringsstatus,
     feil,
+    FeltState,
     ok,
     useFelt,
     useSkjema,
+    Valideringsstatus,
 } from '@navikt/familie-skjema';
-import { RessursStatus, Ressurs } from '@navikt/familie-typer';
+import { Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import {
     Brevmal,
@@ -22,6 +22,11 @@ import { IManueltBrevRequestPåBehandling } from '../typer/dokument';
 import { IGrunnlagPerson, PersonType } from '../typer/person';
 import { Målform } from '../typer/søknad';
 import { fjernWhitespace } from '../utils/commons';
+import {
+    genererIdBasertPåAndreFritekster,
+    IFritekstFelt,
+    lagInitiellFritekst,
+} from '../utils/fritekstfelter';
 import { useBehandling } from './behandlingContext/BehandlingContext';
 
 export const hentMuligeBrevmalerImplementering = (
@@ -59,6 +64,10 @@ export const mottakersMålformImplementering = (
 
 const [BrevModulProvider, useBrevModul] = createUseContext(() => {
     const { åpenBehandling } = useBehandling();
+
+    // TODO: Sjekk disse
+    const maksAntallKulepunkter = 3;
+    const makslengdeFritekst = 220;
 
     const mottakerIdent = useFelt({
         verdi: '',
@@ -118,11 +127,29 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         avhengigheter: { brevmal },
     });
 
+    const fritekster = useFelt<FeltState<IFritekstFelt>[]>({
+        verdi: [],
+        valideringsfunksjon: (felt: FeltState<FeltState<IFritekstFelt>[]>) => {
+            return felt.verdi.some(
+                fritekst =>
+                    fritekst.valideringsstatus === Valideringsstatus.FEIL ||
+                    fritekst.verdi.tekst.length === 0
+            )
+                ? feil(felt, '')
+                : ok(felt);
+        },
+        skalFeltetVises: (avhengigheter: Avhengigheter) => {
+            return avhengigheter?.brevmal.valideringsstatus === Valideringsstatus.OK;
+        },
+        avhengigheter: { brevmal },
+    });
+
     const { kanSendeSkjema, onSubmit, skjema } = useSkjema<
         {
             mottakerIdent: string;
             brevmal: Brevmal | '';
             multiselect: ISelectOptionMedBrevtekst[];
+            fritekster: FeltState<IFritekstFelt>[];
         },
         IBehandling
     >({
@@ -130,6 +157,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
             mottakerIdent,
             brevmal,
             multiselect,
+            fritekster,
         },
         skjemanavn: 'brevmodul',
     });
@@ -157,17 +185,25 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
 
     const hentMuligeBrevMaler = (): Brevmal[] => hentMuligeBrevmalerImplementering(åpenBehandling);
 
+    const leggTilFritekst = () => {
+        skjema.felter.fritekster.validerOgSettFelt([
+            ...skjema.felter.fritekster.verdi,
+            lagInitiellFritekst('', genererIdBasertPåAndreFritekster(fritekster)),
+        ]);
+    };
+
     const hentSkjemaData = (): IManueltBrevRequestPåBehandling => ({
         mottakerIdent: skjema.felter.mottakerIdent.verdi,
-        multiselectVerdier: skjema.felter.multiselect.verdi.map(
-            (selectOption: ISelectOptionMedBrevtekst) => {
+        multiselectVerdier: [
+            ...skjema.felter.multiselect.verdi.map((selectOption: ISelectOptionMedBrevtekst) => {
                 if (selectOption.brevtekst) {
                     return selectOption.brevtekst[mottakersMålform()];
                 } else {
                     return selectOption.value;
                 }
-            }
-        ),
+            }),
+            ...skjema.felter.fritekster.verdi.map(f => f.verdi.tekst),
+        ],
         brevmal: skjema.felter.brevmal.verdi as Brevmal,
     });
 
@@ -181,6 +217,9 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         onSubmit,
         personer,
         settNavigerTilOpplysningsplikt,
+        leggTilFritekst,
+        makslengdeFritekst,
+        maksAntallKulepunkter,
     };
 });
 

--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -65,8 +65,7 @@ export const mottakersMålformImplementering = (
 const [BrevModulProvider, useBrevModul] = createUseContext(() => {
     const { åpenBehandling } = useBehandling();
 
-    // TODO: Sjekk disse
-    const maksAntallKulepunkter = 3;
+    const maksAntallKulepunkter = 20;
     const makslengdeFritekst = 220;
 
     const mottakerIdent = useFelt({

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -22,17 +22,17 @@ import {
     IVedtaksperiodeMedBegrunnelser,
     Vedtaksperiodetype,
 } from '../../../../../typer/vedtaksperiode';
+import {
+    genererIdBasertPåAndreFritekster,
+    IFritekstFelt,
+    lagInitiellFritekst,
+} from '../../../../../utils/fritekstfelter';
 import { IPeriode } from '../../../../../utils/kalender';
 import { useVilkårBegrunnelser } from '../Hooks/useVedtaksbegrunnelser';
 
 interface IProps {
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
     åpenBehandling: IBehandling;
-}
-
-export interface IFritekstFelt {
-    tekst: string;
-    id: number;
 }
 
 const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] = constate(
@@ -72,14 +72,6 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
                     : ok(felt);
             },
         });
-
-        const genererIdBasertPåAndreFritekster = () => {
-            if (fritekster.verdi.length > 0) {
-                return Math.max(...fritekster.verdi.map(fritekst => fritekst.verdi.id, 10)) + 1;
-            } else {
-                return 1;
-            }
-        };
 
         const { hentFeilTilOppsummering, kanSendeSkjema, onSubmit, settVisfeilmeldinger, skjema } =
             useSkjema<
@@ -122,31 +114,6 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
                 genererOgSettBegrunnelserForForhåndsvisning(vedtaksperiodeMedBegrunnelser.id);
             }
         }, [vedtaksbegrunnelseTekster, vedtaksperiodeMedBegrunnelser]);
-
-        const lagInitiellFritekst = (
-            initiellVerdi: string,
-            id?: number
-        ): FeltState<IFritekstFelt> => ({
-            feilmelding: initiellVerdi === '' ? 'Fritekstfeltet er tomt.' : '',
-            verdi: {
-                tekst: initiellVerdi,
-                id: id ?? genererIdBasertPåAndreFritekster(),
-            },
-            valider: (felt: FeltState<IFritekstFelt>) => {
-                if (felt.verdi.tekst.length > 220) {
-                    return feil(felt, 'Du har nådd maks antall tegn: 220.');
-                } else if (felt.verdi.tekst.trim().length === 0) {
-                    return feil(
-                        felt,
-                        'Du må skrive tekst i feltet, eller fjerne det om du ikke skal ha fritekst.'
-                    );
-                } else {
-                    return ok(felt);
-                }
-            },
-            valideringsstatus:
-                initiellVerdi === '' ? Valideringsstatus.IKKE_VALIDERT : Valideringsstatus.OK,
-        });
 
         const onChangeBegrunnelse = (action: ActionMeta<ISelectOption>) => {
             switch (action.action) {
@@ -228,7 +195,7 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
         const leggTilFritekst = () => {
             skjema.felter.fritekster.validerOgSettFelt([
                 ...skjema.felter.fritekster.verdi,
-                lagInitiellFritekst(''),
+                lagInitiellFritekst('', genererIdBasertPåAndreFritekster(skjema.felter.fritekster)),
             ]);
         };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -18,15 +18,13 @@ import { EksternLenke } from '../../../../../ikoner/EksternLenke';
 import Pluss from '../../../../../ikoner/Pluss';
 import Slett from '../../../../../ikoner/Slett';
 import { målform } from '../../../../../typer/søknad';
+import { IFritekstFelt } from '../../../../../utils/fritekstfelter';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import Hjelpetekst44px from '../../../../Felleskomponenter/Hjelpetekst44px';
 import IkonKnapp, { IkonPosisjon } from '../../../../Felleskomponenter/IkonKnapp/IkonKnapp';
 import Knapperekke from '../../../../Felleskomponenter/Knapperekke';
 import SkjultLegend from '../../../../Felleskomponenter/SkjultLegend';
-import {
-    IFritekstFelt,
-    useVedtaksperiodeMedBegrunnelser,
-} from '../Context/VedtaksperiodeMedBegrunnelserContext';
+import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 
 const FritekstContainer = styled.div`
     background-color: ${navFarger.navGraBakgrunn};

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brev.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brev.tsx
@@ -19,7 +19,7 @@ interface IProps {
 const Brev = ({ onOkIModalClick }: IProps) => {
     const { fagsakId } = useSakOgBehandlingParams();
     const { åpenBehandling } = useBehandling();
-    const { hentMuligeBrevMaler, navigerTilOpplysningsplikt } = useBrevModul();
+    const { navigerTilOpplysningsplikt } = useBrevModul();
 
     const [visInnsendtBrevModal, settVisInnsendtBrevModal] = React.useState(false);
 
@@ -30,7 +30,6 @@ const Brev = ({ onOkIModalClick }: IProps) => {
     return (
         <div className={'brev'}>
             <Brevskjema
-                brevMaler={hentMuligeBrevMaler()}
                 onSubmitSuccess={() => {
                     settVisInnsendtBrevModal(true);
                 }}

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -252,7 +252,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                     }
                                 >
                                     {skjema.felter.fritekster.verdi.map(
-                                        (fritekst: FeltState<IFritekstFelt>) => {
+                                        (fritekst: FeltState<IFritekstFelt>, index: number) => {
                                             const fritekstId = fritekst.verdi.id;
 
                                             return (
@@ -277,25 +277,32 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                                         /* eslint-disable-next-line jsx-a11y/no-autofocus */
                                                         autoFocus
                                                     />
-                                                    <SletteKnapp
-                                                        erLesevisning={false}
-                                                        onClick={() => {
-                                                            skjema.felter.fritekster.validerOgSettFelt(
-                                                                [
-                                                                    ...skjema.felter.fritekster.verdi.filter(
-                                                                        mapFritekst =>
-                                                                            mapFritekst.verdi.id !==
-                                                                            fritekst.verdi.id
-                                                                    ),
-                                                                ]
-                                                            );
-                                                        }}
-                                                        id={`fjern_fritekst-${fritekstId}`}
-                                                        mini={true}
-                                                        label={'Fjern'}
-                                                        aria-label={'Fjern fritekst'}
-                                                        ikon={<Slett />}
-                                                    />
+                                                    {!(
+                                                        index === 0 &&
+                                                        skjema.felter.brevmal.verdi ===
+                                                            Brevmal.VARSEL_OM_REVURDERING
+                                                    ) && (
+                                                        <SletteKnapp
+                                                            erLesevisning={false}
+                                                            onClick={() => {
+                                                                skjema.felter.fritekster.validerOgSettFelt(
+                                                                    [
+                                                                        ...skjema.felter.fritekster.verdi.filter(
+                                                                            mapFritekst =>
+                                                                                mapFritekst.verdi
+                                                                                    .id !==
+                                                                                fritekst.verdi.id
+                                                                        ),
+                                                                    ]
+                                                                );
+                                                            }}
+                                                            id={`fjern_fritekst-${fritekstId}`}
+                                                            mini={true}
+                                                            label={'Fjern'}
+                                                            aria-label={'Fjern fritekst'}
+                                                            ikon={<Slett />}
+                                                        />
+                                                    )}
                                                 </StyledFamilieFritekstFelt>
                                             );
                                         }

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -6,8 +6,7 @@ import styled from 'styled-components';
 import navFarger from 'nav-frontend-core';
 import { EtikettInfo } from 'nav-frontend-etiketter';
 import { Knapp } from 'nav-frontend-knapper';
-import { SkjemaGruppe } from 'nav-frontend-skjema';
-import { Normaltekst } from 'nav-frontend-typografi';
+import { Label, SkjemaGruppe } from 'nav-frontend-skjema';
 
 import { FamilieReactSelect, FamilieSelect, FamilieTextarea } from '@navikt/familie-form-elements';
 import { Felt, FeltState } from '@navikt/familie-skjema';
@@ -203,11 +202,17 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                         {...skjema.felter.multiselect.hentNavInputProps(skjema.visFeilmeldinger)}
                         label={
                             <LabelOgEtikett>
-                                <Normaltekst>
+                                <Label
+                                    htmlFor={
+                                        skjema.felter.multiselect.hentNavInputProps(
+                                            skjema.visFeilmeldinger
+                                        ).id
+                                    }
+                                >
                                     {valgtBrevmal.verdi !== ''
                                         ? selectLabelsForBrevmaler[valgtBrevmal.verdi]
                                         : ''}
-                                </Normaltekst>
+                                </Label>
                                 <StyledEtikettInfo mini={true}>
                                     Skriv {målform[mottakersMålform()].toLowerCase()}
                                 </StyledEtikettInfo>
@@ -228,6 +233,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 )}
                 {skjema.felter.fritekster.erSynlig && (
                     <>
+                        <Label htmlFor={skjemaGruppeId}>Fritekst til kulepunkt i brev</Label>
                         {erLesevisning() ? (
                             <StyledList id={skjemaGruppeId}>
                                 {skjema.felter.fritekster.verdi.map(

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer.ts
@@ -41,13 +41,12 @@ export const hentSelectOptions = (brevmal: Brevmal | ''): ISelectOptionMedBrevte
     }
 
     return (
-        selectOptionsMedBrevtekst?.map((selectOptionMedBrevtekst: ISelectOptionMedBrevtekst) => ({
-            ...selectOptionMedBrevtekst,
-            value:
-                selectOptionMedBrevtekst.value !== ''
-                    ? selectOptionMedBrevtekst.value
-                    : selectOptionMedBrevtekst.label.toLocaleLowerCase().replace(' ', '_'),
-        })) ?? []
+        selectOptionsMedBrevtekst?.map(
+            (selectOptionMedBrevtekst: Omit<ISelectOptionMedBrevtekst, 'value'>) => ({
+                ...selectOptionMedBrevtekst,
+                value: selectOptionMedBrevtekst.label.toLocaleLowerCase().replace(' ', '_'),
+            })
+        ) ?? []
     );
 };
 
@@ -62,10 +61,8 @@ export interface ISelectOptionMedBrevtekst extends OptionType {
     brevtekst?: Record<Målform, string>;
 }
 
-// Value settes ved henting av select option basert på label
-const dokumenter: ISelectOptionMedBrevtekst[] = [
+const dokumenter: Omit<ISelectOptionMedBrevtekst, 'value'>[] = [
     {
-        value: '',
         label: 'Adopsjon - barna',
         brevtekst: {
             NB: 'Dokumentasjon på adopsjon som viser hvilken dato du overtok omsorgen for barna.',
@@ -73,7 +70,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Adopsjon - barnet',
         brevtekst: {
             NB: 'Dokumentasjon på adopsjon som viser hvilken dato du overtok omsorgen for barnet.',
@@ -81,7 +77,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Ankomst Norge - barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser når barna kom til Norge.',
@@ -89,7 +84,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Ankomst Norge - barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser når barnet kom til Norge.',
@@ -97,7 +91,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Ankomst Norge - søker',
         brevtekst: {
             NB: 'Dokumentasjon som viser når du kom til Norge.',
@@ -105,7 +98,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Ankomst Norge - søker og barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser når du og barna kom til Norge.',
@@ -113,7 +105,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Ankomst Norge - søker og barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser når du og barnet kom til Norge.',
@@ -121,7 +112,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Avtale om delt bosted',
         brevtekst: {
             NB: 'Avtale om delt bosted.',
@@ -129,7 +119,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Avtale om fast bosted',
         brevtekst: {
             NB: 'Avtale om fast bosted.',
@@ -137,7 +126,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Bor sammen med - barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser at barna bor sammen med deg.',
@@ -145,7 +133,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Bor sammen med - barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser at barnet bor sammen med deg.',
@@ -153,7 +140,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Flyttet til søker - barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser hvilken dato barna flyttet til deg. Du må melde flytting til Folkeregisteret.',
@@ -161,7 +147,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Flyttet til søker - barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser hvilken dato barnet flyttet til deg. Du må melde flytting til Folkeregisteret.',
@@ -169,7 +154,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Folkeregistrert i Norge - barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser at barna har norsk fødselsnummer og er bosatt i Norge.',
@@ -177,7 +161,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Folkeregistrert i Norge - barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser at barnet har norsk fødselsnummer og er bosatt i Norge.',
@@ -185,7 +168,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Folkeregistrert i Norge - søker',
         brevtekst: {
             NB: 'Dokumentasjon som viser at du har norsk fødselsnummer og er bosatt i Norge.',
@@ -193,7 +175,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Folkeregistrert i Norge - søker og barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser at du og barna har norsk fødselsnummer og er bosatt i Norge.',
@@ -201,7 +182,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Folkeregistrert i Norge - søker og barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser at du og barnet har norsk fødselsnummer og er bosatt i Norge.',
@@ -209,7 +189,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Oppholdstillatelse - barna',
         brevtekst: {
             NB: 'Kopi av vedtak om oppholdstillatelse for barna.',
@@ -217,7 +196,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Oppholdstillatelse - barnet',
         brevtekst: {
             NB: 'Kopi av vedtak om oppholdstillatelse for barnet.',
@@ -225,7 +203,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Oppholdstillatelse - søker',
         brevtekst: {
             NB: 'Kopi av vedtak om oppholdstillatelse for deg.',
@@ -233,7 +210,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Oppholdstillatelse - søker og barna',
         brevtekst: {
             NB: 'Kopi av vedtak om oppholdstillatelse for deg og barna.',
@@ -241,7 +217,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Oppholdstillatelse - søker og barnet',
         brevtekst: {
             NB: 'Kopi av vedtak om oppholdstillatelse for deg og barnet.',
@@ -249,7 +224,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Rettsavgjørelse - barna',
         brevtekst: {
             NB: 'Rettsavgjørelse som viser fra hvilken dato barna bor sammen med deg.',
@@ -257,7 +231,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Rettsavgjørelse - barnet',
         brevtekst: {
             NB: 'Rettsavgjørelse som viser fra hvilken dato barnet bor sammen med deg.',
@@ -265,7 +238,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Utenlandsopphold, perioder - barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser hvilke perioder barna har vært i Norge og hvilke perioder barna har vært i utlandet. For eksempel kopi av flybilletter, kopi av pass med stempel, bekreftelse fra skole, barnehage eller helsestasjon.',
@@ -273,7 +245,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Utenlandsopphold, perioder - barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser hvilke perioder barnet har vært i Norge og hvilke perioder barnet har vært i utlandet. For eksempel kopi av flybilletter, kopi av pass med stempel, bekreftelse fra skole, barnehage eller helsestasjon.',
@@ -281,7 +252,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Utenlandsopphold, perioder - søker',
         brevtekst: {
             NB: 'Dokumentasjon som viser hvilke perioder du har vært i Norge og hvilke perioder du har vært i utlandet. For eksempel kopi av flybilletter eller kopi av pass med stempel.',
@@ -289,7 +259,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Utenlandsopphold, perioder - søker og barna',
         brevtekst: {
             NB: 'Dokumentasjon som viser hvilke perioder du og barna har vært i Norge og hvilke perioder dere har vært i utlandet. For eksempel kopi av flybilletter, kopi av pass med stempel, bekreftelse fra skole barnehage eller helsestasjon.',
@@ -297,7 +266,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Utenlandsopphold, perioder - søker og barnet',
         brevtekst: {
             NB: 'Dokumentasjon som viser hvilke perioder du og barnet har vært i Norge og hvilke perioder dere har vært i utlandet. For eksempel kopi av flybilletter, kopi av pass med stempel, bekreftelse fra skole barnehage eller helsestasjon.',
@@ -305,7 +273,6 @@ const dokumenter: ISelectOptionMedBrevtekst[] = [
         },
     },
     {
-        value: '',
         label: 'Vergefullmakt',
         brevtekst: {
             NB: 'Vergefullmakt.',

--- a/src/frontend/utils/fritekstfelter.ts
+++ b/src/frontend/utils/fritekstfelter.ts
@@ -1,0 +1,39 @@
+import { feil, Felt, FeltState, ok, Valideringsstatus } from '@navikt/familie-skjema';
+
+export interface IFritekstFelt {
+    tekst: string;
+    id: number;
+}
+
+export const genererIdBasertPåAndreFritekster = (fritekster?: Felt<FeltState<IFritekstFelt>[]>) => {
+    if (fritekster && fritekster.verdi.length > 0) {
+        return Math.max(...fritekster.verdi.map(fritekst => fritekst.verdi.id, 10)) + 1;
+    } else {
+        return 1;
+    }
+};
+
+export const lagInitiellFritekst = (
+    initiellVerdi: string,
+    id: number
+): FeltState<IFritekstFelt> => ({
+    feilmelding: initiellVerdi === '' ? 'Fritekstfeltet er tomt.' : '',
+    verdi: {
+        tekst: initiellVerdi,
+        id: id,
+    },
+    valider: (felt: FeltState<IFritekstFelt>) => {
+        if (felt.verdi.tekst.length > 220) {
+            return feil(felt, 'Du har nådd maks antall tegn: 220.');
+        } else if (felt.verdi.tekst.trim().length === 0) {
+            return feil(
+                felt,
+                'Du må skrive tekst i feltet, eller fjerne det om du ikke skal ha fritekst.'
+            );
+        } else {
+            return ok(felt);
+        }
+    },
+    valideringsstatus:
+        initiellVerdi === '' ? Valideringsstatus.IKKE_VALIDERT : Valideringsstatus.OK,
+});


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
legger til mulighet for fritekstfelt, og setter multiselect creatable false

kopierer fra FritekstVedtakbegrunnelser.tsx og VedtaksperiodeMedBegrunnelserContext.ts

trekker ut to hjelpefunksjoner. Tror ikke det er nyttig og trekke ut mer felles... ?

### 👀 Screen shots
<img width="385" alt="Screenshot 2021-11-29 at 21 09 47" src="https://user-images.githubusercontent.com/17552002/143935934-f276e548-9bfa-4883-ba06-a3d359826ec0.png">

<img width="634" alt="Screenshot 2021-11-29 at 21 10 02" src="https://user-images.githubusercontent.com/17552002/143935950-0a9b56cf-bc5a-472d-8ea8-b3e4ffd95a99.png">
