### PR TITLE
TEA-8273 Funksjonalitet for å skjule venstre- eller høyremeny

### DIFF
--- a/src/frontend/context/behandlingContext/BehandlingContext.ts
+++ b/src/frontend/context/behandlingContext/BehandlingContext.ts
@@ -40,6 +40,8 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
     const [åpenBehandling, privatSettÅpenBehandling] = useState<Ressurs<IBehandling>>(
         byggTomRessurs()
     );
+    const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
+    const [åpenVenstremeny, settÅpenVenstremeny] = useState(true);
 
     const settÅpenBehandling = (behandling: Ressurs<IBehandling>, oppdaterMinimalFagsak = true) => {
         if (oppdaterMinimalFagsak && fagsakId) {
@@ -231,6 +233,10 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         erMigreringsbehandling,
         aktivSettPåVent: hentDataFraRessurs(åpenBehandling)?.aktivSettPåVent,
         erBehandleneEnhetMidlertidig,
+        åpenHøyremeny,
+        settÅpenHøyremeny,
+        åpenVenstremeny,
+        settÅpenVenstremeny,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
@@ -37,56 +37,48 @@ const Høyremeny: React.FunctionComponent = () => {
 
     return åpenBehandling.status === RessursStatus.SUKSESS ? (
         <>
-            {åpenHøyremeny ? (
-                <div className={'høyremeny'}>
-                    <ToggleVisningHøyremeny
-                        variant="secondary"
-                        onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
-                        onClick={() => {
-                            settÅpenHøyremeny(!åpenHøyremeny);
-                        }}
-                        size="small"
-                        aria-label="Skjul høyremeny"
-                        åpenhøyremeny={åpenHøyremeny ? 1 : 0}
-                    >
-                        <NextFilled />
-                    </ToggleVisningHøyremeny>
-                    <Behandlingskort åpenBehandling={åpenBehandling.data} />
-                    <Hendelsesoversikt
-                        hendelser={hentDataFraRessursMedFallback(logg, []).map(
-                            (loggElement: ILogg): Hendelse => {
-                                return {
-                                    id: loggElement.id.toString(),
-                                    dato: formaterIsoDato(
-                                        loggElement.opprettetTidspunkt,
-                                        datoformat.DATO_TID
-                                    ),
-                                    utførtAv: loggElement.opprettetAv,
-                                    rolle: loggElement.rolle,
-                                    tittel: loggElement.tittel,
-                                    beskrivelse: loggElement.tekst,
-                                };
-                            }
-                        )}
-                        åpenBehandling={åpenBehandling.data}
-                    />
-                </div>
-            ) : (
-                <div>
-                    <ToggleVisningHøyremeny
-                        variant="secondary"
-                        onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
-                        onClick={() => {
-                            settÅpenHøyremeny(!åpenHøyremeny);
-                        }}
-                        size="small"
-                        aria-label="Åpne høyremeny"
-                        åpenhøyremeny={åpenHøyremeny ? 1 : 0}
-                    >
-                        <BackFilled />
-                    </ToggleVisningHøyremeny>
-                </div>
-            )}
+            <div className={åpenHøyremeny ? 'høyremeny' : ''}>
+                <ToggleVisningHøyremeny
+                    variant="secondary"
+                    onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                    onClick={() => {
+                        settÅpenHøyremeny(!åpenHøyremeny);
+                    }}
+                    size="small"
+                    aria-label="Skjul høyremeny"
+                    åpenhøyremeny={åpenHøyremeny ? 1 : 0}
+                    title={åpenHøyremeny ? 'Skjul høyremeny' : 'Vis høyremeny'}
+                >
+                    {åpenHøyremeny ? (
+                        <NextFilled aria-label="Skjul høyremeny" />
+                    ) : (
+                        <BackFilled aria-label="Vis høyremeny" />
+                    )}
+                </ToggleVisningHøyremeny>
+                {åpenHøyremeny && (
+                    <>
+                        <Behandlingskort åpenBehandling={åpenBehandling.data} />
+                        <Hendelsesoversikt
+                            hendelser={hentDataFraRessursMedFallback(logg, []).map(
+                                (loggElement: ILogg): Hendelse => {
+                                    return {
+                                        id: loggElement.id.toString(),
+                                        dato: formaterIsoDato(
+                                            loggElement.opprettetTidspunkt,
+                                            datoformat.DATO_TID
+                                        ),
+                                        utførtAv: loggElement.opprettetAv,
+                                        rolle: loggElement.rolle,
+                                        tittel: loggElement.tittel,
+                                        beskrivelse: loggElement.tekst,
+                                    };
+                                }
+                            )}
+                            åpenBehandling={åpenBehandling.data}
+                        />
+                    </>
+                )}
+            </div>
         </>
     ) : null;
 };

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
 
+import styled from 'styled-components';
+
+import { BackFilled, NextFilled } from '@navikt/ds-icons';
+import { Button } from '@navikt/ds-react';
 import { hentDataFraRessursMedFallback, RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
@@ -9,8 +13,21 @@ import Hendelsesoversikt from '../../Felleskomponenter/Hendelsesoversikt/Hendels
 import type { Hendelse } from '../../Felleskomponenter/Hendelsesoversikt/typer';
 import Behandlingskort from '../Behandlingskort/Behandlingskort';
 
+const ToggleVisningHøyremeny = styled(Button)`
+    position: absolute;
+    margin-left: ${(props: { åpenhøyremeny: boolean }) =>
+        !props.åpenhøyremeny ? '-20px' : '-17px'};
+    top: 370px;
+    width: 34px;
+    min-width: 34px;
+    height: 34px;
+    padding: 0px;
+    border-radius: 50%;
+    filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+`;
+
 const Høyremeny: React.FunctionComponent = () => {
-    const { åpenBehandling, logg, hentLogg } = useBehandling();
+    const { åpenBehandling, logg, hentLogg, åpenHøyremeny, settÅpenHøyremeny } = useBehandling();
 
     React.useEffect(() => {
         if (åpenBehandling && åpenBehandling.status === RessursStatus.SUKSESS) {
@@ -19,27 +36,58 @@ const Høyremeny: React.FunctionComponent = () => {
     }, [åpenBehandling]);
 
     return åpenBehandling.status === RessursStatus.SUKSESS ? (
-        <div className={'høyremeny'}>
-            <Behandlingskort åpenBehandling={åpenBehandling.data} />
-            <Hendelsesoversikt
-                hendelser={hentDataFraRessursMedFallback(logg, []).map(
-                    (loggElement: ILogg): Hendelse => {
-                        return {
-                            id: loggElement.id.toString(),
-                            dato: formaterIsoDato(
-                                loggElement.opprettetTidspunkt,
-                                datoformat.DATO_TID
-                            ),
-                            utførtAv: loggElement.opprettetAv,
-                            rolle: loggElement.rolle,
-                            tittel: loggElement.tittel,
-                            beskrivelse: loggElement.tekst,
-                        };
-                    }
-                )}
-                åpenBehandling={åpenBehandling.data}
-            />
-        </div>
+        <>
+            {åpenHøyremeny ? (
+                <div className={'høyremeny'}>
+                    <ToggleVisningHøyremeny
+                        variant="secondary"
+                        onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                        onClick={() => {
+                            settÅpenHøyremeny(!åpenHøyremeny);
+                        }}
+                        size="small"
+                        aria-label="Skjul høyremeny"
+                        åpenhøyremeny={åpenHøyremeny ? 1 : 0}
+                    >
+                        <NextFilled />
+                    </ToggleVisningHøyremeny>
+                    <Behandlingskort åpenBehandling={åpenBehandling.data} />
+                    <Hendelsesoversikt
+                        hendelser={hentDataFraRessursMedFallback(logg, []).map(
+                            (loggElement: ILogg): Hendelse => {
+                                return {
+                                    id: loggElement.id.toString(),
+                                    dato: formaterIsoDato(
+                                        loggElement.opprettetTidspunkt,
+                                        datoformat.DATO_TID
+                                    ),
+                                    utførtAv: loggElement.opprettetAv,
+                                    rolle: loggElement.rolle,
+                                    tittel: loggElement.tittel,
+                                    beskrivelse: loggElement.tekst,
+                                };
+                            }
+                        )}
+                        åpenBehandling={åpenBehandling.data}
+                    />
+                </div>
+            ) : (
+                <div>
+                    <ToggleVisningHøyremeny
+                        variant="secondary"
+                        onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                        onClick={() => {
+                            settÅpenHøyremeny(!åpenHøyremeny);
+                        }}
+                        size="small"
+                        aria-label="Åpne høyremeny"
+                        åpenhøyremeny={åpenHøyremeny ? 1 : 0}
+                    >
+                        <BackFilled />
+                    </ToggleVisningHøyremeny>
+                </div>
+            )}
+        </>
     ) : null;
 };
 

--- a/src/frontend/komponenter/Fagsak/fagsak.less
+++ b/src/frontend/komponenter/Fagsak/fagsak.less
@@ -4,7 +4,7 @@
         height: calc(100vh - 6rem);
 
         &--venstremeny {
-            min-width: 10rem;
+            min-width: 1rem;
             border-right: 1px solid @navGra20;
             overflow: hidden;
         }

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
@@ -40,86 +40,90 @@ const Venstremeny: React.FunctionComponent = () => {
     const { åpenBehandling, trinnPåBehandling, åpenVenstremeny, settÅpenVenstremeny } =
         useBehandling();
 
-    return åpenVenstremeny ? (
+    return (
         <ÅpenMenyContainer>
-            <MenyItem>
-                <nav className={'venstremeny'}>
-                    {åpenBehandling.status === RessursStatus.SUKSESS ? (
-                        <>
-                            {Object.entries(trinnPåBehandling).map(
-                                ([sideId, side], index: number) => {
-                                    const tilPath = `/fagsak/${fagsakId}/${åpenBehandling.data.behandlingId}/${side.href}`;
+            {åpenVenstremeny && (
+                <MenyItem>
+                    <nav className={'venstremeny'}>
+                        {åpenBehandling.status === RessursStatus.SUKSESS ? (
+                            <>
+                                {Object.entries(trinnPåBehandling).map(
+                                    ([sideId, side], index: number) => {
+                                        const tilPath = `/fagsak/${fagsakId}/${åpenBehandling.data.behandlingId}/${side.href}`;
 
-                                    const undersider: IUnderside[] = side.undersider
-                                        ? side.undersider(åpenBehandling.data)
-                                        : [];
+                                        const undersider: IUnderside[] = side.undersider
+                                            ? side.undersider(åpenBehandling.data)
+                                            : [];
 
-                                    return (
-                                        <React.Fragment key={sideId}>
-                                            <Link
-                                                active={erSidenAktiv(side, åpenBehandling.data)}
-                                                id={sideId}
-                                                to={tilPath}
-                                                className={classNames(
-                                                    'venstremeny__link',
-                                                    erSidenAktiv(side, åpenBehandling.data) &&
-                                                        'hover-effekt'
-                                                )}
-                                            >
-                                                {`${side.steg ? `${index + 1}. ` : ''}${side.navn}`}
-                                            </Link>
-                                            {undersider.map((underside: IUnderside) => {
-                                                const antallAksjonspunkter =
-                                                    underside.antallAksjonspunkter();
-                                                return (
-                                                    <Link
-                                                        active={erSidenAktiv(
-                                                            side,
-                                                            åpenBehandling.data
-                                                        )}
-                                                        key={`${sideId}_${underside.hash}`}
-                                                        id={`${sideId}_${underside.hash}`}
-                                                        to={`${tilPath}#${underside.hash}`}
-                                                        className={classNames(
-                                                            'venstremeny__link',
-                                                            'underside',
-                                                            erSidenAktiv(
+                                        return (
+                                            <React.Fragment key={sideId}>
+                                                <Link
+                                                    active={erSidenAktiv(side, åpenBehandling.data)}
+                                                    id={sideId}
+                                                    to={tilPath}
+                                                    className={classNames(
+                                                        'venstremeny__link',
+                                                        erSidenAktiv(side, åpenBehandling.data) &&
+                                                            'hover-effekt'
+                                                    )}
+                                                >
+                                                    {`${side.steg ? `${index + 1}. ` : ''}${
+                                                        side.navn
+                                                    }`}
+                                                </Link>
+                                                {undersider.map((underside: IUnderside) => {
+                                                    const antallAksjonspunkter =
+                                                        underside.antallAksjonspunkter();
+                                                    return (
+                                                        <Link
+                                                            active={erSidenAktiv(
                                                                 side,
                                                                 åpenBehandling.data
-                                                            ) && 'hover-effekt'
-                                                        )}
-                                                    >
-                                                        <>
-                                                            {antallAksjonspunkter > 0 ? (
-                                                                <div
-                                                                    className={
-                                                                        'underside__sirkel-tall'
-                                                                    }
-                                                                >
-                                                                    {antallAksjonspunkter}
-                                                                </div>
-                                                            ) : (
-                                                                <div
-                                                                    className={
-                                                                        'underside__sirkel-plass'
-                                                                    }
-                                                                />
                                                             )}
-                                                            <BodyShort size="small">
-                                                                {underside.navn}
-                                                            </BodyShort>
-                                                        </>
-                                                    </Link>
-                                                );
-                                            })}
-                                        </React.Fragment>
-                                    );
-                                }
-                            )}
-                        </>
-                    ) : null}
-                </nav>
-            </MenyItem>
+                                                            key={`${sideId}_${underside.hash}`}
+                                                            id={`${sideId}_${underside.hash}`}
+                                                            to={`${tilPath}#${underside.hash}`}
+                                                            className={classNames(
+                                                                'venstremeny__link',
+                                                                'underside',
+                                                                erSidenAktiv(
+                                                                    side,
+                                                                    åpenBehandling.data
+                                                                ) && 'hover-effekt'
+                                                            )}
+                                                        >
+                                                            <>
+                                                                {antallAksjonspunkter > 0 ? (
+                                                                    <div
+                                                                        className={
+                                                                            'underside__sirkel-tall'
+                                                                        }
+                                                                    >
+                                                                        {antallAksjonspunkter}
+                                                                    </div>
+                                                                ) : (
+                                                                    <div
+                                                                        className={
+                                                                            'underside__sirkel-plass'
+                                                                        }
+                                                                    />
+                                                                )}
+                                                                <BodyShort size="small">
+                                                                    {underside.navn}
+                                                                </BodyShort>
+                                                            </>
+                                                        </Link>
+                                                    );
+                                                })}
+                                            </React.Fragment>
+                                        );
+                                    }
+                                )}
+                            </>
+                        ) : null}
+                    </nav>
+                </MenyItem>
+            )}
             <MenyItem>
                 <ToggleVisningVenstremeny
                     variant="secondary"
@@ -130,26 +134,16 @@ const Venstremeny: React.FunctionComponent = () => {
                     size="small"
                     aria-label="Skjul venstremeny"
                     åpenvenstremeny={åpenVenstremeny ? 1 : 0}
+                    title={åpenVenstremeny ? 'Skjul venstremeny' : 'Vis venstremeny'}
                 >
-                    <BackFilled />
+                    {åpenVenstremeny ? (
+                        <BackFilled aria-label="Vis venstremeny" />
+                    ) : (
+                        <NextFilled aria-label="Skjul venstremeny" />
+                    )}
                 </ToggleVisningVenstremeny>
             </MenyItem>
         </ÅpenMenyContainer>
-    ) : (
-        <div>
-            <ToggleVisningVenstremeny
-                variant="secondary"
-                onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
-                onClick={() => {
-                    settÅpenVenstremeny(!åpenVenstremeny);
-                }}
-                size="small"
-                aria-label="Åpne venstremeny"
-                åpenvenstremeny={åpenVenstremeny ? 1 : 0}
-            >
-                <NextFilled />
-            </ToggleVisningVenstremeny>
-        </div>
     );
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
+import styled from 'styled-components';
 
-import { Normaltekst } from 'nav-frontend-typografi';
-
+import { BackFilled, NextFilled } from '@navikt/ds-icons';
+import { BodyShort, Button } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
@@ -12,66 +13,143 @@ import Link from './Link';
 import type { IUnderside } from './sider';
 import { erSidenAktiv } from './sider';
 
+const ToggleVisningVenstremeny = styled(Button)`
+    position: fixed;
+    margin-left: ${(props: { åpenvenstremeny: boolean }) =>
+        props.åpenvenstremeny ? '-17px' : '0px'};
+    top: 370px;
+    width: 34px;
+    min-width: 34px;
+    height: 34px;
+    padding: 0px;
+    border-radius: 50%;
+    filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+`;
+
+const ÅpenMenyContainer = styled.div`
+    display: flex;
+    justify-content: flex-start;
+`;
+
+const MenyItem = styled.div`
+    display: inline-block;
+`;
+
 const Venstremeny: React.FunctionComponent = () => {
     const { fagsakId } = useSakOgBehandlingParams();
-    const { åpenBehandling, trinnPåBehandling } = useBehandling();
+    const { åpenBehandling, trinnPåBehandling, åpenVenstremeny, settÅpenVenstremeny } =
+        useBehandling();
 
-    return (
-        <nav className={'venstremeny'}>
-            {åpenBehandling.status === RessursStatus.SUKSESS
-                ? Object.entries(trinnPåBehandling).map(([sideId, side], index: number) => {
-                      const tilPath = `/fagsak/${fagsakId}/${åpenBehandling.data.behandlingId}/${side.href}`;
+    return åpenVenstremeny ? (
+        <ÅpenMenyContainer>
+            <MenyItem>
+                <nav className={'venstremeny'}>
+                    {åpenBehandling.status === RessursStatus.SUKSESS ? (
+                        <>
+                            {Object.entries(trinnPåBehandling).map(
+                                ([sideId, side], index: number) => {
+                                    const tilPath = `/fagsak/${fagsakId}/${åpenBehandling.data.behandlingId}/${side.href}`;
 
-                      const undersider: IUnderside[] = side.undersider
-                          ? side.undersider(åpenBehandling.data)
-                          : [];
+                                    const undersider: IUnderside[] = side.undersider
+                                        ? side.undersider(åpenBehandling.data)
+                                        : [];
 
-                      return (
-                          <React.Fragment key={sideId}>
-                              <Link
-                                  active={erSidenAktiv(side, åpenBehandling.data)}
-                                  id={sideId}
-                                  to={tilPath}
-                                  className={classNames(
-                                      'venstremeny__link',
-                                      erSidenAktiv(side, åpenBehandling.data) && 'hover-effekt'
-                                  )}
-                              >
-                                  {`${side.steg ? `${index + 1}. ` : ''}${side.navn}`}
-                              </Link>
-                              {undersider.map((underside: IUnderside) => {
-                                  const antallAksjonspunkter = underside.antallAksjonspunkter();
-                                  return (
-                                      <Link
-                                          active={erSidenAktiv(side, åpenBehandling.data)}
-                                          key={`${sideId}_${underside.hash}`}
-                                          id={`${sideId}_${underside.hash}`}
-                                          to={`${tilPath}#${underside.hash}`}
-                                          className={classNames(
-                                              'venstremeny__link',
-                                              'underside',
-                                              erSidenAktiv(side, åpenBehandling.data) &&
-                                                  'hover-effekt'
-                                          )}
-                                      >
-                                          <>
-                                              {antallAksjonspunkter > 0 ? (
-                                                  <div className={'underside__sirkel-tall'}>
-                                                      {antallAksjonspunkter}
-                                                  </div>
-                                              ) : (
-                                                  <div className={'underside__sirkel-plass'} />
-                                              )}
-                                              <Normaltekst>{underside.navn}</Normaltekst>
-                                          </>
-                                      </Link>
-                                  );
-                              })}
-                          </React.Fragment>
-                      );
-                  })
-                : null}
-        </nav>
+                                    return (
+                                        <React.Fragment key={sideId}>
+                                            <Link
+                                                active={erSidenAktiv(side, åpenBehandling.data)}
+                                                id={sideId}
+                                                to={tilPath}
+                                                className={classNames(
+                                                    'venstremeny__link',
+                                                    erSidenAktiv(side, åpenBehandling.data) &&
+                                                        'hover-effekt'
+                                                )}
+                                            >
+                                                {`${side.steg ? `${index + 1}. ` : ''}${side.navn}`}
+                                            </Link>
+                                            {undersider.map((underside: IUnderside) => {
+                                                const antallAksjonspunkter =
+                                                    underside.antallAksjonspunkter();
+                                                return (
+                                                    <Link
+                                                        active={erSidenAktiv(
+                                                            side,
+                                                            åpenBehandling.data
+                                                        )}
+                                                        key={`${sideId}_${underside.hash}`}
+                                                        id={`${sideId}_${underside.hash}`}
+                                                        to={`${tilPath}#${underside.hash}`}
+                                                        className={classNames(
+                                                            'venstremeny__link',
+                                                            'underside',
+                                                            erSidenAktiv(
+                                                                side,
+                                                                åpenBehandling.data
+                                                            ) && 'hover-effekt'
+                                                        )}
+                                                    >
+                                                        <>
+                                                            {antallAksjonspunkter > 0 ? (
+                                                                <div
+                                                                    className={
+                                                                        'underside__sirkel-tall'
+                                                                    }
+                                                                >
+                                                                    {antallAksjonspunkter}
+                                                                </div>
+                                                            ) : (
+                                                                <div
+                                                                    className={
+                                                                        'underside__sirkel-plass'
+                                                                    }
+                                                                />
+                                                            )}
+                                                            <BodyShort size="small">
+                                                                {underside.navn}
+                                                            </BodyShort>
+                                                        </>
+                                                    </Link>
+                                                );
+                                            })}
+                                        </React.Fragment>
+                                    );
+                                }
+                            )}
+                        </>
+                    ) : null}
+                </nav>
+            </MenyItem>
+            <MenyItem>
+                <ToggleVisningVenstremeny
+                    variant="secondary"
+                    onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                    onClick={() => {
+                        settÅpenVenstremeny(!åpenVenstremeny);
+                    }}
+                    size="small"
+                    aria-label="Skjul venstremeny"
+                    åpenvenstremeny={åpenVenstremeny ? 1 : 0}
+                >
+                    <BackFilled />
+                </ToggleVisningVenstremeny>
+            </MenyItem>
+        </ÅpenMenyContainer>
+    ) : (
+        <div>
+            <ToggleVisningVenstremeny
+                variant="secondary"
+                onMouseDown={(e: React.MouseEvent) => e.preventDefault()}
+                onClick={() => {
+                    settÅpenVenstremeny(!åpenVenstremeny);
+                }}
+                size="small"
+                aria-label="Åpne venstremeny"
+                åpenvenstremeny={åpenVenstremeny ? 1 : 0}
+            >
+                <NextFilled />
+            </ToggleVisningVenstremeny>
+        </div>
     );
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/venstremeny.less
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/venstremeny.less
@@ -42,9 +42,10 @@
 
         &__sirkel-tall {
             border-radius: 50%;
-            width: 1.25rem;
-            height: 1.25rem;
-            padding: 2px;
+            width: 1.3rem;
+            height: 1.3rem;
+            padding-top: 1px;
+            font-size: 1rem;
         
             background: @navOransje;
             color: black;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Venstre- og høyremeny tar stor plass av vinduet, spesielt på laptop. Implementert funksjonalitet for å kunne skjule venstre- og/eller høyremeny.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8273

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Menyane opne:
![Skjermbilde 2022-06-24 kl  15 04 55](https://user-images.githubusercontent.com/58559732/175542003-a508eabe-6010-4a1d-bad3-0858ec4d5c8c.png)

Menyane skjult:
![Skjermbilde 2022-06-24 kl  15 05 49](https://user-images.githubusercontent.com/58559732/175542094-20f27e05-e0d6-45f6-8d8b-88c36ea28699.png)
