### PR TITLE
Tea-9093: Skjule endre enhets modal dersom behandling er avsluttet.

### DIFF
--- a/src/frontend/context/behandlingContext/BehandlingContext.ts
+++ b/src/frontend/context/behandlingContext/BehandlingContext.ts
@@ -211,6 +211,10 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         åpenBehandling.data.arbeidsfordelingPåBehandling.behandlendeEnhetId ===
             MIDLERTIDIG_BEHANDLENDE_ENHET_ID;
 
+    const erBehandlingAvsluttet =
+        åpenBehandling.status === RessursStatus.SUKSESS &&
+        åpenBehandling.data.status === BehandlingStatus.AVSLUTTET;
+
     return {
         erLesevisning,
         forrigeÅpneSide,
@@ -236,6 +240,7 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         settÅpenHøyremeny,
         åpenVenstremeny,
         settÅpenVenstremeny,
+        erBehandlingAvsluttet,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -21,7 +21,7 @@ interface IProps {
 }
 
 const EndreBehandlendeEnhet: React.FC<IProps> = ({ onListElementClick }) => {
-    const { åpenBehandling, erLesevisning, erBehandleneEnhetMidlertidig } = useBehandling();
+    const { åpenBehandling, erLesevisning, erBehandleneEnhetMidlertidig, erBehandlingAvsluttet } = useBehandling();
     const [visModal, settVisModal] = useState(erBehandleneEnhetMidlertidig);
     const { innloggetSaksbehandler } = useApp();
 
@@ -98,7 +98,7 @@ const EndreBehandlendeEnhet: React.FC<IProps> = ({ onListElementClick }) => {
                     onClose: lukkBehandlendeEnhetModal,
                     lukkKnapp: true,
                     tittel: 'Endre enhet for denne behandlingen',
-                    visModal,
+                    visModal: visModal && !erBehandlingAvsluttet,
                 }}
             >
                 <SkjemaGruppe feil={hentFrontendFeilmelding(submitRessurs)}>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -21,7 +21,8 @@ interface IProps {
 }
 
 const EndreBehandlendeEnhet: React.FC<IProps> = ({ onListElementClick }) => {
-    const { åpenBehandling, erLesevisning, erBehandleneEnhetMidlertidig, erBehandlingAvsluttet } = useBehandling();
+    const { åpenBehandling, erLesevisning, erBehandleneEnhetMidlertidig, erBehandlingAvsluttet } =
+        useBehandling();
     const [visModal, settVisModal] = useState(erBehandleneEnhetMidlertidig);
     const { innloggetSaksbehandler } = useApp();
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -209,12 +209,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                         åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
                         åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (
                             <Alert variant="info" style={{ margin: '2rem 0 1rem 0' }}>
-                                <b>
-                                    {hentInfostripeTekst(
-                                        åpenBehandling.årsak,
-                                        åpenBehandling.status
-                                    )}
-                                </b>
+                                {hentInfostripeTekst(åpenBehandling.årsak, åpenBehandling.status)}
                             </Alert>
                         ) : (
                             <VedtaksbegrunnelseTeksterProvider>

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -77,8 +77,13 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
     feilmelding = '',
 }) => {
     const location = useLocation();
-    const { forrigeÅpneSide, åpenBehandling, erLesevisning, erBehandleneEnhetMidlertidig } =
-        useBehandling();
+    const {
+        forrigeÅpneSide,
+        åpenBehandling,
+        erLesevisning,
+        erBehandleneEnhetMidlertidig,
+        erBehandlingAvsluttet,
+    } = useBehandling();
     const erBehandlingSattPåVent = hentDataFraRessurs(åpenBehandling)?.aktivSettPåVent;
 
     useEffect(() => {
@@ -109,8 +114,8 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
                 </StyledAlert>
             )}
 
-            {erBehandleneEnhetMidlertidig && (
-                <StyledAlert variant="info">
+            {erBehandleneEnhetMidlertidig && !erBehandlingAvsluttet && (
+                <StyledAlert variant="warning">
                     Denne behandlingen er låst fordi vi ikke har klart å sette behandlende enhet. Du
                     må endre dette i menyen før du kan fortsette.
                 </StyledAlert>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9093

Endre enhet modalen skal ikke dukke opp dersom behandling er avsluttet.
Det var også ønsket noe små endringer rundt alert type samt fjerning av bold tekst. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Før:

https://user-images.githubusercontent.com/110383605/186835268-4e3bd631-8c16-4b44-92bd-895c4131cdd3.mov

Etter:

https://user-images.githubusercontent.com/110383605/186835114-ae50c6ea-c47c-4f3a-99f7-8ab23e12f730.mov


