### PR TITLE
Gjør tidslinjen grønn ved løpende nullutbetaling

### DIFF
--- a/src/frontend/context/TidslinjeContext.ts
+++ b/src/frontend/context/TidslinjeContext.ts
@@ -112,7 +112,7 @@ const [TidslinjeProvider, useTidslinje] = createUseContext(() => {
                                   id: `${
                                       personMedAndelerTilkjentYtelse.personIdent
                                   }_${fom.getMonth()}_${fom.getDay()}`,
-                                  status: ytelsePeriode.beløp > 0 ? 'suksess' : 'feil',
+                                  status: ytelsePeriode.skalUtbetales ? 'suksess' : 'feil',
                               };
 
                               if (ytelsePeriode.ytelseType === YtelseType.UTVIDET_BARNETRYGD) {

--- a/src/frontend/typer/beregning.ts
+++ b/src/frontend/typer/beregning.ts
@@ -14,13 +14,13 @@ export interface IYtelsePeriode {
     stønadFom: YearMonth;
     stønadTom: YearMonth;
     ytelseType: YtelseType;
+    skalUtbetales: boolean;
 }
 
 export enum YtelseType {
     ORDINÆR_BARNETRYGD = 'ORDINÆR_BARNETRYGD',
     UTVIDET_BARNETRYGD = 'UTVIDET_BARNETRYGD',
     SMÅBARNSTILLEGG = 'SMÅBARNSTILLEGG',
-    EØS = 'EØS',
 }
 
 export const ytelsetype: INøkkelPar = {
@@ -35,9 +35,5 @@ export const ytelsetype: INøkkelPar = {
     SMÅBARNSTILLEGG: {
         id: 'SMÅBARNSTILLEGG',
         navn: 'Småbarnstillegg',
-    },
-    EØS: {
-        id: 'EØS',
-        navn: 'EØS-forordningen',
     },
 };

--- a/src/frontend/utils/test/tidslinje.test.ts
+++ b/src/frontend/utils/test/tidslinje.test.ts
@@ -18,6 +18,7 @@ describe('utils/tidslinje', () => {
         stønadFom: '2020-01',
         stønadTom: '2020-12',
         ytelseType: YtelseType.UTVIDET_BARNETRYGD,
+        skalUtbetales: true,
     };
 
     const småbarnstilleggPeriodeOverlapperStartenAvÅret: IYtelsePeriode = {
@@ -25,18 +26,21 @@ describe('utils/tidslinje', () => {
         stønadFom: '2019-05',
         stønadTom: '2020-03',
         ytelseType: YtelseType.SMÅBARNSTILLEGG,
+        skalUtbetales: true,
     };
     const småbarnstilleggPeriodeMidtIÅret: IYtelsePeriode = {
         beløp: 660,
         stønadFom: '2020-05',
         stønadTom: '2020-07',
         ytelseType: YtelseType.SMÅBARNSTILLEGG,
+        skalUtbetales: true,
     };
     const småbarnstilleggPeriodeOverlapperSluttenAvÅret: IYtelsePeriode = {
         beløp: 660,
         stønadFom: '2020-09',
         stønadTom: '2021-05',
         ytelseType: YtelseType.SMÅBARNSTILLEGG,
+        skalUtbetales: true,
     };
 
     const fom = kalenderDatoTilDate(hentFørsteDagIYearMonth(utvidetYtelsePeriode.stønadFom));


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8993
Tidligere har vi gjort negative tidslinjeandelbeløp røde. Fremover ønsker vi at fargen skal bestemmes av flagget `skalUtbetales`, som vil være `false` dersom beløpet har blitt overstyrt til 0kr via endret utbetalingsperiode.
Knyttet til denne backendkoden: https://github.com/navikt/familie-ba-sak/pull/2639

Se denne saken i preprod: https://barnetrygd.dev.intern.nav.no/fagsak/100074751/100088001/tilkjent-ytelse
På denne branchen får den denne visningen: 
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/2379098/175033690-79f92058-7e1b-4874-9d14-f4fff42c8791.png">

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
