### PR TITLE
TEA-8583 Disabler valget opprett med varsel dersom bruker er død

### DIFF
--- a/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
@@ -251,97 +251,105 @@ const TilbakekrevingSkjema: React.FC<{
                         </FlexDiv>
                     }
                 >
-                    <Radio
-                        label={'Opprett tilbakekreving, send varsel'}
-                        name={'tilbakekreving'}
-                        disabled={!bruker || bruker.dødsfallDato !== undefined}
-                        checked={
-                            tilbakekrevingsvalg.verdi ===
-                            Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL
-                        }
-                        onChange={() =>
-                            radioOnChange(Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL)
-                        }
-                        id={'Opprett-tilbakekreving-send-varsel'}
-                    />
-                    {fritekstVarsel.erSynlig && (
-                        <FritekstVarsel>
-                            <FamilieTextarea
-                                label={
-                                    <FritektsVarselLabel>
-                                        <FlexRad>
-                                            <Element>Fritekst i varselet</Element>
-                                            <StyledHelpText placement="right">
-                                                <StyledHelpTextContainer>
-                                                    <BodyLong size="small" spacing={true}>
-                                                        Her skal du oppgi hvorfor brukeren ikke
-                                                        skulle fått utbetalt ytelsen i perioden(e).
-                                                        Du må også oppgi hvordan feilutbetalingen
-                                                        ble oppdaget, hvem som oppdaget den og når
-                                                        den ble oppdaget eller meldt til NAV.
-                                                    </BodyLong>
-                                                    <BodyLong size="small" spacing={true}>
-                                                        Eksempel på tekst:
-                                                    </BodyLong>
-                                                    <BodyLong size="small" spacing={true}>
-                                                        Vi mottok melding fra deg (dato) om at du
-                                                        flyttet utenlands (dato). Du har ikke rett
-                                                        på barnetrygd når du oppholder deg
-                                                        utenlands. Da vi mottok meldingen fra deg,
-                                                        var det allerede utbetalt barnetrygd for
-                                                        perioden (Fom dato - Tom dato).
-                                                    </BodyLong>
-                                                    <Lenke
-                                                        href="https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Språk.aspx"
-                                                        target="_blank"
-                                                    >
-                                                        <span>
-                                                            Se retningslinjer for klarspråk:
-                                                        </span>
-                                                        <ExternalLink />
-                                                    </Lenke>
-                                                </StyledHelpTextContainer>
-                                            </StyledHelpText>
-                                        </FlexRad>
-                                        <StyledEtikettInfo>
-                                            <Undertekst>
-                                                Skriv {målform[søkerMålform].toLowerCase()}
-                                            </Undertekst>
-                                        </StyledEtikettInfo>
-                                    </FritektsVarselLabel>
+                    {bruker && !bruker.dødsfallDato && (
+                        <>
+                            <Radio
+                                label={'Opprett tilbakekreving, send varsel'}
+                                name={'tilbakekreving'}
+                                checked={
+                                    tilbakekrevingsvalg.verdi ===
+                                    Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL
                                 }
-                                {...fritekstVarsel.hentNavInputProps(
-                                    tilbakekrevingSkjema.visFeilmeldinger ||
-                                        fritekstVarsel.verdi.length > maksLengdeTekst
-                                )}
-                                erLesevisning={erLesevisning()}
-                                maxLength={maksLengdeTekst}
+                                onChange={() =>
+                                    radioOnChange(
+                                        Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL
+                                    )
+                                }
+                                id={'Opprett-tilbakekreving-send-varsel'}
                             />
+                            {fritekstVarsel.erSynlig && (
+                                <FritekstVarsel>
+                                    <FamilieTextarea
+                                        label={
+                                            <FritektsVarselLabel>
+                                                <FlexRad>
+                                                    <Element>Fritekst i varselet</Element>
+                                                    <StyledHelpText placement="right">
+                                                        <StyledHelpTextContainer>
+                                                            <BodyLong size="small" spacing={true}>
+                                                                Her skal du oppgi hvorfor brukeren
+                                                                ikke skulle fått utbetalt ytelsen i
+                                                                perioden(e). Du må også oppgi
+                                                                hvordan feilutbetalingen ble
+                                                                oppdaget, hvem som oppdaget den og
+                                                                når den ble oppdaget eller meldt til
+                                                                NAV.
+                                                            </BodyLong>
+                                                            <BodyLong size="small" spacing={true}>
+                                                                Eksempel på tekst:
+                                                            </BodyLong>
+                                                            <BodyLong size="small" spacing={true}>
+                                                                Vi mottok melding fra deg (dato) om
+                                                                at du flyttet utenlands (dato). Du
+                                                                har ikke rett på barnetrygd når du
+                                                                oppholder deg utenlands. Da vi
+                                                                mottok meldingen fra deg, var det
+                                                                allerede utbetalt barnetrygd for
+                                                                perioden (Fom dato - Tom dato).
+                                                            </BodyLong>
+                                                            <Lenke
+                                                                href="https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Språk.aspx"
+                                                                target="_blank"
+                                                            >
+                                                                <span>
+                                                                    Se retningslinjer for klarspråk:
+                                                                </span>
+                                                                <ExternalLink />
+                                                            </Lenke>
+                                                        </StyledHelpTextContainer>
+                                                    </StyledHelpText>
+                                                </FlexRad>
+                                                <StyledEtikettInfo>
+                                                    <Undertekst>
+                                                        Skriv {målform[søkerMålform].toLowerCase()}
+                                                    </Undertekst>
+                                                </StyledEtikettInfo>
+                                            </FritektsVarselLabel>
+                                        }
+                                        {...fritekstVarsel.hentNavInputProps(
+                                            tilbakekrevingSkjema.visFeilmeldinger ||
+                                                fritekstVarsel.verdi.length > maksLengdeTekst
+                                        )}
+                                        erLesevisning={erLesevisning()}
+                                        maxLength={maksLengdeTekst}
+                                    />
 
-                            <ForhåndsvisVarselKnappContainer>
-                                <IkonKnapp
-                                    id={'forhandsvis-varsel'}
-                                    erLesevisning={false}
-                                    label={'Forhåndsvis varsel'}
-                                    ikon={<DokumentIkon />}
-                                    onClick={() =>
-                                        åpenBehandling.status === RessursStatus.SUKSESS &&
-                                        hentForhåndsvisning<IForhåndsvisTilbakekrevingsvarselbrevRequest>(
-                                            {
-                                                method: 'POST',
-                                                url: `/familie-ba-sak/api/tilbakekreving/${åpenBehandling.data.behandlingId}/forhandsvis-varselbrev`,
-                                                data: {
-                                                    fritekst: fritekstVarsel.verdi,
-                                                },
+                                    <ForhåndsvisVarselKnappContainer>
+                                        <IkonKnapp
+                                            id={'forhandsvis-varsel'}
+                                            erLesevisning={false}
+                                            label={'Forhåndsvis varsel'}
+                                            ikon={<DokumentIkon />}
+                                            onClick={() =>
+                                                åpenBehandling.status === RessursStatus.SUKSESS &&
+                                                hentForhåndsvisning<IForhåndsvisTilbakekrevingsvarselbrevRequest>(
+                                                    {
+                                                        method: 'POST',
+                                                        url: `/familie-ba-sak/api/tilbakekreving/${åpenBehandling.data.behandlingId}/forhandsvis-varselbrev`,
+                                                        data: {
+                                                            fritekst: fritekstVarsel.verdi,
+                                                        },
+                                                    }
+                                                )
                                             }
-                                        )
-                                    }
-                                    spinner={hentetDokument.status === RessursStatus.HENTER}
-                                    ikonPosisjon={IkonPosisjon.VENSTRE}
-                                    mini={true}
-                                />
-                            </ForhåndsvisVarselKnappContainer>
-                        </FritekstVarsel>
+                                            spinner={hentetDokument.status === RessursStatus.HENTER}
+                                            ikonPosisjon={IkonPosisjon.VENSTRE}
+                                            mini={true}
+                                        />
+                                    </ForhåndsvisVarselKnappContainer>
+                                </FritekstVarsel>
+                            )}
+                        </>
                     )}
                     <Radio
                         label={'Opprett tilbakekreving, ikke send varsel'}

--- a/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
@@ -16,6 +16,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 import type { Ressurs } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
+import { useFagsakRessurser } from '../../../context/FagsakContext';
 import { useSimulering } from '../../../context/SimuleringContext';
 import useDokument from '../../../hooks/useDokument';
 import { DokumentIkon } from '../../../ikoner/DokumentIkon';
@@ -94,6 +95,8 @@ const TilbakekrevingSkjema: React.FC<{
     const { fritekstVarsel, begrunnelse, tilbakekrevingsvalg } = tilbakekrevingSkjema.felter;
     const { hentForhåndsvisning, visDokumentModal, hentetDokument, settVisDokumentModal } =
         useDokument();
+    const { bruker: brukerRessurs } = useFagsakRessurser();
+    const bruker = brukerRessurs.status === RessursStatus.SUKSESS ? brukerRessurs.data : undefined;
 
     const radioOnChange = (tilbakekrevingsalternativ: Tilbakekrevingsvalg) => {
         tilbakekrevingSkjema.felter.tilbakekrevingsvalg.validerOgSettFelt(
@@ -251,6 +254,7 @@ const TilbakekrevingSkjema: React.FC<{
                     <Radio
                         label={'Opprett tilbakekreving, send varsel'}
                         name={'tilbakekreving'}
+                        disabled={!bruker || bruker.dødsfallDato !== undefined}
                         checked={
                             tilbakekrevingsvalg.verdi ===
                             Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Varselbrevet som blir sendt ut av familie-tilbake har litt uheldig ordlyd når bruker er død. Så inntil varselbrevet er endret til å støtte at bruker er død, må valget "Opprett tilbakekreving, send varsel" disables i ba-sak.

Har ikke byttet til nye Radio-knapper frå det nye design-systemet. Eg tror det bør fyrst støttes i familie-felles-frontend.

Favro-kortet [TEA-8583](https://favro.com/organization/98c34fb974ce445eac854de0/86f241541982404a7491d82d?card=Tea-8583) ligger i Tilbakekrevings-boardet.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
