### PR TITLE
Skjul endring av behandlingstema for institusjonssaker

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -13,7 +13,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import { Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
-import type { IMinimalFagsak } from '../../../../typer/fagsak';
+import { FagsakType, type IMinimalFagsak } from '../../../../typer/fagsak';
 import type { IPersonInfo } from '../../../../typer/person';
 import { ToggleNavn } from '../../../../typer/toggles';
 import EndreBehandlendeEnhet from './EndreBehandlendeEnhet/EndreBehandlendeEnhet';
@@ -54,7 +54,8 @@ const Behandlingsmeny: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
                 <Dropdown.Menu.List>
                     {åpenBehandling.status === RessursStatus.SUKSESS && <EndreBehandlendeEnhet />}
                     {åpenBehandling.status === RessursStatus.SUKSESS &&
-                        åpenBehandling.data.årsak !== BehandlingÅrsak.SØKNAD && (
+                        åpenBehandling.data.årsak !== BehandlingÅrsak.SØKNAD &&
+                        minimalFagsak.fagsakType !== FagsakType.INSTITUSJON && (
                             <EndreBehandlingstema />
                         )}
                     <OpprettBehandling minimalFagsak={minimalFagsak} />

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -1,16 +1,15 @@
 import React, { useState } from 'react';
 
-import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
-import { Button } from '@navikt/ds-react';
+import { Button, Heading, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import type { IMinimalFagsak } from '../../../../../typer/fagsak';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import UIModalWrapper from '../../../../Felleskomponenter/Modal/UIModalWrapper';
 import SkjultLegend from '../../../../Felleskomponenter/SkjultLegend';
 import OpprettBehandlingValg from './OpprettBehandlingValg';
 import useOpprettBehandling from './useOpprettBehandling';
@@ -19,11 +18,24 @@ interface IProps {
     minimalFagsak: IMinimalFagsak;
 }
 
+const Knapperad = styled.div`
+    margin-top: 2rem;
+    display: flex;
+    justify-content: center;
+`;
+
+const StyledModal = styled(Modal)`
+    width: 35rem;
+`;
+
+const KnappHøyre = styled(Button)`
+    margin-left: 1rem;
+`;
+
 const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
     const [visModal, settVisModal] = useState(false);
     const [visBekreftelseTilbakekrevingModal, settVisBekreftelseTilbakekrevingModal] =
         useState(false);
-    const navigate = useNavigate();
 
     const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus, bruker } =
         useOpprettBehandling(
@@ -53,20 +65,41 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
             <Dropdown.Menu.List.Item onClick={() => settVisModal(true)}>
                 Opprett behandling
             </Dropdown.Menu.List.Item>
-            <UIModalWrapper
-                modal={{
-                    actions: [
+            <StyledModal
+                open={visModal}
+                onClose={lukkOpprettBehandlingModal}
+                aria-label="Opprett ny behandling"
+            >
+                <Modal.Content>
+                    <Heading size="medium" level="2" spacing>
+                        Opprett ny behandling
+                    </Heading>
+                    <SkjemaGruppe
+                        feil={hentFrontendFeilmelding(opprettBehandlingSkjema.submitRessurs)}
+                    >
+                        <SkjultLegend>Opprett ny behandling</SkjultLegend>
+                        <OpprettBehandlingValg
+                            behandlingstype={behandlingstype}
+                            behandlingsårsak={behandlingsårsak}
+                            behandlingstema={behandlingstema}
+                            migreringsdato={migreringsdato}
+                            søknadMottattDato={søknadMottattDato}
+                            minimalFagsak={minimalFagsak}
+                            visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
+                            bruker={bruker}
+                            valgteBarn={valgteBarn}
+                        />
+                    </SkjemaGruppe>
+                    <Knapperad>
                         <Button
                             key={'avbryt'}
                             variant="tertiary"
-                            size="small"
                             onClick={lukkOpprettBehandlingModal}
                             children={'Avbryt'}
-                        />,
-                        <Button
+                        />
+                        <KnappHøyre
                             key={'bekreft'}
                             variant="primary"
-                            size="small"
                             onClick={() =>
                                 onBekreft(
                                     minimalFagsak.søkerFødselsnummer,
@@ -82,64 +115,34 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                                 opprettBehandlingSkjema.submitRessurs.status ===
                                 RessursStatus.HENTER
                             }
-                        />,
-                    ],
-                    onClose: lukkOpprettBehandlingModal,
-                    lukkKnapp: true,
-                    tittel: 'Opprett ny behandling',
-                    visModal,
-                }}
+                        />
+                    </Knapperad>
+                </Modal.Content>
+            </StyledModal>
+            <StyledModal
+                open={visBekreftelseTilbakekrevingModal}
+                onClose={() => settVisBekreftelseTilbakekrevingModal(false)}
+                aria-label="Tilbakekrevingsbehandling opprettes"
             >
-                <SkjemaGruppe feil={hentFrontendFeilmelding(opprettBehandlingSkjema.submitRessurs)}>
-                    <SkjultLegend>Opprett ny behandling</SkjultLegend>
-                    <OpprettBehandlingValg
-                        behandlingstype={behandlingstype}
-                        behandlingsårsak={behandlingsårsak}
-                        behandlingstema={behandlingstema}
-                        migreringsdato={migreringsdato}
-                        søknadMottattDato={søknadMottattDato}
-                        minimalFagsak={minimalFagsak}
-                        visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
-                        bruker={bruker}
-                        valgteBarn={valgteBarn}
-                    />
-                </SkjemaGruppe>
-            </UIModalWrapper>
-
-            {visBekreftelseTilbakekrevingModal && (
-                <UIModalWrapper
-                    modal={{
-                        tittel: 'Tilbakekreving opprettes...',
-                        lukkKnapp: false,
-                        visModal: visBekreftelseTilbakekrevingModal,
-                        actions: [
-                            <Button
-                                key={'saksoversikt'}
-                                variant="secondary"
-                                size="small"
-                                onClick={() => {
-                                    settVisBekreftelseTilbakekrevingModal(false);
-                                    navigate(`/fagsak/${minimalFagsak.id}/saksoversikt`);
-                                }}
-                                children={'Gå til saksoversikten'}
-                            />,
-                            <Button
-                                key={'oppgavebenk'}
-                                variant="primary"
-                                size="small"
-                                onClick={() => {
-                                    settVisBekreftelseTilbakekrevingModal(false);
-                                    navigate('/oppgaver');
-                                }}
-                                children={'Gå til oppgavebenken'}
-                            />,
-                        ],
-                    }}
-                >
+                <Modal.Content>
+                    <Heading size="medium" level="2" spacing>
+                        Tilbakekrevingsbehandling opprettes
+                    </Heading>
                     Tilbakekrevingsbehandling opprettes, men det kan ta litt tid (ca 30 sekunder)
                     før den blir tilgjengelig i saksoversikten og oppgavebenken.
-                </UIModalWrapper>
-            )}
+                    <Knapperad>
+                        <Button
+                            key={'oppgavebenk'}
+                            variant="primary"
+                            size="medium"
+                            onClick={() => {
+                                settVisBekreftelseTilbakekrevingModal(false);
+                            }}
+                            children={'Lukk'}
+                        />
+                    </Knapperad>
+                </Modal.Content>
+            </StyledModal>
         </>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/BehandlingstemaSelect.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/BehandlingstemaSelect.tsx
@@ -4,7 +4,11 @@ import { FamilieSelect } from '@navikt/familie-form-elements';
 import type { IFamilieSelectProps } from '@navikt/familie-form-elements/src/select/FamilieSelect';
 import type { Felt } from '@navikt/familie-skjema';
 
-import type { Behandlingstema, IBehandlingstema } from '../../typer/behandlingstema';
+import {
+    BehandlingUnderkategori,
+    type Behandlingstema,
+    type IBehandlingstema,
+} from '../../typer/behandlingstema';
 import { behandlingstemaer } from '../../typer/behandlingstema';
 
 interface EgneProps {
@@ -45,17 +49,19 @@ export const BehandlingstemaSelect = ({
                     Velg behandlingstema
                 </option>
             )}
-            {Object.values(behandlingstemaer).map(tema => {
-                return (
-                    <option
-                        key={tema.id}
-                        aria-selected={verdi !== undefined && verdi.id === tema.id}
-                        value={tema.id}
-                    >
-                        {tema.navn}
-                    </option>
-                );
-            })}
+            {Object.values(behandlingstemaer)
+                .filter(it => it.underkategori !== BehandlingUnderkategori.INSTITUSJON)
+                .map(tema => {
+                    return (
+                        <option
+                            key={tema.id}
+                            aria-selected={verdi !== undefined && verdi.id === tema.id}
+                            value={tema.id}
+                        >
+                            {tema.navn}
+                        </option>
+                    );
+                })}
         </FamilieSelect>
     );
 };

--- a/src/frontend/typer/behandlingstema.ts
+++ b/src/frontend/typer/behandlingstema.ts
@@ -10,11 +10,13 @@ export enum BehandlingKategori {
 export enum BehandlingUnderkategori {
     ORDINÆR = 'ORDINÆR',
     UTVIDET = 'UTVIDET',
+    INSTITUSJON = 'INSTITUSJON',
 }
 
 export enum Behandlingstema {
     NASJONAL_ORDINÆR = 'NASJONAL_ORDINÆR',
     NASJONAL_UTVIDET = 'NASJONAL_UTVIDET',
+    NASJONAL_INSTITUSJON = 'NASJONAL_INSTITUSJON',
     EØS_ORDINÆR = 'EØS_ORDINÆR',
     EØS_UTVIDET = 'EØS_UTVIDET',
 }
@@ -30,6 +32,7 @@ export const behandlingKategori: Record<BehandlingKategori, string> = {
 export const behandlingUnderkategori: Record<BehandlingUnderkategori, string> = {
     ORDINÆR: 'Ordinær',
     UTVIDET: 'Utvidet',
+    INSTITUSJON: 'Institusjon',
 };
 
 export interface IBehandlingstema {
@@ -51,6 +54,12 @@ export const behandlingstemaer: Record<Behandlingstema, IBehandlingstema> = {
         underkategori: BehandlingUnderkategori.UTVIDET,
         navn: 'Nasjonal utvidet',
         id: 'NASJONAL_UTVIDET',
+    },
+    NASJONAL_INSTITUSJON: {
+        kategori: BehandlingKategori.NASJONAL,
+        underkategori: BehandlingUnderkategori.INSTITUSJON,
+        navn: 'Nasjonal institusjon',
+        id: 'NASJONAL_INSTITUSJON',
     },
     EØS_ORDINÆR: {
         kategori: BehandlingKategori.EØS,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
For institusjonssaker hardkodes behandlingstema til å være 'Nasjonal institusjon', så alle steder der man kan endre behandlingstema blir irrelevante. På samme måte skal man ikke kunne sette en annen type fagsak til å ha behandlingstema 'Nasjonal institusjon'

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Lurer litt på om det hadde vært like greit å _ikke_ hardkode behandlingstemaverdien i frontendskjema for å opprette behandling, men la backend ha ansvaret for det alene. Altså at vi sender inn `undefined` som tema - og validerer det dersom fagsaktypen er institusjon. Se `useOpprettBehandling` linje 70

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Det velger du!

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<details>
<summary>Tilstander ved opprettelse av behandling</summary>
<h4>Tilstand ved åpning av "Opprett ny behandling"-modal for normalfagsak</h4>
<img width="424" alt="Screenshot 2022-11-02 at 11 44 13" src="https://user-images.githubusercontent.com/2379098/199480199-4c60e9ba-a408-4ca9-9c19-24dea1bc328d.png">
<h4>Tilstand ved åpning av "Opprett ny behandling"-modal for institusjonssak</h4>
<img width="388" alt="Screenshot 2022-11-02 at 11 44 22" src="https://user-images.githubusercontent.com/2379098/199480239-fc573220-7abe-4dbf-807f-91f28bd8d6b1.png">
</details>
<details>
<summary>Nasjonal institusjon er ikke et alternativ ved endring av behandlingstema</summary>
<img width="576" alt="Screenshot 2022-11-02 at 12 23 22" src="https://user-images.githubusercontent.com/2379098/199480422-0442231e-87d7-4daa-98e9-1d27a4cb97e3.png">

</details>