### PR TITLE
Forbedrer adressevisning i samhandlertabell

### DIFF
--- a/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/SamhandlerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/SamhandlerTabell.tsx
@@ -26,20 +26,14 @@ export const SamhandlerTabell: React.FC<{ samhandler: ISamhandlerInfo }> = ({ sa
                     <Table.DataCell>TSS-ident</Table.DataCell>
                     <Table.DataCell>{samhandler.tssEksternId}</Table.DataCell>
                 </Table.Row>
-                <Table.Row>
-                    <Table.DataCell>Adresse</Table.DataCell>
-                    <Table.DataCell>
-                        <div>
-                            {samhandler.adresser.map((adresse, index) => (
-                                <div key={index}>
-                                    {adresse.adresseType}: <br />
-                                    {adresse.adresselinjer} {adresse.postNr} {adresse.postSted}{' '}
-                                    <br />
-                                </div>
-                            ))}
-                        </div>
-                    </Table.DataCell>
-                </Table.Row>
+                {samhandler.adresser.map((adresse, index) => (
+                    <Table.Row key={index}>
+                        <Table.DataCell>{adresse.adresseType}</Table.DataCell>
+                        <Table.DataCell>
+                            {`${adresse.adresselinjer}, ${adresse.postNr} ${adresse.postSted}`}
+                        </Table.DataCell>
+                    </Table.Row>
+                ))}
             </Table.Body>
         </Table>
     );

--- a/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/SamhandlerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/SamhandlerTabell.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Table } from '@navikt/ds-react';
 
 import type { ISamhandlerInfo } from '../../../typer/samhandler';
-import { formaterIdent } from '../../../utils/formatter';
+import { formaterIdent, formaterTekstStorForbokstav } from '../../../utils/formatter';
 
 export const SamhandlerTabell: React.FC<{ samhandler: ISamhandlerInfo }> = ({ samhandler }) => {
     return (
@@ -30,7 +30,9 @@ export const SamhandlerTabell: React.FC<{ samhandler: ISamhandlerInfo }> = ({ sa
                     <Table.Row key={index}>
                         <Table.DataCell>{adresse.adresseType}</Table.DataCell>
                         <Table.DataCell>
-                            {`${adresse.adresselinjer}, ${adresse.postNr} ${adresse.postSted}`}
+                            {formaterTekstStorForbokstav(
+                                `${adresse.adresselinjer}, ${adresse.postNr} ${adresse.postSted}`
+                            )}
                         </Table.DataCell>
                     </Table.Row>
                 ))}

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -143,3 +143,10 @@ export const sorterUtbetaling = (
 export const slåSammenListeTilStreng = (liste: string[]) => {
     return liste.join(', ').replace(new RegExp('(.*),'), '$1 og');
 };
+
+export const formaterTekstStorForbokstav = (tekst: string) => {
+    return tekst
+        .split(' ')
+        .map(it => it.toLowerCase().replace(/[a-zæøå]/, match => match.toUpperCase()))
+        .join(' ');
+};

--- a/src/frontend/utils/test/formatter.test.ts
+++ b/src/frontend/utils/test/formatter.test.ts
@@ -13,7 +13,7 @@ import {
 import { iDag, KalenderEnhet, leggTil, serializeIso8601String, trekkFra } from '../kalender';
 import { mockBarn, mockSøker } from './person/person.mock';
 
-describe('utils/formatter', () => {
+describe('formaterIdent', () => {
     test('Skal formatere ident', () => {
         expect(formaterIdent('12345678910')).toBe('123456 78910');
     });
@@ -38,7 +38,9 @@ describe('utils/formatter', () => {
     test('Skal returnere ukjent ident når feil lengde på numerisk ident', () => {
         expect(formaterIdent('123456789123')).toBe('Ukjent id');
     });
+});
 
+describe('hentAlder', () => {
     test('Skal hente riktig alder fra fødselsdato', () => {
         const toÅrSiden = trekkFra(iDag(), 2, KalenderEnhet.ÅR);
         expect(hentAlder(serializeIso8601String(trekkFra(toÅrSiden, 1, KalenderEnhet.DAG)))).toBe(
@@ -53,89 +55,90 @@ describe('utils/formatter', () => {
         );
         expect(hentAlder(serializeIso8601String(leggTil(toÅrSiden, 1, KalenderEnhet.DAG)))).toBe(1);
     });
+});
 
-    describe('formaterIsoDato', () => {
-        const dato = familieDayjs('2020-12-01T14:02');
-        const datoString = dato.toISOString();
+describe('formaterIsoDato', () => {
+    const dato = familieDayjs('2020-12-01T14:02');
+    const datoString = dato.toISOString();
 
-        test('Skal returnere dato på format MM.YY', () => {
-            expect(formaterIsoDato(datoString, datoformat.MÅNED)).toEqual('12.20');
-        });
-        test('Skal returnere dato på format DD.MM.YYYY', () => {
-            expect(formaterIsoDato(datoString, datoformat.DATO)).toEqual('01.12.2020');
-        });
-        test('Skal returnere dato på format DD.MM.YY', () => {
-            expect(formaterIsoDato(datoString, datoformat.DATO_FORKORTTET)).toEqual('01.12.20');
-        });
-        test('Skal returnere dato på format LL', () => {
-            expect(formaterIsoDato(datoString, datoformat.DATO_FORLENGET)).toEqual(
-                '1. desember 2020'
-            );
-        });
-        test('Skal returnere dato på format LLL', () => {
-            expect(formaterIsoDato(datoString, datoformat.DATO_FORLENGET_MED_TID)).toEqual(
-                `1. desember 2020 kl. ${dato.format('HH:mm')}`
-            );
-        });
-        test('Skal returnere dato på format YYYY-MM', () => {
-            expect(formaterIsoDato(datoString, datoformat.ISO_MÅNED)).toEqual('2020-12');
-        });
-        test('Skal returnere dato på format YYYY-MM-DD', () => {
-            expect(formaterIsoDato(datoString, datoformat.ISO_DAG)).toEqual('2020-12-01');
-        });
-        test('Skal returnere dato på format DD.MM.YY HH:mm', () => {
-            expect(formaterIsoDato(datoString, datoformat.DATO_TID)).toEqual(
-                `01.12.20 ${dato.format('HH:mm')}`
-            );
-        });
-        test('Skal returnere dato på format HH:mm', () => {
-            expect(formaterIsoDato(datoString, datoformat.TID)).toEqual(dato.format('HH:mm'));
-        });
-        test('Skal returnere dato på format MMMM YYYY', () => {
-            expect(formaterIsoDato(datoString, datoformat.MÅNED_ÅR_NAVN)).toEqual('desember 2020');
-        });
-
-        test('Skal gi riktig rekkefølge på utbetalinger', () => {
-            const utbetalingBarn = lagUtbetalingsperiodeDetalj({
-                person: mockBarn,
-                ytelseType: YtelseType.ORDINÆR_BARNETRYGD,
-            });
-
-            const utbetalingSmåbarnstillegg = lagUtbetalingsperiodeDetalj({
-                person: mockSøker(),
-                ytelseType: YtelseType.SMÅBARNSTILLEGG,
-            });
-
-            const utbetalingUtvidet = lagUtbetalingsperiodeDetalj({
-                person: mockSøker(),
-                ytelseType: YtelseType.UTVIDET_BARNETRYGD,
-            });
-
-            const sorterteUtbetalingsperiodedetaljer = [
-                utbetalingBarn,
-                utbetalingSmåbarnstillegg,
-                utbetalingUtvidet,
-            ].sort(sorterUtbetaling);
-
-            expect(sorterteUtbetalingsperiodedetaljer[0]).toEqual(utbetalingUtvidet);
-            expect(sorterteUtbetalingsperiodedetaljer[1]).toEqual(utbetalingSmåbarnstillegg);
-            expect(sorterteUtbetalingsperiodedetaljer[2]).toEqual(utbetalingBarn);
-        });
+    test('Skal returnere dato på format MM.YY', () => {
+        expect(formaterIsoDato(datoString, datoformat.MÅNED)).toEqual('12.20');
+    });
+    test('Skal returnere dato på format DD.MM.YYYY', () => {
+        expect(formaterIsoDato(datoString, datoformat.DATO)).toEqual('01.12.2020');
+    });
+    test('Skal returnere dato på format DD.MM.YY', () => {
+        expect(formaterIsoDato(datoString, datoformat.DATO_FORKORTTET)).toEqual('01.12.20');
+    });
+    test('Skal returnere dato på format LL', () => {
+        expect(formaterIsoDato(datoString, datoformat.DATO_FORLENGET)).toEqual('1. desember 2020');
+    });
+    test('Skal returnere dato på format LLL', () => {
+        expect(formaterIsoDato(datoString, datoformat.DATO_FORLENGET_MED_TID)).toEqual(
+            `1. desember 2020 kl. ${dato.format('HH:mm')}`
+        );
+    });
+    test('Skal returnere dato på format YYYY-MM', () => {
+        expect(formaterIsoDato(datoString, datoformat.ISO_MÅNED)).toEqual('2020-12');
+    });
+    test('Skal returnere dato på format YYYY-MM-DD', () => {
+        expect(formaterIsoDato(datoString, datoformat.ISO_DAG)).toEqual('2020-12-01');
+    });
+    test('Skal returnere dato på format DD.MM.YY HH:mm', () => {
+        expect(formaterIsoDato(datoString, datoformat.DATO_TID)).toEqual(
+            `01.12.20 ${dato.format('HH:mm')}`
+        );
+    });
+    test('Skal returnere dato på format HH:mm', () => {
+        expect(formaterIsoDato(datoString, datoformat.TID)).toEqual(dato.format('HH:mm'));
+    });
+    test('Skal returnere dato på format MMMM YYYY', () => {
+        expect(formaterIsoDato(datoString, datoformat.MÅNED_ÅR_NAVN)).toEqual('desember 2020');
     });
 
-    test('formaterTekstStorForbokstav', () => {
-        //Skal gjøre om tekst til små bokstaver og store forbokstaver
+    test('Skal gi riktig rekkefølge på utbetalinger', () => {
+        const utbetalingBarn = lagUtbetalingsperiodeDetalj({
+            person: mockBarn,
+            ytelseType: YtelseType.ORDINÆR_BARNETRYGD,
+        });
+
+        const utbetalingSmåbarnstillegg = lagUtbetalingsperiodeDetalj({
+            person: mockSøker(),
+            ytelseType: YtelseType.SMÅBARNSTILLEGG,
+        });
+
+        const utbetalingUtvidet = lagUtbetalingsperiodeDetalj({
+            person: mockSøker(),
+            ytelseType: YtelseType.UTVIDET_BARNETRYGD,
+        });
+
+        const sorterteUtbetalingsperiodedetaljer = [
+            utbetalingBarn,
+            utbetalingSmåbarnstillegg,
+            utbetalingUtvidet,
+        ].sort(sorterUtbetaling);
+
+        expect(sorterteUtbetalingsperiodedetaljer[0]).toEqual(utbetalingUtvidet);
+        expect(sorterteUtbetalingsperiodedetaljer[1]).toEqual(utbetalingSmåbarnstillegg);
+        expect(sorterteUtbetalingsperiodedetaljer[2]).toEqual(utbetalingBarn);
+    });
+});
+
+describe('formaterTekstStorForbokstav', () => {
+    test('Skal gjøre om tekst til små bokstaver og store forbokstaver', () => {
         expect(formaterTekstStorForbokstav('HEI')).toBe('Hei');
         expect(formaterTekstStorForbokstav('hei PÅ deg')).toBe('Hei På Deg');
         expect(formaterTekstStorForbokstav('HEI, Hallo og hei Tilbake.')).toBe(
             'Hei, Hallo Og Hei Tilbake.'
         );
+    });
+    test('Skal håndtere postadresser, husbokstaver og poststeder', () => {
         expect(formaterTekstStorForbokstav('HALLOGATEN 22A')).toBe('Hallogaten 22A');
         expect(formaterTekstStorForbokstav('1234 helsfyr')).toBe('1234 Helsfyr');
         expect(formaterTekstStorForbokstav('hallOGATen, postboks 1234')).toBe(
             'Hallogaten, Postboks 1234'
         );
-        expect(formaterTekstStorForbokstav('postboks 1234 sentrum')).toBe('Postboks 1234 Sentrum');
+        expect(formaterTekstStorForbokstav('postboks 1234 åsnes')).toBe('Postboks 1234 Åsnes');
         expect(formaterTekstStorForbokstav('HALLOgaten 22A, 1234 helsfyr')).toBe(
             'Hallogaten 22A, 1234 Helsfyr'
         );

--- a/src/frontend/utils/test/formatter.test.ts
+++ b/src/frontend/utils/test/formatter.test.ts
@@ -5,6 +5,7 @@ import {
     datoformat,
     formaterIdent,
     formaterIsoDato,
+    formaterTekstStorForbokstav,
     hentAlder,
     kunSiffer,
     sorterUtbetaling,
@@ -120,5 +121,23 @@ describe('utils/formatter', () => {
             expect(sorterteUtbetalingsperiodedetaljer[1]).toEqual(utbetalingSmåbarnstillegg);
             expect(sorterteUtbetalingsperiodedetaljer[2]).toEqual(utbetalingBarn);
         });
+    });
+
+    test('formaterTekstStorForbokstav', () => {
+        //Skal gjøre om tekst til små bokstaver og store forbokstaver
+        expect(formaterTekstStorForbokstav('HEI')).toBe('Hei');
+        expect(formaterTekstStorForbokstav('hei PÅ deg')).toBe('Hei På Deg');
+        expect(formaterTekstStorForbokstav('HEI, Hallo og hei Tilbake.')).toBe(
+            'Hei, Hallo Og Hei Tilbake.'
+        );
+        expect(formaterTekstStorForbokstav('HALLOGATEN 22A')).toBe('Hallogaten 22A');
+        expect(formaterTekstStorForbokstav('1234 helsfyr')).toBe('1234 Helsfyr');
+        expect(formaterTekstStorForbokstav('hallOGATen, postboks 1234')).toBe(
+            'Hallogaten, Postboks 1234'
+        );
+        expect(formaterTekstStorForbokstav('postboks 1234 sentrum')).toBe('Postboks 1234 Sentrum');
+        expect(formaterTekstStorForbokstav('HALLOgaten 22A, 1234 helsfyr')).toBe(
+            'Hallogaten 22A, 1234 Helsfyr'
+        );
     });
 });


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-9440

Trekker ut hver adresse i sin egen rad i samhandlertabellen, og formatterer adressen.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
Før:
![image](https://user-images.githubusercontent.com/25459913/196642113-36fb8d72-6c63-44fd-988f-36816bd164dd.png)


Etter:
<img width="444" alt="Screenshot 2022-10-19 at 10 42 58" src="https://user-images.githubusercontent.com/2379098/196644042-d75e4f15-e4ee-4fff-8b1a-ba62095aae5d.png">
