### PR TITLE
Tea-8952: Fix for pdf visning i dokument oversikt

### DIFF
--- a/src/frontend/komponenter/Fagsak/journalposter/JournalpostDokument.tsx
+++ b/src/frontend/komponenter/Fagsak/journalposter/JournalpostDokument.tsx
@@ -6,7 +6,7 @@ import { ExternalLink } from '@navikt/ds-icons';
 import { Link } from '@navikt/ds-react';
 import type { IDokumentInfo } from '@navikt/familie-typer';
 
-import useDokument from '../../../hooks/useDokument';
+import type { FamilieAxiosRequestConfig } from '../../../context/AppContext';
 import { Vedleggsliste, EllipsisBodyShort } from './JournalpostListe';
 
 const ListeElement = styled.li`
@@ -29,15 +29,19 @@ const StyledLink = styled(Link)`
 interface IProps {
     dokument: IDokumentInfo;
     journalpostId: string;
+    hentForhåndsvisning: <D>(familieAxiosRequestConfig: FamilieAxiosRequestConfig<D>) => void;
 }
 
-export const JournalpostDokument: React.FC<IProps> = ({ dokument, journalpostId }) => {
-    const { hentForhåndsvisning } = useDokument();
+export const JournalpostDokument: React.FC<IProps> = ({
+    dokument,
+    journalpostId,
+    hentForhåndsvisning,
+}) => {
     const hentPdfDokument = (dokumentId: string | undefined) => {
         if (dokumentId !== undefined) {
             hentForhåndsvisning({
                 method: 'GET',
-                url: `/familie-ba-sak/api/journalpost/${journalpostId}/hent/${dokumentId}`,
+                url: `/familie-ba-sak/api/journalpost/${journalpostId}/hent/${dokumentId}`
             });
         } else {
             alert('Klarer ikke å åpne dokument. Ta kontakt med teamet.');

--- a/src/frontend/komponenter/Fagsak/journalposter/JournalpostDokument.tsx
+++ b/src/frontend/komponenter/Fagsak/journalposter/JournalpostDokument.tsx
@@ -41,7 +41,7 @@ export const JournalpostDokument: React.FC<IProps> = ({
         if (dokumentId !== undefined) {
             hentForhåndsvisning({
                 method: 'GET',
-                url: `/familie-ba-sak/api/journalpost/${journalpostId}/hent/${dokumentId}`
+                url: `/familie-ba-sak/api/journalpost/${journalpostId}/hent/${dokumentId}`,
             });
         } else {
             alert('Klarer ikke å åpne dokument. Ta kontakt med teamet.');

--- a/src/frontend/komponenter/Fagsak/journalposter/JournalpostListe.tsx
+++ b/src/frontend/komponenter/Fagsak/journalposter/JournalpostListe.tsx
@@ -122,7 +122,8 @@ const JournalpostListe: React.FC<IProps> = ({ bruker }) => {
     const [sortering, settSortering] = useState<Sorteringsrekkefølge>(
         Sorteringsrekkefølge.INGEN_SORTERING
     );
-    const { visDokumentModal, hentetDokument, settVisDokumentModal } = useDokument();
+    const { visDokumentModal, hentetDokument, settVisDokumentModal, hentForhåndsvisning } =
+        useDokument();
 
     useEffect(() => {
         settJournalposterRessurs(byggHenterRessurs());
@@ -225,6 +226,7 @@ const JournalpostListe: React.FC<IProps> = ({ bruker }) => {
                                                     dokument={dokument}
                                                     journalpostId={journalpost.journalpostId}
                                                     key={dokument.dokumentInfoId}
+                                                    hentForhåndsvisning={hentForhåndsvisning}
                                                 />
                                             ))}
                                         </Vedleggsliste>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8952

Forhåndsvisning og visning av dokument fungerte ikke i dokumentoversikten.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Litt usikker på løsningen 🤔 

### 🤷‍♀ ️Hvor er det lurt å starte?
1 commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Oppførsel før:

https://user-images.githubusercontent.com/110383605/186472962-34f3e55b-2899-4a92-bff2-97310d743716.mov

Oppførsel etter:

https://user-images.githubusercontent.com/110383605/186472995-8725f134-e4dc-4e0b-bad0-d81dbedb299e.mov





