### PR TITLE
Rydd opp lesevisning i BrukerPanel

### DIFF
--- a/src/frontend/komponenter/ManuellJournalfør/BrukerPanel.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/BrukerPanel.tsx
@@ -109,9 +109,7 @@ export const BrukerPanel: React.FC = () => {
                 />
             }
         >
-            {erLesevisning() ? (
-                <>Lesevisning</>
-            ) : (
+            {!erLesevisning() && (
                 <>
                     <FlexDiv>
                         <TextField


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ref #2334 
Ooops - nå rendrer vi ut "Lesevisning" i lesevisning av BrukerPanel i Manuell journalføring, det var jo ikke meningen.. Men ingen skade skjedd, for tidligere (før vi begynte å jobbe med institusjon) har vi bare rendret ut tomt innhold i lesevisningen. Så nå går vi tilbake til akkurat det. 

Historikk for lesevisning inni dette panelet:
- tomt innhold
- to checkboxer du ikke får lov til å interagere med
- "Lesevisning" 😬 
- nå: tomt innhold
  
### 👀 Screen shots
**Før**
![image](https://user-images.githubusercontent.com/2379098/193830231-a960783f-2fcd-4e56-9a76-25248a4ae515.png)
