### PR TITLE
Fjern lesevisning på begrunnelsefeltet på endre enhet modal når enhet er midlertidig

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -42,6 +42,8 @@ const EndreBehandlendeEnhet: React.FC<IProps> = ({ onListElementClick }) => {
         settVisModal(false);
     };
 
+    const erLesevisningPåBehandling = erLesevisning(false, true);
+
     return (
         <>
             <KnappBase
@@ -86,7 +88,7 @@ const EndreBehandlendeEnhet: React.FC<IProps> = ({ onListElementClick }) => {
                 <SkjemaGruppe feil={hentFrontendFeilmelding(submitRessurs)}>
                     <SkjultLegend>Endre enhet</SkjultLegend>
                     <FamilieSelect
-                        erLesevisning={erLesevisning(false, true)}
+                        erLesevisning={erLesevisningPåBehandling}
                         lesevisningVerdi={valgtArbeidsfordelingsenhet?.enhetNavn}
                         name="enhet"
                         value={enhetId}
@@ -116,7 +118,7 @@ const EndreBehandlendeEnhet: React.FC<IProps> = ({ onListElementClick }) => {
 
                     <FamilieTextarea
                         disabled={submitRessurs.status === RessursStatus.HENTER}
-                        erLesevisning={erLesevisning(false)}
+                        erLesevisning={erLesevisningPåBehandling}
                         label={'Begrunnelse'}
                         value={begrunnelse}
                         maxLength={4000}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Nå er det lesevisning på begrunnelsefeltet til endre enhet modalen når enheten er midlertidig. Det gjør at man ikke får oppdatert enhet i de tilfellene. 

Endrer så det ikke er lesevisning på begrunnelsefelt når enheten er midlertidig
### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
