### PR TITLE
Endre visningsnavn på alternativ i utdyp.vilkårsvurd

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -50,11 +50,11 @@ const utdypendeVilkårsvurderingTekst: Record<UtdypendeVilkårsvurdering, string
     [UtdypendeVilkårsvurderingEøsBarnBorMedSøker.BARN_BOR_I_EØS_MED_SØKER]:
         'Barn bor i EØS-land med søker',
     [UtdypendeVilkårsvurderingEøsBarnBorMedSøker.BARN_BOR_I_EØS_MED_ANNEN_FORELDER]:
-        'Barn bor i EØS-land med annen forelder',
+        'Barn bor i EØS-land med annen forelder (EFTA)',
     [UtdypendeVilkårsvurderingEøsBarnBorMedSøker.BARN_BOR_I_STORBRITANNIA_MED_SØKER]:
         'Barn bor i Storbritannia med søker',
     [UtdypendeVilkårsvurderingEøsBarnBorMedSøker.BARN_BOR_I_STORBRITANNIA_MED_ANNEN_FORELDER]:
-        'Barn bor i Storbritannia med annen forelder',
+        'Barn bor i Storbritannia med annen forelder (EFTA)',
     [UtdypendeVilkårsvurderingEøsBarnBorMedSøker.BARN_BOR_ALENE_I_ANNET_EØS_LAND]:
         'Barn bor alene i annet EØS-land',
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: [Tea-8959](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8959)
Etter opplæring ser vi at det er nyttig å markere disse to alternativene i utdypende vilkårsvurdering for _Barn->Bor med søker_ med **EFTA**

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Jeg tenker at dette kun trenger å vises tekstlig i frontend når alternativene presenteres i multiselecten, så jeg har ikke endret navnet på enumen (som ville trigget behov for å endre enum backend også)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Dette er kun en tekstlig endring

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

