### PR TITLE
Gjør første kulepunkt obligatorisk i eøs-varselbrev

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -276,6 +276,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         [
             Brevmal.VARSEL_OM_REVURDERING,
             Brevmal.VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS,
+            Brevmal.VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED,
         ].includes(brevmal);
 
     /**

--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -272,16 +272,19 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         ]);
     };
 
+    const erBrevmalMedObligatoriskFritekst = (brevmal: Brevmal) =>
+        [
+            Brevmal.VARSEL_OM_REVURDERING,
+            Brevmal.VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS,
+        ].includes(brevmal);
+
     /**
      * Legger til initielt fritekstpunkt for brevmaler med obligatorisk fritekst
      */
     useEffect(() => {
         if (
             fritekster.verdi.length === 0 &&
-            [
-                Brevmal.VARSEL_OM_REVURDERING,
-                Brevmal.VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS,
-            ].includes(brevmal.verdi as Brevmal)
+            erBrevmalMedObligatoriskFritekst(brevmal.verdi as Brevmal)
         ) {
             const valideringsmelding =
                 'Dette kulepunktet er obligatorisk. Du må skrive tekst i feltet.';
@@ -347,6 +350,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         makslengdeFritekst,
         maksAntallKulepunkter,
         settVisfeilmeldinger,
+        erBrevmalMedObligatoriskFritekst,
     };
 });
 

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -95,6 +95,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
         maksAntallKulepunkter,
         leggTilFritekst,
         settVisfeilmeldinger,
+        erBrevmalMedObligatoriskFritekst,
     } = useBrevModul();
 
     const [visForhåndsvisningModal, settForhåndsviningModal] = useState(false);
@@ -119,12 +120,6 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
 
     const skjemaGruppeId = 'Fritekster-brev';
     const erMaksAntallKulepunkter = skjema.felter.fritekster.verdi.length >= maksAntallKulepunkter;
-
-    const erBrevmalMedObligatoriskFritekst = () =>
-        [
-            Brevmal.VARSEL_OM_REVURDERING,
-            Brevmal.VARSEL_OM_REVURDERING_FRA_NASJONAL_TIL_EØS,
-        ].includes(skjema.felter.brevmal.verdi as Brevmal);
 
     const onChangeFritekst = (event: React.ChangeEvent<HTMLTextAreaElement>, fritekstId: number) =>
         skjema.felter.fritekster.validerOgSettFelt([
@@ -284,8 +279,9 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                                         autoFocus
                                                     />
                                                     {!(
-                                                        erBrevmalMedObligatoriskFritekst() &&
-                                                        index === 0
+                                                        erBrevmalMedObligatoriskFritekst(
+                                                            skjema.felter.brevmal.verdi as Brevmal
+                                                        ) && index === 0
                                                     ) && (
                                                         <SletteKnapp
                                                             erLesevisning={false}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: [Tea-8458](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8458)
Linda påpekte at første kulepunkt skulle være obligatorisk - det hadde jeg glemt 😇 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Jeg slo sammen to like utils som begge ble brukt i/under BrevModulContext og gjorde den tilgjengelig via contexten. Har testet at de to brevene som brukte utilen fremdeles har riktig oppførsel

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Fordi den evt testen på denne utilen blir såpass tynn

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Det går nok fint å lese alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<h4>Før:</h4>
<div style="display:flex">
<img src="https://user-images.githubusercontent.com/2379098/173348623-d0d56bef-d1a3-4ad6-a4e4-1b25ec666fe6.png"/>
</div>
<h4>Etter:</h4>
<div style="display:flex">
<img src="https://user-images.githubusercontent.com/2379098/173349171-83957ead-ded3-4a46-b608-8ae4de145230.png"/>
<img src="https://user-images.githubusercontent.com/2379098/173349232-d26ee91b-bea0-4f48-aaa0-19f397bf9d40.png" />
</div>