### PR TITLE
Endre husky til å kun verifisere, ikke endre filer ved commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:one": "jest -t",
     "lint": "eslint './src/**/*.{js,ts,tsx}'",
     "lint:fix": "eslint './src/**/*.{js,ts,tsx}' --fix",
+    "prettier:fix": "prettier --write",
     "prepare": "husky install",
     "start:cypress": "tsc -p tsconfig.backend.json && NODE_ENV=production node --loader ts-node/esm --es-module-specifier-resolution=node node_dist/backend/cypress-server.js",
     "run:cypress": "cypress run",
@@ -23,8 +24,8 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css}": [
-      "prettier --write",
-      "eslint --fix src/ --max-warnings=0"
+      "prettier --check",
+      "eslint --max-warnings=0"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Vi har satt opp husky og lint-staged til å on-commit kjøre prettier og eslint **med skriving** i de filene som er lagt inn i commiten (_staged_):
- filen stages
- du kjører `git commit`
- prettier kjører på filen og skriver evt endringer
- eslint kjører på filen og skriver evt endringer
- filen stages på nytt, for å få med disse endringene
- commit fullføres

Det er helt supert dersom man commiter en hel fil av gangen. Men om man skal cherry-picke deler av en fil som skal stages stegvis vil prettier/eslint føre til at _hele filen_ blir med i commiten. Dermed kan man ikke faktisk cherry-picke ☹️ 

Foreslår at vi endrer dette til at husky kun kjører **verifisering** med prettier og eslint, som feiler dersom noe er galt. Legger til et npm-script som kjører prettier med skriving, altså det samme som husky har pleid å gjøre. Vi har allerede et script for dette med eslint

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke en funksjonell endring

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

