### PR TITLE
Fikser z-index for utdypende vilkårsvurdering

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -175,7 +175,7 @@ export const UtdypendeVilkårsvurderingMultiselect: React.FC<Props> = ({
             propSelectStyles={{
                 menu: provided => ({
                     ...provided,
-                    ZIndex: '3',
+                    zIndex: 3,
                 }),
             }}
             creatable={false}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Select for utdypende vilkårsvurdering legger seg ikke lenger bak datovelger-knapper

Før:
![image](https://user-images.githubusercontent.com/70642183/202659270-368bb7c2-4ef3-4a66-ad3e-e844e80db217.png)

Etter:
![image](https://user-images.githubusercontent.com/70642183/202659369-c931819f-aa9c-4d97-9c87-721c4b312fc6.png)

