### PR TITLE
Tea-4925: Valider at tom-dato er før dødsfalldato dersom person er død

### DIFF
--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -44,6 +44,7 @@ describe('utils/validators', () => {
     const mockBarn = {
         personIdent: '12345678930',
         fødselsdato: '2000-05-17',
+        dødsfallDato: '2020-12-12',
         type: PersonType.BARN,
         kjønn: 'KVINNE',
         navn: 'Mock Barn',
@@ -120,6 +121,18 @@ describe('utils/validators', () => {
         expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
         expect(valideringsresultat.feilmelding).toEqual(
             'Du kan ikke legge til periode før barnets fødselsdato'
+        );
+    });
+
+    test('Periode med tom-dato etter barnets dødsfalldato gir feil', () => {
+        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2000-05-17', '2021-05-17'));
+        const valideringsresultat = erPeriodeGyldig(periode, {
+            person: mockBarn,
+            erEksplisittAvslagPåSøknad: false,
+        });
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual(
+            'Du kan ikke sette til og med dato etter dødsfalldato'
         );
     });
 

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -121,6 +121,14 @@ export const erPeriodeGyldig = (
             );
         }
 
+        if (tom && person?.dødsfallDato) {
+            const dødsfallKalenderDato = kalenderDato(person.dødsfallDato);
+
+            if (erEtter(tomKalenderDato, dødsfallKalenderDato)) {
+                return feil(felt, 'Du kan ikke sette til og med dato etter dødsfalldato');
+            }
+        }
+
         return fomDatoErFørTomDato ? ok(felt) : feil(felt, 'F.o.m må settes tidligere enn t.o.m');
     } else {
         if (erEksplisittAvslagPåSøknad) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Jeg har lagt til validering av tom-dato dersom en person er død slik at denne ikke kan være lengre framover i tid enn dødsfalldato under vilkårsvurderingen (se bilde).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Første PR jeg lager, så jeg ønsker egentlig en gjennomgang av veien videre etter merge (hvordan deploye ut til prod osv).

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 🤷‍♀ ️Hvor er det lurt å starte?
Se b41cb05

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
![error når tom dato er lengre fram enn dødsfalldato](https://user-images.githubusercontent.com/110383605/182470207-a34a9249-41db-436d-a9c5-3c9c690c6df0.png)

