### PR TITLE
Feat/oppdatere totrinnskontroll modal

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import Lenke from 'nav-frontend-lenker';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
-import { BodyShort, Button } from '@navikt/ds-react';
+import { BodyShort, Button, Heading, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
 import { FamilieSelect, FamilieTextarea } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -14,7 +14,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import useDokument from '../../../../../hooks/useDokument';
-import StatusIkon, { Status } from '../../../../../ikoner/StatusIkon';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingSteg, henleggÅrsak, HenleggÅrsak } from '../../../../../typer/behandling';
 import { ToggleNavn } from '../../../../../typer/toggles';
@@ -33,14 +32,17 @@ interface HenleggÅrsakSelect extends HTMLSelectElement {
     value: HenleggÅrsak | '';
 }
 
-const StyledVeivalgTekst = styled(BodyShort)`
-    position: relative;
-    top: -32px;
-    svg {
-        position: relative;
-        top: 6px;
-        margin-right: 10px;
-    }
+const StyledBodyShort = styled(BodyShort)`
+    margin: 2rem 2rem 2rem 0;
+`;
+
+const KnappHøyre = styled(Button)`
+    margin-left: 1rem;
+`;
+
+const Knapperad = styled.div`
+    display: flex;
+    justify-content: end;
 `;
 
 const StyledLenke = styled(Lenke)<{ visLenke: boolean }>`
@@ -203,43 +205,43 @@ const HenleggBehandling: React.FC<IProps> = ({ fagsakId, behandling }) => {
                 </SkjemaGruppe>
             </UIModalWrapper>
 
-            <UIModalWrapper
-                modal={{
-                    actions: [
-                        <Button
-                            key={'Gå til saksoversikten'}
-                            variant="secondary"
-                            size="small"
-                            onClick={() => {
-                                navigate(`/fagsak/${fagsakId}/saksoversikt`);
-                            }}
-                            children={'Gå til saksoversikten'}
-                        />,
+            <Modal
+                open={visVeivalgModal}
+                onClose={() => {
+                    settVisVeivalgModal(false);
+                }}
+            >
+                <Modal.Content>
+                    <Heading size={'medium'} level={'2'}>
+                        Behandling henlagt
+                    </Heading>
+                    <StyledBodyShort>
+                        {årsak === HenleggÅrsak.SØKNAD_TRUKKET
+                            ? 'Behandlingen er henlagt og brev til bruker er sendt'
+                            : 'Behandlingen er henlagt'}
+                    </StyledBodyShort>
+                    <Knapperad>
                         <Button
                             key={'Gå til oppgavebenken'}
                             variant="secondary"
-                            size="small"
+                            size="medium"
                             onClick={() => {
                                 navigate('/oppgaver');
                             }}
-                            children={'Gå til oppgavebenken'}
-                        />,
-                    ],
-                    onClose: () => {
-                        settVisVeivalgModal(false);
-                    },
-                    lukkKnapp: true,
-                    tittel: '',
-                    visModal: visVeivalgModal,
-                }}
-            >
-                <StyledVeivalgTekst>
-                    <StatusIkon status={Status.OK} />
-                    {årsak === HenleggÅrsak.SØKNAD_TRUKKET
-                        ? 'Behandlingen er henlagt og brev til bruker er sendt'
-                        : 'Behandlingen er henlagt'}
-                </StyledVeivalgTekst>
-            </UIModalWrapper>
+                            children={'Se oppgavebenk'}
+                        />
+                        <KnappHøyre
+                            key={'Gå til saksoversikten'}
+                            variant="secondary"
+                            size="medium"
+                            onClick={() => {
+                                navigate(`/fagsak/${fagsakId}/saksoversikt`);
+                            }}
+                            children={'Se saksoversikt'}
+                        />
+                    </Knapperad>
+                </Modal.Content>
+            </Modal>
             <PdfVisningModal
                 åpen={visDokumentModal}
                 onRequestClose={() => settVisDokumentModal(false)}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
@@ -210,6 +210,7 @@ const HenleggBehandling: React.FC<IProps> = ({ fagsakId, behandling }) => {
                 onClose={() => {
                     settVisVeivalgModal(false);
                 }}
+                shouldCloseOnOverlayClick={false}
             >
                 <Modal.Content>
                     <Heading size={'medium'} level={'2'}>

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -59,7 +59,7 @@ const KorrigertEtterbetalingsbeløpAlert = styled(Alert)`
 `;
 
 const Modaltekst = styled(BodyShort)`
-    margin-bottom: 2rem;
+    margin: 2rem 0;
 `;
 
 const KnappHøyre = styled(Button)`
@@ -260,7 +260,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
 
                     <Modal open={visModal} onClose={() => settVisModal(false)} closeButton={true}>
                         <Modal.Content>
-                            <Heading size={'medium'} level={'2'} spacing>
+                            <Heading size={'medium'} level={'2'}>
                                 Totrinnskontroll
                             </Heading>
                             <Modaltekst>Behandlingen er nå sendt til totrinnskontroll</Modaltekst>

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -258,7 +258,12 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                         </Button>
                     </Container>
 
-                    <Modal open={visModal} onClose={() => settVisModal(false)} closeButton={true}>
+                    <Modal
+                        open={visModal}
+                        onClose={() => settVisModal(false)}
+                        closeButton={true}
+                        shouldCloseOnOverlayClick={false}
+                    >
                         <Modal.Content>
                             <Heading size={'medium'} level={'2'}>
                                 Totrinnskontroll

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { FileContent, InformationColored, Notes } from '@navikt/ds-icons';
-import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react';
+import { Alert, BodyShort, Button, Heading, Modal } from '@navikt/ds-react';
 import { FamilieSelect, FlexDiv } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -23,7 +23,6 @@ import {
     hentStegNummer,
 } from '../../../typer/behandling';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
-import UIModalWrapper from '../../Felleskomponenter/Modal/UIModalWrapper';
 import PdfVisningModal from '../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
 import KorrigerEtterbetalingModal from './KorrigerEtterbetalingModal/KorrigerEtterbetalingModal';
@@ -57,6 +56,19 @@ const StyleHeading = styled(Heading)`
 
 const KorrigertEtterbetalingsbeløpAlert = styled(Alert)`
     margin-bottom: 1.5rem;
+`;
+
+const Modaltekst = styled(BodyShort)`
+    margin-bottom: 2rem;
+`;
+
+const KnappHøyre = styled(Button)`
+    margin-left: 1rem;
+`;
+
+const Knapperad = styled.div`
+    display: flex;
+    justify-content: center;
 `;
 
 interface FortsattInnvilgetPerioderSelect extends HTMLSelectElement {
@@ -245,40 +257,38 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                             )}
                         </Button>
                     </Container>
-                    {visModal && (
-                        <UIModalWrapper
-                            modal={{
-                                tittel: 'Totrinnskontroll',
-                                lukkKnapp: false,
-                                visModal: visModal,
-                                actions: [
-                                    <Button
-                                        key={'saksoversikt'}
-                                        variant={'secondary'}
-                                        size={'small'}
-                                        onClick={() => {
-                                            settVisModal(false);
-                                            navigate(`/fagsak/${fagsakId}/saksoversikt`);
-                                            window.location.reload();
-                                        }}
-                                        children={'Gå til saksoversikten'}
-                                    />,
-                                    <Button
-                                        key={'oppgavebenk'}
-                                        variant={'primary'}
-                                        size={'small'}
-                                        onClick={() => {
-                                            settVisModal(false);
-                                            navigate('/oppgaver');
-                                        }}
-                                        children={'Gå til oppgavebenken'}
-                                    />,
-                                ],
-                            }}
-                        >
-                            <BodyShort>Behandlingen er nå sendt til totrinnskontroll</BodyShort>
-                        </UIModalWrapper>
-                    )}
+
+                    <Modal open={visModal} onClose={() => settVisModal(false)} closeButton={true}>
+                        <Modal.Content>
+                            <Heading size={'medium'} level={'2'} spacing>
+                                Totrinnskontroll
+                            </Heading>
+                            <Modaltekst>Behandlingen er nå sendt til totrinnskontroll</Modaltekst>
+                            <Knapperad>
+                                <Button
+                                    key={'oppgavebenk'}
+                                    variant={'secondary'}
+                                    size={'medium'}
+                                    onClick={() => {
+                                        settVisModal(false);
+                                        navigate('/oppgaver');
+                                    }}
+                                    children={'Gå til oppgavebenken'}
+                                />
+                                <KnappHøyre
+                                    key={'saksoversikt'}
+                                    variant={'secondary'}
+                                    size={'medium'}
+                                    onClick={() => {
+                                        settVisModal(false);
+                                        navigate(`/fagsak/${fagsakId}/saksoversikt`);
+                                        window.location.reload();
+                                    }}
+                                    children={'Gå til saksoversikten'}
+                                />
+                            </Knapperad>
+                        </Modal.Content>
+                    </Modal>
                 </>
             ) : erMigreringFraInfotrygd ? (
                 <Alert variant="info">

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontroll.tsx
@@ -4,7 +4,7 @@ import type { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Button } from '@navikt/ds-react';
+import { Button, Heading, Modal } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import {
     byggFeiletRessurs,
@@ -21,7 +21,6 @@ import type { IBehandling } from '../../../../typer/behandling';
 import { BehandlingStatus } from '../../../../typer/behandling';
 import type { ITotrinnskontrollData } from '../../../../typer/totrinnskontroll';
 import { TotrinnskontrollBeslutning } from '../../../../typer/totrinnskontroll';
-import UIModalWrapper from '../../Modal/UIModalWrapper';
 import type { ITrinn } from '../../Venstremeny/sider';
 import { KontrollertStatus } from '../../Venstremeny/sider';
 import TotrinnskontrollModalInnhold from './TotrinnskontrollModalInnhold';
@@ -34,6 +33,15 @@ interface IProps {
 const Container = styled.div`
     padding: 0.5rem 1.5rem;
     display: flex;
+`;
+
+const KnappHøyre = styled(Button)`
+    margin-left: 1rem;
+`;
+
+const Knapperad = styled.div`
+    display: flex;
+    justify-content: end;
 `;
 
 interface IModalVerdier {
@@ -148,39 +156,40 @@ const Totrinnskontroll: React.FunctionComponent<IProps> = ({ åpenBehandling }) 
                 </Container>
             )}
 
-            {modalVerdi && (
-                <UIModalWrapper
-                    modal={{
-                        tittel: 'Totrinnskontroll',
-                        lukkKnapp: false,
-                        visModal: modalVerdi.skalVises,
-                        actions: [
-                            <Button
-                                variant={'secondary'}
-                                key={'saksoversikt'}
-                                size={'small'}
-                                onClick={() => {
-                                    settModalVerdi(initiellModalVerdi);
-                                    navigate(`/fagsak/${fagsakId}/saksoversikt`);
-                                }}
-                                children={'Gå til saksoversikten'}
-                            />,
-                            <Button
-                                key={'oppgavebenk'}
-                                variant={'primary'}
-                                size={'small'}
-                                onClick={() => {
-                                    settModalVerdi(initiellModalVerdi);
-                                    navigate('/oppgaver');
-                                }}
-                                children={'Gå til oppgavebenken'}
-                            />,
-                        ],
-                    }}
-                >
+            <Modal
+                open={modalVerdi.skalVises}
+                onClose={() => settModalVerdi(initiellModalVerdi)}
+                shouldCloseOnOverlayClick={false}
+            >
+                <Modal.Content>
+                    <Heading size={'medium'} level={'2'}>
+                        Totrinnskontroll
+                    </Heading>
                     <TotrinnskontrollModalInnhold beslutning={modalVerdi.beslutning} />
-                </UIModalWrapper>
-            )}
+                    <Knapperad>
+                        <Button
+                            key={'oppgavebenk'}
+                            variant={'secondary'}
+                            size={'medium'}
+                            onClick={() => {
+                                settModalVerdi(initiellModalVerdi);
+                                navigate('/oppgaver');
+                            }}
+                            children={'Se oppgavebenk'}
+                        />
+                        <KnappHøyre
+                            key={'saksoversikt'}
+                            variant={'secondary'}
+                            size={'medium'}
+                            onClick={() => {
+                                settModalVerdi(initiellModalVerdi);
+                                navigate(`/fagsak/${fagsakId}/saksoversikt`);
+                            }}
+                            children={'Se saksoversikt'}
+                        />
+                    </Knapperad>
+                </Modal.Content>
+            </Modal>
         </>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/TotrinnskontrollModalInnhold.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/TotrinnskontrollModalInnhold.tsx
@@ -1,32 +1,37 @@
 import * as React from 'react';
 
-import StatusIkon, { Status } from '../../../../ikoner/StatusIkon';
+import styled from 'styled-components';
+
+import { BodyShort } from '@navikt/ds-react';
+
 import { TotrinnskontrollBeslutning } from '../../../../typer/totrinnskontroll';
 
 interface IProps {
     beslutning: TotrinnskontrollBeslutning;
 }
 
+const ModalInnholdContainer = styled.div`
+    display: flex;
+    align-items: center;
+    margin: 2rem 2rem 2rem 0;
+`;
+
 const TotrinnskontrollModalInnhold: React.FunctionComponent<IProps> = ({ beslutning }) => {
     if (beslutning === TotrinnskontrollBeslutning.IKKE_VURDERT) {
         return (
-            <div className={'totrinnsvurdering-modal-innhold'}>
-                <StatusIkon status={Status.FEIL} />
-                <div className={'totrinnsvurdering-modal-tekst'}>
-                    Beslutning er IKKE_VURDERT. Ta kontakt med barnetrygdteamet.
-                </div>
-            </div>
+            <ModalInnholdContainer>
+                <BodyShort>Beslutning er IKKE_VURDERT. Ta kontakt med barnetrygdteamet.</BodyShort>
+            </ModalInnholdContainer>
         );
     } else {
         return (
-            <div className={'totrinnsvurdering-modal-innhold'}>
-                <StatusIkon status={Status.OK} />
-                <div className={'totrinnsvurdering-modal-tekst'}>
+            <ModalInnholdContainer>
+                <BodyShort>
                     {beslutning === TotrinnskontrollBeslutning.GODKJENT
                         ? 'Behandlingen er godkjent, og vedtaket er iverksatt'
                         : 'Behandlingen er ikke godkjent og er sendt tilbake til saksbehandler'}
-                </div>
-            </div>
+                </BodyShort>
+            </ModalInnholdContainer>
         );
     }
 };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/totrinnskontroll.less
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/totrinnskontroll.less
@@ -1,12 +1,3 @@
-.totrinnsvurdering-modal-innhold {
-  display: flex;
-  align-items: center;
-
-  .totrinnsvurdering-modal-tekst {
-    margin-left: 1rem;
-  }
-}
-
 .totrinnskontroll {
   .totrinnskontroll-tittel {
     display: flex;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Har oppdatert modaler til nye fra designsystemet i stedet for å fikse styling på gamle modalen som brakk under designoppgraderingen. Gunn ønsket at man ikke skulle kunne trykke utenfor modalene for å gå ut, men kun bruke knappene. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots

<img width="459" alt="Skjermbilde 2022-10-27 kl  14 44 32" src="https://user-images.githubusercontent.com/11887409/198287677-9acd271f-7a67-43b3-976c-d5e6211b6083.png">
<img width="1410" alt="image" src="https://user-images.githubusercontent.com/11887409/198287804-3486116b-ab01-43e3-a1a9-0fbc8919935f.png">

