### PR TITLE
Tea-9072: Oppdaterer til nyaste versjon av fnrvalidator-biblioteket, som har støtte for test Norge-numre

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@navikt/familie-typer": "^5.0.0",
     "@navikt/familie-visittkort": "^3.0.3",
     "@navikt/flagg-ikoner": "^3.2.0",
-    "@navikt/fnrvalidator": "^1.2.0",
+    "@navikt/fnrvalidator": "^1.3.0",
     "@navikt/hoykontrast": "^3.1.0",
     "@navikt/land-verktoy": "^3.1.1",
     "@navikt/landvelger": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,10 +2772,15 @@
     svg-country-flags "^1.2.10"
     uuid "^8.3.2"
 
-"@navikt/fnrvalidator@^1.1.3", "@navikt/fnrvalidator@^1.2.0":
+"@navikt/fnrvalidator@^1.1.3":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@navikt/fnrvalidator/-/fnrvalidator-1.2.0.tgz#41799586c418bb98bc6b45a62bedbcb5869792a3"
   integrity sha512-WMK+Y+BLw/4qbdKRQCo2TZQDiELidnXNU+GZ3bpk9DdfOi6UbxBDrNYU/s5QOKyzX/Duws1QCnYKm4nz9lq+xw==
+
+"@navikt/fnrvalidator@^1.3.0":
+  version "1.3.0"
+  resolved "https://npm.pkg.github.com/download/@navikt/fnrvalidator/1.3.0/57e0b0b2bfe6ba79ad3c33dc6529c51ca8d573ca8cdd4c4dd3d3aa59446fe56f#8cea6bae592f772d07efebe9a5ab7179552e1d6f"
+  integrity sha512-k1MEZ8xwxtmY570gB+BF38kr9Xta1KIcx0yUExHQZWIsD1PNGSVagoriRTxqGyyTTkt4ajk1Z18WPfWX7rtpgQ==
 
 "@navikt/hoykontrast@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sørge for at vi støttar test Norge-numre. NAV-syntetiske numre ser det ut til at vi allereie støttar.

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9072

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Er usikker på om denne løyser alle problema, sia det (av ein eller annan grunn) fungerer lokalt hos meg, men feilar i preprod. Men det å bruke nyaste versjon av dette biblioteket er uansett fint.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Kun endring i biblioteksversjon

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg?
Nei