### PR TITLE
🐛 Feilutbetalt valuta komponent dukker ikke opp ved valg i vedtaksmeny

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/TrekkILøpendeUtbetalingNy/TrekkILøpendeUtbetaling.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/TrekkILøpendeUtbetalingNy/TrekkILøpendeUtbetaling.tsx
@@ -38,7 +38,7 @@ const TrekkILøpendeUtbetaling: React.FC<ITrekkILøpendeUtbetaling> = ({
     behandlingId,
 }) => {
     const [ønskerÅLeggeTilNyPeriode, settØnskerÅLeggeTilNyPeriode] = useState(
-        !trekkILøpendeUtbetalingListe
+        trekkILøpendeUtbetalingListe.length === 0
     );
 
     useEffect(() => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser feil som gjør at feilutbetalt valuta komponent ikke vises når man trykker på "Legg til feilutbetalt valuta". Feilen kom av at det ble sjekket om feilutbetaltValuta ikke eksisterer i behandlingen, men sjekken må gjøres på lengden på tabellen. Tom liste = ingen perioder med feilutbetalt valuta.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
