### PR TITLE
Bredde familieTextArea og nye ikoner

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -5,15 +5,13 @@ import styled from 'styled-components';
 import navFarger from 'nav-frontend-core';
 import { Label, SkjemaGruppe } from 'nav-frontend-skjema';
 
-import { ExternalLink } from '@navikt/ds-icons';
+import { AddCircle, Delete, ExternalLink } from '@navikt/ds-icons';
 import { BodyLong, Button, Heading, Link, Tag } from '@navikt/ds-react';
 import { FamilieKnapp, FamilieTextarea } from '@navikt/familie-form-elements';
 import type { FeltState } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
-import Pluss from '../../../../../ikoner/Pluss';
-import Slett from '../../../../../ikoner/Slett';
 import { målform } from '../../../../../typer/søknad';
 import type { IFritekstFelt } from '../../../../../utils/fritekstfelter';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
@@ -28,10 +26,9 @@ const FritekstContainer = styled.div`
 `;
 
 const FamilieTextareaBegrunnelseFritekst = styled(FamilieTextarea)`
-    .skjemaelement {
-        margin-top: 0.5rem;
-        margin-bottom: 0.5rem;
-    }
+    margin-bottom: 0.5rem;
+    display: flex;
+    flex: auto;
 `;
 
 const StyledList = styled.ul`
@@ -41,10 +38,7 @@ const StyledList = styled.ul`
 
 const StyledFamilieFritekstFelt = styled.div`
     display: flex;
-
-    .textarea__container {
-        width: 100% !important;
-    }
+    align-items: center;
 `;
 
 const StyledLabel = styled(Label)`
@@ -198,8 +192,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                                             id={`fjern_fritekst-${fritekstId}`}
                                             size={'small'}
                                             aria-label={'Fjern fritekst'}
-                                            icon={<Slett />}
-                                            iconPosition={'right'}
+                                            icon={<Delete />}
                                         >
                                             {'Fjern'}
                                         </SletteKnapp>
@@ -214,7 +207,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
                             onClick={leggTilFritekst}
                             id={`legg-til-fritekst`}
                             size={'small'}
-                            icon={<Pluss />}
+                            icon={<AddCircle />}
                         >
                             {'Legg til fritekst'}
                         </Button>
@@ -252,7 +245,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
             onClick={leggTilFritekst}
             id={`legg-til-fritekst`}
             size={'small'}
-            icon={<Pluss />}
+            icon={<AddCircle />}
         >
             {'Legg til fritekst'}
         </Button>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bredden på fritekstfeltet ble endret med designoppdateringen, så denne er justert tilbake at fyller hele bredden. Tok samtidig og oppdaterte noen gamle ikoner og noe avstander etter avklaring med Gunn. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
Før
![Skjermbilde 2022-11-01 kl  12 51 58](https://user-images.githubusercontent.com/11887409/199226676-99d2c6f8-22ab-4094-8766-ff5f8ca2ebbd.png)


Etter
![Skjermbilde 2022-11-01 kl  12 16 52](https://user-images.githubusercontent.com/11887409/199226612-8d606ef7-7778-4201-b4cf-90430d1c55f6.png)
![Skjermbilde 2022-11-01 kl  12 16 38](https://user-images.githubusercontent.com/11887409/199226616-4096ff8a-e09c-4d58-83a8-0a5c5c9d287e.png)
