### PR TITLE
Unngå at nedetid i Sentry fører til feil i byggsteget vårt

### DIFF
--- a/src/webpack/webpack.prod.js
+++ b/src/webpack/webpack.prod.js
@@ -62,6 +62,9 @@ const prodConfig = merge.mergeWithRules({
             url: 'https://sentry.gc.nav.no/',
             release: process.env.SENTRY_RELEASE,
             urlPrefix: `~/assets`,
+            errorHandler: (err, invokeErr, compilation) => {
+                compilation.warnings.push('Sentry CLI Plugin: ' + err.message);
+            },
         }),
     ],
 });


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Sånn det er nå vil byggsteget vårt kaste feil dersom det ikke får kontakt med Sentry under bygging. Vi opplever jo litt nedetid iblant i Sentry... Denne endringen gjør at byggsteget kaster en advarsel i stedet for en feil. Vi kan leve med at sourcemap ikke stemmer på Sentry i en kort periode inntil vi deployer og får kontakt med Sentry igjen.

Koden er hentet fra [pluginens dokumentasjon](https://github.com/getsentry/sentry-webpack-plugin#options)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Dette er en del av byggsteget vårt og det testes ved at PR-branchen bygger grønt

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
