### PR TITLE
Gjøre det umulig å manuelt journalføre uten å plukke oppgaven først

### DIFF
--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -5,8 +5,9 @@ import createUseContext from 'constate';
 import { useHistory, useParams } from 'react-router';
 
 import { useHttp } from '@navikt/familie-http';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
+import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
+import type { IDokumentInfo, Ressurs } from '@navikt/familie-typer';
 import {
     byggFeiletRessurs,
     byggHenterRessurs,
@@ -14,7 +15,6 @@ import {
     Journalstatus,
     RessursStatus,
 } from '@navikt/familie-typer';
-import type { IDokumentInfo, Ressurs } from '@navikt/familie-typer';
 
 import useDokument from '../hooks/useDokument';
 import type { VisningBehandling } from '../komponenter/Fagsak/Saksoversikt/visningBehandling';
@@ -396,7 +396,10 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
     const erLesevisning = () => {
         return (
             dataForManuellJournalføring.status === RessursStatus.SUKSESS &&
-            dataForManuellJournalføring.data.journalpost.journalstatus !== Journalstatus.MOTTATT
+            (dataForManuellJournalføring.data.journalpost.journalstatus !== Journalstatus.MOTTATT ||
+                (innloggetSaksbehandler !== undefined &&
+                    dataForManuellJournalføring.data.oppgave.tilordnetRessurs !==
+                        innloggetSaksbehandler.navIdent))
         );
     };
 

--- a/src/frontend/context/OppgaverContext.tsx
+++ b/src/frontend/context/OppgaverContext.tsx
@@ -17,9 +17,9 @@ import {
     byggFeiletRessurs,
     byggHenterRessurs,
     byggTomRessurs,
-    type Ressurs,
     RessursStatus,
 } from '@navikt/familie-typer';
+import type { Ressurs } from '@navikt/familie-typer';
 
 import useFagsakApi from '../komponenter/Fagsak/useFagsakApi';
 import { ToastTyper } from '../komponenter/Felleskomponenter/Toast/typer';

--- a/src/frontend/komponenter/ManuellJournalfør/AvsenderPanel.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/AvsenderPanel.tsx
@@ -60,7 +60,7 @@ export const AvsenderPanel: React.FC = () => {
             }}
         >
             <FamilieCheckbox
-                erLesevisning={false}
+                erLesevisning={erLesevisning()}
                 label={'Avsender er bruker'}
                 checked={brukerErAvsender}
                 onChange={() => {

--- a/src/frontend/komponenter/ManuellJournalfør/JournalpostSkjema.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/JournalpostSkjema.tsx
@@ -7,6 +7,7 @@ import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import { Feiloppsummering } from 'nav-frontend-skjema';
 import { Undertittel } from 'nav-frontend-typografi';
 
+import { Back } from '@navikt/ds-icons';
 import { FamilieKnapp } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -26,6 +27,18 @@ const Container = styled.div`
 const StyledSectionDiv = styled.div`
     margin-top: 2.5rem;
 `;
+
+const StyledIkonKnappDiv = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const tilbakeKnappInnhold = (
+    <StyledIkonKnappDiv>
+        <Back />
+        Tilbake
+    </StyledIkonKnappDiv>
+);
 
 export const JournalpostSkjema: React.FC = () => {
     const { skjema, journalfør, hentFeilTilOppsummering, erLesevisning } = useManuellJournalfør();
@@ -69,7 +82,7 @@ export const JournalpostSkjema: React.FC = () => {
                     onClick={() => history.push(`/oppgaver`)}
                     disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                 >
-                    {erLesevisning() ? 'Tilbake' : 'Avbryt'}
+                    {erLesevisning() ? tilbakeKnappInnhold : 'Avbryt'}
                 </FamilieKnapp>
                 <FamilieKnapp
                     mini={true}

--- a/src/frontend/komponenter/ManuellJournalfør/JournalpostSkjema.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/JournalpostSkjema.tsx
@@ -69,7 +69,7 @@ export const JournalpostSkjema: React.FC = () => {
                     onClick={() => history.push(`/oppgaver`)}
                     disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                 >
-                    Avbryt
+                    {erLesevisning() ? 'Tilbake' : 'Avbryt'}
                 </FamilieKnapp>
                 <FamilieKnapp
                     mini={true}

--- a/src/frontend/typer/oppgave.ts
+++ b/src/frontend/typer/oppgave.ts
@@ -40,7 +40,7 @@ export interface IOppgave {
     opprettetTidspunkt: string;
     prioritet: string;
     status: string;
-    tilordnetRessurs: string;
+    tilordnetRessurs?: string;
 }
 
 export interface IOppgaveIdent {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8259

Innfører lesevisning i manuell journalføring om oppgaven ikke er plukket av den innloggede saksbehandleren.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
