### PR TITLE
Tea-8838: Viss ei behandling manglar resultat, treng vi ikkje skjule ho. Henlagte har jo eksplisitt henlagt-status

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -37,8 +37,8 @@ interface BehandlingTabellobjekt {
 
 const visRad = (behandling: BehandlingTabellobjekt, visHenlagteBehandlinger: boolean) => {
     if (visHenlagteBehandlinger) return true;
-    if (!behandling.behandlingEllerTilbakekreving.resultat) return false;
     if (behandling.type === BehandlingEllerTilbakekreving.BEHANDLING) {
+        if (!behandling.behandlingEllerTilbakekreving.resultat) return false;
         return !erBehandlingHenlagt(
             behandling.behandlingEllerTilbakekreving.resultat as BehandlingResultat
         );

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -37,8 +37,8 @@ interface BehandlingTabellobjekt {
 
 const visRad = (behandling: BehandlingTabellobjekt, visHenlagteBehandlinger: boolean) => {
     if (visHenlagteBehandlinger) return true;
+    if (!behandling.behandlingEllerTilbakekreving.resultat) return true;
     if (behandling.type === BehandlingEllerTilbakekreving.BEHANDLING) {
-        if (!behandling.behandlingEllerTilbakekreving.resultat) return false;
         return !erBehandlingHenlagt(
             behandling.behandlingEllerTilbakekreving.resultat as BehandlingResultat
         );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Tilbakekrevingsbehandlingar kan mangle resultat. Da er dei ikkje henlagt, men pga ein feil logikk her blir dei skjult med mindre saksbehandlar vel å vise henlagte behandlingar.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei