### PR TITLE
[Journalføring] Oppdater bruker i personlinja hvis brukeren blir endret

### DIFF
--- a/src/frontend/komponenter/ManuellJournalfør/ManuellJournalfør.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/ManuellJournalfør.tsx
@@ -26,7 +26,7 @@ const ToKolonnerDiv = styled.div(
 );
 
 const ManuellJournalførContent: React.FC = () => {
-    const { dataForManuellJournalføring, minimalFagsak } = useManuellJournalfør();
+    const { dataForManuellJournalføring, minimalFagsak, skjema } = useManuellJournalfør();
 
     switch (dataForManuellJournalføring.status) {
         case RessursStatus.SUKSESS:
@@ -36,7 +36,7 @@ const ManuellJournalførContent: React.FC = () => {
             return (
                 <>
                     <Personlinje
-                        bruker={dataForManuellJournalføring.data.person}
+                        bruker={skjema.felter.bruker.verdi}
                         minimalFagsak={minimalFagsak}
                     />
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Snakket med Gunn om en bug på journalføringssiden i dag som det var en enkel fiks på: Når man endrer bruker så blir ikke personinformasjonen oppdatert i personlinja øverst, MEN det som er knyttet til fagsak blir  oppdatert (ref at ikonet blir insitusjon på øverste bildet). Det betyr at informasjonen i personlinja er inkonsistent, da bruker-info viser til forrige/gammel bruker, og linker til fagsak og meny er knyttet til den nye brukeren.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Gunn og jeg skal dobbeltsjekke med fag at dette er ønskelig før merge.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Unødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
🤷 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før: 
![image](https://user-images.githubusercontent.com/25459913/195617641-eea3e0fd-90e1-4069-9990-2c16f08b3ae4.png)

Etter:
![image](https://user-images.githubusercontent.com/25459913/195618249-c0ee34d9-d567-45a6-a7d6-4fafadb415ec.png)

