### PR TITLE
Legg til nye opplysningsdokumenter for EØS

### DIFF
--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/Dokumentvelger.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/Dokumentvelger.tsx
@@ -10,7 +10,7 @@ import { useDokumentutsending } from '../../../../context/DokumentutsendingConte
 import type { ISelectOptionMedBrevtekst } from '../../../Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
 import {
     leggTilValuePåOption,
-    opplysningsdokumenter,
+    opplysningsdokumenterNasjonal,
 } from '../../../Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
 
 const LabelOgEtikett = styled.div`
@@ -38,7 +38,7 @@ export const Dokumentvelger = () => {
                     valgteOptions === null ? [] : (valgteOptions as ISelectOptionMedBrevtekst[])
                 );
             }}
-            options={opplysningsdokumenter.map(leggTilValuePåOption)}
+            options={opplysningsdokumenterNasjonal.map(leggTilValuePåOption)}
         />
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -21,6 +21,7 @@ import Pluss from '../../../../ikoner/Pluss';
 import Slett from '../../../../ikoner/Slett';
 import type { IBehandling } from '../../../../typer/behandling';
 import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
+import { BehandlingKategori } from '../../../../typer/behandlingstema';
 import type { IManueltBrevRequestPåBehandling } from '../../../../typer/dokument';
 import type { IGrunnlagPerson } from '../../../../typer/person';
 import { PersonType } from '../../../../typer/person';
@@ -37,7 +38,13 @@ import PdfVisningModal from '../../PdfVisningModal/PdfVisningModal';
 import SkjultLegend from '../../SkjultLegend';
 import BarnBrevetGjelder from './BarnBrevetGjelder';
 import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
-import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';
+import {
+    Brevmal,
+    brevmaler,
+    leggTilValuePåOption,
+    opplysningsdokumenterEØS,
+    opplysningsdokumenterNasjonal,
+} from './typer';
 
 interface IProps {
     onSubmitSuccess: () => void;
@@ -234,7 +241,12 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                     : (valgteOptions as ISelectOptionMedBrevtekst[])
                             );
                         }}
-                        options={opplysningsdokumenter.map(leggTilValuePåOption)}
+                        options={
+                            åpenBehandling.status === RessursStatus.SUKSESS &&
+                            åpenBehandling.data.kategori === BehandlingKategori.EØS
+                                ? opplysningsdokumenterEØS.map(leggTilValuePåOption)
+                                : opplysningsdokumenterNasjonal.map(leggTilValuePåOption)
+                        }
                     />
                 )}
                 {skjema.felter.fritekster.erSynlig && (

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer.ts
@@ -55,7 +55,7 @@ export interface ISelectOptionMedBrevtekst extends OptionType {
     brevtekst?: Record<Målform, string>;
 }
 
-export const opplysningsdokumenter: Omit<ISelectOptionMedBrevtekst, 'value'>[] = [
+export const opplysningsdokumenterNasjonal: Omit<ISelectOptionMedBrevtekst, 'value'>[] = [
     {
         label: 'Adopsjon - barna',
         brevtekst: {
@@ -362,6 +362,156 @@ export const opplysningsdokumenter: Omit<ISelectOptionMedBrevtekst, 'value'>[] =
         brevtekst: {
             NB: 'Vergefullmakt.',
             NN: 'Vergefullmakt.',
+        },
+    },
+];
+
+export const opplysningsdokumenterEØS: Omit<ISelectOptionMedBrevtekst, 'value'>[] = [
+    {
+        label: 'Adopsjon - barna',
+        brevtekst: {
+            NB: 'Dokumentasjon på adopsjon som viser hvilken dato du overtok omsorgen for barna.',
+            NN: 'Dokumentasjon på adopsjon som viser frå kva dato du overtok omsorga for barna.',
+        },
+    },
+    {
+        label: 'Adopsjon - barnet',
+        brevtekst: {
+            NB: 'Dokumentasjon på adopsjon som viser hvilken dato du overtok omsorgen for barnet.',
+            NN: 'Dokumentasjon på adopsjon som viser frå kva dato du overtok omsorga for barnet.',
+        },
+    },
+    {
+        label: 'Adresse',
+        brevtekst: {
+            NB: 'Du må registrere adresse på din side på nav.no for at vi kan utbetale deg barnetrygd.',
+            NN: 'Du må registrere adresse på din side på nav.no for at vi kan utbetale deg barnetrygd.',
+        },
+    },
+    {
+        label: 'Arbeidskontrakt',
+        brevtekst: {
+            NB: 'Arbeidskontrakt.',
+            NN: 'Arbeidskontrakt.',
+        },
+    },
+    {
+        label: 'Avtale om delt bosted',
+        brevtekst: {
+            NB: 'Avtale om delt bosted.',
+            NN: 'Avtale om delt bustad.',
+        },
+    },
+    {
+        label: 'Dokumentasjon på at barnetrygden kommer barnet til gode',
+        brevtekst: {
+            NB: 'Dokumentasjon på at barnetrygden kommer barnet til gode.',
+            NN: 'Dokumentasjon på at barnetrygden kommer barnet til gode.',
+        },
+    },
+    {
+        label: 'Dokumentasjon på at familien har frasagt seg retten til barnetrygd fra Storbritannia',
+        brevtekst: {
+            NB: 'Dokumentasjon på at familien har frasagt seg retten til barnetrygd fra Storbritannia.',
+            NN: 'Dokumentasjon på at familien har frasagt seg retten til barnetrygd fra Storbritannia.',
+        },
+    },
+    {
+        label: 'Dokumentasjon på at familien har betalt “High Income Child Benefit Charge”',
+        brevtekst: {
+            NB: 'Dokumentasjon på at familien har betalt “High Income Child Benefit Charge”.',
+            NN: 'Dokumentasjon på at familien har betalt “High Income Child Benefit Charge”.',
+        },
+    },
+    {
+        label: 'Dokumentasjon på utført arbeid',
+        brevtekst: {
+            NB: 'Dokumentasjon på utført arbeid.',
+            NN: 'Dokumentasjon på utført arbeid.',
+        },
+    },
+    {
+        label: 'Folkeregistrert i Norge - barna',
+        brevtekst: {
+            NB: 'Dokumentasjon som viser at barna har norsk fødselsnummer og er bosatt i Norge.',
+            NN: 'Dokumentasjon på at barna har norsk fødselsnummer og er busett  i Noreg.',
+        },
+    },
+    {
+        label: 'Folkeregistrert i Norge - barnet',
+        brevtekst: {
+            NB: 'Dokumentasjon som viser at barnet har norsk fødselsnummer og er bosatt i Norge.',
+            NN: 'Dokumentasjon på at barnet har norsk fødselsnummer og er busett  i Noreg.',
+        },
+    },
+    {
+        label: 'Fullmakt som er gitt til en person',
+        brevtekst: {
+            NB: 'Fullmakt som er gitt til en person.',
+            NN: 'Fullmakt som er gitt til en person.',
+        },
+    },
+    {
+        label: 'Kontonummer',
+        brevtekst: {
+            NB: 'Kontonummer.',
+            NN: 'Kontonummer.',
+        },
+    },
+    {
+        label: 'Lønnslipper',
+        brevtekst: {
+            NB: 'Lønnslipper.',
+            NN: 'Lønnslipper.',
+        },
+    },
+    {
+        label: 'MVA-melding med referanse fra Altinn og attest for skatt of merverdiavgift fra Skatteetaten',
+        brevtekst: {
+            NB: 'MVA-melding med referanse fra Altinn og attest for skatt of merverdiavgift fra Skatteetaten.',
+            NN: 'MVA-melding med referanse fra Altinn og attest for skatt of merverdiavgift fra Skatteetaten.',
+        },
+    },
+    {
+        label: 'Næringsspesifikasjon og/eller resultatregnskap som dokumenterer næring i Norge',
+        brevtekst: {
+            NB: 'Næringsspesifikasjon og/eller resultatregnskap som dokumenterer næring i Norge.',
+            NN: 'Næringsspesifikasjon og/eller resultatregnskap som dokumenterer næring i Norge.',
+        },
+    },
+    {
+        label: 'Rettsavgjørelse - barna',
+        brevtekst: {
+            NB: 'Rettsavgjørelse som viser fra hvilken dato barna bor sammen med deg.',
+            NN: 'Avgjersle frå retten som viser frå kva dato barna bur saman med deg.',
+        },
+    },
+    {
+        label: 'Rettsavgjørelse - barnet',
+        brevtekst: {
+            NB: 'Rettsavgjørelse som viser fra hvilken dato barnet bor sammen med deg.',
+            NN: 'Avgjersle frå retten som viser frå kva dato barnet bur saman med deg.',
+        },
+    },
+    {
+        label: 'Registerutskrift fra Enhetsregisteret i Brønnøysundregistrene',
+        brevtekst: {
+            NB: 'Registerutskrift fra Enhetsregisteret i Brønnøysundregistrene.',
+            NN: 'Registerutskrift fra Enhetsregisteret i Brønnøysundregistrene.',
+        },
+    },
+    {
+        label: 'Sentrum for livsinteresser',
+        brevtekst: {
+            NB: 'Informasjon og dokumentasjon på hvor du mener at du, og familien din, er bosatt, enten i Norge eller et annet EØS-land.',
+            NN: 'Informasjon og dokumentasjon på hvor du mener at du, og familien din, er bosatt, enten i Norge eller et annet EØS-land.',
+        },
+    },
+    {
+        label: 'Selvforsørgelse',
+        brevtekst: {
+            NB: 'Dokumentasjon på at du kan forsørge deg selv /familien din mens du er bosatt i Norge. Det kan du gjøre ved å sende oss dokumenter som viser at du har pensjon, oppsparte midler eller inntekt på eiendom i Norge.',
+            NN: 'Dokumentasjon på at du kan forsørge deg selv /familien din mens du er bosatt i Norge. Det kan du gjøre ved å sende oss dokumenter som viser at du har pensjon, oppsparte midler eller inntekt på eiendom i Norge.',
         },
     },
 ];


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8845

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Venter fortsatt noen funksjonelle avklaringer:
- [ ] Dobbeltsjekke at det er samme brevmal som for nasjonal som skal brukes
- [ ] Skal EØS-dokumentene også være mulig å velge under "Send informasjonsbrev" -> årsak "Kan søke" -> "Velg dokumenter"?
- [ ] Venter på nynorsk-tekster
- [ ] Er det riktig tittel og dokument-tekst for alle alternativene?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
