### PR TITLE
Gjenopprett luft mellom ident og utbetalingsbeløp på vedtaksside

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Felles/Utbetalingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Felles/Utbetalingsresultat.tsx
@@ -15,8 +15,8 @@ const UtbetalingsperiodeDetalj = styled.div`
     display: flex;
     flex-direction: row;
 
-    .typo-normal {
-        margin-right: 1.5rem;
+    p + p {
+        margin-left: 1.5rem;
     }
 `;
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10194
Denne luften var definert ved bruk av klassenavnet fra `<Normaltekst>`, og forsvant derfor da vi oppgraderte designkomponentene. Her skulle det ha vært luft til venstre for beløpene `1 054 kr` og `1 354 kr`
<img width="591" alt="Screenshot 2022-10-26 at 11 15 08" src="https://user-images.githubusercontent.com/2379098/198527482-63654a5c-327a-47f1-9fab-946ae50b201b.png">
