### PR TITLE
Valutakurs-skjema endret for å støtte ny backend-integrasjon med ECB

### DIFF
--- a/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
+++ b/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
@@ -66,6 +66,7 @@ interface IProps {
 
 const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
     const [erValutakursEkspandert, settErValutakursEkspandert] = React.useState<boolean>(false);
+    const [sletterValutakurs, settSletterValutakurs] = React.useState<boolean>(false);
     const { åpenBehandling, settÅpenBehandling } = useBehandling();
     const behandlingId =
         åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : null;
@@ -161,10 +162,12 @@ const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
     const slettValutakurs = () => {
         settSubmitRessurs(byggTomRessurs());
         settVisfeilmeldinger(false);
+        settSletterValutakurs(true);
         request<void, IBehandling>({
             method: 'DELETE',
             url: `/familie-ba-sak/api/differanseberegning/valutakurs/${behandlingId}/${valutakurs.id}`,
         }).then((response: Ressurs<IBehandling>) => {
+            settSletterValutakurs(false);
             if (response.status === RessursStatus.SUKSESS) {
                 nullstillSkjema();
                 settErValutakursEkspandert(false);
@@ -209,6 +212,7 @@ const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
         erValutakursSkjemaEndret,
         nullstillSkjema,
         slettValutakurs,
+        sletterValutakurs,
         erManuellInputAvKurs,
     };
 };

--- a/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
+++ b/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import type { OptionType } from '@navikt/familie-form-elements';
 import { useHttp } from '@navikt/familie-http';
@@ -17,6 +17,7 @@ import {
     tellAntallDesimaler,
 } from '../../utils/eøsValidators';
 import type { IYearMonthPeriode } from '../../utils/kalender';
+import { sammenlignDatoer } from '../../utils/kalender';
 import { nyYearMonthPeriode } from '../../utils/kalender';
 import { useBehandling } from '../behandlingContext/BehandlingContext';
 import {
@@ -28,23 +29,29 @@ const erValutakursDatoGyldig = (
     felt: FeltState<string | undefined>
 ): FeltState<string | undefined> =>
     !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Valutakursdato er påkrevd, men mangler input');
-const erValutakursGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> => {
-    if (!felt.verdi || isEmpty(felt.verdi) || typeof felt.verdi != 'string') {
-        return feil(felt, 'Valutakurs er påkrevd, men mangler input');
-    }
-    const nyKurs = konverterSkjemaverdiTilDesimal(felt.verdi);
-    if (!nyKurs) {
-        return feil(felt, 'Valutakurs er påkrevd, men mangler input');
-    }
-    if (!isNumeric(nyKurs)) {
-        return feil(felt, `Valutakurs innholder ugyldige verdier, kurs: ${felt.verdi}`);
-    }
-    if (tellAntallDesimaler(nyKurs) !== 4) {
-        return feil(felt, `Valutakurs må ha 4 desimaler, kurs: ${felt.verdi}`);
-    }
-    const kurs = Number(nyKurs);
-    if (kurs < 0) {
-        return feil(felt, `Kan ikke registrere negativt kurs: ${felt.verdi}`);
+const erValutakursGyldig = (
+    felt: FeltState<string | undefined>,
+    skalValideres: boolean
+): FeltState<string | undefined> => {
+    if (skalValideres) {
+        if (!felt.verdi || isEmpty(felt.verdi) || typeof felt.verdi != 'string') {
+            return feil(felt, 'Valutakurs er påkrevd, men mangler input');
+        }
+        const nyKurs = konverterSkjemaverdiTilDesimal(felt.verdi);
+        if (!nyKurs) {
+            return feil(felt, 'Valutakurs er påkrevd, men mangler input');
+        }
+        if (!isNumeric(nyKurs)) {
+            return feil(felt, `Valutakurs innholder ugyldige verdier, kurs: ${felt.verdi}`);
+        }
+        if (tellAntallDesimaler(nyKurs) === 0) {
+            return feil(felt, `Valutakurs må oppgis med desimaler, kurs: ${felt.verdi}`);
+        }
+        const kurs = Number(nyKurs);
+        if (kurs < 0) {
+            return feil(felt, `Kan ikke registrere negativt kurs: ${felt.verdi}`);
+        }
+        return ok(felt);
     }
     return ok(felt);
 };
@@ -64,6 +71,31 @@ const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
         åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.behandlingId : null;
     const initelFom = useFelt<string>({ verdi: valutakurs.fom });
     const { request } = useHttp();
+
+    const valutakode = useFelt<string | undefined>({
+        verdi: valutakurs.valutakode,
+        valideringsfunksjon: erValutakodeGyldig,
+    });
+
+    const valutakursdato = useFelt<string | undefined>({
+        verdi: valutakurs.valutakursdato,
+        valideringsfunksjon: erValutakursDatoGyldig,
+    });
+
+    const erManuellInputAvKurs: boolean =
+        valutakode?.verdi === 'ISK' &&
+        !!valutakursdato?.verdi &&
+        sammenlignDatoer(valutakursdato.verdi, new Date(2018, 1, 1, 0, 0, 0)) < 0;
+
+    const kurs = useFelt<string | undefined>({
+        avhengigheter: {
+            erManuellInputAvKurs,
+        },
+        verdi: konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs),
+        valideringsfunksjon: (felt, avhengigheter): FeltState<string | undefined> => {
+            return erValutakursGyldig(felt, avhengigheter?.erManuellInputAvKurs);
+        },
+    });
 
     const {
         skjema,
@@ -90,28 +122,15 @@ const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
                 avhengigheter: { initelFom },
                 valideringsfunksjon: erEøsPeriodeGyldig,
             }),
-            valutakode: useFelt<string | undefined>({
-                verdi: valutakurs.valutakode,
-                valideringsfunksjon: erValutakodeGyldig,
-            }),
-            valutakursdato: useFelt<string | undefined>({
-                verdi: valutakurs.valutakursdato,
-                valideringsfunksjon: erValutakursDatoGyldig,
-            }),
-            kurs: useFelt<string | undefined>({
-                verdi: konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs),
-                valideringsfunksjon: erValutakursGyldig,
-            }),
+            valutakode,
+            valutakursdato,
+            kurs,
         },
         skjemanavn: valutakursFeilmeldingId(valutakurs),
     });
 
     const sendInnSkjema = () => {
         if (kanSendeSkjema()) {
-            const nyKurs = konverterSkjemaverdiTilDesimal(skjema.felter.kurs?.verdi);
-            if (!nyKurs || !isNumeric(nyKurs)) {
-                throw Error('Skal ikke kunne skje. Valutakurs er validert annen plass i koden.');
-            }
             settSubmitRessurs(byggTomRessurs());
             settVisfeilmeldinger(false);
             onSubmit(
@@ -124,7 +143,7 @@ const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
                         barnIdenter: skjema.felter.barnIdenter.verdi.map(barn => barn.value),
                         valutakode: skjema.felter.valutakode?.verdi,
                         valutakursdato: skjema.felter.valutakursdato?.verdi,
-                        kurs: nyKurs,
+                        kurs: konverterSkjemaverdiTilDesimal(skjema.felter.kurs?.verdi),
                     },
                     url: `/familie-ba-sak/api/differanseberegning/valutakurs/${behandlingId}`,
                 },
@@ -174,6 +193,12 @@ const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
         );
     };
 
+    useEffect(() => {
+        if (valutakursdato.verdi !== valutakurs.valutakursdato) {
+            skjema.felter.kurs?.validerOgSettFelt('');
+        }
+    }, [valutakursdato.verdi]);
+
     return {
         erValutakursEkspandert,
         settErValutakursEkspandert,
@@ -184,6 +209,7 @@ const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
         erValutakursSkjemaEndret,
         nullstillSkjema,
         slettValutakurs,
+        erManuellInputAvKurs,
     };
 };
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
@@ -39,6 +39,7 @@ const ValutakursTabellRad: React.FC<IProps> = ({
         kanSendeSkjema,
         erValutakursSkjemaEndret,
         slettValutakurs,
+        sletterValutakurs,
         erManuellInputAvKurs,
     } = useValutakursSkjema({
         valutakurs,
@@ -83,6 +84,7 @@ const ValutakursTabellRad: React.FC<IProps> = ({
                     sendInnSkjema={sendInnSkjema}
                     toggleForm={toggleForm}
                     slettValutakurs={slettValutakurs}
+                    sletterValutakurs={sletterValutakurs}
                     erManuellInputAvKurs={erManuellInputAvKurs}
                 />
             }

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
@@ -39,6 +39,7 @@ const ValutakursTabellRad: React.FC<IProps> = ({
         kanSendeSkjema,
         erValutakursSkjemaEndret,
         slettValutakurs,
+        erManuellInputAvKurs,
     } = useValutakursSkjema({
         valutakurs,
         barnIValutakurs: barn,
@@ -82,6 +83,7 @@ const ValutakursTabellRad: React.FC<IProps> = ({
                     sendInnSkjema={sendInnSkjema}
                     toggleForm={toggleForm}
                     slettValutakurs={slettValutakurs}
+                    erManuellInputAvKurs={erManuellInputAvKurs}
                 />
             }
         >

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -85,6 +85,7 @@ interface IProps {
     sendInnSkjema: () => void;
     toggleForm: (visAlert: boolean) => void;
     slettValutakurs: () => void;
+    sletterValutakurs: boolean;
     erManuellInputAvKurs: boolean;
 }
 
@@ -96,6 +97,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
     valideringErOk,
     toggleForm,
     slettValutakurs,
+    sletterValutakurs,
     erManuellInputAvKurs,
 }) => {
     const { erLesevisning } = useBehandling();
@@ -252,8 +254,8 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
                             id={`slett_valutakurs_${skjema.felter.barnIdenter.verdi.map(
                                 barn => `${barn}-`
                             )}_${skjema.felter.initielFom.verdi}`}
-                            spinner={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                            spinner={sletterValutakurs}
+                            disabled={sletterValutakurs}
                             mini={true}
                             label={'Fjern'}
                             ikonPosisjon={IkonPosisjon.VENSTRE}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -160,6 +160,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
                             {...skjema.felter.valutakursdato?.hentNavBaseSkjemaProps(
                                 skjema.visFeilmeldinger
                             )}
+                            limitations={{ weekendsNotSelectable: true }}
                             className="skjemaelement"
                             id={`valutakurs_${skjema.felter.periodeId}`}
                             label={'Valutakursdato'}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
 import { Delete } from '@navikt/ds-icons';
-import { Label } from '@navikt/ds-react';
+import { Alert, Label, Link, Heading } from '@navikt/ds-react';
 import {
     FamilieDatovelger,
     FamilieInput,
@@ -55,12 +55,16 @@ const ValutakursRad = styled.div`
         }
 
         &:nth-of-type(3) {
-            width: 16rem;
+            width: 7.5rem;
         }
         &:nth-of-type(2) {
-            width: 4.5rem;
+            width: 13rem;
         }
     }
+`;
+
+const StyledISKAlert = styled(Alert)`
+    margin-top: 2rem;
 `;
 
 const valutakursPeriodeFeilmeldingId = (valutakurs: ISkjema<IValutakurs, IBehandling>): string =>
@@ -81,6 +85,7 @@ interface IProps {
     sendInnSkjema: () => void;
     toggleForm: (visAlert: boolean) => void;
     slettValutakurs: () => void;
+    erManuellInputAvKurs: boolean;
 }
 
 const ValutakursTabellRadEndre: React.FC<IProps> = ({
@@ -91,6 +96,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
     valideringErOk,
     toggleForm,
     slettValutakurs,
+    erManuellInputAvKurs,
 }) => {
     const { erLesevisning } = useBehandling();
     const lesevisning = erLesevisning(true);
@@ -169,14 +175,6 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
                                     : undefined
                             }
                         />
-                        <FamilieInput
-                            label={'Valutakurs'}
-                            erLesevisning={lesevisning}
-                            value={skjema.felter.kurs?.verdi}
-                            onChange={event =>
-                                skjema.felter.kurs?.validerOgSettFelt(event.target.value)
-                            }
-                        />
                         <FamilieValutavelger
                             erLesevisning={true}
                             id={'valuta'}
@@ -195,7 +193,32 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
                             utenMargin
                             kanNullstilles
                         />
+                        <FamilieInput
+                            label={'Valutakurs'}
+                            erLesevisning={lesevisning}
+                            value={skjema.felter.kurs?.verdi}
+                            onChange={event =>
+                                skjema.felter.kurs?.validerOgSettFelt(event.target.value)
+                            }
+                            disabled={!erManuellInputAvKurs}
+                        />
                     </ValutakursRad>
+                    {erManuellInputAvKurs && (
+                        <StyledISKAlert variant="warning" size="small" inline>
+                            <Heading size="small">
+                                Manuell innhenting av valutakurs for Islandske kroner (ISK)
+                            </Heading>
+                            Systemet har ikke valutakurser for valutakursdatoer før 1. februar 2018.
+                            Disse må hentes fra{' '}
+                            <Link
+                                href="https://navno.sharepoint.com/:x:/r/sites/fag-og-ytelser-familie-barnetrygd/Delte%20dokumenter/E%C3%98S/Valutakalkulator%202022.xlsm?d=w200955f53e1d4323ae72f9d1b15f617c&csf=1&web=1&e=w3OE5N"
+                                target="_blank"
+                            >
+                                Valutakalkulator
+                            </Link>
+                            .
+                        </StyledISKAlert>
+                    )}
                 </SkjemaGruppe>
 
                 <Knapperad>

--- a/src/frontend/utils/eøsValidators.ts
+++ b/src/frontend/utils/eøsValidators.ts
@@ -70,8 +70,7 @@ const erBarnGyldig = (felt: FeltState<OptionType[]>): FeltState<OptionType[]> =>
 const erValutakodeGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> =>
     !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Valuta er påkrevd, men mangler input');
 
-const tellAntallDesimaler = (verdi: string): number | undefined =>
-    verdi.split(/,|\./)[1]?.length ?? 0;
+const tellAntallDesimaler = (verdi: string): number => verdi.split(/,|\./)[1]?.length ?? 0;
 
 const isNumeric = (val: string): boolean => !isNaN(Number(val));
 

--- a/src/frontend/utils/kalender/kalender.ts
+++ b/src/frontend/utils/kalender/kalender.ts
@@ -59,14 +59,3 @@ export const sisteDagIInneværendeMåned = () => {
         dag: antallDagerIMåned({ måned: inneværende.måned, år: inneværende.år }),
     };
 };
-
-export const sammenlignDatoer = (dato1: string, dato2: Date): number => {
-    const dato1SomKalenderdato = kalenderDatoTilDate(kalenderDato(dato1));
-    if (dato1SomKalenderdato < dato2) {
-        return -1;
-    } else if (dato1SomKalenderdato > dato2) {
-        return 1;
-    } else {
-        return 0;
-    }
-};

--- a/src/frontend/utils/kalender/kalender.ts
+++ b/src/frontend/utils/kalender/kalender.ts
@@ -59,3 +59,14 @@ export const sisteDagIInneværendeMåned = () => {
         dag: antallDagerIMåned({ måned: inneværende.måned, år: inneværende.år }),
     };
 };
+
+export const sammenlignDatoer = (dato1: string, dato2: Date): number => {
+    const dato1SomKalenderdato = kalenderDatoTilDate(kalenderDato(dato1));
+    if (dato1SomKalenderdato < dato2) {
+        return -1;
+    } else if (dato1SomKalenderdato > dato2) {
+        return 1;
+    } else {
+        return 0;
+    }
+};

--- a/src/frontend/utils/kalender/sammenligning.ts
+++ b/src/frontend/utils/kalender/sammenligning.ts
@@ -1,4 +1,5 @@
 import type { DagMånedÅr } from '.';
+import { kalenderDato, kalenderDatoFraDate } from '.';
 
 export const erISammeMåned = (dato1: DagMånedÅr, dato2: DagMånedÅr) => {
     return dato1.måned === dato2.måned && dato1.år === dato2.år;
@@ -26,3 +27,15 @@ export const erSamme = (dato1: DagMånedÅr, dato2: DagMånedÅr) => {
 
 export const valgtDatoErNesteMånedEllerSenere = (valgtDato: DagMånedÅr, today: DagMånedÅr) =>
     valgtDato.år > today.år || (valgtDato.år === today.år && valgtDato.måned > today.måned);
+
+export const sammenlignDatoer = (dato1: string, dato2: Date): number => {
+    const dato1SomKalenderdato = kalenderDato(dato1);
+    const dato2SomKalenderdato = kalenderDatoFraDate(dato2);
+    if (erFør(dato1SomKalenderdato, dato2SomKalenderdato)) {
+        return -1;
+    } else if (erEtter(dato1SomKalenderdato, dato2SomKalenderdato)) {
+        return 1;
+    } else {
+        return 0;
+    }
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Saksbehandlere skal nå slippe å manuelt slå opp og fylle inn valutakurs for `utenlandskValuta -> NOK`. Det eneste de trenger å gjøre er å bestemme en valutakursdato. Backend vil da hente riktig kurs og bruke denne i videre differanseberegning. Dette med unntak av islandske kroner (ISK), som den europeiske sentralbank ikke har kurser for før 1. februar 2018. Dersom valuta er ISK og valgt valutakursdato er før 1.februar 2018 gjøres valutakurs feltet tilgjengelig for manuell input.

Endringen i denne PRen består stort sett i håndtering av hvorvidt valutakurs-feltet skal være disablet eller ikke, samt hva slags valideringsregler som skal gjelde for valutakurs-skjemaet.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.
  
### 👀 Screen shots
Skjema før utfylt:
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/70642183/186896848-0741dff7-e7dc-41ce-bf69-fae9857702e3.png">
Skjema utfylt:
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/70642183/186897090-110f1cbe-aefb-4172-8c2c-e12534925e83.png">
Dersom ISK og dato før 1. februar 2018
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/70642183/186897298-49ae5a16-a83d-480b-b6ed-a60bbd32e5e3.png">
