### PR TITLE
Fiks at fritekstfelt ikke er tilgjengelig for vedtaksbrev

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -209,7 +209,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                     </SkjemaGruppe>
 
                     {!erMaksAntallKulepunkter &&
-                        (!erLesevisning ? (
+                        (!erLesevisning() ? (
                             <Button
                                 variant={'tertiary'}
                                 onClick={leggTilFritekst}
@@ -247,7 +247,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                 </>
             )}
         </FritekstContainer>
-    ) : !erLesevisning ? (
+    ) : !erLesevisning() ? (
         <Button
             variant={'tertiary'}
             onClick={leggTilFritekst}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -247,19 +247,17 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                 </>
             )}
         </FritekstContainer>
-    ) : (
-        !erLesevisning() && (
-            <Button
-                variant={'tertiary'}
-                onClick={leggTilFritekst}
-                id={`legg-til-fritekst`}
-                size={'small'}
-                icon={<Pluss />}
-            >
-                {'Legg til fritekst'}
-            </Button>
-        )
-    );
+    ) : !erLesevisning() ? (
+        <Button
+            variant={'tertiary'}
+            onClick={leggTilFritekst}
+            id={`legg-til-fritekst`}
+            size={'small'}
+            icon={<Pluss />}
+        >
+            {'Legg til fritekst'}
+        </Button>
+    ) : null;
 };
 
 export default FritekstVedtakbegrunnelser;

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -176,6 +176,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                                             className={'fritekst-textarea'}
                                             label={`Kulepunkt ${fritekstId}`}
                                             hideLabel
+                                            resize
                                             value={fritekst.verdi.tekst}
                                             maxLength={makslengdeFritekst}
                                             onChange={event => onChangeFritekst(event, fritekstId)}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -209,18 +209,17 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                         )}
                     </SkjemaGruppe>
 
-                    {!erMaksAntallKulepunkter &&
-                        (!erLesevisning() ? (
-                            <Button
-                                variant={'tertiary'}
-                                onClick={leggTilFritekst}
-                                id={`legg-til-fritekst`}
-                                size={'small'}
-                                icon={<Pluss />}
-                            >
-                                {'Legg til fritekst'}
-                            </Button>
-                        ) : null)}
+                    {!erMaksAntallKulepunkter && !erLesevisning() && (
+                        <Button
+                            variant={'tertiary'}
+                            onClick={leggTilFritekst}
+                            id={`legg-til-fritekst`}
+                            size={'small'}
+                            icon={<Pluss />}
+                        >
+                            {'Legg til fritekst'}
+                        </Button>
+                    )}
                     <Knapperekke>
                         <FamilieKnapp
                             erLesevisning={erLesevisning()}
@@ -248,17 +247,19 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                 </>
             )}
         </FritekstContainer>
-    ) : !erLesevisning() ? (
-        <Button
-            variant={'tertiary'}
-            onClick={leggTilFritekst}
-            id={`legg-til-fritekst`}
-            size={'small'}
-            icon={<Pluss />}
-        >
-            {'Legg til fritekst'}
-        </Button>
-    ) : null;
+    ) : (
+        !erLesevisning() && (
+            <Button
+                variant={'tertiary'}
+                onClick={leggTilFritekst}
+                id={`legg-til-fritekst`}
+                size={'small'}
+                icon={<Pluss />}
+            >
+                {'Legg til fritekst'}
+            </Button>
+        )
+    );
 };
 
 export default FritekstVedtakbegrunnelser;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Etter at vi prodsatte #2301 har det ikke vært mulig å legge til fritekst i vedtaksbrev, ettersom vi har antatt at `erLesevisning` var en boolsk verdi, men i den gjeldende filen er det en funksjon som returnerer en boolean. Retter dette slik at det igjen vil fungere

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Vi bør omdøpe funksjonen `erLesevisning` slik at den ikke lenger har samme navn som boolske verdier som representerer resultatet av funksjonen
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Før:
<img width="830" alt="Screenshot 2022-10-20 at 14 55 29" src="https://user-images.githubusercontent.com/2379098/196955701-5993254c-46cb-4e10-af5d-bcbce19a4677.png">

Etter:
<img width="845" alt="Screenshot 2022-10-20 at 14 55 36" src="https://user-images.githubusercontent.com/2379098/196955718-2269ddd6-2f5f-4d3d-847c-be3e7994b0c4.png">
