### PR TITLE
Formattering av person på endret utbetalingsandel

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
@@ -14,7 +14,7 @@ import StatusIkon, { Status } from '../../../ikoner/StatusIkon';
 import type { IBehandling } from '../../../typer/behandling';
 import type { IRestEndretUtbetalingAndel } from '../../../typer/utbetalingAndel';
 import { IEndretUtbetalingAndelÅrsak, årsakTekst } from '../../../typer/utbetalingAndel';
-import { formaterIdent } from '../../../utils/formatter';
+import { lagPersonLabel } from '../../../utils/formatter';
 import { yearMonthPeriodeToString } from '../../../utils/kalender';
 import EndretUtbetalingAndelSkjema from './EndretUtbetalingAndelSkjema';
 
@@ -113,12 +113,12 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
                             heigth={20}
                             width={20}
                         />
-                        {formaterIdent(
-                            endretUtbetalingAndel.personIdent
-                                ? endretUtbetalingAndel.personIdent
-                                : '',
-                            'Ikke satt'
-                        )}
+                        {endretUtbetalingAndel.personIdent
+                            ? lagPersonLabel(
+                                  endretUtbetalingAndel.personIdent,
+                                  åpenBehandling.personer
+                              )
+                            : 'Ikke satt'}
                     </PersonCelle>
                 </TdUtenUnderstrek>
                 <TdUtenUnderstrek erÅpen={åpenUtbetalingsAndel}>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -30,7 +30,7 @@ import {
     årsaker,
     årsakTekst,
 } from '../../../typer/utbetalingAndel';
-import { datoformatNorsk, formaterIdent } from '../../../utils/formatter';
+import { datoformatNorsk, lagPersonLabel } from '../../../utils/formatter';
 import type { YearMonth } from '../../../utils/kalender';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
 import IkonKnapp, { IkonPosisjon } from '../../Felleskomponenter/IkonKnapp/IkonKnapp';
@@ -200,7 +200,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                     value={person.personIdent}
                                     key={`${index}_${person.fødselsdato}`}
                                 >
-                                    {formaterIdent(person.personIdent)}
+                                    {lagPersonLabel(person.personIdent, åpenBehandling.personer)}
                                 </option>
                             ))}
                     </StyledPersonvelger>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
@@ -6,7 +6,8 @@ import { Alert, Heading } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
 
 import type { IBehandling } from '../../../../typer/behandling';
-import { type IKompetanse, KompetanseStatus } from '../../../../typer/kompetanse';
+import type { IKompetanse } from '../../../../typer/kompetanse';
+import { KompetanseStatus } from '../../../../typer/kompetanse';
 import KompetanseTabellRad from './KompetanseTabellRad';
 
 const KompetanseContainer = styled.div`
@@ -16,7 +17,6 @@ const KompetanseContainer = styled.div`
 const Tabell = styled.table`
     margin-top: 2rem;
     table-layout: fixed;
-    min-width: 64rem;
 
     & fieldset.skjemagruppe {
         margin-bottom: 1.5rem;

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
@@ -12,7 +12,7 @@ import StatusIkon, { Status } from '../../../../ikoner/StatusIkon';
 import type { IBehandling } from '../../../../typer/behandling';
 import type { IKompetanse } from '../../../../typer/kompetanse';
 import { KompetanseStatus, KompetanseResultat } from '../../../../typer/kompetanse';
-import { datoformat, formaterIsoDato, hentAlder } from '../../../../utils/formatter';
+import { datoformat, formaterIsoDato, lagPersonLabel } from '../../../../utils/formatter';
 import type { IYearMonthPeriode } from '../../../../utils/kalender';
 import IkonKnapp from '../../../Felleskomponenter/IkonKnapp/IkonKnapp';
 import { kompetanseFeilmeldingId } from './KompetanseSkjema';
@@ -96,18 +96,9 @@ const KompetanseTabellRad: React.FC<IProps> = ({
         }
     };
 
-    const lagLabelBarn = (barnetsIdent: string): string => {
-        const barnet = åpenBehandling.personer.find(person => person.personIdent === barnetsIdent);
-        if (barnet) {
-            return `${barnet.navn} (${hentAlder(barnet.fødselsdato)} år) ${barnet.personIdent}`;
-        } else {
-            return barnetsIdent;
-        }
-    };
-
     const barn: OptionType[] = kompetanse.verdi?.barnIdenter.verdi.map(barn => ({
         value: barn,
-        label: lagLabelBarn(barn),
+        label: lagPersonLabel(barn, åpenBehandling.personer),
     }));
 
     const formatterPeriode = (periode: IYearMonthPeriode): string => {
@@ -131,7 +122,7 @@ const KompetanseTabellRad: React.FC<IProps> = ({
                         <BarnDiv>
                             {kompetanse.verdi?.barnIdenter.verdi.map(barn => (
                                 <BodyShort size="small" key={barn}>
-                                    {lagLabelBarn(barn)}
+                                    {lagPersonLabel(barn, åpenBehandling.personer)}
                                 </BodyShort>
                             ))}
                         </BarnDiv>

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -87,6 +87,17 @@ export const formaterIdent = (personIdent: string, ukjentTekst = 'Ukjent id') =>
         : ukjentTekst;
 };
 
+export const lagPersonLabel = (ident: string, personer: IGrunnlagPerson[]): string => {
+    const person = personer.find(person => person.personIdent === ident);
+    if (person) {
+        return `${person.navn} (${hentAlder(person.fødselsdato)} år) ${formaterIdent(
+            person.personIdent
+        )}`;
+    } else {
+        return ident;
+    }
+};
+
 export const sorterFødselsdato = (fødselsDatoA: string, fødselsDatoB: string) =>
     familieDayjs(fødselsDatoA).isBefore(fødselsDatoB) ? 1 : -1;
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8729

Formatterer personer i endret utbetalingsperiode på samme måte som i kompetanse-tabell. 

Fjerner i tillegg min-width på kompetanse-tabellen, da den var alt for bred for vanlig skjermbredde.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nop

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Mest visuelle endringer

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før:
![image](https://user-images.githubusercontent.com/25459913/169832310-2e68547e-626a-4f1c-a168-046451b15396.png)


Etter:
![image](https://user-images.githubusercontent.com/25459913/169829330-44a4e757-b9af-4988-95ed-db8e1c8c9379.png)
