### PR TITLE
Bug: Vise perioder uten begrunnelser så lenge status ikke er avsluttet

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -138,10 +138,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                             </Alertstripe>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>
-                                <VedtaksperioderMedBegrunnelser
-                                    åpenBehandling={åpenBehandling}
-                                    erLesevisning={erLesevisning()}
-                                />
+                                <VedtaksperioderMedBegrunnelser åpenBehandling={åpenBehandling} />
                             </VedtaksbegrunnelseTeksterProvider>
                         )}
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -8,7 +8,7 @@ import type { IBehandling } from '../../../../../typer/behandling';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import { partition } from '../../../../../utils/commons';
-import { filtrerOgSorterPerioderMedBegrunnelseBehov2 } from '../../../../../utils/vedtakUtils';
+import { filtrerOgSorterPerioderMedBegrunnelseBehov } from '../../../../../utils/vedtakUtils';
 import { useVedtaksbegrunnelseTekster } from '../Context/VedtaksbegrunnelseTeksterContext';
 import { VedtaksperiodeMedBegrunnelserProvider } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 import OverskriftMedHjelpetekst from '../Felles/OverskriftMedHjelpetekst';
@@ -16,19 +16,17 @@ import VedtaksperiodeMedBegrunnelserPanel from './VedtaksperiodeMedBegrunnelserP
 
 interface IVedtakBegrunnelserTabell {
     åpenBehandling: IBehandling;
-    erLesevisning: boolean;
 }
 
 const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
     åpenBehandling,
-    erLesevisning,
 }) => {
     const { vedtaksbegrunnelseTekster } = useVedtaksbegrunnelseTekster();
 
-    const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov2(
+    const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
         åpenBehandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
-        erLesevisning,
-        åpenBehandling.resultat
+        åpenBehandling.resultat,
+        åpenBehandling.status
     );
 
     if (

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -1,4 +1,4 @@
-import { BehandlingResultat } from '../../../../../typer/behandling';
+import { BehandlingResultat, BehandlingStatus } from '../../../../../typer/behandling';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import {
@@ -13,7 +13,7 @@ import {
     mockOpphørsperiode,
     mockUtbetalingsperiode,
 } from '../../../../../utils/test/vedtak/vedtaksperiode.mock';
-import { filtrerOgSorterPerioderMedBegrunnelseBehov2 } from '../../../../../utils/vedtakUtils';
+import { filtrerOgSorterPerioderMedBegrunnelseBehov } from '../../../../../utils/vedtakUtils';
 
 describe('VedtakBegrunnelserContext', () => {
     describe('Test filtrerOgSorterPerioderMedBegrunnelseBehov', () => {
@@ -27,10 +27,10 @@ describe('VedtakBegrunnelserContext', () => {
                 mockUtbetalingsperiode({ fom: fom, tom: tom }),
                 mockAvslagsperiode({ fom: fom, tom: tom }),
             ];
-            const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov2(
+            const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                 vedtaksperioder,
-                false,
-                BehandlingResultat.AVSLÅTT_ENDRET_OG_OPPHØRT
+                BehandlingResultat.AVSLÅTT_ENDRET_OG_OPPHØRT,
+                BehandlingStatus.UTREDES
             );
             expect(perioder.length).toBe(3);
             expect(perioder[0].type).toBe(Vedtaksperiodetype.UTBETALING);
@@ -39,16 +39,15 @@ describe('VedtakBegrunnelserContext', () => {
         });
 
         describe('Test lesevisning', () => {
-            const erLesevisning = true;
-            test(`Test at ubegrunnede perioder ikke returneres ved lesevisning`, () => {
+            test(`Test at ubegrunnede perioder ikke returneres ved avsluttet behandling`, () => {
                 const vedtaksperioder: IVedtaksperiodeMedBegrunnelser[] = [
                     mockOpphørsperiode({ fom: opphørFom }),
                     mockUtbetalingsperiode({ fom: fom, tom: tom, begrunnelser: [] }),
                 ];
-                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov2(
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     vedtaksperioder,
-                    erLesevisning,
-                    BehandlingResultat.INNVILGET_OG_OPPHØRT
+                    BehandlingResultat.INNVILGET_OG_OPPHØRT,
+                    BehandlingStatus.AVSLUTTET
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toEqual(Vedtaksperiodetype.OPPHØR);
@@ -67,15 +66,15 @@ describe('VedtakBegrunnelserContext', () => {
                     1,
                     KalenderEnhet.MÅNED
                 );
-                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov2(
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     [
                         mockUtbetalingsperiode({
                             fom: serializeIso8601String(enMndFremITidFom),
                             tom: serializeIso8601String(enMndFremITidTom),
                         }),
                     ],
-                    false,
-                    BehandlingResultat.INNVILGET
+                    BehandlingResultat.INNVILGET,
+                    BehandlingStatus.UTREDES
                 );
                 expect(perioder.length).toBe(1);
             });
@@ -91,15 +90,15 @@ describe('VedtakBegrunnelserContext', () => {
                     KalenderEnhet.MÅNED
                 );
 
-                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov2(
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     [
                         mockUtbetalingsperiode({
                             fom: serializeIso8601String(toMndFremITidFom),
                             tom: serializeIso8601String(toMndFremITidTom),
                         }),
                     ],
-                    false,
-                    BehandlingResultat.INNVILGET
+                    BehandlingResultat.INNVILGET,
+                    BehandlingStatus.UTREDES
                 );
                 expect(perioder.length).toBe(0);
             });
@@ -109,10 +108,10 @@ describe('VedtakBegrunnelserContext', () => {
                     mockUtbetalingsperiode({ fom: fom, tom: tom }),
                     mockAvslagsperiode({ fom: fom, tom: tom }),
                 ];
-                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov2(
+                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     vedtaksperioder,
-                    false,
-                    BehandlingResultat.OPPHØRT
+                    BehandlingResultat.OPPHØRT,
+                    BehandlingStatus.UTREDES
                 );
                 expect(perioder.length).toBe(1);
                 expect(perioder[0].type).toBe(Vedtaksperiodetype.OPPHØR);

--- a/src/frontend/utils/vedtakUtils.ts
+++ b/src/frontend/utils/vedtakUtils.ts
@@ -3,7 +3,7 @@ import navFarger from 'nav-frontend-core';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { BehandlingResultat } from '../typer/behandling';
+import { BehandlingResultat, BehandlingStatus } from '../typer/behandling';
 import type { IRestVedtakBegrunnelseTilknyttetVilkår, VedtakBegrunnelse } from '../typer/vedtak';
 import { VedtakBegrunnelseType } from '../typer/vedtak';
 import type { IVedtaksperiodeMedBegrunnelser } from '../typer/vedtaksperiode';
@@ -19,10 +19,10 @@ import {
     TIDENES_MORGEN,
 } from './kalender';
 
-export const filtrerOgSorterPerioderMedBegrunnelseBehov2 = (
+export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
     vedtaksperioder: IVedtaksperiodeMedBegrunnelser[],
-    erLesevisning: boolean,
-    behandlingResultat: BehandlingResultat
+    behandlingResultat: BehandlingResultat,
+    behandlingStatus: BehandlingStatus
 ): IVedtaksperiodeMedBegrunnelser[] => {
     const sorterteOgFiltrertePerioder = vedtaksperioder
         .slice()
@@ -33,7 +33,7 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov2 = (
             )
         )
         .filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
-            if (erLesevisning) {
+            if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
                 return harPeriodeBegrunnelse(vedtaksperiode);
             } else {
                 return erPeriodeFomMindreEnn2MndFramITid(vedtaksperiode);
@@ -41,7 +41,7 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov2 = (
         });
 
     if (behandlingResultat === BehandlingResultat.OPPHØRT) {
-        return [hentSisteOpphørsperiode(sorterteOgFiltrertePerioder)];
+        return hentSisteOpphørsperiode(sorterteOgFiltrertePerioder);
     } else {
         return sorterteOgFiltrertePerioder;
     }
@@ -64,7 +64,9 @@ const hentSisteOpphørsperiode = (sortertePerioder: IVedtaksperiodeMedBegrunnels
         (vedtaksperiode: IVedtaksperiodeMedBegrunnelser) =>
             vedtaksperiode.type === Vedtaksperiodetype.OPPHØR
     );
-    return sorterteOgFiltrerteOpphørsperioder[sorterteOgFiltrerteOpphørsperioder.length - 1];
+    const sisteOpphørsPeriode =
+        sorterteOgFiltrerteOpphørsperioder[sorterteOgFiltrerteOpphørsperioder.length - 1];
+    return sisteOpphørsPeriode ? [sisteOpphørsPeriode] : [];
 };
 
 export const finnVedtakBegrunnelseType = (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Kom ikke inn på åpen behandling med status opphørt med veileder rolle. Det skyldtes at funksjonen som hentet siste opphørsperiode returnerte undefined (og ikke tom liste) hvis det ikke var noen opphørsperioder.

- Returnerer tom liste hvis det ikke er noen siste opphørsperiode
- Viser alltid perioder hvis behandlingen er åpen. Hvis behandlingen er avsluttet vises kun de med begrunnelser knyttet til seg.

![image](https://user-images.githubusercontent.com/25459913/158159832-07dedca9-3cba-4c56-9fb6-5ae802503f12.png)


### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
