### PR TITLE
Tea-9297: Viss søkaren kun har ungar med adressegradering, skal vi ikkje vise dialogboksen om at "Folkeregisteret har ikke registrerte barn på denne søkeren", for det er jo feil

### DIFF
--- a/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
@@ -66,35 +66,33 @@ const Barna: React.FunctionComponent = () => {
         }
     );
 
+    const maskerteRelasjoner =
+        bruker.status === RessursStatus.SUKSESS
+            ? bruker.data.forelderBarnRelasjonMaskert.filter(
+                  (forelderBarnRelasjonMaskert: IForelderBarnRelasjonMaskert) =>
+                      forelderBarnRelasjonMaskert.relasjonRolle === ForelderBarnRelasjonRolle.BARN
+              )
+            : [];
+
     return (
         <BarnaWrapper className={'søknad__barna'}>
             <Systemtittel children={'Opplysninger om barn'} />
-            {bruker.status === RessursStatus.SUKSESS &&
-                bruker.data.forelderBarnRelasjonMaskert
-                    .filter(
-                        (forelderBarnRelasjonMaskert: IForelderBarnRelasjonMaskert) =>
-                            forelderBarnRelasjonMaskert.relasjonRolle ===
-                            ForelderBarnRelasjonRolle.BARN
-                    )
-                    .map(
-                        (
-                            forelderBarnRelasjonMaskert: IForelderBarnRelasjonMaskert,
-                            index: number
-                        ) => {
-                            return (
-                                <BarnMedDiskresjonskode
-                                    key={`${index}_${forelderBarnRelasjonMaskert.relasjonRolle}`}
-                                >
-                                    <StyledRødError height={24} width={24} />
-                                    {`Bruker har barn med diskresjonskode ${
-                                        adressebeskyttelsestyper[
-                                            forelderBarnRelasjonMaskert.adressebeskyttelseGradering
-                                        ] ?? 'ukjent'
-                                    }`}
-                                </BarnMedDiskresjonskode>
-                            );
-                        }
-                    )}
+            {maskerteRelasjoner.map(
+                (forelderBarnRelasjonMaskert: IForelderBarnRelasjonMaskert, index: number) => {
+                    return (
+                        <BarnMedDiskresjonskode
+                            key={`${index}_${forelderBarnRelasjonMaskert.relasjonRolle}`}
+                        >
+                            <StyledRødError height={24} width={24} />
+                            {`Bruker har barn med diskresjonskode ${
+                                adressebeskyttelsestyper[
+                                    forelderBarnRelasjonMaskert.adressebeskyttelseGradering
+                                ] ?? 'ukjent'
+                            }`}
+                        </BarnMedDiskresjonskode>
+                    );
+                }
+            )}
 
             <br />
             <StyledCheckboxGruppe
@@ -117,7 +115,7 @@ const Barna: React.FunctionComponent = () => {
                     />
                 ))}
 
-                {sorterteBarnMedOpplysninger.length === 0 && (
+                {sorterteBarnMedOpplysninger.length === 0 && maskerteRelasjoner.length === 0 && (
                     <IngenBarnRegistrertInfo
                         variant="info"
                         children={'Folkeregisteret har ikke registrerte barn på denne søkeren'}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Viss søkaren kun har ungar med adressegradering, viser vi i dag at søkaren per folkeregisteret ikkje har ungar, og det er jo feil.

https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9297

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ x] Nei
  
### 👀 Screen shots
Før:
![image](https://user-images.githubusercontent.com/71336041/186852345-f380b8ba-4a1b-4007-bde4-8626379cc989.png)

Etter:
![image](https://user-images.githubusercontent.com/71336041/186852305-bafbda7b-4b9a-4326-8282-709635f59dfa.png)
