### PR TITLE
Oppgrader til ny Alert i pdfVisningModal, BehandlingContainer og FagsakContainer

### DIFF
--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -2,8 +2,7 @@ import React, { useEffect } from 'react';
 
 import { Redirect, Route, Switch, useHistory } from 'react-router';
 
-import AlertStripe from 'nav-frontend-alertstriper';
-
+import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../context/behandlingContext/BehandlingContext';
@@ -110,14 +109,14 @@ const BehandlingContainer: React.FunctionComponent = () => {
             );
         case RessursStatus.IKKE_TILGANG:
             return (
-                <AlertStripe
+                <Alert
+                    variant="warning"
                     children={`Du har ikke tilgang til å se denne behandlingen.`}
-                    type={'advarsel'}
                 />
             );
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
-            return <AlertStripe children={åpenBehandling.frontendFeilmelding} type={'feil'} />;
+            return <Alert children={åpenBehandling.frontendFeilmelding} variant="error" />;
         default:
             return <div />;
     }

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -3,8 +3,7 @@ import React, { useEffect } from 'react';
 import { Redirect, useHistory } from 'react-router';
 import { Route, Switch } from 'react-router-dom';
 
-import AlertStripe from 'nav-frontend-alertstriper';
-
+import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { DokumentutsendingProvider } from '../../context/DokumentutsendingContext';
@@ -33,6 +32,8 @@ const FagsakContainer: React.FunctionComponent = () => {
     const skalHaHøyremeny = !erPåSaksoversikt && !erPåDokumentutsending;
 
     const { bruker, minimalFagsak, hentMinimalFagsak } = useFagsakRessurser();
+
+    console.log(bruker);
 
     useEffect(() => {
         if (fagsakId !== undefined) {
@@ -133,20 +134,17 @@ const FagsakContainer: React.FunctionComponent = () => {
                 case RessursStatus.FEILET:
                 case RessursStatus.FUNKSJONELL_FEIL:
                 case RessursStatus.IKKE_TILGANG:
-                    return <AlertStripe children={bruker.frontendFeilmelding} type={'feil'} />;
+                    return <Alert children={bruker.frontendFeilmelding} variant="error" />;
                 default:
                     return <div />;
             }
         case RessursStatus.IKKE_TILGANG:
             return (
-                <AlertStripe
-                    children={`Du har ikke tilgang til å se denne saken.`}
-                    type={'advarsel'}
-                />
+                <Alert children={`Du har ikke tilgang til å se denne saken.`} variant="warning" />
             );
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
-            return <AlertStripe children={minimalFagsak.frontendFeilmelding} type={'feil'} />;
+            return <Alert children={minimalFagsak.frontendFeilmelding} variant="error" />;
         default:
             return <div />;
     }

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -33,8 +33,6 @@ const FagsakContainer: React.FunctionComponent = () => {
 
     const { bruker, minimalFagsak, hentMinimalFagsak } = useFagsakRessurser();
 
-    console.log(bruker);
-
     useEffect(() => {
         if (fagsakId !== undefined) {
             if (minimalFagsak.status !== RessursStatus.SUKSESS) {

--- a/src/frontend/komponenter/Felleskomponenter/PdfVisningModal/PdfVisningModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PdfVisningModal/PdfVisningModal.tsx
@@ -2,11 +2,11 @@ import React, { useEffect } from 'react';
 
 import styled from 'styled-components';
 
-import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import Modal from 'nav-frontend-modal';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { Undertittel } from 'nav-frontend-typografi';
 
+import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 import type { Ressurs } from '@navikt/familie-typer';
 
@@ -73,7 +73,8 @@ const Dokument: React.FC<{ pdfdata: Ressurs<string> }> = ({ pdfdata }) => {
         case RessursStatus.FUNKSJONELL_FEIL:
         case RessursStatus.IKKE_TILGANG:
             return (
-                <AlertStripeFeil
+                <Alert
+                    variant="error"
                     className={'pdfvisning-modal__document--feil'}
                     children={pdfdata.frontendFeilmelding}
                 />


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Oppgraderer til det nye designsystemet sin alert-komponent.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
På behandlingcontainer-siden er det en liten bug med venstre sidemeny som jeg har laget et favro-kort på.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Unødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
Samma

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
**PdfVisningModal**
_Før_
![Skjermbilde 2022-07-18 kl  14 11 27](https://user-images.githubusercontent.com/25459913/179509812-f038c734-0c68-4b6e-b256-915f4a887b3c.png)

_Etter_
![image](https://user-images.githubusercontent.com/25459913/179509776-52d3363c-3cae-4cc7-81d4-51aae3d4cdd0.png)


**BehandlingContainer**
-> Ikke tilgang-feil
_Før_
![image](https://user-images.githubusercontent.com/25459913/179511028-44e80a58-24a8-4954-9ed3-079b9faaa5d9.png)

_Etter_
![image](https://user-images.githubusercontent.com/25459913/179511187-5c42d4b1-aa8b-4d72-90bf-d38a1cdeca61.png)


-> Funksjonell feil/annen feil
_Før_
![image](https://user-images.githubusercontent.com/25459913/179511692-dfeb2720-5656-431d-bfc4-70ac136a6703.png)

_Etter_
![image](https://user-images.githubusercontent.com/25459913/179511822-6062092c-1a0f-4c2f-9e15-a002182d1847.png)


**Fagsakcontainer**
-> Ikke tilgang til fagsak
_Før_
![image](https://user-images.githubusercontent.com/25459913/179512970-ad708a70-8dc7-4be1-bdca-cfe5e145e83d.png)

_Etter_
![image](https://user-images.githubusercontent.com/25459913/179513044-d396eedf-033b-443b-890d-ad3f8443186b.png)

-> Funksjonell feil/annen feil på fagsak
_Før_
![image](https://user-images.githubusercontent.com/25459913/179513482-6e0ebc5b-6f4a-40dc-b03a-58d12370f3cb.png)

_Etter_
![image](https://user-images.githubusercontent.com/25459913/179514335-8d22b465-443b-427d-8ee2-3f7a2a10e73d.png)

