### PR TITLE
Korriger visning av nullstilt kompetanseskjema

### DIFF
--- a/src/frontend/context/Kompetanse/valideringKompetanse.ts
+++ b/src/frontend/context/Kompetanse/valideringKompetanse.ts
@@ -1,11 +1,5 @@
 import type { Felt } from '@navikt/familie-skjema';
-import {
-    type Avhengigheter,
-    feil,
-    type FeltState,
-    ok,
-    Valideringsstatus,
-} from '@navikt/familie-skjema';
+import { type Avhengigheter, feil, type FeltState, ok } from '@navikt/familie-skjema';
 
 import {
     AnnenForelderAktivitet,
@@ -31,7 +25,6 @@ const erAnnenForeldersAktivitetslandGyldig = (
     const annenForeldersAktivitet =
         avhengigheter?.annenForeldersAktivitet as Felt<AnnenForelderAktivitet>;
     if (
-        annenForeldersAktivitet?.valideringsstatus === Valideringsstatus.IKKE_VALIDERT ||
         annenForeldersAktivitet?.verdi === AnnenForelderAktivitet.IKKE_AKTUELT ||
         annenForeldersAktivitet?.verdi === AnnenForelderAktivitet.INAKTIV
     ) {
@@ -44,10 +37,7 @@ const erSøkersAktivitetslandGyldig = (
     avhengigheter?: Avhengigheter
 ): FeltState<string | undefined> => {
     const søkersAktivitet = avhengigheter?.annenForeldersAktivitet as Felt<SøkersAktivitet>;
-    if (
-        søkersAktivitet?.valideringsstatus === Valideringsstatus.IKKE_VALIDERT ||
-        søkersAktivitet?.verdi === SøkersAktivitet.INAKTIV
-    ) {
+    if (søkersAktivitet?.verdi === SøkersAktivitet.INAKTIV) {
         return ok(felt);
     }
     return !isEmpty(felt.verdi) ? ok(felt) : feil(felt, ikkeUtfyltFelt);

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/FamilieLandvelger.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EøsPeriode/FamilieLandvelger.tsx
@@ -95,6 +95,7 @@ interface IBaseLandvelgerProps {
     utenMargin: boolean;
     kanNullstilles: boolean;
     feil?: string;
+    size?: 'small' | 'medium';
 }
 
 const BaseFamilieLandvelger: React.FC<IBaseLandvelgerProps> = ({
@@ -104,6 +105,7 @@ const BaseFamilieLandvelger: React.FC<IBaseLandvelgerProps> = ({
     utenMargin,
     kanNullstilles,
     feil,
+    size,
 }) => {
     return (
         <div className={classNames('skjemaelement', className)}>
@@ -113,7 +115,7 @@ const BaseFamilieLandvelger: React.FC<IBaseLandvelgerProps> = ({
                 feil={feil}
                 {...countrySelectProps}
                 place
-                label={<Label size="small">{label}</Label>}
+                label={<Label size={size}>{label}</Label>}
             />
         </div>
     );
@@ -245,7 +247,7 @@ const FamilieValutavelger: React.FC<IFamilieValutavelgerProps> = ({
                 feil={feil}
                 {...landvelgerProps}
                 place
-                label={<Label size="small">{label}</Label>}
+                label={<Label size={size}>{label}</Label>}
             />
         </div>
     );

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -111,7 +111,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                     {...skjema.felter.søkersAktivitet.hentNavInputProps(skjema.visFeilmeldinger)}
                     erLesevisning={lesevisning}
                     label={'Søkers aktivitet'}
-                    value={skjema.felter.søkersAktivitet.verdi || undefined}
+                    value={skjema.felter.søkersAktivitet.verdi || ''}
                     lesevisningVerdi={
                         skjema.felter.søkersAktivitet.verdi
                             ? søkersAktiviteter[skjema.felter.søkersAktivitet.verdi]
@@ -122,7 +122,6 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                             event.target.value as SøkersAktivitet
                         )
                     }
-                    size={'small'}
                 >
                     <option value={''}>Velg</option>
                     {Object.values(SøkersAktivitet).map(aktivitet => {
@@ -140,7 +139,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                     )}
                     erLesevisning={lesevisning}
                     label={'Annen forelders aktivitet'}
-                    value={skjema.felter.annenForeldersAktivitet.verdi || undefined}
+                    value={skjema.felter.annenForeldersAktivitet.verdi || ''}
                     lesevisningVerdi={
                         skjema.felter.annenForeldersAktivitet?.verdi
                             ? annenForelderAktiviteter[skjema.felter.annenForeldersAktivitet?.verdi]
@@ -151,7 +150,6 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                             event.target.value as AnnenForelderAktivitet
                         );
                     }}
-                    size={'small'}
                 >
                     <option value={''}>Velg</option>
                     {Object.values(AnnenForelderAktivitet).map(aktivitet => {
@@ -235,7 +233,7 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                     {...skjema.felter.resultat.hentNavInputProps(skjema.visFeilmeldinger)}
                     erLesevisning={lesevisning}
                     label={'Kompetanse'}
-                    value={skjema.felter.resultat.verdi || undefined}
+                    value={skjema.felter.resultat.verdi || ''}
                     lesevisningVerdi={
                         skjema.felter.resultat.verdi
                             ? kompetanseResultater[skjema.felter.resultat.verdi]


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Retter en innmeldt feil fra Eivind:

> Dette gjorde jeg:
> - Jeg fylte ut skjema.
> - Lagret
> - Så fjernet perioden
> - Åpnet skjema igjen og forsøkte å lagre igjen
> - Feltene i skjema blir ikke tømt og når jeg forsøker å lagre igjen får jeg feilmelding på alle obligatoriske felter.

Gjør også etikettstørrelsen for landvelgeren avhengig av landvelgerens størrelse, og fjerner en valideringsklausul som gjorde at landvalgsfeltene ikke viste feilmelding når hele skjemaet var tomt

### 🔎️ Er det noe spesielt du ønsker å fremheve?
**Merk** at dette ikke er helt i mål. Landvalgsfeltene har en `value`-prop som kun brukes for å sette _initiell verdi_, disse feltene er altså ikke kontrollerte og tar ikke imot programmatisk oppdatering av verdien (som er det vi gjør når vi nullstiller skjemaet). Jeg har tatt kontakt med utvikleren av landvelgeren for å høre hva vi kan gjøre med det

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Før:
![image](https://user-images.githubusercontent.com/2379098/197977518-37fce64e-c8ec-49ad-b617-006e35da3f4c.png)
Etter:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/2379098/197981845-8d20b44d-48bd-4c9e-97ab-96b97b945c53.png">

