### PR TITLE
BUG: navigering oppgavebenk og fordeling 

### DIFF
--- a/src/frontend/komponenter/Oppgavebenk/OppgaveDirektelenke.tsx
+++ b/src/frontend/komponenter/Oppgavebenk/OppgaveDirektelenke.tsx
@@ -8,7 +8,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../context/AppContext';
 import { useFagsakRessurser } from '../../context/FagsakContext';
-import { useOppgaver } from '../../context/OppgaverContext';
 import { IOppgave, oppgaveTypeFilter, OppgavetypeFilter } from '../../typer/oppgave';
 import { hentFnrFraOppgaveIdenter } from '../../utils/oppgave';
 import FamilieBaseKnapp from '../Felleskomponenter/FamilieBaseKnapp';
@@ -20,7 +19,6 @@ interface IOppgaveDirektelenke {
 
 const OppgaveDirektelenke: React.FC<IOppgaveDirektelenke> = ({ oppgave }) => {
     const { settToast } = useApp();
-    const { harLøpendeSakIInfotrygd } = useOppgaver();
     const { hentFagsakForPerson } = useFagsakRessurser();
     const { sjekkTilgang } = useApp();
     const [laster, settLaster] = useState<boolean>(false);
@@ -28,22 +26,17 @@ const OppgaveDirektelenke: React.FC<IOppgaveDirektelenke> = ({ oppgave }) => {
     const oppgavetype = oppgaveTypeFilter[oppgave.oppgavetype as OppgavetypeFilter]?.id;
 
     const visTilgangsmodalEllerSendVidere = async (oppgave: IOppgave) => {
-        const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
+        settLaster(true);
 
+        const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
         if (brukerident) {
             if (await sjekkTilgang(brukerident, false)) {
-                const løpendeSak = await harLøpendeSakIInfotrygd(brukerident);
-                if (løpendeSak.status === RessursStatus.SUKSESS) {
-                    if (løpendeSak.data.harLøpendeSak) {
-                        history.push('/infotrygd', { bruker: brukerident });
-                    } else {
-                        history.push(`/oppgaver/journalfør/${oppgave.id}`);
-                    }
-                }
+                history.push(`/oppgaver/journalfør/${oppgave.id}`);
             }
         } else {
             history.push(`/oppgaver/journalfør/${oppgave.id}`);
         }
+        settLaster(false);
     };
 
     const sjekkTilgangOgGåTilBehandling = async (oppgave: IOppgave) => {
@@ -80,7 +73,6 @@ const OppgaveDirektelenke: React.FC<IOppgaveDirektelenke> = ({ oppgave }) => {
                     <FamilieBaseKnapp
                         key={'tiloppg'}
                         onClick={() => {
-                            settLaster(true);
                             visTilgangsmodalEllerSendVidere(oppgave);
                         }}
                         children={'Gå til oppgave'}

--- a/src/frontend/komponenter/Oppgavebenk/OppgavelisteSaksbehandler.tsx
+++ b/src/frontend/komponenter/Oppgavebenk/OppgavelisteSaksbehandler.tsx
@@ -69,7 +69,7 @@ const OppgavelisteSaksbehandler: React.FunctionComponent<IOppgavelisteSaksbehand
                         const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
 
                         if (!brukerident || (brukerident && (await sjekkTilgang(brukerident)))) {
-                            fordelOppgave(oppgave, innloggetSaksbehandler?.navIdent, brukerident);
+                            fordelOppgave(oppgave, innloggetSaksbehandler?.navIdent);
                         }
                     }}
                     children={'Plukk'}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-7833

Fjerner sjekk mot løpende sak i infotrygd ved navigering og fordeling av oppgaver ettersom dette skaper litt trøbbel i overgangen ved migrering av saker.

Avklart med Anna og Birgitte at vi ikke trenger å sjekke for løpende sak i infotrygd.