### PR TITLE
Tea-9071: Valider at valutakurs inneholder 4 desimaler

### DIFF
--- a/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
+++ b/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
@@ -27,6 +27,7 @@ const erValutakursDatoGyldig = (
     felt: FeltState<string | undefined>
 ): FeltState<string | undefined> =>
     !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Valutakursdato er påkrevd, men mangler input');
+
 const erValutakursGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> => {
     if (!felt.verdi || isEmpty(felt.verdi) || typeof felt.verdi != 'string') {
         return feil(felt, 'Valutakurs er påkrevd, men mangler input');
@@ -38,12 +39,18 @@ const erValutakursGyldig = (felt: FeltState<string | undefined>): FeltState<stri
     if (!isNumeric(nyKurs)) {
         return feil(felt, `Valutakurs innholder ugyldige verdier, kurs: ${felt.verdi}`);
     }
+    if (!valutakursHarGyldigAntallDesimaler(nyKurs)) {
+        return feil(felt, `Valutakurs må ha 4 desimaler, kurs: ${felt.verdi}`);
+    }
     const kurs = Number(nyKurs);
     if (kurs < 0) {
         return feil(felt, `Kan ikke registrere negativt kurs: ${felt.verdi}`);
     }
     return ok(felt);
 };
+
+export const valutakursHarGyldigAntallDesimaler = (valutakurs: string) =>
+    valutakurs?.split('.')[1]?.length === 4;
 
 export const valutakursFeilmeldingId = (valutakurs: IRestValutakurs): string =>
     `valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${valutakurs.fom}`;

--- a/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
+++ b/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
@@ -14,6 +14,7 @@ import {
     erValutakodeGyldig,
     isEmpty,
     isNumeric,
+    tellAntallDesimaler,
 } from '../../utils/eøsValidators';
 import type { IYearMonthPeriode } from '../../utils/kalender';
 import { nyYearMonthPeriode } from '../../utils/kalender';
@@ -27,7 +28,6 @@ const erValutakursDatoGyldig = (
     felt: FeltState<string | undefined>
 ): FeltState<string | undefined> =>
     !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Valutakursdato er påkrevd, men mangler input');
-
 const erValutakursGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> => {
     if (!felt.verdi || isEmpty(felt.verdi) || typeof felt.verdi != 'string') {
         return feil(felt, 'Valutakurs er påkrevd, men mangler input');
@@ -39,7 +39,7 @@ const erValutakursGyldig = (felt: FeltState<string | undefined>): FeltState<stri
     if (!isNumeric(nyKurs)) {
         return feil(felt, `Valutakurs innholder ugyldige verdier, kurs: ${felt.verdi}`);
     }
-    if (!valutakursHarGyldigAntallDesimaler(nyKurs)) {
+    if (tellAntallDesimaler(nyKurs) !== 4) {
         return feil(felt, `Valutakurs må ha 4 desimaler, kurs: ${felt.verdi}`);
     }
     const kurs = Number(nyKurs);
@@ -48,9 +48,6 @@ const erValutakursGyldig = (felt: FeltState<string | undefined>): FeltState<stri
     }
     return ok(felt);
 };
-
-export const valutakursHarGyldigAntallDesimaler = (valutakurs: string) =>
-    valutakurs?.split('.')[1]?.length === 4;
 
 export const valutakursFeilmeldingId = (valutakurs: IRestValutakurs): string =>
     `valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${valutakurs.fom}`;

--- a/src/frontend/utils/eøsValidators.ts
+++ b/src/frontend/utils/eøsValidators.ts
@@ -70,9 +70,16 @@ const erBarnGyldig = (felt: FeltState<OptionType[]>): FeltState<OptionType[]> =>
 const erValutakodeGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> =>
     !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Valuta er påkrevd, men mangler input');
 
-const isNumeric = (val: string): boolean => {
-    if (typeof val != 'string') return false;
-    return !isNaN(Number(val));
-};
+const tellAntallDesimaler = (verdi: string): number | undefined =>
+    verdi.split(/,|\./)[1]?.length ?? 0;
 
-export { isEmpty, erEøsPeriodeGyldig, erBarnGyldig, erValutakodeGyldig, isNumeric };
+const isNumeric = (val: string): boolean => !isNaN(Number(val));
+
+export {
+    erEøsPeriodeGyldig,
+    erBarnGyldig,
+    erValutakodeGyldig,
+    isEmpty,
+    isNumeric,
+    tellAntallDesimaler,
+};

--- a/src/frontend/utils/test/eøsValidators.test.ts
+++ b/src/frontend/utils/test/eøsValidators.test.ts
@@ -50,7 +50,7 @@ describe('utils/eøsValidators', () => {
         );
     });
 
-    test('erEøsPeriodeGyldig skal kaste feilmelding hvis fom dato er lengre fram i tid enn initielFom', () => {
+    test('erEøsPeriodeGyldig skal kaste feilmelding hvis fom dato er satt før initielFom dato', () => {
         const eøsPeriode: FeltState<IYearMonthPeriode> = nyFeltState(
             nyYearMonthPeriode('2010-12', '2009-05')
         );
@@ -61,6 +61,16 @@ describe('utils/eøsValidators', () => {
         expect(valideringsresultat.feilmelding).toEqual(
             'Du kan ikke legge inn fra og med måned som er før: 2011-10'
         );
+    });
+
+    test('erEøsPeriodeGyldig skal returnere OK dersom alle felter er fylt inn korrekt', () => {
+        const eøsPeriode: FeltState<IYearMonthPeriode> = nyFeltState(
+            nyYearMonthPeriode('2010-12', '2012-05')
+        );
+
+        const valideringsresultat = erEøsPeriodeGyldig(eøsPeriode, { initielFom: '2009-10' });
+
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
     });
 
     test('isNumeric skal sjekke at string er numerisk', () => {

--- a/src/frontend/utils/test/eøsValidators.test.ts
+++ b/src/frontend/utils/test/eøsValidators.test.ts
@@ -1,0 +1,86 @@
+import type { FeltState } from '@navikt/familie-skjema';
+import { Valideringsstatus } from '@navikt/familie-skjema';
+
+import { erEøsPeriodeGyldig, isEmpty, isNumeric, tellAntallDesimaler } from '../eøsValidators';
+import type { IYearMonthPeriode } from '../kalender';
+import { nyYearMonthPeriode } from '../kalender';
+
+describe('utils/eøsValidators', () => {
+    const nyFeltState = <T>(verdi: T): FeltState<T> => ({
+        feilmelding: '',
+        valider: (feltState, _) => feltState,
+        valideringsstatus: Valideringsstatus.IKKE_VALIDERT,
+        verdi,
+    });
+
+    test('erEøsPeriodeGyldig skal kaste feilmelding hvis fom dato ikke er utfylt', () => {
+        const eøsPeriode: FeltState<IYearMonthPeriode> = nyFeltState(
+            nyYearMonthPeriode(undefined, '2010-05')
+        );
+
+        const valideringsresultat = erEøsPeriodeGyldig(eøsPeriode);
+
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual('Fra og med måned må være utfylt');
+    });
+
+    test('erEøsPeriodeGyldig skal kaste feilmelding hvis fom dato er mer enn 1mnd senere enn dagens dato', () => {
+        const eøsPeriode: FeltState<IYearMonthPeriode> = nyFeltState(
+            nyYearMonthPeriode('2099-12', '2100-05')
+        );
+
+        const valideringsresultat = erEøsPeriodeGyldig(eøsPeriode);
+
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual(
+            'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere'
+        );
+    });
+
+    test('erEøsPeriodeGyldig skal kaste feilmelding hvis tom dato er mer enn 1mnd senere enn dagens dato', () => {
+        const eøsPeriode: FeltState<IYearMonthPeriode> = nyFeltState(
+            nyYearMonthPeriode('2010-12', '2100-05')
+        );
+
+        const valideringsresultat = erEøsPeriodeGyldig(eøsPeriode);
+
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual(
+            'Du kan ikke sette til og med (t.o.m.) til neste måned eller senere'
+        );
+    });
+
+    test('erEøsPeriodeGyldig skal kaste feilmelding hvis fom dato er lengre fram i tid enn initielFom', () => {
+        const eøsPeriode: FeltState<IYearMonthPeriode> = nyFeltState(
+            nyYearMonthPeriode('2010-12', '2009-05')
+        );
+
+        const valideringsresultat = erEøsPeriodeGyldig(eøsPeriode, { initielFom: '2011-10' });
+
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual(
+            'Du kan ikke legge inn fra og med måned som er før: 2011-10'
+        );
+    });
+
+    test('isNumeric skal sjekke at string er numerisk', () => {
+        expect(isNumeric('1.42')).toEqual(true);
+        expect(isNumeric('1.24')).toEqual(true);
+        expect(isNumeric('1b4')).toEqual(false);
+    });
+
+    test('isEmpty skal sjekke at text er tom', () => {
+        expect(isEmpty('')).toEqual(true);
+        expect(isEmpty(undefined)).toEqual(true);
+        expect(isEmpty(null)).toEqual(true);
+        expect(isEmpty(Date())).toEqual(false);
+        expect(isEmpty('text')).toEqual(false);
+    });
+
+    test('tellAntallDesimaler skal returnere antall desimaler i string', () => {
+        expect(tellAntallDesimaler('1')).toEqual(0);
+        expect(tellAntallDesimaler('1.2')).toEqual(1);
+        expect(tellAntallDesimaler('1.2345')).toEqual(4);
+        expect(tellAntallDesimaler('1,2345')).toEqual(4);
+    });
+});


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Det er ønskelig at valutakursen man legger inn i EØS vurderingen skal ha 4 desimaler.
Valutakursen blir nå validert, og feilmelding vises dersom det ikke innholder 4 desimaler.
Jeg har også lagt inn flere tester da jeg ikke fant noen eksisterende tester på eøsValidators.

### 🔎️ Er det noe spesielt du ønsker å fremheve?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Liten endring, så alt i ett funker nok fint.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_

Før:
<img width="674" alt="før valutakurs validering" src="https://user-images.githubusercontent.com/110383605/182953028-95cf099f-26a4-4a57-80b2-a65dbdf90977.png">

Etter:
<img width="909" alt="Etter valutakurs validering" src="https://user-images.githubusercontent.com/110383605/182953067-26d29810-0022-4603-b6cb-46b0d883a036.png">


