### PR TITLE
Ta i bruk Table fra nytt designsystem for registeropplysninger og EØS-skjemaer

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/EøsPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/EøsPeriodeSkjema.tsx
@@ -21,6 +21,7 @@ const FlexDiv = styled.div`
     width: ${(props: { maxWidth?: number }) => (props.maxWidth ? `${props.maxWidth}rem` : '28rem')};
     display: flex;
     justify-content: space-between;
+    font-size: 1rem;
 
     div {
         z-index: 0;

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Collapse, Expand } from '@navikt/ds-icons';
-import { BodyShort, Button } from '@navikt/ds-react';
+import { BodyShort, Button, Table } from '@navikt/ds-react';
 
 import { mapEøsPeriodeStatusTilStatus } from '../../../../context/Eøs/EøsContext';
 import StatusIkon from '../../../../ikoner/StatusIkon';
@@ -16,7 +16,7 @@ interface IEkspanderbarTrProps {
     ekspandert?: boolean;
 }
 
-export const EkspanderbarTr = styled.tr`
+export const EkspanderbarTr = styled(Table.Row)`
     td {
         border-bottom: ${(props: IEkspanderbarTrProps) =>
             props.ekspandert
@@ -32,7 +32,7 @@ export const EkspanderbarTr = styled.tr`
     }
 `;
 
-export const EkspandertTd = styled.td`
+export const EkspandertTd = styled(Table.DataCell)`
     padding: 0 1rem 1rem 1.6rem;
 `;
 
@@ -89,7 +89,7 @@ interface IStatusBarnCelleOgPeriodeCelleProps {
 export const StatusBarnCelleOgPeriodeCelle = (props: IStatusBarnCelleOgPeriodeCelleProps) => {
     return (
         <>
-            <td>
+            <Table.DataCell>
                 <EøsPeriodeVurdertCelle>
                     <div>
                         <StatusIkon
@@ -106,10 +106,10 @@ export const StatusBarnCelleOgPeriodeCelle = (props: IStatusBarnCelleOgPeriodeCe
                         ))}
                     </BarnDiv>
                 </EøsPeriodeVurdertCelle>
-            </td>
-            <td>
+            </Table.DataCell>
+            <Table.DataCell>
                 <BodyShort size="small">{formatterPeriode(props.periode)}</BodyShort>
-            </td>
+            </Table.DataCell>
         </>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/fellesKomponenter.tsx
@@ -45,6 +45,7 @@ export const EøsPeriodeSkjemaContainer = styled.div`
         props.maxWidth ? `${props.maxWidth}rem` : '30rem'};
     border-left: 0.0625rem solid var(--navds-global-color-orange-500);
     padding-left: 2rem;
+    margin-left: -2rem;
 `;
 
 export const StyledLegend = styled.legend`

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
@@ -14,7 +14,18 @@ const KompetanseContainer = styled.div`
     margin-top: 5rem;
 `;
 
-const TabellHeader = styled(Table.HeaderCell)`
+const StyledTable = styled(Table)`
+    margin-top: 2rem;
+
+    & fieldset.skjemagruppe {
+        margin-bottom: 1.5rem;
+    }
+    & div.skjemaelement {
+        margin-bottom: 1.5rem;
+    }
+`;
+
+const StyledHeaderCell = styled(Table.HeaderCell)`
     &:nth-of-type(2) {
         width: 11rem;
     }
@@ -59,13 +70,13 @@ const KompetanseSkjema: React.FC<IProps> = ({ kompetanser, åpenBehandling, visF
                     children={'For EØS-perioder med tilkjent ytelse, må det fastsettes kompetanse'}
                 />
             )}
-            <Table size="small">
+            <StyledTable size="small">
                 <Table.Header>
                     <Table.Row>
-                        <TabellHeader scope="col">Barn</TabellHeader>
-                        <TabellHeader scope="col">Periode</TabellHeader>
-                        <TabellHeader scope="col">Kompetanse</TabellHeader>
-                        <TabellHeader />
+                        <StyledHeaderCell scope="col">Barn</StyledHeaderCell>
+                        <StyledHeaderCell scope="col">Periode</StyledHeaderCell>
+                        <StyledHeaderCell scope="col">Kompetanse</StyledHeaderCell>
+                        <StyledHeaderCell />
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
@@ -80,7 +91,7 @@ const KompetanseSkjema: React.FC<IProps> = ({ kompetanser, åpenBehandling, visF
                         />
                     ))}
                 </Table.Body>
-            </Table>
+            </StyledTable>
         </KompetanseContainer>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, Heading } from '@navikt/ds-react';
+import { Alert, Heading, Table } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
 
 import type { IBehandling } from '../../../../typer/behandling';
@@ -14,28 +14,15 @@ const KompetanseContainer = styled.div`
     margin-top: 5rem;
 `;
 
-const Tabell = styled.table`
-    margin-top: 2rem;
-    table-layout: fixed;
-
-    & fieldset.skjemagruppe {
-        margin-bottom: 1.5rem;
-    }
-
-    & div.skjemaelement {
-        margin-bottom: 1.5rem;
-    }
-`;
-
-const TabellHeader = styled.th`
+const TabellHeader = styled(Table.HeaderCell)`
     &:nth-of-type(2) {
         width: 11rem;
     }
     &:nth-of-type(3) {
-        width: 9rem;
+        width: 14rem;
     }
     &:nth-of-type(4) {
-        width: 14rem;
+        width: 2.25rem;
     }
 `;
 
@@ -72,16 +59,16 @@ const KompetanseSkjema: React.FC<IProps> = ({ kompetanser, åpenBehandling, visF
                     children={'For EØS-perioder med tilkjent ytelse, må det fastsettes kompetanse'}
                 />
             )}
-            <Tabell className={`tabell`}>
-                <thead>
-                    <tr>
-                        <TabellHeader>Barn</TabellHeader>
-                        <TabellHeader>Periode</TabellHeader>
-                        <TabellHeader>Kompetanse</TabellHeader>
-                        <TabellHeader></TabellHeader>
-                    </tr>
-                </thead>
-                <tbody>
+            <Table size={'small'}>
+                <Table.Header>
+                    <Table.Row>
+                        <TabellHeader scope={'column'}>Barn</TabellHeader>
+                        <TabellHeader scope={'column'}>Periode</TabellHeader>
+                        <TabellHeader scope={'column'}>Kompetanse</TabellHeader>
+                        <TabellHeader />
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
                     {kompetanser.map(kompetanse => (
                         <KompetanseTabellRad
                             key={`${kompetanse.verdi?.barnIdenter.verdi.map(barn => `${barn}-`)}-${
@@ -92,8 +79,8 @@ const KompetanseSkjema: React.FC<IProps> = ({ kompetanser, åpenBehandling, visF
                             visFeilmeldinger={visFeilmeldinger}
                         />
                     ))}
-                </tbody>
-            </Tabell>
+                </Table.Body>
+            </Table>
         </KompetanseContainer>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
@@ -59,12 +59,12 @@ const KompetanseSkjema: React.FC<IProps> = ({ kompetanser, åpenBehandling, visF
                     children={'For EØS-perioder med tilkjent ytelse, må det fastsettes kompetanse'}
                 />
             )}
-            <Table size={'small'}>
+            <Table size="small">
                 <Table.Header>
                     <Table.Row>
-                        <TabellHeader scope={'column'}>Barn</TabellHeader>
-                        <TabellHeader scope={'column'}>Periode</TabellHeader>
-                        <TabellHeader scope={'column'}>Kompetanse</TabellHeader>
+                        <TabellHeader scope="col">Barn</TabellHeader>
+                        <TabellHeader scope="col">Periode</TabellHeader>
+                        <TabellHeader scope="col">Kompetanse</TabellHeader>
                         <TabellHeader />
                     </Table.Row>
                 </Table.Header>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
@@ -58,7 +58,7 @@ const KompetanseTabellRad: React.FC<IProps> = ({
 
     return (
         <Table.ExpandableRow
-            togglePlacement={'right'}
+            togglePlacement="right"
             open={ekspandertKompetanse}
             onOpenChange={() => toggleForm(true)}
             id={kompetanseFeilmeldingId(redigerbartKompetanse)}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import deepEqual from 'deep-equal';
 
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, Table } from '@navikt/ds-react';
 import type { OptionType } from '@navikt/familie-form-elements';
 import type { FeltState } from '@navikt/familie-skjema';
 
@@ -10,12 +10,7 @@ import type { IBehandling } from '../../../../typer/behandling';
 import type { IKompetanse } from '../../../../typer/eøsPerioder';
 import { KompetanseResultat } from '../../../../typer/eøsPerioder';
 import { lagPersonLabel } from '../../../../utils/formatter';
-import {
-    EkspanderbarTr,
-    EkspandertTd,
-    EøsPeriodeEkspanderKnapp,
-    StatusBarnCelleOgPeriodeCelle,
-} from '../EøsPeriode/fellesKomponenter';
+import { StatusBarnCelleOgPeriodeCelle } from '../EøsPeriode/fellesKomponenter';
 import { kompetanseFeilmeldingId } from './KompetanseSkjema';
 import KompetanseTabellRadEndre from './KompetanseTabellRadEndre';
 
@@ -62,42 +57,32 @@ const KompetanseTabellRad: React.FC<IProps> = ({
     }));
 
     return (
-        <>
-            <EkspanderbarTr ekspandert={ekspandertKompetanse}>
-                <StatusBarnCelleOgPeriodeCelle
-                    status={kompetanse.verdi.status}
-                    barnIdenter={kompetanse.verdi.barnIdenter.verdi}
-                    personer={åpenBehandling.personer}
-                    periode={kompetanse.verdi.periode.verdi}
+        <Table.ExpandableRow
+            togglePlacement={'right'}
+            open={ekspandertKompetanse}
+            onOpenChange={() => toggleForm(true)}
+            id={kompetanseFeilmeldingId(redigerbartKompetanse)}
+            content={
+                <KompetanseTabellRadEndre
+                    redigerbartKompetanse={redigerbartKompetanse}
+                    tilgjengeligeBarn={barn}
+                    visFeilmeldinger={visFeilmeldinger}
+                    settRedigerbartKompetanse={settRedigerbartKompetanse}
+                    toggleForm={toggleForm}
+                    settEkspandertKompetanse={settEkspandertKompetanse}
                 />
-                <td>
-                    <BodyShort size="small">{visVurdertKompetanse()}</BodyShort>
-                </td>
-                <td>
-                    <EøsPeriodeEkspanderKnapp
-                        feilmeldingId={kompetanseFeilmeldingId(kompetanse)}
-                        toggleForm={toggleForm}
-                        erEkspandert={ekspandertKompetanse}
-                        periodeStatus={kompetanse.verdi.status}
-                        ikkeUtfyltLabel={'Fastsett kompetanse'}
-                    />
-                </td>
-            </EkspanderbarTr>
-            {ekspandertKompetanse && (
-                <tr>
-                    <EkspandertTd colSpan={4}>
-                        <KompetanseTabellRadEndre
-                            redigerbartKompetanse={redigerbartKompetanse}
-                            tilgjengeligeBarn={barn}
-                            visFeilmeldinger={visFeilmeldinger}
-                            settRedigerbartKompetanse={settRedigerbartKompetanse}
-                            toggleForm={toggleForm}
-                            settEkspandertKompetanse={settEkspandertKompetanse}
-                        />
-                    </EkspandertTd>
-                </tr>
-            )}
-        </>
+            }
+        >
+            <StatusBarnCelleOgPeriodeCelle
+                status={kompetanse.verdi.status}
+                barnIdenter={kompetanse.verdi.barnIdenter.verdi}
+                personer={åpenBehandling.personer}
+                periode={kompetanse.verdi.periode.verdi}
+            />
+            <Table.DataCell>
+                <BodyShort size="small">{visVurdertKompetanse()}</BodyShort>
+            </Table.DataCell>
+        </Table.ExpandableRow>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, Heading } from '@navikt/ds-react';
+import { Alert, Heading, Table } from '@navikt/ds-react';
 
 import { useEøs } from '../../../../context/Eøs/EøsContext';
 import type { IBehandling } from '../../../../typer/behandling';
@@ -13,16 +13,7 @@ const UtenlandskPeriodeBeløperContainer = styled.div`
     margin-top: 5rem;
 `;
 
-const Tabell = styled.table`
-    margin-top: 2rem;
-    table-layout: fixed;
-
-    & fieldset.skjemagruppe {
-        margin-bottom: 1.5rem;
-    }
-`;
-
-const TabellHeader = styled.th`
+const TabellHeader = styled(Table.HeaderCell)`
     &:nth-of-type(2) {
         width: 11rem;
     }
@@ -30,10 +21,10 @@ const TabellHeader = styled.th`
         width: 9.5rem;
     }
     &:nth-of-type(4) {
-        width: 5rem;
+        width: 11rem;
     }
     &:nth-of-type(5) {
-        width: 11rem;
+        width: 2.25rem;
     }
 `;
 
@@ -64,17 +55,17 @@ const UtbetaltAnnetLand: React.FC<IProps> = ({
                     }
                 />
             )}
-            <Tabell className={`tabell`}>
-                <thead>
-                    <tr>
-                        <TabellHeader>Barn</TabellHeader>
-                        <TabellHeader>Periode</TabellHeader>
-                        <TabellHeader>Beløp per måned</TabellHeader>
-                        <TabellHeader>Valuta</TabellHeader>
+            <Table size="small">
+                <Table.Header>
+                    <Table.Row>
+                        <TabellHeader scope="col">Barn</TabellHeader>
+                        <TabellHeader scope="col">Periode</TabellHeader>
+                        <TabellHeader scope="col">Beløp per måned</TabellHeader>
+                        <TabellHeader scope="col">Valuta</TabellHeader>
                         <TabellHeader></TabellHeader>
-                    </tr>
-                </thead>
-                <tbody>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
                     {utbetaltAnnetLandBeløp.map(utenlandskPeriodeBeløp => (
                         <UtenlandskPeriodeBeløpRad
                             key={`${utenlandskPeriodeBeløp.barnIdenter.map(barn => `${barn}-`)}-${
@@ -85,8 +76,8 @@ const UtbetaltAnnetLand: React.FC<IProps> = ({
                             visFeilmeldinger={visFeilmeldinger}
                         />
                     ))}
-                </tbody>
-            </Tabell>
+                </Table.Body>
+            </Table>
         </UtenlandskPeriodeBeløperContainer>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
@@ -13,6 +13,14 @@ const UtenlandskPeriodeBeløperContainer = styled.div`
     margin-top: 5rem;
 `;
 
+const StyledTable = styled(Table)`
+    margin-top: 2rem;
+
+    & fieldset.skjemagruppe {
+        margin-bottom: 1.5rem;
+    }
+`;
+
 const TabellHeader = styled(Table.HeaderCell)`
     &:nth-of-type(2) {
         width: 11rem;
@@ -55,7 +63,7 @@ const UtbetaltAnnetLand: React.FC<IProps> = ({
                     }
                 />
             )}
-            <Table size="small">
+            <StyledTable size="small">
                 <Table.Header>
                     <Table.Row>
                         <TabellHeader scope="col">Barn</TabellHeader>
@@ -77,7 +85,7 @@ const UtbetaltAnnetLand: React.FC<IProps> = ({
                         />
                     ))}
                 </Table.Body>
-            </Table>
+            </StyledTable>
         </UtenlandskPeriodeBeløperContainer>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Table } from '@navikt/ds-react';
 import type { OptionType } from '@navikt/familie-form-elements';
 
 import {
@@ -9,12 +10,7 @@ import {
 import type { IBehandling } from '../../../../typer/behandling';
 import type { IRestUtenlandskPeriodeBeløp } from '../../../../typer/eøsPerioder';
 import { lagPersonLabel } from '../../../../utils/formatter';
-import {
-    EkspanderbarTr,
-    EkspandertTd,
-    EøsPeriodeEkspanderKnapp,
-    StatusBarnCelleOgPeriodeCelle,
-} from '../EøsPeriode/fellesKomponenter';
+import { StatusBarnCelleOgPeriodeCelle } from '../EøsPeriode/fellesKomponenter';
 import UtenlandskPeriodeBeløpTabellRadEndre from './UtenlandskPeriodeBeløpTabellRadEndre';
 
 interface IProps {
@@ -83,50 +79,38 @@ const UtenlandskPeriodeBeløpRad: React.FC<IProps> = ({
     };
 
     return (
-        <>
-            <EkspanderbarTr ekspandert={erUtenlandskPeriodeBeløpEkspandert}>
-                <StatusBarnCelleOgPeriodeCelle
-                    status={utenlandskPeriodeBeløp.status}
-                    barnIdenter={utenlandskPeriodeBeløp.barnIdenter}
-                    personer={åpenBehandling.personer}
-                    periode={{
-                        fom: utenlandskPeriodeBeløp.fom,
-                        tom: utenlandskPeriodeBeløp.tom,
-                    }}
+        <Table.ExpandableRow
+            open={erUtenlandskPeriodeBeløpEkspandert}
+            togglePlacement="right"
+            onOpenChange={() => toggleForm(true)}
+            id={utenlandskPeriodeBeløpFeilmeldingId(utenlandskPeriodeBeløp)}
+            content={
+                <UtenlandskPeriodeBeløpTabellRadEndre
+                    skjema={skjema}
+                    tilgjengeligeBarn={barn}
+                    valideringErOk={valideringErOk}
+                    sendInnSkjema={sendInnSkjema}
+                    toggleForm={toggleForm}
+                    slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
                 />
-                <td>
-                    {utenlandskPeriodeBeløp.kalkulertMånedligBeløp
-                        ? formatterKalkulertBeløp()
-                        : '-'}
-                </td>
-                <td>
-                    {utenlandskPeriodeBeløp.valutakode ? utenlandskPeriodeBeløp.valutakode : '-'}
-                </td>
-                <td>
-                    <EøsPeriodeEkspanderKnapp
-                        feilmeldingId={utenlandskPeriodeBeløpFeilmeldingId(utenlandskPeriodeBeløp)}
-                        toggleForm={toggleForm}
-                        erEkspandert={erUtenlandskPeriodeBeløpEkspandert}
-                        periodeStatus={utenlandskPeriodeBeløp.status}
-                        ikkeUtfyltLabel={'Registrer beløp'}
-                    />
-                </td>
-            </EkspanderbarTr>
-            {erUtenlandskPeriodeBeløpEkspandert && (
-                <tr>
-                    <EkspandertTd colSpan={5}>
-                        <UtenlandskPeriodeBeløpTabellRadEndre
-                            skjema={skjema}
-                            tilgjengeligeBarn={barn}
-                            valideringErOk={valideringErOk}
-                            sendInnSkjema={sendInnSkjema}
-                            toggleForm={toggleForm}
-                            slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
-                        />
-                    </EkspandertTd>
-                </tr>
-            )}
-        </>
+            }
+        >
+            <StatusBarnCelleOgPeriodeCelle
+                status={utenlandskPeriodeBeløp.status}
+                barnIdenter={utenlandskPeriodeBeløp.barnIdenter}
+                personer={åpenBehandling.personer}
+                periode={{
+                    fom: utenlandskPeriodeBeløp.fom,
+                    tom: utenlandskPeriodeBeløp.tom,
+                }}
+            />
+            <Table.DataCell>
+                {utenlandskPeriodeBeløp.kalkulertMånedligBeløp ? formatterKalkulertBeløp() : '-'}
+            </Table.DataCell>
+            <Table.DataCell>
+                {utenlandskPeriodeBeløp.valutakode ? utenlandskPeriodeBeløp.valutakode : '-'}
+            </Table.DataCell>
+        </Table.ExpandableRow>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -45,10 +45,12 @@ const UtbetaltBeløpRad = styled.div`
 
         label {
             font-weight: normal;
+            margin-bottom: 0.5rem;
         }
 
         p.navds-label {
             font-weight: normal;
+            margin-bottom: 0.5rem;
         }
 
         &:nth-of-type(1) {

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Table } from '@navikt/ds-react';
 import type { OptionType } from '@navikt/familie-form-elements';
 
 import {
@@ -9,12 +10,7 @@ import {
 import type { IBehandling } from '../../../../typer/behandling';
 import type { IRestValutakurs } from '../../../../typer/eøsPerioder';
 import { datoformat, formaterIsoDato, lagPersonLabel } from '../../../../utils/formatter';
-import {
-    EkspanderbarTr,
-    EkspandertTd,
-    EøsPeriodeEkspanderKnapp,
-    StatusBarnCelleOgPeriodeCelle,
-} from '../EøsPeriode/fellesKomponenter';
+import { StatusBarnCelleOgPeriodeCelle } from '../EøsPeriode/fellesKomponenter';
 import ValutakursTabellRadEndre from './ValutakursTabellRadEndre';
 
 interface IProps {
@@ -64,48 +60,38 @@ const ValutakursTabellRad: React.FC<IProps> = ({
     };
 
     return (
-        <>
-            <EkspanderbarTr ekspandert={erValutakursEkspandert}>
-                <StatusBarnCelleOgPeriodeCelle
-                    status={valutakurs.status}
-                    barnIdenter={valutakurs.barnIdenter}
-                    personer={åpenBehandling.personer}
-                    periode={{
-                        fom: valutakurs.fom,
-                        tom: valutakurs.tom,
-                    }}
+        <Table.ExpandableRow
+            togglePlacement="right"
+            open={erValutakursEkspandert}
+            onOpenChange={() => toggleForm(true)}
+            id={valutakursFeilmeldingId(valutakurs)}
+            content={
+                <ValutakursTabellRadEndre
+                    skjema={skjema}
+                    tilgjengeligeBarn={barn}
+                    valideringErOk={valideringErOk}
+                    sendInnSkjema={sendInnSkjema}
+                    toggleForm={toggleForm}
+                    slettValutakurs={slettValutakurs}
                 />
-                <td>
-                    {valutakurs.valutakursdato
-                        ? formaterIsoDato(valutakurs.valutakursdato, datoformat.DATO)
-                        : '-'}
-                </td>
-                <td>{valutakurs.valutakode ? valutakurs.valutakode : '-'}</td>
-                <td>
-                    <EøsPeriodeEkspanderKnapp
-                        feilmeldingId={valutakursFeilmeldingId(valutakurs)}
-                        toggleForm={toggleForm}
-                        erEkspandert={erValutakursEkspandert}
-                        periodeStatus={valutakurs.status}
-                        ikkeUtfyltLabel={'Registrer valutakursdato'}
-                    />
-                </td>
-            </EkspanderbarTr>
-            {erValutakursEkspandert && (
-                <tr>
-                    <EkspandertTd colSpan={5}>
-                        <ValutakursTabellRadEndre
-                            skjema={skjema}
-                            tilgjengeligeBarn={barn}
-                            valideringErOk={valideringErOk}
-                            sendInnSkjema={sendInnSkjema}
-                            toggleForm={toggleForm}
-                            slettValutakurs={slettValutakurs}
-                        />
-                    </EkspandertTd>
-                </tr>
-            )}
-        </>
+            }
+        >
+            <StatusBarnCelleOgPeriodeCelle
+                status={valutakurs.status}
+                barnIdenter={valutakurs.barnIdenter}
+                personer={åpenBehandling.personer}
+                periode={{
+                    fom: valutakurs.fom,
+                    tom: valutakurs.tom,
+                }}
+            />
+            <Table.DataCell>
+                {valutakurs.valutakursdato
+                    ? formaterIsoDato(valutakurs.valutakursdato, datoformat.DATO)
+                    : '-'}
+            </Table.DataCell>
+            <Table.DataCell>{valutakurs.valutakode ? valutakurs.valutakode : '-'}</Table.DataCell>
+        </Table.ExpandableRow>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -46,10 +46,12 @@ const ValutakursRad = styled.div`
 
         label {
             font-weight: normal;
+            margin-bottom: 0.5rem;
         }
 
         p.navds-label {
             font-weight: normal;
+            margin-bottom: 0.5rem;
         }
 
         &:nth-of-type(3) {

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
@@ -29,10 +29,10 @@ const StyledHeaderCell = styled(Table.HeaderCell)`
         width: 7.5rem;
     }
     &:nth-of-type(4) {
-        width: 4rem;
+        width: 14rem;
     }
     &:nth-of-type(5) {
-        width: 15rem;
+        width: 2.25rem;
     }
 `;
 
@@ -58,7 +58,7 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
                     }
                 />
             )}
-            <StyledTable className={`tabell`}>
+            <StyledTable size="small">
                 <Table.Header>
                     <Table.Row>
                         <StyledHeaderCell scope="col">Barn</StyledHeaderCell>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, Heading } from '@navikt/ds-react';
+import { Alert, Heading, Table } from '@navikt/ds-react';
 
 import { useEøs } from '../../../../context/Eøs/EøsContext';
 import type { IBehandling } from '../../../../typer/behandling';
@@ -13,16 +13,15 @@ const ValutakurserContainer = styled.div`
     margin-top: 5rem;
 `;
 
-const Tabell = styled.table`
+const StyledTable = styled(Table)`
     margin-top: 2rem;
-    table-layout: fixed;
 
     & fieldset.skjemagruppe {
         margin-bottom: 1.5rem;
     }
 `;
 
-const TabellHeader = styled.th`
+const StyledHeaderCell = styled(Table.HeaderCell)`
     &:nth-of-type(2) {
         width: 11rem;
     }
@@ -59,17 +58,17 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
                     }
                 />
             )}
-            <Tabell className={`tabell`}>
-                <thead>
-                    <tr>
-                        <TabellHeader>Barn</TabellHeader>
-                        <TabellHeader>Periode</TabellHeader>
-                        <TabellHeader>Valutakursdato</TabellHeader>
-                        <TabellHeader>Valuta</TabellHeader>
-                        <TabellHeader></TabellHeader>
-                    </tr>
-                </thead>
-                <tbody>
+            <StyledTable className={`tabell`}>
+                <Table.Header>
+                    <Table.Row>
+                        <StyledHeaderCell scope="col">Barn</StyledHeaderCell>
+                        <StyledHeaderCell scope="col">Periode</StyledHeaderCell>
+                        <StyledHeaderCell scope="col">Valutakursdato</StyledHeaderCell>
+                        <StyledHeaderCell scope="col">Valuta</StyledHeaderCell>
+                        <StyledHeaderCell></StyledHeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
                     {valutakurser.map(valutakurs => (
                         <ValutakursTabellRad
                             key={`${valutakurs.barnIdenter.map(barn => `${barn}-`)}-${
@@ -80,8 +79,8 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
                             visFeilmeldinger={visFeilmeldinger}
                         />
                     ))}
-                </tbody>
-            </Tabell>
+                </Table.Body>
+            </StyledTable>
         </ValutakurserContainer>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { Collapse, Expand } from '@navikt/ds-icons';
-import { Button } from '@navikt/ds-react';
+import { Button, Table } from '@navikt/ds-react';
 
 import type { IRestRegisteropplysning } from '../../../../typer/person';
 import { Registeropplysning, registeropplysning } from '../../../../typer/registeropplysning';
@@ -25,10 +25,7 @@ const Container = styled.div`
     width: 100%;
 `;
 
-const TabellHeader = styled.th`
-    text-align: left;
-    padding: 0.5rem !important;
-
+const StyledHeaderCell = styled(Table.HeaderCell)`
     &:nth-of-type(1) {
         width: 15rem;
     }
@@ -37,16 +34,8 @@ const TabellHeader = styled.th`
     }
 `;
 
-const Tabell = styled.table`
+const StyledTable = styled(Table)`
     margin-left: 1rem;
-    table-layout: fixed;
-`;
-
-const TabellRad = styled.tr`
-    td {
-        border-bottom: 1px solid rgba(0, 0, 0, 0.15) !important;
-        padding: 0.5rem;
-    }
 `;
 
 const OpplysningsIkon = styled.div`
@@ -103,28 +92,28 @@ const RegisteropplysningerTabell: React.FC<IRegisteropplysningerTabellProps> = (
         <>
             <Container>
                 <OpplysningsIkon children={ikon} />
-                <Tabell
-                    className={'tabell'}
+                <StyledTable
+                    size={'small'}
                     aria-label={`Registeropplysninger for ${registeropplysning[opplysningstype]}`}
                 >
-                    <thead>
-                        <tr>
-                            <TabellHeader children={registeropplysning[opplysningstype]} />
-                            <TabellHeader children={hentDatoHeader(opplysningstype)} />
-                        </tr>
-                    </thead>
-                    <tbody>
+                    <Table.Header>
+                        <Table.Row>
+                            <StyledHeaderCell children={registeropplysning[opplysningstype]} />
+                            <StyledHeaderCell children={hentDatoHeader(opplysningstype)} />
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
                         {manglerOpplysninger && (
-                            <TabellRad key={`${opplysningstype}_ukjent`}>
-                                <td children={'Ingen opplysninger'} />
-                                <td children={'-'} />
-                            </TabellRad>
+                            <Table.Row key={`${opplysningstype}_ukjent`}>
+                                <Table.DataCell children={'Ingen opplysninger'} />
+                                <Table.DataCell children={'-'} />
+                            </Table.Row>
                         )}
                         {!manglerOpplysninger &&
                             synligHistorikk.map(periode => (
-                                <TabellRad key={`${periode.fom}_${periode.tom}_${periode.verdi}`}>
-                                    <td children={periode.verdi} />
-                                    <td
+                                <Table.Row key={`${periode.fom}_${periode.tom}_${periode.verdi}`}>
+                                    <Table.DataCell children={periode.verdi} />
+                                    <Table.DataCell
                                         children={
                                             opplysningstype === Registeropplysning.SIVILSTAND ||
                                             opplysningstype === Registeropplysning.DØDSBOADRESSE
@@ -139,10 +128,10 @@ const RegisteropplysningerTabell: React.FC<IRegisteropplysningerTabellProps> = (
                                                   })
                                         }
                                     />
-                                </TabellRad>
+                                </Table.Row>
                             ))}
-                    </tbody>
-                </Tabell>
+                    </Table.Body>
+                </StyledTable>
             </Container>
             {skalVæreEkspanderbar && (
                 <HøyrejustertKnapperad>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Oppgraderer designet på tabeller for registeropplysninger og EØS-skjemaer til å bruke nye Table: https://aksel.nav.no/designsystem/komponenter/table

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Tidligere hadde EØS-periodenes toggle også knappetekst - det mister de nå. 

Vi bruker gammel tabellvisning flere steder i appen, men jeg tar det i nye PR-er for å gjøre det overkommelig å gjøre QA av

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Visuell oppgradering

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Tror jeg ville ha lest commit for commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots

#### Registeropplysninger før
<img width="629" alt="image" src="https://user-images.githubusercontent.com/2379098/178470198-aa8fb601-a689-4976-a1ac-7ea93a5261a9.png">

#### Etter
<img width="628" alt="image" src="https://user-images.githubusercontent.com/2379098/178470258-0c42de8c-ea40-48b6-a356-e4bae3f52a32.png">

#### Kompetanse før
<img width="979" alt="image" src="https://user-images.githubusercontent.com/2379098/178493972-5f89ff32-37ba-4395-bea7-1e1113819954.png">

#### Etter
<img width="977" alt="image" src="https://user-images.githubusercontent.com/2379098/178494024-a1bf5106-fb81-4b5d-bb60-b57d927259e0.png">

#### Utbetalt i det andre landet, før
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/2379098/178685121-c13cf08c-13e4-4b5b-bda6-3d5bbe8b49fd.png">
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/2379098/178685167-c8924197-db22-4b9b-a6c6-d2d68f45151d.png">

#### Etter
<img width="959" alt="image" src="https://user-images.githubusercontent.com/2379098/178685249-2293cf9f-7c23-4253-837e-e5d17887beb8.png">
<img width="957" alt="image" src="https://user-images.githubusercontent.com/2379098/178685308-bbb7d6af-9673-4759-8388-9d787c1af562.png">

#### Valutakurs før
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/2379098/178685374-17c17483-b003-4307-9a31-47942f56b9d7.png">
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/2379098/178685408-306baf26-234a-48dd-8a5b-d450e255f349.png">

#### Etter
<img width="1048" alt="image" src="https://user-images.githubusercontent.com/2379098/178685474-eaec84b7-68fe-4eeb-be7d-42257b421b69.png">
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/2379098/178685514-266e3146-db1c-4c46-95cd-c184f8760187.png">
