### PR TITLE
Lagt inn "Må beregnes" alert dersom sekundærland og nødvendige skjemaer ikke er utfylt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -227,6 +227,9 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
                         åpenBehandling.utbetalingsperioder
                     )}
                     aktivEtikett={aktivEtikett}
+                    kompetanser={kompetanser}
+                    utbetaltAnnetLandBeløp={utbetaltAnnetLandBeløp}
+                    valutakurser={valutakurser}
                 />
             )}
             {åpenBehandling.endretUtbetalingAndeler.length > 0 && (

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -1,12 +1,23 @@
 import * as React from 'react';
 
+import styled from 'styled-components';
+
 import { Xknapp } from 'nav-frontend-ikonknapper';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 
+import { Alert } from '@navikt/ds-react';
+import type { FeltState } from '@navikt/familie-skjema';
 import type { Etikett } from '@navikt/familie-tidslinje';
 
 import { useTidslinje } from '../../../context/TidslinjeContext';
 import { ytelsetype } from '../../../typer/beregning';
+import type {
+    IKompetanse,
+    IRestEøsPeriode,
+    IRestUtenlandskPeriodeBeløp,
+    IRestValutakurs,
+} from '../../../typer/eøsPerioder';
+import { EøsPeriodeStatus, KompetanseResultat } from '../../../typer/eøsPerioder';
 import type { Utbetalingsperiode } from '../../../typer/vedtaksperiode';
 import {
     datoformat,
@@ -18,16 +29,85 @@ import {
 } from '../../../utils/formatter';
 import { kalenderDatoFraDate, serializeIso8601String } from '../../../utils/kalender';
 
+const TableHeaderAlignedRight = styled.th`
+    text-align: right;
+`;
+
+const TableDataAlignedRight = styled.td`
+    text-align: right;
+`;
+
+const AlertAlignedRight = styled(Alert)`
+    float: right;
+`;
+
+const UtbetalingsbeløpTable = styled.table`
+    width: 100%;
+`;
+
 interface IProps {
     utbetalingsperiode: Utbetalingsperiode | undefined;
     aktivEtikett: Etikett;
+    kompetanser: FeltState<IKompetanse>[];
+    utbetaltAnnetLandBeløp: IRestUtenlandskPeriodeBeløp[];
+    valutakurser: IRestValutakurs[];
 }
+
+const validerUtbetalingsBeløp = (
+    utbetalingsperiode: Utbetalingsperiode | undefined,
+    kompetanser: FeltState<IKompetanse>[],
+    utbetaltAnnetLandBeløp: IRestUtenlandskPeriodeBeløp[],
+    valutakurser: IRestValutakurs[]
+): Map<string, boolean> => {
+    const utbetalingsMap = new Map<string, boolean>();
+    utbetalingsperiode?.utbetalingsperiodeDetaljer.forEach(upd => {
+        const barnIdent = upd.person.personIdent;
+        const kompetanseForBarn = finnKompetanseForBarn(kompetanser, barnIdent);
+        const norgeErSekundærland =
+            kompetanseForBarn?.resultat.verdi === KompetanseResultat.NORGE_ER_SEKUNDÆRLAND;
+
+        let skalViseUtbetalingsBeløp = !norgeErSekundærland;
+
+        if (norgeErSekundærland) {
+            const kompetanseStatusOk = kompetanseForBarn?.status === EøsPeriodeStatus.OK;
+            const utbetaltAnnetLandStatusOk =
+                finnEøsPeriodeForBarn(utbetaltAnnetLandBeløp, barnIdent)?.status ===
+                EøsPeriodeStatus.OK;
+            const valutakursStatusOk =
+                finnEøsPeriodeForBarn(valutakurser, barnIdent)?.status === EøsPeriodeStatus.OK;
+            skalViseUtbetalingsBeløp =
+                kompetanseStatusOk && utbetaltAnnetLandStatusOk && valutakursStatusOk;
+        }
+        utbetalingsMap.set(barnIdent, skalViseUtbetalingsBeløp);
+    });
+    return utbetalingsMap;
+};
+
+const finnEøsPeriodeForBarn = (
+    restEøsPerioder: IRestEøsPeriode[],
+    barnIdent: string
+): IRestEøsPeriode | undefined => {
+    return restEøsPerioder.find(restEøsPeriode => restEøsPeriode.barnIdenter.includes(barnIdent));
+};
+
+const finnKompetanseForBarn = (
+    felter: FeltState<IKompetanse>[],
+    barnIdent: string
+): IKompetanse | undefined => {
+    return felter.find(felt => felt.verdi.barnIdenter.verdi.includes(barnIdent))?.verdi;
+};
 
 const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
     utbetalingsperiode,
     aktivEtikett,
+    kompetanser,
+    utbetaltAnnetLandBeløp,
+    valutakurser,
 }) => {
     const { settAktivEtikett } = useTidslinje();
+    const [utbetalingsBeløpStatusMap, setUtbetalingsBeløpStatusMap] = React.useState(
+        new Map<string, boolean>()
+    );
 
     const månedNavnOgÅr = () => {
         const navn = formaterIsoDato(
@@ -36,6 +116,17 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
         );
         return navn[0].toUpperCase() + navn.substr(1);
     };
+
+    React.useEffect(() => {
+        setUtbetalingsBeløpStatusMap(
+            validerUtbetalingsBeløp(
+                utbetalingsperiode,
+                kompetanser,
+                utbetaltAnnetLandBeløp,
+                valutakurser
+            )
+        );
+    }, [utbetalingsperiode, kompetanser, utbetaltAnnetLandBeløp, valutakurser]);
 
     return (
         <div className={'behandlingsresultat-informasjonsboks'}>
@@ -65,7 +156,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                 />
             </div>
             {utbetalingsperiode !== undefined && (
-                <table>
+                <UtbetalingsbeløpTable>
                     <thead>
                         <tr>
                             <th>
@@ -74,9 +165,9 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                             <th>
                                 <Normaltekst>Sats</Normaltekst>
                             </th>
-                            <th>
+                            <TableHeaderAlignedRight>
                                 <Normaltekst>Beløp</Normaltekst>
-                            </th>
+                            </TableHeaderAlignedRight>
                         </tr>
                     </thead>
                     <tbody>
@@ -99,16 +190,27 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                                 {ytelsetype[detalj.ytelseType].navn}
                                             </Normaltekst>
                                         </td>
-                                        <td>
-                                            <Normaltekst>
-                                                {formaterBeløp(detalj.utbetaltPerMnd)}
-                                            </Normaltekst>
-                                        </td>
+                                        <TableDataAlignedRight>
+                                            {utbetalingsBeløpStatusMap.get(
+                                                detalj.person.personIdent
+                                            ) ? (
+                                                <Normaltekst>
+                                                    {formaterBeløp(detalj.utbetaltPerMnd)}
+                                                </Normaltekst>
+                                            ) : (
+                                                <AlertAlignedRight
+                                                    variant="warning"
+                                                    children={'Må beregnes'}
+                                                    size={'small'}
+                                                    inline
+                                                />
+                                            )}
+                                        </TableDataAlignedRight>
                                     </tr>
                                 );
                             })}
                     </tbody>
-                </table>
+                </UtbetalingsbeløpTable>
             )}
         </div>
     );

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -54,7 +54,7 @@ interface IProps {
     valutakurser: IRestValutakurs[];
 }
 
-const validerUtbetalingsBeløp = (
+const finnUtbetalingsBeløpStatusMap = (
     utbetalingsperiode: Utbetalingsperiode | undefined,
     kompetanser: FeltState<IKompetanse>[],
     utbetaltAnnetLandBeløp: IRestUtenlandskPeriodeBeløp[],
@@ -64,13 +64,10 @@ const validerUtbetalingsBeløp = (
     utbetalingsperiode?.utbetalingsperiodeDetaljer.forEach(upd => {
         const barnIdent = upd.person.personIdent;
         const kompetanserForBarn = finnKompetanserForBarn(kompetanser, barnIdent);
-        const norgeErSekundærland = kompetanserForBarn.find(
+        const norgeErSekundærland = kompetanserForBarn.some(
             kompetanseForBarn =>
                 kompetanseForBarn.resultat.verdi === KompetanseResultat.NORGE_ER_SEKUNDÆRLAND
-        )
-            ? true
-            : false;
-
+        );
         let skalViseUtbetalingsBeløp = !norgeErSekundærland;
 
         if (norgeErSekundærland) {
@@ -100,20 +97,18 @@ const finnEøsPerioderForBarn = (
 };
 
 const finnKompetanserForBarn = (
-    felter: FeltState<IKompetanse>[],
+    kompetanseFelter: FeltState<IKompetanse>[],
     barnIdent: string
 ): IKompetanse[] => {
     return (
-        felter
-            .filter(felt => felt.verdi.barnIdenter.verdi.includes(barnIdent))
-            ?.map(kompetanse => kompetanse.verdi) ?? []
+        kompetanseFelter
+            .filter(kompetanseFelt => kompetanseFelt.verdi.barnIdenter.verdi.includes(barnIdent))
+            ?.map(kompetanseFelt => kompetanseFelt.verdi) ?? []
     );
 };
 
 const erAllePerioderUtfyltForBarn = (eøsPeriodeStatus: IEøsPeriodeStatus[]) => {
-    return eøsPeriodeStatus.find(eøsPeriode => eøsPeriode.status !== EøsPeriodeStatus.OK)
-        ? false
-        : true;
+    return eøsPeriodeStatus.every(eøsPeriode => eøsPeriode.status === EøsPeriodeStatus.OK);
 };
 
 const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
@@ -138,7 +133,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
 
     React.useEffect(() => {
         setUtbetalingsBeløpStatusMap(
-            validerUtbetalingsBeløp(
+            finnUtbetalingsBeløpStatusMap(
                 utbetalingsperiode,
                 kompetanser,
                 utbetaltAnnetLandBeløp,

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -78,9 +78,12 @@ export enum EøsPeriodeStatus {
     OK = 'OK',
 }
 
-export interface IRestEøsPeriode {
-    id: number;
+export interface IEøsPeriodeStatus {
     status: EøsPeriodeStatus;
+}
+
+export interface IRestEøsPeriode extends IEøsPeriodeStatus {
+    id: number;
     fom: YearMonth;
     tom?: YearMonth;
     barnIdenter: string[];
@@ -94,9 +97,8 @@ export interface IRestKompetanse extends IRestEøsPeriode {
     resultat?: KompetanseResultat;
 }
 
-export interface IKompetanse {
+export interface IKompetanse extends IEøsPeriodeStatus {
     id: number;
-    status: EøsPeriodeStatus;
     initielFom: YearMonth;
     periode: FeltState<IYearMonthPeriode>;
     barnIdenter: FeltState<string[]>;


### PR DESCRIPTION
Lenke til sak i Favro: [TEA-9021](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9021)

### 💰 Hva forsøker du å løse i denne PR'en
Dersom et barn har Norge som sekundærland skal utbetalingsbeløp skjules for barnet frem til UtenlandskPeriodebeløp og Valutakurs er fylt ut. Fremfor å vise beløpet skal en "alert" vises med teksten "Må beregnes".

Løsning:
I komponenten `Oppsummeringsboks` har jeg lagt inn logikk som for hvert barn sjekker kompetanse, upb og valutakurs og sjekker om kompetanse.resultat = NORGE_ER_SEKUNDÆRLAND. Dersom det er tilfellet sjekkes tilhørende upb- og valutakurs-skjema for om de er ferdig utfylt. Dersom de er ferdig utfylt oppdateres visnings-status til barnets utbetalingsbeløp. 

Har også lagt inn noen visuelle endringer på `Oppsummeringsboks`.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/70642183/175531567-b3fa0287-be5b-42fa-bdcf-e0772b11020b.png)
![image](https://user-images.githubusercontent.com/70642183/175531681-983f7fcf-c099-4bd0-8eef-d84608c40b4c.png)
