### PR TITLE
Legge til unntak for når det er mulig å sette f.o.m dato == t.o.m dato i vilkårsvurderingen.

### DIFF
--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -141,6 +141,15 @@ describe('utils/validators', () => {
         );
     });
 
+    test('Periode med fom-dato lik som tom-dato skal være mulig dersom det er barnets dødsfallsdato', () => {
+        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2020-12-12', '2020-12-12'));
+        const valideringsresultat = erPeriodeGyldig(periode, {
+            person: grunnlagPersonFixture({ dødsfallDato: '2020-12-12' }),
+            erEksplisittAvslagPåSøknad: false,
+        });
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
+    });
+
     test('Periode med etter barnets fødselsdato gir feil på 18 årsvilkåret', () => {
         const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2000-05-17', '2018-05-17'));
         const valideringsresultat = erPeriodeGyldig(periode, {

--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -141,6 +141,16 @@ describe('utils/validators', () => {
         );
     });
 
+    test('Periode med fom-dato lik som tom-dato skal ikke være mulig dersom det ikke er barnets dødsfallsdato', () => {
+        const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2020-12-12', '2020-12-12'));
+        const valideringsresultat = erPeriodeGyldig(periode, {
+            person: grunnlagPersonFixture(),
+            erEksplisittAvslagPåSøknad: false,
+        });
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.FEIL);
+        expect(valideringsresultat.feilmelding).toEqual('F.o.m må settes tidligere enn t.o.m');
+    });
+
     test('Periode med fom-dato lik som tom-dato skal være mulig dersom det er barnets dødsfallsdato', () => {
         const periode: FeltState<IPeriode> = nyFeltState(nyPeriode('2020-12-12', '2020-12-12'));
         const valideringsresultat = erPeriodeGyldig(periode, {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -112,6 +112,7 @@ export const erPeriodeGyldig = (
             kalenderDatoMedFallback(fom, TIDENES_MORGEN),
             tomKalenderDato
         );
+        const fomDatoErLikDødsfallDato = fom === person?.dødsfallDato;
 
         const idag = kalenderDatoMedFallback(familieDayjs().toISOString(), TIDENES_ENDE);
         if (tom && !er18ÅrsVilkår && valgtDatoErNesteMånedEllerSenere(tomKalenderDato, idag)) {
@@ -129,7 +130,9 @@ export const erPeriodeGyldig = (
             }
         }
 
-        return fomDatoErFørTomDato ? ok(felt) : feil(felt, 'F.o.m må settes tidligere enn t.o.m');
+        return fomDatoErFørTomDato || fomDatoErLikDødsfallDato
+            ? ok(felt)
+            : feil(felt, 'F.o.m må settes tidligere enn t.o.m');
     } else {
         if (erEksplisittAvslagPåSøknad) {
             return !tom


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?onShow=mycards&card=Tea-9380

Saksbehandler blir hindret i å behandle søknad av barnetrygd for dødfødt barn. Dette fordi det er krav om at f.o.m dato må settes tidligere en t.o.m. Jeg har derfor lagt til et unntak at dette er mulig å gjøre dersom fom dato settes == dødsfallsdato.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Før:
![Før](https://user-images.githubusercontent.com/110383605/187638409-112ac8be-1b1b-4cb7-96a9-ad389dabe35a.png)

Etter:
![Etter](https://user-images.githubusercontent.com/110383605/187638446-13b48505-4d73-4bad-8a3c-0598865650c3.png)

