### PR TITLE
Send med fagsakType direkte i journalfør-request

### DIFF
--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -408,6 +408,11 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
                         navIdent: innloggetSaksbehandler?.navIdent ?? '',
                         erEnsligMindreårig: skjema.felter.erEnsligMindreårig.verdi,
                         erPåInstitusjon: skjema.felter.erPåInstitusjon.verdi,
+                        fagsakType: skjema.felter.erEnsligMindreårig.verdi
+                            ? FagsakType.BARN_ENSLIG_MINDREÅRIG
+                            : skjema.felter.erPåInstitusjon.verdi
+                            ? FagsakType.INSTITUSJON
+                            : FagsakType.NORMAL,
                         institusjon:
                             skjema.felter.samhandler && skjema.felter.samhandler.verdi?.orgNummer
                                 ? {

--- a/src/frontend/typer/manuell-journalføring.ts
+++ b/src/frontend/typer/manuell-journalføring.ts
@@ -3,6 +3,7 @@ import type { IJournalpost } from '@navikt/familie-typer';
 import type { BehandlingKategori, BehandlingUnderkategori } from './behandlingstema';
 import type { INøkkelPar } from './common';
 import type { IMinimalFagsak } from './fagsak';
+import type { FagsakType } from './fagsak';
 import type { IOppgave } from './oppgave';
 import type { IPersonInfo } from './person';
 
@@ -80,6 +81,7 @@ export interface IRestJournalføring {
     underkategori: BehandlingUnderkategori | null;
     erEnsligMindreårig: boolean;
     erPåInstitusjon: boolean;
+    fagsakType: FagsakType;
 }
 
 export interface ILogiskVedlegg {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Forberedelser til denne oppgaven: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9440

Sender med fagsakTypen direkte i journalføringsrequesten. Tanken er å bytte ut de boolske flaggene erEnsligMindreårig og erPåInstitusjon med enumen FagsakType. Grunnen til dette er fordi det er mer ryddig, blir enklere å implementere oppgaven over, og fordi backend gjør denne mappingen i dag noe som egentlig ikke er nødvendig.

Kommer en backend PR som bytter ut de boolske flaggene med fagsakType.
 
### 🔎️ Er det noe spesielt du ønsker å fremheve?
Må merge denne PRen før backend PRen (antar at det går fint å sende med et parameter for mye fra frontend til backend? 🤠 )

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Unødvendig imo

### 🤷‍♀ ️Hvor er det lurt å starte?
🤷 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
