### PR TITLE
Tea-8941: navident -> navIdent mot backend

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -198,7 +198,7 @@ const useOpprettBehandling = (
                             søkersIdent,
                             behandlingType: behandlingstype.verdi as Behandlingstype,
                             behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
-                            navident: innloggetSaksbehandler?.navIdent,
+                            navIdent: innloggetSaksbehandler?.navIdent,
                             nyMigreringsdato: erMigreringFraInfoTrygd
                                 ? skjema.felter.migreringsdato.verdi
                                 : undefined,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-8941

Jeg så at vi allerede hadde logikken for å tildele nye behandlinger til SB som opprettet dem i backend, så stusset over at dette ikke allerede fungerte. Ser da at i request mot backend at det er feil casing på `navident`.
Endret derfor fra `navident` -> `navIdent`. Dette må gjøres siden vi ikke har slått på `ACCEPT_CASE_INSENSITIVE_PROPERTIES` i objectmappern i backend, og det er heller ikke noe vi ønsker å gjøre.

Testet at behandling blir satt på saksbehandler ved oppretting 👍 


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
1 commit.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
