### PR TITLE
Presiser betydning av annen forelders aktivitet ikke aktuell

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
@@ -19,7 +19,7 @@ const StyledTable = styled(Table)`
     & fieldset.skjemagruppe {
         margin-bottom: 1.5rem;
     }
-    & div.skjemaelement {
+    & div.skjemaelement:not(.unset-margin-bottom) {
         margin-bottom: 1.5rem;
     }
 `;

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import styled from 'styled-components';
+
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
 import { Delete } from '@navikt/ds-icons';
@@ -46,6 +48,10 @@ interface IProps {
     toggleForm: (visAlert: boolean) => void;
     slettKompetanse: () => void;
 }
+
+const StyledAlert = styled(Alert)`
+    margin-bottom: 1.5rem;
+`;
 
 const KompetanseTabellRadEndre: React.FC<IProps> = ({
     skjema,
@@ -123,6 +129,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                     })}
                 </FamilieSelect>
                 <FamilieSelect
+                    className="unset-margin-bottom"
                     {...skjema.felter.annenForeldersAktivitet.hentNavInputProps(
                         skjema.visFeilmeldinger
                     )}
@@ -149,6 +156,12 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                         );
                     })}
                 </FamilieSelect>
+                {skjema.felter.annenForeldersAktivitet.verdi ===
+                    AnnenForelderAktivitet.IKKE_AKTUELT && (
+                    <StyledAlert variant="info" size="small" inline>
+                        Søker har enten aleneomsorg for egne barn eller forsørger andre barn
+                    </StyledAlert>
+                )}
                 <FamilieLandvelger
                     erLesevisning={lesevisning}
                     id={'annenForeldersAktivitetsland'}

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -56,7 +56,7 @@ export const annenForelderAktiviteter: Record<AnnenForelderAktivitet, string> = 
     FORSIKRET_I_BOSTEDSLAND: 'Forsikret i bostedsland',
     MOTTAR_PENSJON: 'Mottar pensjon',
     INAKTIV: 'Inaktiv',
-    IKKE_AKTUELT: 'Ikke aktuelt',
+    IKKE_AKTUELT: 'Ikke aktuelt (aleneomsorg for egne barn eller forsørger andre barn)',
 };
 
 export enum KompetanseResultat {

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -56,7 +56,7 @@ export const annenForelderAktiviteter: Record<AnnenForelderAktivitet, string> = 
     FORSIKRET_I_BOSTEDSLAND: 'Forsikret i bostedsland',
     MOTTAR_PENSJON: 'Mottar pensjon',
     INAKTIV: 'Inaktiv',
-    IKKE_AKTUELT: 'Ikke aktuelt (aleneomsorg for egne barn eller forsørger andre barn)',
+    IKKE_AKTUELT: 'Ikke aktuelt',
 };
 
 export enum KompetanseResultat {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fag ønsker å presisere innslagsteksten for annen forelders aktivitet "Ikke aktuelt" ettersom SB feiltolker denne og dermed svarer feil i skjemaet
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9079

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ingen funksjonell endring
  
### 👀 Screen shots
_Skjermbildet er oppdatert etter at fag endret ønsket løsning_
![image](https://user-images.githubusercontent.com/2379098/185076918-4e181d3b-864f-4b16-821f-b0a57c41e854.png)


