### PR TITLE
Fikset logikken som viser valg til å opprette migreringsbehandling

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -108,15 +108,16 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
     const erHelmanuellMigrering =
         erMigreringFraInfotrygd && behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
     const kanOppretteMigreringsbehandlingMedEndreMigreringsdato =
+        kanOppretteMigreringFraInfotrygd &&
         (!minimalFagsak
             ? false
             : minimalFagsak.behandlinger.filter(
                   behandling =>
                       !erBehandlingHenlagt(behandling.resultat) &&
                       behandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD
-              ).length > 0 && kanOppretteBehandling) && erMigreringFraInfotrygd;
+              ).length > 0);
     const kanOpprettMigreringsbehandlingMedHelmanuellMigrering =
-        kanOppretteFørstegangsbehandling && !kanOppretteMigreringsbehandlingMedEndreMigreringsdato;
+        kanOppretteMigreringFraInfotrygd && !kanOppretteMigreringsbehandlingMedEndreMigreringsdato;
 
     const barn = bruker?.forelderBarnRelasjon
         .filter(relasjon => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -107,6 +107,16 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
         !manuellJournalfør && behandlingstype.verdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
     const erHelmanuellMigrering =
         erMigreringFraInfotrygd && behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
+    const kanOppretteMigreringsbehandlingMedEndreMigreringsdato =
+        (!minimalFagsak
+            ? false
+            : minimalFagsak.behandlinger.filter(
+                  behandling =>
+                      !erBehandlingHenlagt(behandling.resultat) &&
+                      behandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD
+              ).length > 0 && kanOppretteBehandling) && erMigreringFraInfotrygd;
+    const kanOpprettMigreringsbehandlingMedHelmanuellMigrering =
+        kanOppretteFørstegangsbehandling && !kanOppretteMigreringsbehandlingMedEndreMigreringsdato;
 
     const barn = bruker?.forelderBarnRelasjon
         .filter(relasjon => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
@@ -194,9 +204,9 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                         ? Object.values(BehandlingÅrsak)
                               .filter(
                                   årsak =>
-                                      (kanOppretteFørstegangsbehandling &&
+                                      (kanOpprettMigreringsbehandlingMedHelmanuellMigrering &&
                                           årsak === BehandlingÅrsak.HELMANUELL_MIGRERING) ||
-                                      (!kanOppretteFørstegangsbehandling &&
+                                      (kanOppretteMigreringsbehandlingMedEndreMigreringsdato &&
                                           årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO)
                               )
                               .map(årsak => {


### PR DESCRIPTION
Fikset logikken som viser valg til å opprette migreringsbehandling med endre migreringsdato. Nå viser det alltid når det finnes minst en migreringsbehandling og ikke er henlagt

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8512

Signed-off-by: Saikat Halder <saikat.halder@nav.no>

### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
