### PR TITLE
Støtte for manuell migrering av flere sakstyper

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -19,17 +19,18 @@ interface IProps {
 }
 
 const Knapperad = styled.div`
-    margin-top: 2rem;
+    margin-top: 2.5rem;
+    width: 100%;
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
 `;
 
 const StyledModal = styled(Modal)`
     width: 35rem;
 `;
 
-const KnappHøyre = styled(Button)`
-    margin-left: 1rem;
+const KnappVenstre = styled(Button)`
+    margin-right: 1rem;
 `;
 
 const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
@@ -43,6 +44,7 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
         nullstillSkjemaStatus,
         bruker,
         maksdatoForMigrering,
+        valideringErOk,
     } = useOpprettBehandling(
         minimalFagsak.id,
         () => settVisModal(false),
@@ -97,31 +99,33 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                         />
                     </SkjemaGruppe>
                     <Knapperad>
-                        <Button
-                            key={'avbryt'}
-                            variant="tertiary"
-                            onClick={lukkOpprettBehandlingModal}
-                            children={'Avbryt'}
-                        />
-                        <KnappHøyre
-                            key={'bekreft'}
-                            variant="primary"
-                            onClick={() =>
-                                onBekreft(
-                                    minimalFagsak.søkerFødselsnummer,
-                                    minimalFagsak.fagsakType
-                                )
-                            }
-                            children={'Bekreft'}
-                            loading={
-                                opprettBehandlingSkjema.submitRessurs.status ===
-                                RessursStatus.HENTER
-                            }
-                            disabled={
-                                opprettBehandlingSkjema.submitRessurs.status ===
-                                RessursStatus.HENTER
-                            }
-                        />
+                        <div>
+                            <KnappVenstre
+                                key={'bekreft'}
+                                variant={valideringErOk() ? 'primary' : 'secondary'}
+                                onClick={() =>
+                                    onBekreft(
+                                        minimalFagsak.søkerFødselsnummer,
+                                        minimalFagsak.fagsakType
+                                    )
+                                }
+                                children={'Bekreft'}
+                                loading={
+                                    opprettBehandlingSkjema.submitRessurs.status ===
+                                    RessursStatus.HENTER
+                                }
+                                disabled={
+                                    opprettBehandlingSkjema.submitRessurs.status ===
+                                    RessursStatus.HENTER
+                                }
+                            />
+                            <Button
+                                key={'avbryt'}
+                                variant="tertiary"
+                                onClick={lukkOpprettBehandlingModal}
+                                children={'Avbryt'}
+                            />
+                        </div>
                     </Knapperad>
                 </Modal.Content>
             </StyledModal>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -37,15 +37,20 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
     const [visBekreftelseTilbakekrevingModal, settVisBekreftelseTilbakekrevingModal] =
         useState(false);
 
-    const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus, bruker } =
-        useOpprettBehandling(
-            minimalFagsak.id,
-            () => settVisModal(false),
-            () => {
-                settVisModal(false);
-                settVisBekreftelseTilbakekrevingModal(true);
-            }
-        );
+    const {
+        onBekreft,
+        opprettBehandlingSkjema,
+        nullstillSkjemaStatus,
+        bruker,
+        maksdatoForMigrering,
+    } = useOpprettBehandling(
+        minimalFagsak.id,
+        () => settVisModal(false),
+        () => {
+            settVisModal(false);
+            settVisBekreftelseTilbakekrevingModal(true);
+        }
+    );
     const {
         behandlingsårsak,
         behandlingstype,
@@ -83,6 +88,7 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                             behandlingsårsak={behandlingsårsak}
                             behandlingstema={behandlingstema}
                             migreringsdato={migreringsdato}
+                            maksdatoForMigrering={maksdatoForMigrering().toISOString()}
                             søknadMottattDato={søknadMottattDato}
                             minimalFagsak={minimalFagsak}
                             visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import navFarger from 'nav-frontend-core';
-
 import { BodyShort } from '@navikt/ds-react';
 import type { FormatOptionLabelMeta, ISelectOption } from '@navikt/familie-form-elements';
 import {
@@ -44,12 +42,6 @@ const FixedDatoVelger = styled(FamilieDatovelger)`
     margin-top: 2rem;
 `;
 
-const FeltFeilmelding = styled(BodyShort)`
-    margin-top: 0.5rem;
-    font-weight: 600;
-    color: ${navFarger.redError};
-`;
-
 const StyledFamilieSelect = styled(FamilieSelect)`
     label {
         margin-top: 2rem;
@@ -66,6 +58,7 @@ const StyledFamilieReactSelect = styled(FamilieReactSelect)`
     label {
         margin-top: 2rem;
     }
+    margin-bottom: -1rem;
 `;
 
 interface IProps {
@@ -80,6 +73,7 @@ interface IProps {
     manuellJournalfør?: boolean;
     bruker?: IPersonInfo | undefined;
     valgteBarn?: Felt<ISelectOption[]> | undefined;
+    maksdatoForMigrering?: FamilieIsoDate | undefined;
 }
 
 interface BehandlingstypeSelect extends HTMLSelectElement {
@@ -102,6 +96,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
     manuellJournalfør = false,
     bruker = undefined,
     valgteBarn = undefined,
+    maksdatoForMigrering = undefined,
 }) => {
     const { toggles } = useApp();
     const aktivBehandling: VisningBehandling | undefined = minimalFagsak
@@ -262,16 +257,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                 </StyledFamilieSelect>
             )}
 
-            {behandlingstema.erSynlig && (
-                <StyledBehandlingstemaSelect
-                    behandlingstema={behandlingstema}
-                    erLesevisning={erLesevisning}
-                    visFeilmeldinger={visFeilmeldinger}
-                    name="Behandlingstema"
-                    label="Velg behandlingstema"
-                />
-            )}
-
             {erHelmanuellMigrering && valgteBarn?.erSynlig && (
                 <StyledFamilieReactSelect
                     {...valgteBarn.hentNavInputProps(visFeilmeldinger)}
@@ -302,37 +287,39 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                 />
             )}
 
+            {behandlingstema.erSynlig && (
+                <StyledBehandlingstemaSelect
+                    behandlingstema={behandlingstema}
+                    erLesevisning={erLesevisning}
+                    visFeilmeldinger={visFeilmeldinger}
+                    name="Behandlingstema"
+                    label="Velg behandlingstema"
+                />
+            )}
+
             {erMigreringFraInfotrygd && migreringsdato?.erSynlig && (
-                <>
-                    <FixedDatoVelger
-                        {...migreringsdato.hentNavInputProps(visFeilmeldinger)}
-                        valgtDato={migreringsdato.verdi}
-                        label={'Ny migreringsdato'}
-                        placeholder={'DD.MM.ÅÅÅÅ'}
-                        limitations={{
-                            maxDate: new Date().toISOString(),
-                        }}
-                    />
-                    {migreringsdato.feilmelding && visFeilmeldinger && (
-                        <FeltFeilmelding>{migreringsdato.feilmelding}</FeltFeilmelding>
-                    )}
-                </>
+                <FixedDatoVelger
+                    {...migreringsdato.hentNavInputProps(visFeilmeldinger)}
+                    valgtDato={migreringsdato.verdi}
+                    label={'Ny migreringsdato'}
+                    placeholder={'DD.MM.ÅÅÅÅ'}
+                    limitations={{
+                        maxDate: maksdatoForMigrering,
+                    }}
+                    feil={migreringsdato.feilmelding}
+                />
             )}
             {søknadMottattDato?.erSynlig && (
-                <>
-                    <FixedDatoVelger
-                        {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}
-                        valgtDato={søknadMottattDato.verdi}
-                        label={'Mottatt dato'}
-                        placeholder={'DD.MM.ÅÅÅÅ'}
-                        limitations={{
-                            maxDate: new Date().toISOString(),
-                        }}
-                    />
-                    {søknadMottattDato.feilmelding && visFeilmeldinger && (
-                        <FeltFeilmelding>{søknadMottattDato.feilmelding}</FeltFeilmelding>
-                    )}
-                </>
+                <FixedDatoVelger
+                    {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}
+                    valgtDato={søknadMottattDato.verdi}
+                    label={'Mottatt dato'}
+                    placeholder={'DD.MM.ÅÅÅÅ'}
+                    limitations={{
+                        maxDate: new Date().toISOString(),
+                    }}
+                    feil={søknadMottattDato.feilmelding}
+                />
             )}
         </>
     );

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -46,6 +46,7 @@ const StyledFamilieSelect = styled(FamilieSelect)`
     label {
         margin-top: 2rem;
     }
+    margin-bottom: 1rem;
 `;
 
 const StyledBehandlingstemaSelect = styled(BehandlingstemaSelect)`
@@ -287,16 +288,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                 />
             )}
 
-            {behandlingstema.erSynlig && (
-                <StyledBehandlingstemaSelect
-                    behandlingstema={behandlingstema}
-                    erLesevisning={erLesevisning}
-                    visFeilmeldinger={visFeilmeldinger}
-                    name="Behandlingstema"
-                    label="Velg behandlingstema"
-                />
-            )}
-
             {erMigreringFraInfotrygd && migreringsdato?.erSynlig && (
                 <FixedDatoVelger
                     {...migreringsdato.hentNavInputProps(visFeilmeldinger)}
@@ -309,6 +300,17 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                     feil={migreringsdato.feilmelding}
                 />
             )}
+
+            {behandlingstema.erSynlig && (
+                <StyledBehandlingstemaSelect
+                    behandlingstema={behandlingstema}
+                    erLesevisning={erLesevisning}
+                    visFeilmeldinger={visFeilmeldinger}
+                    name="Behandlingstema"
+                    label="Velg behandlingstema"
+                />
+            )}
+
             {søknadMottattDato?.erSynlig && (
                 <FixedDatoVelger
                     {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -162,27 +162,28 @@ const useOpprettBehandling = (
         },
     });
 
-    const { skjema, nullstillSkjema, kanSendeSkjema, onSubmit, settSubmitRessurs } = useSkjema<
-        {
-            behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
-            behandlingsårsak: BehandlingÅrsak | '';
-            behandlingstema: IBehandlingstema | undefined;
-            migreringsdato: FamilieIsoDate | undefined;
-            søknadMottattDato: FamilieIsoDate | undefined;
-            valgteBarn: ISelectOption[];
-        },
-        IBehandling
-    >({
-        felter: {
-            behandlingstype,
-            behandlingsårsak,
-            behandlingstema,
-            migreringsdato,
-            søknadMottattDato,
-            valgteBarn,
-        },
-        skjemanavn: 'Opprett behandling modal',
-    });
+    const { skjema, nullstillSkjema, kanSendeSkjema, onSubmit, settSubmitRessurs, valideringErOk } =
+        useSkjema<
+            {
+                behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | '';
+                behandlingsårsak: BehandlingÅrsak | '';
+                behandlingstema: IBehandlingstema | undefined;
+                migreringsdato: FamilieIsoDate | undefined;
+                søknadMottattDato: FamilieIsoDate | undefined;
+                valgteBarn: ISelectOption[];
+            },
+            IBehandling
+        >({
+            felter: {
+                behandlingstype,
+                behandlingsårsak,
+                behandlingstema,
+                migreringsdato,
+                søknadMottattDato,
+                valgteBarn,
+            },
+            skjemanavn: 'Opprett behandling modal',
+        });
 
     useEffect(() => {
         switch (skjema.felter.behandlingstype.verdi) {
@@ -290,6 +291,7 @@ const useOpprettBehandling = (
         nullstillSkjemaStatus,
         bruker,
         maksdatoForMigrering: dagenførForrigeMånedStartet,
+        valideringErOk,
     };
 };
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -96,7 +96,10 @@ const useOpprettBehandling = (
         valideringsfunksjon: (felt: FeltState<FamilieIsoDate | undefined>) =>
             felt.verdi && erIsoStringGyldig(felt.verdi) && erDatoFørForrigeMåned(felt.verdi)
                 ? ok(felt)
-                : feil(felt, 'Du må velge en migreringsdato som er før inneværende eller forrige måned'),
+                : feil(
+                    felt,
+                    'Du må velge en migreringsdato som er før inneværende eller forrige måned'
+                  ),
         avhengigheter: { behandlingstype, behandlingsårsak },
         skalFeltetVises: avhengigheter => {
             const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -96,7 +96,7 @@ const useOpprettBehandling = (
         valideringsfunksjon: (felt: FeltState<FamilieIsoDate | undefined>) =>
             felt.verdi && erIsoStringGyldig(felt.verdi) && erDatoFørForrigeMåned(felt.verdi)
                 ? ok(felt)
-                : feil(felt, 'Du må velge en ny migreringsdato'),
+                : feil(felt, 'Du må velge en migreringsdato som er før inneværende eller forrige måned'),
         avhengigheter: { behandlingstype, behandlingsårsak },
         skalFeltetVises: avhengigheter => {
             const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -96,7 +96,7 @@ const useOpprettBehandling = (
         valideringsfunksjon: (felt: FeltState<FamilieIsoDate | undefined>) =>
             felt.verdi && erIsoStringGyldig(felt.verdi) && erDatoFørForrigeMåned(felt.verdi)
                 ? ok(felt)
-                : feil(felt, 'Du må velge en ny migreringsdato.'),
+                : feil(felt, 'Du må velge en ny migreringsdato'),
         avhengigheter: { behandlingstype, behandlingsårsak },
         skalFeltetVises: avhengigheter => {
             const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -97,8 +97,8 @@ const useOpprettBehandling = (
             felt.verdi && erIsoStringGyldig(felt.verdi) && erDatoFørForrigeMåned(felt.verdi)
                 ? ok(felt)
                 : feil(
-                    felt,
-                    'Du må velge en migreringsdato som er før inneværende eller forrige måned'
+                      felt,
+                      'Du må velge en migreringsdato som er før inneværende eller forrige måned'
                   ),
         avhengigheter: { behandlingstype, behandlingsårsak },
         skalFeltetVises: avhengigheter => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10433)
Tilpasser tilgjengelige valg ved opprettelse av en migreringsbehandling:

- Synliggjør BehandlingstemaSelect for behandlingsårsakene relatert til migrering
- Strengere validering av migreringsdato for å sikre at det ikke kan velges en dato fra inneværende eller forrige måned.

Fikser også et problem med duplikat visning av datovelger-feilmelding, samt oppdaterer styling iht. ny standard. tilsvarende stylingen i KorrigerEtterbetaling-modalen.
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/47184872/206151598-a9a6c26d-5dcb-4c65-b7b3-3b50eb5ca002.png)
