### PR TITLE
Lagt til checked prop på BarnBrevetGjelder checkbox

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
@@ -40,7 +40,7 @@ interface IProps {
 const BarnBrevetGjelder = (props: IProps) => {
     const { barnBrevetGjelderFelt, visFeilmeldinger, settVisFeilmeldinger, alternativer } = props;
 
-    const sorterteBarn = alternativer.sort((a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
+    alternativer.sort((a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
         if (!a.fødselsdato || a.fødselsdato === '') {
             return 1;
         }
@@ -62,7 +62,7 @@ const BarnBrevetGjelder = (props: IProps) => {
             {...barnBrevetGjelderFelt.hentNavBaseSkjemaProps(visFeilmeldinger)}
             legend={'Hvilke barn gjelder brevet?'}
         >
-            {sorterteBarn.map((barn: IBarnMedOpplysninger) => {
+            {alternativer.map((barn: IBarnMedOpplysninger) => {
                 const barnLabel = lagBarnLabel(barn);
                 return (
                     <StyledFamilieCheckbox
@@ -72,6 +72,7 @@ const BarnBrevetGjelder = (props: IProps) => {
                                 <LabelTekst title={barnLabel}>{barnLabel}</LabelTekst>
                             </LabelContent>
                         }
+                        checked={barn.merket}
                         onChange={event => {
                             const barnSkalMerkes = event.target.checked;
                             if (barnSkalMerkes) {

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -341,7 +341,10 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                     ident: person.personIdent,
                                     fødselsdato: person.fødselsdato,
                                     navn: person.navn,
-                                    merket: false,
+                                    merket:
+                                        skjema.felter.barnBrevetGjelder.verdi.find(
+                                            markertFelt => markertFelt.ident === person.personIdent
+                                        )?.merket ?? false,
                                     manueltRegistrert: false,
                                     erFolkeregistrert: true,
                                 })


### PR DESCRIPTION
Lenke til Favro: [TEA-8940](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8940) 

### 💰 Hva forsøker du å løse i denne PR'en
Løser bug hvor feltet `BarnBrevetGjelder` tilsynelatende er fylt ut etter å ha blitt resatt. Ser ut som at checkbox er huket av selv om det bakenforliggende feltet i skjemaet ikke har noen verdi. 

Sørger for at listen med barn som sendes inn til `BarnBrevetGjelder` har riktig `merket`-status. Bruker `merket` status i checkbox-prop `checked` for å fjerne avkryssingen (visuelt) når skjemaet ikke har noen verdi for feltet `BarnBrevetGjelder`.

### ✅ Checklist

Jeg har ikke skrevet tester fordi: endrer kun på det visuelle.


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
