### PR TITLE
innhente-opplysninger-brev-til-institusjon

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -114,7 +114,7 @@ export const mottakersMålformImplementering = (
     mottakerIdent: string | readonly string[] | number
 ) =>
     (erOrgNr(mottakerIdent.toString())
-        ? personer.at(0)?.målform
+        ? personer[0]?.målform
         : personer.find((person: IGrunnlagPerson) => {
               if (skjemaValideringsStatus === Valideringsstatus.OK) {
                   return person.personIdent === mottakerIdent;

--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -28,18 +28,16 @@ import { useFagsakContext } from './FagsakContext';
 
 export const hentMuligeBrevmalerImplementering = (
     åpenBehandling: Ressurs<IBehandling>,
-    hentTilpassetInstitusjon = false
+    tilpassetInstitusjon = false
 ): Brevmal[] => {
     if (åpenBehandling.status !== RessursStatus.SUKSESS) {
         return [];
     }
 
-    const brevmaler: Brevmal[] = Object.keys(Brevmal) as Brevmal[];
-    return brevmaler.filter(
-        brevmal =>
-            brevmalKanVelgesForBehandling(brevmal, åpenBehandling.data) &&
-            hentTilpassetInstitusjon === brevmalKanVelgesForInstitusjon(brevmal)
+    const brevmaler: Brevmal[] = (Object.keys(Brevmal) as Brevmal[]).filter(
+        brevmal => tilpassetInstitusjon === brevmal.endsWith('INSTITUSJON')
     );
+    return brevmaler.filter(brevmal => brevmalKanVelgesForBehandling(brevmal, åpenBehandling.data));
 };
 
 const brevmalKanVelgesForBehandling = (brevmal: Brevmal, åpenBehandling: IBehandling): boolean => {
@@ -96,15 +94,6 @@ const brevmalKanVelgesForBehandling = (brevmal: Brevmal, åpenBehandling: IBehan
             );
         case Brevmal.INNHENTE_OPPLYSNINGER_INSTITUSJON:
             return åpenBehandling.årsak === BehandlingÅrsak.SØKNAD;
-    }
-};
-
-const brevmalKanVelgesForInstitusjon = (brevmal: Brevmal): boolean => {
-    switch (brevmal) {
-        case Brevmal.INNHENTE_OPPLYSNINGER_INSTITUSJON:
-            return true;
-        default: // TODO: FORLENGET_SVARTIDSBREV_INSTITUSJON og SVARTIDSBREV_INSTITUSJON
-            return false;
     }
 };
 

--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -366,6 +366,11 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
                 datoAvtale: skjema.felter.datoAvtale.verdi,
                 behandlingKategori,
                 antallUkerSvarfrist: skjema.felter.antallUkerSvarfrist.verdi,
+                mottakerMålform: institusjon ? personer.at(0)?.målform : mottakersMålform(),
+                mottakerNavn:
+                    mottakerIdent.verdi === institusjon?.orgNummer
+                        ? institusjon.navn
+                        : personer.find(person => person.personIdent === mottakerIdent.verdi)?.navn,
             };
         }
     };

--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -103,7 +103,7 @@ const brevmalKanVelgesForInstitusjon = (brevmal: Brevmal): boolean => {
     switch (brevmal) {
         case Brevmal.INNHENTE_OPPLYSNINGER_INSTITUSJON:
             return true;
-        default:
+        default: // TODO: FORLENGET_SVARTIDSBREV_INSTITUSJON og SVARTIDSBREV_INSTITUSJON
             return false;
     }
 };

--- a/src/frontend/context/test/BrevModulContext.test.ts
+++ b/src/frontend/context/test/BrevModulContext.test.ts
@@ -99,7 +99,6 @@ describe('BrevmodulContext', () => {
                 mottakersMålformImplementering(personerNN, Valideringsstatus.OK, personIdent)
             ).toEqual(Målform.NN);
         });
-
         test('Skal returnere målformen registrert på barnet når mottakeren er en institusjon', () => {
             expect(
                 mottakersMålformImplementering([mockBarn], Valideringsstatus.OK, orgNummer)

--- a/src/frontend/context/test/BrevModulContext.test.ts
+++ b/src/frontend/context/test/BrevModulContext.test.ts
@@ -66,10 +66,26 @@ describe('BrevmodulContext', () => {
                     );
             }
         );
+        const hentTilpassetInstitusjon = true;
+        test('Skal returnere liste med brev tilpasset institusjon', () => {
+            expect(
+                hentMuligeBrevmalerImplementering(
+                    lagBehandlignRessursSuksess(behandlingSøknad),
+                    hentTilpassetInstitusjon
+                ).sort()
+            ).toEqual(
+                [
+                    Brevmal.INNHENTE_OPPLYSNINGER_INSTITUSJON,
+                    // Brevmal.FORLENGET_SVARTIDSBREV_INSTITUSJON, TODO
+                    // Brevmal.SVARTIDSBREV_INSTITUSJON,
+                ].sort()
+            );
+        });
     });
 
     describe('mottakersMålformImplementering', () => {
         const personIdent = '12345678930';
+        const orgNummer = '123456789';
         const personerNB = [mockBarn, mockSøker({ målform: Målform.NB, personIdent })];
         const personerNN = [mockBarn, mockSøker({ målform: Målform.NN, personIdent })];
         test('Skal returnere NB når søkers målform er NB', () => {
@@ -82,6 +98,12 @@ describe('BrevmodulContext', () => {
             expect(
                 mottakersMålformImplementering(personerNN, Valideringsstatus.OK, personIdent)
             ).toEqual(Målform.NN);
+        });
+
+        test('Skal returnere målformen registrert på barnet når mottakeren er en institusjon', () => {
+            expect(
+                mottakersMålformImplementering([mockBarn], Valideringsstatus.OK, orgNummer)
+            ).toEqual(mockBarn.målform);
         });
     });
 });

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -43,7 +43,13 @@ import PdfVisningModal from '../../PdfVisningModal/PdfVisningModal';
 import SkjultLegend from '../../SkjultLegend';
 import BarnBrevetGjelder from './BarnBrevetGjelder';
 import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
-import { Brevmal, brevmaler, leggTilValuePåOption, opplysningsdokumenter } from './typer';
+import {
+    Brevmal,
+    brevmaler,
+    leggTilValuePåOption,
+    opplysningsdokumenter,
+    opplysningsdokumenterTilInstitusjon,
+} from './typer';
 
 interface IProps {
     onSubmitSuccess: () => void;
@@ -268,7 +274,11 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                     : (valgteOptions as ISelectOptionMedBrevtekst[])
                             );
                         }}
-                        options={opplysningsdokumenter.map(leggTilValuePåOption)}
+                        options={
+                            institusjon
+                                ? opplysningsdokumenterTilInstitusjon.map(leggTilValuePåOption)
+                                : opplysningsdokumenter.map(leggTilValuePåOption)
+                        }
                     />
                 )}
                 {skjema.felter.fritekster.erSynlig && (

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer.ts
@@ -7,6 +7,7 @@ export interface BrevtypeSelect extends HTMLSelectElement {
 export enum Brevmal {
     INNHENTE_OPPLYSNINGER = 'INNHENTE_OPPLYSNINGER',
     INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED = 'INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED',
+    INNHENTE_OPPLYSNINGER_INSTITUSJON = 'INNHENTE_OPPLYSNINGER_INSTITUSJON',
     VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED = 'VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED',
     VARSEL_OM_REVURDERING = 'VARSEL_OM_REVURDERING',
     VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14 = 'VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14',
@@ -29,6 +30,7 @@ export enum Informasjonsbrev {
 export const brevmaler: Record<Brevmal, string> = {
     INNHENTE_OPPLYSNINGER: 'Innhent opplysninger',
     INNHENTE_OPPLYSNINGER_ETTER_SØKNAD_I_SED: 'Innhente opplysninger etter søknad i SED',
+    INNHENTE_OPPLYSNINGER_INSTITUSJON: 'Innhente opplysninger institusjon',
     VARSEL_OM_VEDTAK_ETTER_SØKNAD_I_SED: 'Varsel om vedtak etter søknad i SED',
     VARSEL_OM_REVURDERING: 'Varsel om revurdering',
     HENLEGGE_TRUKKET_SØKNAD: 'Henlegg søknad',
@@ -56,6 +58,30 @@ export interface ISelectOptionMedBrevtekst extends OptionType {
     label: string;
     brevtekst?: Record<Målform, string>;
 }
+
+export const opplysningsdokumenterTilInstitusjon: Omit<ISelectOptionMedBrevtekst, 'value'>[] = [
+    {
+        label: 'Bekreftelse fra barnevernet',
+        brevtekst: {
+            NB: 'Dokumentasjon fra barneverntjenesten som viser at barnet bor fast i institusjonen, og fra hvilken dato det gjelder.',
+            NN: 'Dokumentasjon frå barneverntenesta som viser at barnet bur fast i institusjonen, og frå kva dato det gjeld.',
+        },
+    },
+    {
+        label: 'Oppholdstillatelse',
+        brevtekst: {
+            NB: 'Dokumentasjon som viser at barnet har lovlig opphold i Norge.',
+            NN: 'Dokumentasjon som viser at barnet har lovleg opphald i Noreg.',
+        },
+    },
+    {
+        label: 'Opplysninger om kontonummer',
+        brevtekst: {
+            NB: 'Opplysninger om hvilket kontonummer barnetrygden skal utbetales til.',
+            NN: 'Opplysningar om kva kontonummer barnetrygda skal utbetalast til.',
+        },
+    },
+];
 
 export const opplysningsdokumenter: Omit<ISelectOptionMedBrevtekst, 'value'>[] = [
     {

--- a/src/frontend/typer/dokument.ts
+++ b/src/frontend/typer/dokument.ts
@@ -14,6 +14,8 @@ export interface IManueltBrevRequestPåBehandling {
     barnasFødselsdager?: string[];
     behandlingKategori?: BehandlingKategori | undefined;
     antallUkerSvarfrist?: number;
+    mottakerMålform?: Målform;
+    mottakerNavn?: string;
 }
 
 export interface IManueltBrevRequestPåFagsak {

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -71,7 +71,7 @@ const erPersonId = (personIdent: string) => {
     return /^[+-]?\d+(\.\d+)?$/.test(id) && id.length === 11;
 };
 
-const erOrgNr = (orgNr: string) => {
+export const erOrgNr = (orgNr: string) => {
     // Sjekker kun etter ni siffer, validerer ikke kontrollsifferet (det 9. sifferet)
     return kunSiffer(orgNr) && orgNr.length === 9;
 };

--- a/src/frontend/utils/test/person/person.mock.ts
+++ b/src/frontend/utils/test/person/person.mock.ts
@@ -10,7 +10,7 @@ export const mockBarn: IGrunnlagPerson = {
     type: PersonType.BARN,
     kjønn: 'KVINNE' as kjønnType,
     navn: 'Mock Barn',
-    målform: Målform.NB,
+    målform: Målform.NN,
 };
 
 interface IMockSøker {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9805

- Legger til den nye brevmalen for innhenting av opplysninger, tilpasset institusjon.
- Legger inn brevtekstene som skal kunne velges og settes inn som kulepunkter i brevet når mottakeren er en institusjon.
- Utvider brevfiltreringslogikken slik at det er den nye brevmalen tilpasset institusjon som brukes når mottakeridenten er orgnr.

- Legger til mottakerNavn og mottakerMålform i IManueltBrevRequestPåBehandling og sender med 
disse verdiene i requesten til backend ved forhånsvisning/sending av manuelt brev.
DTO'en i backend inneholdt disse feltene fra før, og de ble tatt i bruk til å sette navn og målform i brev når mottakeren er en institusjon.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots

![image](https://user-images.githubusercontent.com/47184872/196402140-ce88a729-c4b6-4fa0-946e-3a10a979af89.png)
