### PR TITLE
🐛 ValgtDato endres til value etter oppdatering av familie-form-elements

### DIFF
--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DeltBosted/DeltBostedAvtaler.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DeltBosted/DeltBostedAvtaler.tsx
@@ -119,7 +119,7 @@ const DeltBostedAvtaler: React.FC<IProps> = ({
                                         ),
                                     });
                                 }}
-                                valgtDato={avtaleDato}
+                                value={avtaleDato}
                             />
                             {index !== 0 && (
                                 <FjernAvtaleKnapp

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
@@ -85,7 +85,7 @@ export const SettBehandlingPåVentModal: React.FC<IProps> = ({
                 <Feltmargin>
                     <FamilieDatovelgerWrapper
                         {...skjema.felter.frist.hentNavInputProps(skjema.visFeilmeldinger)}
-                        valgtDato={skjema.felter.frist.verdi}
+                        value={skjema.felter.frist.verdi}
                         label={'Frist'}
                         placeholder={'DD.MM.ÅÅÅÅ'}
                     />

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -291,7 +291,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
             {erMigreringFraInfotrygd && migreringsdato?.erSynlig && (
                 <FixedDatoVelger
                     {...migreringsdato.hentNavInputProps(visFeilmeldinger)}
-                    valgtDato={migreringsdato.verdi}
+                    value={migreringsdato.verdi}
                     label={'Ny migreringsdato'}
                     placeholder={'DD.MM.ÅÅÅÅ'}
                     limitations={{
@@ -314,7 +314,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
             {søknadMottattDato?.erSynlig && (
                 <FixedDatoVelger
                     {...søknadMottattDato.hentNavInputProps(visFeilmeldinger)}
-                    valgtDato={søknadMottattDato.verdi}
+                    value={søknadMottattDato.verdi}
                     label={'Mottatt dato'}
                     placeholder={'DD.MM.ÅÅÅÅ'}
                     limitations={{

--- a/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
@@ -61,7 +61,7 @@ const LeggTilUregistrertBarn: React.FC<IProps> = ({ registrerBarnSkjema }) => {
                             {...registrerBarnSkjema.felter.uregistrertBarnFødselsdato.hentNavInputProps(
                                 registrerBarnSkjema.visFeilmeldinger
                             )}
-                            valgtDato={registrerBarnSkjema.felter.uregistrertBarnFødselsdato.verdi}
+                            value={registrerBarnSkjema.felter.uregistrertBarnFødselsdato.verdi}
                             label={'Fødselsdato (valgfri)'}
                             placeholder={'DD.MM.ÅÅÅÅ'}
                         />

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -116,15 +116,14 @@ const KorrigerVedtak: React.FC<IKorrigerVedtak> = ({
                             id={'korriger-vedtak-dato'}
                             label={'Vedtaksdato'}
                             erLesesvisning={erLesevisning}
-                            value={skjema.felter.vedtaksdato.verdi}
-                            placeholder={datoformatNorsk.DATO}
-                            onChange={(dato?: ISODateString) =>
-                                skjema.felter.vedtaksdato?.validerOgSettFelt(dato)
-                            }
-                            valgtDato={
+                            value={
                                 skjema.felter.vedtaksdato?.verdi !== null
                                     ? skjema.felter.vedtaksdato?.verdi
                                     : undefined
+                            }
+                            placeholder={datoformatNorsk.DATO}
+                            onChange={(dato?: ISODateString) =>
+                                skjema.felter.vedtaksdato?.validerOgSettFelt(dato)
                             }
                         />
                         <StyledFamilieTextarea

--- a/src/frontend/komponenter/Fagsak/Vedtak/TrekkILøpendeUtbetalingNy/FeilutbetaltValutaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/TrekkILøpendeUtbetalingNy/FeilutbetaltValutaSkjema.tsx
@@ -53,7 +53,7 @@ const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjem
                         {...skjema.felter.fom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                         id="fom-dato"
                         label="F.o.m"
-                        valgtDato={skjema.felter.fom.verdi}
+                        value={skjema.felter.fom.verdi}
                         onChange={(dato?: ISODateString) => {
                             skjema.felter.fom?.validerOgSettFelt(
                                 dato ? FamilieIsoTilFørsteDagIMåneden(dato) : ''
@@ -67,7 +67,7 @@ const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjem
                         {...skjema.felter.tom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                         id="fom-dato"
                         label="T.o.m"
-                        valgtDato={skjema.felter.tom.verdi}
+                        value={skjema.felter.tom.verdi}
                         onChange={(dato?: ISODateString) =>
                             skjema.felter.tom?.validerOgSettFelt(
                                 dato ? FamilieIsoTilSisteDagIMåneden(dato) : ''

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/OppdaterEndringstidspunktModal.tsx
@@ -61,7 +61,7 @@ export const OppdaterEndringstidspunktModal: React.FC<IProps> = ({
                             {...skjema.felter.endringstidspunkt.hentNavInputProps(
                                 skjema.visFeilmeldinger
                             )}
-                            valgtDato={skjema.felter.endringstidspunkt.verdi}
+                            value={skjema.felter.endringstidspunkt.verdi}
                             label={'Endringstidspunkt'}
                             placeholder={'DD.MM.ÅÅÅÅ'}
                             erLesesvisning={erLesevisning}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -118,7 +118,7 @@ const VelgPeriode: React.FC<IProps> = ({
                                     },
                                 });
                             }}
-                            valgtDato={redigerbartVilkår.verdi.periode.verdi.fom}
+                            value={redigerbartVilkår.verdi.periode.verdi.fom}
                         />
                     </div>
                 )}
@@ -146,7 +146,7 @@ const VelgPeriode: React.FC<IProps> = ({
                                     },
                                 });
                             }}
-                            valgtDato={redigerbartVilkår.verdi.periode.verdi.tom}
+                            value={redigerbartVilkår.verdi.periode.verdi.tom}
                         />
                     </div>
                 )}

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -424,10 +424,10 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 )}
                 {skjema.felter.brevmal.verdi === Brevmal.VARSEL_OM_REVURDERING_SAMBOER && (
                     <FamilieDatovelgerWrapper
-                        label={'Samboer fra'}
-                        valgtDato={skjema.felter.datoAvtale.verdi}
-                        placeholder={'DD.MM.ÅÅÅÅ'}
                         {...skjema.felter.datoAvtale.hentNavInputProps(skjema.visFeilmeldinger)}
+                        label={'Samboer fra'}
+                        value={skjema.felter.datoAvtale.verdi}
+                        placeholder={'DD.MM.ÅÅÅÅ'}
                     />
                 )}
                 {skjema.felter.brevmal.verdi &&

--- a/src/frontend/komponenter/Oppgavebenk/FilterSkjema.tsx
+++ b/src/frontend/komponenter/Oppgavebenk/FilterSkjema.tsx
@@ -76,7 +76,7 @@ const FilterSkjema: React.FunctionComponent = () => {
                                                 );
                                             }}
                                             placeholder={datoformatNorsk.DATO}
-                                            valgtDato={oppgaveFelt.filter.selectedValue}
+                                            value={oppgaveFelt.filter.selectedValue}
                                             className="filterskjema__filtre--input"
                                         />
                                         {oppgaveFelt.valideringsstatus ===

--- a/src/frontend/utils/skjema/FamilieDatovelgerWrapper.tsx
+++ b/src/frontend/utils/skjema/FamilieDatovelgerWrapper.tsx
@@ -53,9 +53,8 @@ interface IProps {
     label: ReactNode;
     onChange: (dato?: ISODateString) => void;
     placeholder?: string;
-    valgtDato?: string;
+    value?: string;
     description?: ReactNode;
-
     feil: ReactNode | undefined;
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter oppgradering av familie-form-elements kan man både bruke `value` og `valgtDato` i datoinput. Tidligere har kun valgtDato blitt brukt, som ikke gir problem. Men om man importerer props blir value satt og overskriver valgtDato. Dette gir problemer dersom value ikke inneholder sjekk etter nullverdier o.l. som blir gjort i valgtDato. Derfor endres alle valgtDato til value for å overskrive den automatiske verdien som blir satt

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
