### PR TITLE
Endre proxyUrl til ba-sak backend tilbake til localhost

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -8,7 +8,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_development',
             namespace: 'local',
-            proxyUrl: 'https://familie-ba-sak.dev.intern.nav.no',
+            proxyUrl: 'http://localhost:8089',
             familieTilbakeUrl: 'http://localhost:8000',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
         };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Url til ba-sak backend ble med et uhell byttet til preprod-url i denne PRen: https://github.com/navikt/familie-ba-sak-frontend/pull/2121
Gjorde at man får "Ugyldig sesjon" ved lokal kjøring. Endrer tilbake. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nop

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Unødvendig

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
