### PR TITLE
Håndter lesevisning i oppdater endringstidspunkt-modal

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
-import { Button } from '@navikt/ds-react';
+import { Button, Heading, Modal } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -13,10 +13,22 @@ import type { IBehandling } from '../../../../typer/behandling';
 import type { FamilieIsoDate } from '../../../../utils/kalender';
 import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import { FamilieDatovelgerWrapper } from '../../../../utils/skjema/FamilieDatovelgerWrapper';
-import UIModalWrapper from '../../../Felleskomponenter/Modal/UIModalWrapper';
 
 const Feltmargin = styled.div`
-    margin-bottom: 2rem;
+    margin: 2rem 0;
+`;
+
+const StyledModal = styled(Modal)`
+    width: 35rem;
+`;
+
+const KnappHøyre = styled(Button)`
+    margin-left: 1rem;
+`;
+
+const Knapperad = styled.div`
+    display: flex;
+    justify-content: center;
 `;
 
 interface IProps {
@@ -33,49 +45,56 @@ export const OppdaterEndringstidspunktModal: React.FC<IProps> = ({
     skjema,
 }) => {
     const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     return (
-        <UIModalWrapper
-            modal={{
-                tittel: 'Oppdater endringstidspunkt',
-                visModal: visModal,
-                lukkKnapp: true,
-                onClose: onAvbryt,
-                actions: [
-                    <Button
-                        variant={'tertiary'}
-                        key={'Avbryt'}
-                        size={'small'}
-                        onClick={onAvbryt}
-                        children={'Avbryt'}
-                    />,
-                    <Button
-                        variant={'primary'}
-                        key={'Oppdater'}
-                        size={'small'}
-                        onClick={oppdaterEndringstidspunkt}
-                        children={'Oppdater'}
-                        loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                        disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
-                    />,
-                ],
-            }}
-        >
-            <SkjemaGruppe
-                feil={hentFrontendFeilmelding(skjema.submitRessurs)}
-                utenFeilPropagering={true}
-            >
-                <Feltmargin>
-                    <FamilieDatovelgerWrapper
-                        {...skjema.felter.endringstidspunkt.hentNavInputProps(
-                            skjema.visFeilmeldinger
-                        )}
-                        valgtDato={skjema.felter.endringstidspunkt.verdi}
-                        label={'Endringstidspunkt'}
-                        placeholder={'DD.MM.ÅÅÅÅ'}
-                        erLesesvisning={vurderErLesevisning()}
-                    />
-                </Feltmargin>
-            </SkjemaGruppe>
-        </UIModalWrapper>
+        <StyledModal open={visModal} onClose={onAvbryt}>
+            <Modal.Content>
+                <Heading size="medium" level="2" spacing>
+                    Oppdater endringstidspunkt
+                </Heading>
+                <SkjemaGruppe
+                    feil={hentFrontendFeilmelding(skjema.submitRessurs)}
+                    utenFeilPropagering={true}
+                >
+                    <Feltmargin>
+                        <FamilieDatovelgerWrapper
+                            {...skjema.felter.endringstidspunkt.hentNavInputProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            valgtDato={skjema.felter.endringstidspunkt.verdi}
+                            label={'Endringstidspunkt'}
+                            placeholder={'DD.MM.ÅÅÅÅ'}
+                            erLesesvisning={erLesevisning}
+                        />
+                    </Feltmargin>
+                </SkjemaGruppe>
+                <Knapperad>
+                    {erLesevisning ? (
+                        <Button variant="primary" key="Lukk" size="small">
+                            Lukk
+                        </Button>
+                    ) : (
+                        <>
+                            <Button
+                                variant={'tertiary'}
+                                key={'Avbryt'}
+                                size={'small'}
+                                onClick={onAvbryt}
+                                children={'Avbryt'}
+                            />
+                            <KnappHøyre
+                                variant={'primary'}
+                                key={'Oppdater'}
+                                size={'small'}
+                                onClick={oppdaterEndringstidspunkt}
+                                children={'Oppdater'}
+                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                            />
+                        </>
+                    )}
+                </Knapperad>
+            </Modal.Content>
+        </StyledModal>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
@@ -15,7 +15,7 @@ import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import { FamilieDatovelgerWrapper } from '../../../../utils/skjema/FamilieDatovelgerWrapper';
 
 const Feltmargin = styled.div`
-    margin: 2rem 0;
+    margin: 1.5rem 0 2rem;
 `;
 
 const StyledModal = styled(Modal)`
@@ -28,7 +28,7 @@ const KnappHøyre = styled(Button)`
 
 const Knapperad = styled.div`
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
 `;
 
 interface IProps {
@@ -49,7 +49,7 @@ export const OppdaterEndringstidspunktModal: React.FC<IProps> = ({
     return (
         <StyledModal open={visModal} onClose={onAvbryt}>
             <Modal.Content>
-                <Heading size="medium" level="2" spacing>
+                <Heading size="medium" level="2">
                     Oppdater endringstidspunkt
                 </Heading>
                 <SkjemaGruppe
@@ -70,26 +70,24 @@ export const OppdaterEndringstidspunktModal: React.FC<IProps> = ({
                 </SkjemaGruppe>
                 <Knapperad>
                     {erLesevisning ? (
-                        <Button variant="primary" key="Lukk" size="small">
+                        <Button variant="primary" key="Lukk">
                             Lukk
                         </Button>
                     ) : (
                         <>
                             <Button
-                                variant={'tertiary'}
-                                key={'Avbryt'}
-                                size={'small'}
-                                onClick={onAvbryt}
-                                children={'Avbryt'}
-                            />
-                            <KnappHøyre
                                 variant={'primary'}
                                 key={'Oppdater'}
-                                size={'small'}
                                 onClick={oppdaterEndringstidspunkt}
                                 children={'Oppdater'}
                                 loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                                 disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                            />
+                            <KnappHøyre
+                                variant={'tertiary'}
+                                key={'Avbryt'}
+                                onClick={onAvbryt}
+                                children={'Avbryt'}
                             />
                         </>
                     )}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
@@ -8,6 +8,7 @@ import { Button } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import type { IBehandling } from '../../../../typer/behandling';
 import type { FamilieIsoDate } from '../../../../utils/kalender';
 import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
@@ -31,6 +32,7 @@ export const OppdaterEndringstidspunktModal: React.FC<IProps> = ({
     oppdaterEndringstidspunkt,
     skjema,
 }) => {
+    const { vurderErLesevisning } = useBehandling();
     return (
         <UIModalWrapper
             modal={{
@@ -70,6 +72,7 @@ export const OppdaterEndringstidspunktModal: React.FC<IProps> = ({
                         valgtDato={skjema.felter.endringstidspunkt.verdi}
                         label={'Endringstidspunkt'}
                         placeholder={'DD.MM.ÅÅÅÅ'}
+                        erLesesvisning={vurderErLesevisning()}
                     />
                 </Feltmargin>
             </SkjemaGruppe>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10467
Gunn oppdaget at **_Oppdater endringstidspunkt_** ikke forholder seg til lesevisning. Legger til evaluering av lesevisning og oppgraderer modalkomponenten

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Jeg skal ta en avsjekk med Gunn om de visuelle justeringene. Har basert dem på valgene hun har tatt for modalen i **OpprettBehandling.tsx**

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<details><summary>Før, uansett om det er lesevisning eller ikke</summary>
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/2379098/203428818-529e1517-568a-4149-8b47-b3f8ebc98627.png">

</details>
<details><summary>Etter, ikke lesevisning</summary>
<img width="651" alt="image" src="https://user-images.githubusercontent.com/2379098/203511669-5b7ab2c8-06c3-4a84-9f17-592d1e3122f8.png">

</details>
<details><summary>Etter, lesevisning</summary>
<img width="593" alt="image" src="https://user-images.githubusercontent.com/2379098/203508837-07e92487-9f02-4273-95c5-e281b4570074.png">

</details>
