### PR TITLE
TEA-3821 Skal kunne registrere at behandlingen er ein korrigering av tidligare vedtak

### DIFF
--- a/src/frontend/context/KorrigerVedtak/KorrigerVedtakSkjemaContext.ts
+++ b/src/frontend/context/KorrigerVedtak/KorrigerVedtakSkjemaContext.ts
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+
+import {
+    feil,
+    type FeltState,
+    ok,
+    useFelt,
+    useSkjema,
+    Valideringsstatus,
+} from '@navikt/familie-skjema';
+import { byggHenterRessurs, type Ressurs, RessursStatus } from '@navikt/familie-typer';
+
+import type { IBehandling } from '../../typer/behandling';
+import type { IRestKorrigertVedtak } from '../../typer/vedtak';
+import { isEmpty } from '../../utils/eøsValidators';
+import { useBehandling } from '../behandlingContext/BehandlingContext';
+
+interface IProps {
+    onSuccess: () => void;
+    behandlingId: number;
+    korrigertVedtak?: IRestKorrigertVedtak;
+}
+
+const erVedtaksdatoGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> =>
+    !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Dato for vedtaket med feil er påkrevd');
+
+export const useKorrigerVedtakSkjemaContext = ({
+    behandlingId,
+    korrigertVedtak,
+    onSuccess,
+}: IProps) => {
+    const { settÅpenBehandling } = useBehandling();
+    const [restFeil, settRestFeil] = useState<string | undefined>(undefined);
+
+    const {
+        skjema,
+        valideringErOk,
+        kanSendeSkjema,
+        settVisfeilmeldinger,
+        onSubmit,
+        nullstillSkjema,
+        settSubmitRessurs,
+        validerAlleSynligeFelter,
+    } = useSkjema<
+        {
+            vedtaksdato: string | undefined;
+            begrunnelse: string;
+        },
+        IBehandling
+    >({
+        felter: {
+            vedtaksdato: useFelt<string | undefined>({
+                verdi: korrigertVedtak?.vedtaksdato,
+                valideringsfunksjon: erVedtaksdatoGyldig,
+            }),
+            begrunnelse: useFelt<string>({
+                verdi: korrigertVedtak?.begrunnelse || '',
+                valideringsfunksjon: (felt: FeltState<string>): FeltState<string> => ok(felt),
+            }),
+        },
+        skjemanavn: 'korriger-vedtak-skjema',
+    });
+
+    useEffect(() => {
+        nullstillSkjema();
+    }, [korrigertVedtak?.vedtaksdato, korrigertVedtak?.begrunnelse]);
+
+    const valideringsstatuser = [
+        skjema.felter.vedtaksdato.valideringsstatus,
+        skjema.felter.begrunnelse.valideringsstatus,
+    ];
+
+    useEffect(() => {
+        if (
+            valideringsstatuser.some(
+                valideringsstatus => valideringsstatus === Valideringsstatus.IKKE_VALIDERT
+            )
+        ) {
+            validerAlleSynligeFelter();
+        }
+    }, [valideringsstatuser]);
+
+    const korrigertVedtakURL = `/familie-ba-sak/api/korrigertvedtak/behandling/${behandlingId}`;
+
+    const lagreKorrigertVedtak = () => {
+        if (kanSendeSkjema()) {
+            settVisfeilmeldinger(false);
+            settSubmitRessurs(byggHenterRessurs());
+            onSubmit(
+                {
+                    method: 'POST',
+                    data: {
+                        vedtaksdato: skjema.felter.vedtaksdato.verdi,
+                        begrunnelse: skjema.felter.begrunnelse.verdi,
+                    },
+                    url: korrigertVedtakURL,
+                },
+                (response: Ressurs<IBehandling>) => {
+                    if (response.status === RessursStatus.SUKSESS) {
+                        settRestFeil(undefined);
+                        onSuccess();
+                        nullstillSkjema();
+                        settÅpenBehandling(response);
+                    }
+                },
+                (error: Ressurs<IBehandling>) => {
+                    if (
+                        error.status === RessursStatus.FEILET ||
+                        error.status === RessursStatus.FUNKSJONELL_FEIL
+                    ) {
+                        settRestFeil(error.frontendFeilmelding);
+                    } else {
+                        settRestFeil('Teknisk feil ved lagring av korrigert vedtak');
+                    }
+                }
+            );
+        } else {
+            settVisfeilmeldinger(true);
+        }
+    };
+
+    const angreKorrigering = () => {
+        onSubmit(
+            {
+                method: 'PATCH',
+                url: korrigertVedtakURL,
+            },
+            (response: Ressurs<IBehandling>) => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    settRestFeil(undefined);
+                    onSuccess();
+                    nullstillSkjema();
+                    settÅpenBehandling(response);
+                }
+            },
+            () => {
+                settRestFeil('Teknisk feil ved fjerning av korrigert vedtak');
+            }
+        );
+    };
+
+    return {
+        skjema,
+        valideringErOk,
+        lagreKorrigertVedtak,
+        nullstillSkjema,
+        restFeil,
+        angreKorrigering,
+        settVisfeilmeldinger,
+        settRestFeil,
+    };
+};

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetaling.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetaling.tsx
@@ -22,17 +22,16 @@ interface IKorrigerEtterbetaling {
 
 const Knapperad = styled.div`
     width: 100%;
-    position: relative;
-    display: inline-block;
+    display: flex;
+    justify-content: space-between;
 `;
 
 const AngreKnapp = styled(Button)`
-    margin: 0.5rem 1rem 0.5rem 0rem;
+    margin: 0.5rem 0rem;
 `;
 
-const KnappHøyre = styled(Button)`
-    float: right;
-    margin-left: 1rem;
+const KnappVenstre = styled(Button)`
+    margin-right: 1rem;
 `;
 
 const baseSkjemaelementStyle = css`
@@ -59,17 +58,11 @@ const StyledSkjema = styled(SkjemaGruppe)`
 `;
 
 const StyledModalContent = styled(Modal.Content)`
-    padding: 2.5rem;
     width: 35rem;
 `;
 
 const StyledModalHeader = styled(Heading)`
     margin-bottom: 2rem;
-`;
-
-const LukkKnapp = styled(Button)`
-    margin: 0 auto;
-    display: block;
 `;
 
 const KorrigerEtterbetaling: React.FC<IKorrigerEtterbetaling> = ({
@@ -205,35 +198,45 @@ const KorrigerEtterbetaling: React.FC<IKorrigerEtterbetaling> = ({
                             </>
                         )}
                     </StyledSkjema>
-                    {!erLesevisning && (
-                        <Knapperad>
-                            {visAngreKorrigering && (
-                                <AngreKnapp
-                                    id={'angre-korrigering'}
-                                    size={'small'}
-                                    onClick={angreKorrigering}
-                                    variant={'tertiary'}
-                                    loading={angrerKorrigering}
-                                    disabled={angrerKorrigering}
-                                    icon={<Cancel />}
-                                >
-                                    Angre korrigering
-                                </AngreKnapp>
-                            )}
-                            <KnappHøyre
-                                onClick={lagreKorrigering}
-                                variant={valideringErOk() ? 'primary' : 'secondary'}
-                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            >
-                                {korrigertEtterbetaling ? 'Oppdater' : 'Korriger beløp'}
-                            </KnappHøyre>
-                            <KnappHøyre onClick={lukkModal} variant={'tertiary'}>
-                                Avbryt
-                            </KnappHøyre>
-                        </Knapperad>
-                    )}
-                    {erLesevisning && <LukkKnapp onClick={lukkModal}>Lukk</LukkKnapp>}
+                    <Knapperad>
+                        {!erLesevisning && (
+                            <>
+                                <div>
+                                    <KnappVenstre
+                                        onClick={lagreKorrigering}
+                                        variant={valideringErOk() ? 'primary' : 'secondary'}
+                                        loading={
+                                            skjema.submitRessurs.status === RessursStatus.HENTER
+                                        }
+                                        disabled={
+                                            skjema.submitRessurs.status === RessursStatus.HENTER
+                                        }
+                                    >
+                                        {korrigertEtterbetaling ? 'Oppdater' : 'Korriger beløp'}
+                                    </KnappVenstre>
+                                    <Button onClick={lukkModal} variant={'tertiary'}>
+                                        Avbryt
+                                    </Button>
+                                </div>
+                                <div>
+                                    {visAngreKorrigering && (
+                                        <AngreKnapp
+                                            id={'angre-korrigering'}
+                                            size={'small'}
+                                            onClick={angreKorrigering}
+                                            variant={'tertiary'}
+                                            loading={angrerKorrigering}
+                                            disabled={angrerKorrigering}
+                                            icon={<Cancel />}
+                                        >
+                                            Angre korrigering
+                                        </AngreKnapp>
+                                    )}
+                                </div>
+                            </>
+                        )}
+                        {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
+                    </Knapperad>
                 </StyledModalContent>
             </Modal>
         </>

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -18,26 +18,19 @@ import { datoformatNorsk } from '../../../../utils/formatter';
 
 const Knapperad = styled.div`
     width: 100%;
-    display: inline-block;
+    display: flex;
+    justify-content: space-between;
 `;
 
 const KnappVenstre = styled(Button)`
-    float: left;
     margin-right: 1rem;
 `;
 
 const AngreKnapp = styled(Button)`
     margin: 0.5rem 0rem;
-    float: right;
-`;
-
-const LukkKnapp = styled(Button)`
-    margin: 0 auto;
-    display: block;
 `;
 
 const StyledModalContent = styled(Modal.Content)`
-    padding: 2.5rem;
     width: 40rem;
 `;
 
@@ -155,34 +148,48 @@ const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
                             </Alert>
                         )}
                     </div>
-                    {!erLesevisning && (
-                        <Knapperad>
-                            <KnappVenstre
-                                onClick={lagreKorrigertVedtak}
-                                variant={valideringErOk() ? 'primary' : 'secondary'}
-                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            >
-                                {korrigertVedtak ? 'Oppdater' : 'Legg til'}
-                            </KnappVenstre>
-                            <KnappVenstre onClick={lukkModal} variant={'tertiary'}>
-                                Avbryt
-                            </KnappVenstre>
-                            {visAngreKnapp && (
-                                <AngreKnapp
-                                    size={'small'}
-                                    onClick={angreKorrigering}
-                                    variant={'tertiary'}
-                                    loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                    disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                    icon={<Cancel />}
-                                >
-                                    Fjern korrigering
-                                </AngreKnapp>
-                            )}
-                        </Knapperad>
-                    )}
-                    {erLesevisning && <LukkKnapp onClick={lukkModal}>Lukk</LukkKnapp>}
+                    <Knapperad>
+                        {!erLesevisning && (
+                            <>
+                                <div>
+                                    <KnappVenstre
+                                        onClick={lagreKorrigertVedtak}
+                                        variant={valideringErOk() ? 'primary' : 'secondary'}
+                                        loading={
+                                            skjema.submitRessurs.status === RessursStatus.HENTER
+                                        }
+                                        disabled={
+                                            skjema.submitRessurs.status === RessursStatus.HENTER
+                                        }
+                                    >
+                                        {korrigertVedtak ? 'Oppdater' : 'Legg til'}
+                                    </KnappVenstre>
+                                    <Button onClick={lukkModal} variant={'tertiary'}>
+                                        Avbryt
+                                    </Button>
+                                </div>
+                                <div>
+                                    {visAngreKnapp && (
+                                        <AngreKnapp
+                                            size={'small'}
+                                            onClick={angreKorrigering}
+                                            variant={'tertiary'}
+                                            loading={
+                                                skjema.submitRessurs.status === RessursStatus.HENTER
+                                            }
+                                            disabled={
+                                                skjema.submitRessurs.status === RessursStatus.HENTER
+                                            }
+                                            icon={<Cancel />}
+                                        >
+                                            Fjern korrigering
+                                        </AngreKnapp>
+                                    )}
+                                </div>
+                            </>
+                        )}
+                        {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
+                    </Knapperad>
                 </StyledModalContent>
             </Modal>
         </>

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -1,0 +1,192 @@
+import * as React from 'react';
+
+import styled, { css } from 'styled-components';
+
+import { Cancel, Warning } from '@navikt/ds-icons';
+import { Alert, BodyLong, Button, Heading, Modal } from '@navikt/ds-react';
+import { Dropdown } from '@navikt/ds-react-internal';
+import {
+    FamilieDatovelger,
+    FamilieTextarea,
+    type ISODateString,
+} from '@navikt/familie-form-elements';
+import { RessursStatus } from '@navikt/familie-typer';
+
+import { useKorrigerVedtakSkjemaContext } from '../../../../context/KorrigerVedtak/KorrigerVedtakSkjemaContext';
+import type { IRestKorrigertVedtak } from '../../../../typer/vedtak';
+import { datoformatNorsk } from '../../../../utils/formatter';
+
+const Knapperad = styled.div`
+    width: 100%;
+    display: inline-block;
+`;
+
+const KnappVenstre = styled(Button)`
+    float: left;
+    margin-right: 1rem;
+`;
+
+const AngreKnapp = styled(Button)`
+    margin: 0.5rem 0rem;
+    float: right;
+`;
+
+const LukkKnapp = styled(Button)`
+    margin: 0 auto;
+    display: block;
+`;
+
+const StyledModalContent = styled(Modal.Content)`
+    padding: 2.5rem;
+    width: 40rem;
+`;
+
+const baseSkjemaelementStyle = css`
+    margin-bottom: 1.5rem;
+`;
+
+const StyledFamilieDatovelger = styled(FamilieDatovelger)`
+    ${baseSkjemaelementStyle}
+`;
+
+const StyledFamilieTextarea = styled(FamilieTextarea)`
+    ${baseSkjemaelementStyle}
+`;
+
+interface IKorrigerVedtak {
+    korrigertVedtak?: IRestKorrigertVedtak;
+    behandlingId: number;
+    erLesevisning: boolean;
+}
+
+const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
+    korrigertVedtak,
+    behandlingId,
+    erLesevisning,
+}) => {
+    const [visModal, settVisModal] = React.useState<boolean>(false);
+
+    const {
+        skjema,
+        valideringErOk,
+        lagreKorrigertVedtak,
+        nullstillSkjema,
+        angreKorrigering,
+        settVisfeilmeldinger,
+        settRestFeil,
+        restFeil,
+    } = useKorrigerVedtakSkjemaContext({
+        onSuccess: () => settVisModal(false),
+        korrigertVedtak,
+        behandlingId,
+    });
+
+    const lukkModal = () => {
+        nullstillSkjema();
+        settVisfeilmeldinger(false);
+        settRestFeil(undefined);
+        settVisModal(false);
+    };
+
+    const visAngreKnapp = korrigertVedtak != null;
+
+    return (
+        <>
+            <Dropdown.Menu.List.Item
+                onClick={() => {
+                    settVisModal(true);
+                }}
+            >
+                <Warning />
+                {korrigertVedtak ? <>Vis korrigert vedtak</> : <>Korriger vedtak</>}
+            </Dropdown.Menu.List.Item>
+            <Modal open={visModal} onClose={lukkModal}>
+                <StyledModalContent>
+                    <Heading size="medium" level={'2'} spacing>
+                        Korriger vedtak
+                    </Heading>
+                    <div>
+                        <BodyLong>
+                            Dersom det har blitt gjort feil tidligere vedtak, kan denne teksten
+                            legges til i vedtaksbrevet:
+                        </BodyLong>
+                        <ul>
+                            <li>
+                                Vi har oppdaget en feil i vedtaket vi gjorde [DATO]. Derfor har vi
+                                vurdert saken din på nytt.
+                            </li>
+                        </ul>
+                        <StyledFamilieDatovelger
+                            {...skjema.felter.vedtaksdato?.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            id={'korriger-vedtak-dato'}
+                            label={'Vedtaksdato'}
+                            erLesesvisning={erLesevisning}
+                            value={skjema.felter.vedtaksdato.verdi}
+                            placeholder={datoformatNorsk.DATO}
+                            onChange={(dato?: ISODateString) =>
+                                skjema.felter.vedtaksdato?.validerOgSettFelt(dato)
+                            }
+                            valgtDato={
+                                skjema.felter.vedtaksdato?.verdi !== null
+                                    ? skjema.felter.vedtaksdato?.verdi
+                                    : undefined
+                            }
+                        />
+                        <StyledFamilieTextarea
+                            {...skjema.felter.begrunnelse?.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            id={'korriger-vedtak-begrunnelse'}
+                            label={'Begrunnelse (valgfri)'}
+                            description={'Begrunn hva som er gjort feil i tidligere vedtak'}
+                            erLesevisning={erLesevisning}
+                            value={skjema.felter.begrunnelse.verdi}
+                            onChange={changeEvent =>
+                                skjema.felter.begrunnelse.validerOgSettFelt(
+                                    changeEvent.target.value
+                                )
+                            }
+                        />
+                        {restFeil && (
+                            <Alert variant="error" style={{ marginBottom: '1.5rem' }} inline>
+                                {restFeil}
+                            </Alert>
+                        )}
+                    </div>
+                    {!erLesevisning && (
+                        <Knapperad>
+                            <KnappVenstre
+                                onClick={lagreKorrigertVedtak}
+                                variant={valideringErOk() ? 'primary' : 'secondary'}
+                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                            >
+                                {korrigertVedtak ? 'Oppdater' : 'Legg til'}
+                            </KnappVenstre>
+                            <KnappVenstre onClick={lukkModal} variant={'tertiary'}>
+                                Avbryt
+                            </KnappVenstre>
+                            {visAngreKnapp && (
+                                <AngreKnapp
+                                    size={'small'}
+                                    onClick={angreKorrigering}
+                                    variant={'tertiary'}
+                                    loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                    disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                    icon={<Cancel />}
+                                >
+                                    Fjern korrigering
+                                </AngreKnapp>
+                            )}
+                        </Knapperad>
+                    )}
+                    {erLesevisning && <LukkKnapp onClick={lukkModal}>Lukk</LukkKnapp>}
+                </StyledModalContent>
+            </Modal>
+        </>
+    );
+};
+
+export default KorrigerVedtak;

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -40,7 +40,7 @@ const StyledSkjemaSteg = styled(Skjemasteg)`
     }
 `;
 
-const KorrigertEtterbetalingsbeløpAlert = styled(Alert)`
+const BehandlingKorrigertAlert = styled(Alert)`
     margin-bottom: 1.5rem;
 `;
 
@@ -163,9 +163,14 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                     />
                     <div>
                         {åpenBehandling.korrigertEtterbetaling && (
-                            <KorrigertEtterbetalingsbeløpAlert variant="info">
+                            <BehandlingKorrigertAlert variant="info">
                                 Etterbetalingsbeløp i brevet er manuelt korrigert
-                            </KorrigertEtterbetalingsbeløpAlert>
+                            </BehandlingKorrigertAlert>
+                        )}
+                        {åpenBehandling.korrigertVedtak && (
+                            <BehandlingKorrigertAlert variant="info">
+                                Vedtaket er korrigert etter § 35
+                            </BehandlingKorrigertAlert>
                         )}
                         {åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && (
                             <FamilieSelect

--- a/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksmeny.tsx
@@ -7,9 +7,12 @@ import { Button } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
 import { NavdsSpacing10 } from '@navikt/ds-tokens/dist/tokens';
 
+import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import type { IBehandling } from '../../../typer/behandling';
+import { ToggleNavn } from '../../../typer/toggles';
 import KorrigerEtterbetaling from './KorrigerEtterbetaling/KorrigerEtterbetaling';
+import KorrigerVedtak from './KorrigerVedtakModal/KorrigerVedtak';
 import EndreEndringstidspunkt from './VedtakBegrunnelserTabell/EndreEndringstidspunkt';
 
 interface IVedtakmenyProps {
@@ -32,6 +35,7 @@ const Vedtaksmeny: React.FunctionComponent<IVedtakmenyProps> = ({
     erBehandlingMedVedtaksbrevutsending,
 }) => {
     const { vurderErLesevisning } = useBehandling();
+    const { toggles } = useApp();
 
     return (
         <Dropdown>
@@ -47,11 +51,21 @@ const Vedtaksmeny: React.FunctionComponent<IVedtakmenyProps> = ({
             <StyledDropdownMeny>
                 <Dropdown.Menu.List>
                     {erBehandlingMedVedtaksbrevutsending && (
-                        <KorrigerEtterbetaling
-                            erLesevisning={vurderErLesevisning()}
-                            korrigertEtterbetaling={åpenBehandling.korrigertEtterbetaling}
-                            behandlingId={åpenBehandling.behandlingId}
-                        />
+                        <>
+                            <KorrigerEtterbetaling
+                                erLesevisning={vurderErLesevisning()}
+                                korrigertEtterbetaling={åpenBehandling.korrigertEtterbetaling}
+                                behandlingId={åpenBehandling.behandlingId}
+                            />
+                            {(toggles[ToggleNavn.kunneKorrigereVedtak] ||
+                                åpenBehandling.korrigertVedtak) && (
+                                <KorrigerVedtak
+                                    erLesevisning={vurderErLesevisning()}
+                                    korrigertVedtak={åpenBehandling.korrigertVedtak}
+                                    behandlingId={åpenBehandling.behandlingId}
+                                />
+                            )}
+                        </>
                     )}
                     {åpenBehandling.endringstidspunkt && (
                         <EndreEndringstidspunkt åpenBehandling={åpenBehandling} />

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -16,7 +16,11 @@ import type {
 } from './tilbakekrevingsbehandling';
 import type { ITotrinnskontroll } from './totrinnskontroll';
 import type { IRestEndretUtbetalingAndel } from './utbetalingAndel';
-import type { IRestKorrigertEtterbetaling, IVedtakForBehandling } from './vedtak';
+import type {
+    IRestKorrigertEtterbetaling,
+    IRestKorrigertVedtak,
+    IVedtakForBehandling,
+} from './vedtak';
 import type { Utbetalingsperiode } from './vedtaksperiode';
 import type { IRestPersonResultat, IRestStegTilstand } from './vilkår';
 
@@ -247,6 +251,7 @@ export interface IBehandling {
     valutakurser: IRestValutakurs[];
     verge?: IVerge;
     korrigertEtterbetaling?: IRestKorrigertEtterbetaling;
+    korrigertVedtak?: IRestKorrigertVedtak;
 }
 
 export interface IArbeidsfordelingPåBehandling {

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -9,6 +9,7 @@ export enum ToggleNavn {
     tekniskVedlikeholdHenleggelse = 'familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring',
     endreMottakerEndringsårsaker = 'familie-ba-sak.behandling.endringsperiode.endre-mottaker-aarsaker.utgivelse',
     støtterInstitusjon = 'familie-ba-sak.stotter-institusjon',
+    kunneKorrigereVedtak = 'familie-ba-sak.kunne-korrigere-vedtak',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -91,3 +91,8 @@ export enum KorrigertEtterbetalingÅrsak {
     REFUSJON_FRA_ANDRE_MYNDIGHETER = 'REFUSJON_FRA_ANDRE_MYNDIGHETER',
     MOTREGNING = 'MOTREGNING',
 }
+
+export interface IRestKorrigertVedtak {
+    vedtaksdato: string;
+    begrunnelse: string | undefined;
+}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Saksbehandler må kunne registrere at behandlingen og vedtaket korrigerer tidligare vedtak. Saksbehandler må registrere datoen for det korrigerte vedtaket, og kan skrive ein begrunnelse til at vedtaket blir korrigert.

Favro-kort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-3821

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Funksjonaliteten er gjøymt bak togglen familie-ba-sak.kunne-korrigere-vedtak inntil integrasjon mot dvh er avklart og implementert.
Gunn fikk snike med ein liten quick-win endring i KorrigerEtterbetaling-modalen. Knappane er blitt flyttet litt på.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
**_Ny knapp i vedtaksmenyen:_**
<img width="421" alt="Skjermbilde 2022-11-24 kl  12 42 11" src="https://user-images.githubusercontent.com/58559732/203779161-f342bc2a-8a08-4734-80a8-22d3b687b191.png">


**_Ny modal for å kunne korrigere vedtak:_**
<img width="629" alt="Skjermbilde 2022-11-24 kl  12 42 20" src="https://user-images.githubusercontent.com/58559732/203779195-4213247f-e31a-4633-9bb4-4566ff22cf79.png">

<img width="610" alt="Skjermbilde 2022-11-24 kl  12 46 02" src="https://user-images.githubusercontent.com/58559732/203779213-c4243acc-a2cf-413d-b3d1-d1ba14e56b89.png">


**_Lesevisning:_**
<img width="610" alt="Skjermbilde 2022-11-24 kl  12 49 59" src="https://user-images.githubusercontent.com/58559732/203779924-f8897a06-df53-48b3-b6a8-a0d503a8fa48.png">


**_Ny alert i vedtaksbildet:_**
<img width="766" alt="Skjermbilde 2022-11-24 kl  12 45 52" src="https://user-images.githubusercontent.com/58559732/203779439-3134010c-398c-488b-83e8-2358251ca4de.png">


**_Historikkinnslag korrigering av vedtak:_**
<img width="364" alt="Skjermbilde 2022-11-24 kl  12 53 49" src="https://user-images.githubusercontent.com/58559732/203779472-d85366fd-0656-48af-8c5d-b3010b02ccf8.png">


**Flytting av knapper korriger etterbetaling:**
_Før:_
<img width="573" alt="Skjermbilde 2022-11-24 kl  12 58 33" src="https://user-images.githubusercontent.com/58559732/203779824-56057d5b-336a-4868-9671-8de190e0774b.png">


_Etter:_
<img width="521" alt="Skjermbilde 2022-11-24 kl  12 48 14" src="https://user-images.githubusercontent.com/58559732/203779850-6576994a-5ae0-4e10-8284-1b293685e593.png">


