### PR TITLE
Tea-9404: Man skal kunne legge/fjerne småbarnstillegg til og med måned man fyller 3 år

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
@@ -15,10 +15,7 @@ export const kanFjerneSmåbarnstilleggFraPeriode = (
     );
 };
 
-const sjekkOmPersonKvalifisererForSmåbarnstillegg = (
-    fødselsdato: string,
-    periode: Date
-): boolean => {
+const sjekkOmTilOgMed3ÅrIPeriode = (fødselsdato: string, periode: Date): boolean => {
     const antallMndForskjell = kalenderDiffMåned(
         kalenderDato(fødselsdato),
         kalenderDatoFraDate(periode)
@@ -35,17 +32,14 @@ export const kanLeggeSmåbarnstilleggTilPeriode = (
         ytelsetype => ytelsetype === YtelseType.UTVIDET_BARNETRYGD
     );
 
-    const harPersonUnder3ÅrIPeriode = utbetalingsperiode.utbetalingsperiodeDetaljer.some(
+    const harPersonTilOgMed3ÅrIPeriode = utbetalingsperiode.utbetalingsperiodeDetaljer.some(
         utbetalingsPerideDetalj =>
-            sjekkOmPersonKvalifisererForSmåbarnstillegg(
-                utbetalingsPerideDetalj.person.fødselsdato,
-                periode
-            )
+            sjekkOmTilOgMed3ÅrIPeriode(utbetalingsPerideDetalj.person.fødselsdato, periode)
     );
 
     return (
         harUtvidetYtelse &&
-        harPersonUnder3ÅrIPeriode &&
+        harPersonTilOgMed3ÅrIPeriode &&
         !kanFjerneSmåbarnstilleggFraPeriode(utbetalingsperiode)
     );
 };

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/OppsummeringsboksUtils.ts
@@ -15,13 +15,16 @@ export const kanFjerneSmåbarnstilleggFraPeriode = (
     );
 };
 
-const sjekkOmUnder3ÅrIPeriode = (fødselsdato: string, periode: Date): boolean => {
+const sjekkOmPersonKvalifisererForSmåbarnstillegg = (
+    fødselsdato: string,
+    periode: Date
+): boolean => {
     const antallMndForskjell = kalenderDiffMåned(
         kalenderDato(fødselsdato),
         kalenderDatoFraDate(periode)
     );
 
-    return antallMndForskjell < 36;
+    return antallMndForskjell <= 36;
 };
 
 export const kanLeggeSmåbarnstilleggTilPeriode = (
@@ -34,7 +37,10 @@ export const kanLeggeSmåbarnstilleggTilPeriode = (
 
     const harPersonUnder3ÅrIPeriode = utbetalingsperiode.utbetalingsperiodeDetaljer.some(
         utbetalingsPerideDetalj =>
-            sjekkOmUnder3ÅrIPeriode(utbetalingsPerideDetalj.person.fødselsdato, periode)
+            sjekkOmPersonKvalifisererForSmåbarnstillegg(
+                utbetalingsPerideDetalj.person.fødselsdato,
+                periode
+            )
     );
 
     return (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I [TEA-9097](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9097) ble det ønsket at man kunne legge/fjerne småbarnstillegg for barn under 3 år.

Det er nå ønskelig å gjøre dette for barn **til og med** 3 år.

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
 
 Før:
 Barn som blir 3 år i september:
<img width="984" alt="før" src="https://user-images.githubusercontent.com/110383605/187835175-3dea7e6b-25eb-48b8-a36d-ddd44829c225.png">

 Etter:
  Barn som blir 3 år i september:
<img width="955" alt="etter" src="https://user-images.githubusercontent.com/110383605/187835166-f491265f-473a-46f0-82f6-e8f59c78947f.png">
