### PR TITLE
Ikke vis vedtaksperioder hvis behandlingen er avsluttet

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
-import Alertstripe, { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { Knapp } from 'nav-frontend-knapper';
 import { Normaltekst } from 'nav-frontend-typografi';
 
+import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
@@ -93,6 +94,16 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
         åpenBehandling.årsak !== BehandlingÅrsak.SATSENDRING &&
         !erMigreringFraInfotrygd;
 
+    const hentInfostripeTekst = (årsak: BehandlingÅrsak, status: BehandlingStatus): string => {
+        if (status === BehandlingStatus.AVSLUTTET) {
+            return "Behandlingen er avsluttet. Du kan se vedtaksbrevet ved å trykke på 'Vis vedtaksbrev'.";
+        } else if (årsak === BehandlingÅrsak.DØDSFALL_BRUKER) {
+            return 'Vedtak om opphør på grunn av dødsfall er automatisk generert.';
+        } else if (årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV) {
+            return 'Behandling bruker manuelt skrevet vedtaksbrev. Forhåndsvis for å se brevet.';
+        } else return '';
+    };
+
     return (
         <Skjemasteg
             tittel={'Vedtak'}
@@ -124,18 +135,16 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                     />
                     <Container>
                         {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
-                        åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ? (
-                            <Alertstripe
-                                type="info"
-                                style={{ margin: '2rem 0 1rem 0' }}
-                                form="inline"
-                            >
+                        åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
+                        åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (
+                            <Alert variant="info" style={{ margin: '2rem 0 1rem 0' }}>
                                 <b>
-                                    {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER
-                                        ? 'Vedtak om opphør på grunn av dødsfall er automatisk generert.'
-                                        : 'Behandling bruker manuelt skrevet vedtaksbrev. Forhåndsvis for å se brevet.'}
+                                    {hentInfostripeTekst(
+                                        åpenBehandling.årsak,
+                                        åpenBehandling.status
+                                    )}
                                 </b>
-                            </Alertstripe>
+                            </Alert>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>
                                 <VedtaksperioderMedBegrunnelser åpenBehandling={åpenBehandling} />

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -96,7 +96,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
 
     const hentInfostripeTekst = (årsak: BehandlingÅrsak, status: BehandlingStatus): string => {
         if (status === BehandlingStatus.AVSLUTTET) {
-            return "Behandlingen er avsluttet. Du kan se vedtaksbrevet ved å trykke på 'Vis vedtaksbrev'.";
+            return 'Behandlingen er avsluttet. Du kan se vedtaksbrevet ved å trykke på "Vis vedtaksbrev".';
         } else if (årsak === BehandlingÅrsak.DØDSFALL_BRUKER) {
             return 'Vedtak om opphør på grunn av dødsfall er automatisk generert.';
         } else if (årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8314

Kun vise vedtaksbrevet på vedtak-siden om behandlingen er avsluttet. Samtidig har jeg oppgradert Alerten til å være nyeste typen fra designbiblioteket.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Tidligere var Alerten inline, men dvs. at den blå bakgrunnen blir borte. Trodde denne skulle være med, så tar den tilbake igjen 🤔 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/25459913/160636888-87585a6d-8de3-4409-8f73-acf68802abe8.png)