### PR TITLE
Sende med fagsakId i requesten for å opprette ny behandling

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -27,6 +27,7 @@ const OpprettBehandling: React.FC<IProps> = ({ onListElementClick, minimalFagsak
 
     const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus, bruker } =
         useOpprettBehandling(
+            minimalFagsak.id,
             () => settVisModal(false),
             () => {
                 settVisModal(false);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -207,6 +207,7 @@ const useOpprettBehandling = (
                                 ? skjema.felter.valgteBarn.verdi.map(option => option.value)
                                 : undefined,
                             fagsakType: fagsakType,
+                            fagsakId: fagsakId,
                         },
                         method: 'POST',
                         url: '/familie-ba-sak/api/behandlinger',

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -170,7 +170,7 @@ const useOpprettBehandling = (
                 skjema.felter.behandlingstype.verdi ===
                 Tilbakekrevingsbehandlingstype.TILBAKEKREVING
             ) {
-                onSubmit(
+                onSubmit<void>(
                     {
                         method: 'GET',
                         url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -16,7 +16,6 @@ import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/famil
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import { useFagsakContext } from '../../../../../context/FagsakContext';
-import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling, IRestNyBehandling } from '../../../../../typer/behandling';
 import { BehandlingSteg, Behandlingstype, BehandlingÅrsak } from '../../../../../typer/behandling';
 import type { IBehandlingstema } from '../../../../../typer/behandlingstema';
@@ -26,10 +25,10 @@ import type { FamilieIsoDate } from '../../../../../utils/kalender';
 import { erIsoStringGyldig } from '../../../../../utils/kalender';
 
 const useOpprettBehandling = (
+    fagsakId: number,
     lukkModal: () => void,
     onOpprettTilbakekrevingSuccess: () => void
 ) => {
-    const { fagsakId } = useSakOgBehandlingParams();
     const { settÅpenBehandling } = useBehandling();
     const { bruker: brukerRessurs } = useFagsakContext();
     const { innloggetSaksbehandler } = useApp();

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -31,7 +31,7 @@ export interface IRestNyBehandling {
     navIdent?: string;
     barnasIdenter?: string[];
     nyMigreringsdato?: string;
-    fagsakId?: string;
+    fagsakId: number;
 }
 
 export enum HenleggÅrsak {

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -30,6 +30,8 @@ export interface IRestNyBehandling {
     skalBehandlesAutomatisk?: boolean;
     navIdent?: string;
     barnasIdenter?: string[];
+    nyMigreringsdato?: string;
+    fagsakId?: string;
 }
 
 export enum HenleggÅrsak {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Dagens løysning sender berre med personident til requesten, og søker så opp fagsak i backend. Dette er tungvindt siden frontend allereie veit kva fagsak er med tilhørande id.
Og dagens løysning vil ikkje fungere i forbindelse med institusjon, sidan det kan være mange fagsaker av typen INSTITUSJON. Backend veit ikkje kva som er riktig fagsak å opprette behandlingen på, sidan requesten berre inneholder personIdent og fagsakType.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Skal ikkje være nokon visuelle endringer.
