### PR TITLE
Endre valgtDato til value i endret utbetaling

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -307,7 +307,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         feil={
                             !!skjema.felter.søknadstidspunkt.feilmelding && skjema.visFeilmeldinger
                         }
-                        valgtDato={
+                        value={
                             skjema.felter.søknadstidspunkt.verdi !== null
                                 ? skjema.felter.søknadstidspunkt.verdi
                                 : undefined
@@ -336,7 +336,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 !!skjema.felter.avtaletidspunktDeltBosted.feilmelding &&
                                 skjema.visFeilmeldinger
                             }
-                            valgtDato={
+                            value={
                                 skjema.felter.avtaletidspunktDeltBosted.verdi !== null
                                     ? skjema.felter.avtaletidspunktDeltBosted.verdi
                                     : undefined


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Oppdatering av familie-form-elements gjør at både `value` og `valgtDato` kan brukes for å sette verdien til et input-felt. Dersom props importeres så settes value automatisk, som gir problem fordi denne ikke endres fra null til undefined. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
