### PR TITLE
Alerten tilknyttet kompetanseskjema endres for migrerte saker

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseSkjema.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Alert, Heading, Table } from '@navikt/ds-react';
 
 import type { IBehandling } from '../../../../typer/behandling';
+import { BehandlingÅrsak } from '../../../../typer/behandling';
 import type { IRestKompetanse } from '../../../../typer/eøsPerioder';
 import { EøsPeriodeStatus } from '../../../../typer/eøsPerioder';
 import KompetanseTabellRad from './KompetanseTabellRad';
@@ -52,11 +53,20 @@ const KompetanseSkjema: React.FC<IProps> = ({ kompetanser, åpenBehandling, visF
             <Heading spacing size="medium" level="3">
                 Kompetanse
             </Heading>
-            {harUfullstendigeKompetanser && (
+            {harUfullstendigeKompetanser && åpenBehandling.årsak !== BehandlingÅrsak.MIGRERING && (
                 <Alert
                     variant={'warning'}
                     fullWidth
                     children={'For EØS-perioder med tilkjent ytelse, må det fastsettes kompetanse'}
+                />
+            )}
+            {harUfullstendigeKompetanser && åpenBehandling.årsak === BehandlingÅrsak.MIGRERING && (
+                <Alert
+                    variant={'info'}
+                    fullWidth
+                    children={
+                        'Saken er migrert og kompetansen er hentet fra Infotrygd. Kompetanseskjemaet er derfor ikke fullstendig utfylt.'
+                    }
                 />
             )}
             <StyledTable>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9517
Alerten tilknyttet kompetanseskjema endres fra warning til information med ny tekst for migreringsbehandlinger

### 👀 Screen shots
Før:
<img width="837" alt="Screenshot 2022-09-21 at 11 35 27" src="https://user-images.githubusercontent.com/1121978/191473652-dc81d631-9fe1-42ee-b2c8-e044e4cf6917.png">

Etter:
<img width="930" alt="Screenshot 2022-09-21 at 11 25 48" src="https://user-images.githubusercontent.com/1121978/191472749-eb6f61f3-abce-4e63-88e6-086a2d72c821.png">