### PR TITLE
Endre spacing mellom elementer på vedtakssiden

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValuta.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValuta.tsx
@@ -21,8 +21,6 @@ const FlexColumnDiv = styled.div`
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    margin-bottom: 3.5rem;
-    margin-top: 2rem;
 `;
 
 const FlexRowDiv = styled.div`
@@ -51,7 +49,7 @@ const FeilutbetaltValuta: React.FC<IFeilutbetaltValuta> = ({
 
     return (
         <FlexColumnDiv>
-            <Heading level="2" size="small" spacing>
+            <Heading level="2" size="small">
                 Feilutbetalt valuta
             </Heading>
             <Table size="small">

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -59,6 +59,14 @@ const Knapperad = styled.div`
     justify-content: center;
 `;
 
+const InnholdWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    margin-bottom: 2.5rem;
+    margin-top: 1.5rem;
+`;
+
 interface FortsattInnvilgetPerioderSelect extends HTMLSelectElement {
     value: PeriodetypeIVedtaksbrev;
 }
@@ -189,53 +197,62 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                                 Vedtaket er korrigert etter § 35
                             </BehandlingKorrigertAlert>
                         )}
-                        {åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && (
-                            <FamilieSelect
-                                label="Velg brev med eller uten perioder"
-                                erLesevisning={vurderErLesevisning()}
-                                onChange={(
-                                    event: React.ChangeEvent<FortsattInnvilgetPerioderSelect>
-                                ): void => {
-                                    overstyrFortsattInnvilgetVedtaksperioder(event.target.value);
-                                }}
-                                value={periodetypeIVedtaksbrev}
-                            >
-                                <option value={PeriodetypeIVedtaksbrev.UTEN_PERIODER}>
-                                    Fortsatt innvilget: Uten perioder
-                                </option>
-                                <option value={PeriodetypeIVedtaksbrev.MED_PERIODER}>
-                                    Fortsatt innvilget: Med perioder
-                                </option>
-                            </FamilieSelect>
-                        )}
-                        {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
-                        åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
-                        åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (
-                            <Alert variant="info" style={{ margin: '2rem 0 1rem 0' }}>
-                                {hentInfostripeTekst(åpenBehandling.årsak, åpenBehandling.status)}
-                            </Alert>
-                        ) : (
-                            <>
-                                <VedtaksbegrunnelseTeksterProvider>
-                                    <VedtaksperioderMedBegrunnelser
-                                        åpenBehandling={åpenBehandling}
-                                    />
-                                </VedtaksbegrunnelseTeksterProvider>
-                                {visFeilutbetaltValuta && (
-                                    <FeilutbetaltValuta
-                                        feilutbetaltValutaListe={åpenBehandling.feilutbetaltValuta}
-                                        behandlingId={åpenBehandling.behandlingId}
-                                        settErUlagretNyFeilutbetaltValutaPeriode={
-                                            settErUlagretNyFeilutbetaltValutaPeriode
-                                        }
-                                        erLesevisning={vurderErLesevisning()}
-                                        skjulFeilutbetaltValuta={() =>
-                                            settVisFeilutbetaltValuta(false)
-                                        }
-                                    />
-                                )}
-                            </>
-                        )}
+                        <InnholdWrapper>
+                            {åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && (
+                                <FamilieSelect
+                                    label="Velg brev med eller uten perioder"
+                                    erLesevisning={vurderErLesevisning()}
+                                    onChange={(
+                                        event: React.ChangeEvent<FortsattInnvilgetPerioderSelect>
+                                    ): void => {
+                                        overstyrFortsattInnvilgetVedtaksperioder(
+                                            event.target.value
+                                        );
+                                    }}
+                                    value={periodetypeIVedtaksbrev}
+                                >
+                                    <option value={PeriodetypeIVedtaksbrev.UTEN_PERIODER}>
+                                        Fortsatt innvilget: Uten perioder
+                                    </option>
+                                    <option value={PeriodetypeIVedtaksbrev.MED_PERIODER}>
+                                        Fortsatt innvilget: Med perioder
+                                    </option>
+                                </FamilieSelect>
+                            )}
+                            {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
+                            åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
+                            åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (
+                                <Alert variant="info" style={{ margin: '2rem 0 1rem 0' }}>
+                                    {hentInfostripeTekst(
+                                        åpenBehandling.årsak,
+                                        åpenBehandling.status
+                                    )}
+                                </Alert>
+                            ) : (
+                                <>
+                                    <VedtaksbegrunnelseTeksterProvider>
+                                        <VedtaksperioderMedBegrunnelser
+                                            åpenBehandling={åpenBehandling}
+                                        />
+                                    </VedtaksbegrunnelseTeksterProvider>
+                                    {visFeilutbetaltValuta && (
+                                        <FeilutbetaltValuta
+                                            feilutbetaltValutaListe={
+                                                åpenBehandling.feilutbetaltValuta
+                                            }
+                                            behandlingId={åpenBehandling.behandlingId}
+                                            settErUlagretNyFeilutbetaltValutaPeriode={
+                                                settErUlagretNyFeilutbetaltValutaPeriode
+                                            }
+                                            erLesevisning={vurderErLesevisning()}
+                                            skjulFeilutbetaltValuta={() =>
+                                                settVisFeilutbetaltValuta(false)
+                                            }
+                                        />
+                                    )}
+                                </>
+                            )}
+                        </InnholdWrapper>
                         <Button
                             id={'forhandsvis-vedtaksbrev'}
                             variant={'secondary'}

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
@@ -17,8 +17,6 @@ import {
 } from '../../../../../utils/kalender';
 
 const StyledEkspanderbartpanelBase = styled(EkspanderbartpanelBase)`
-    margin-bottom: 1rem;
-
     .ekspanderbartPanel__hode {
         padding: 0 1rem 0 1.6rem;
     }

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -16,7 +16,7 @@ import VedtaksperiodeMedBegrunnelserPanel from './VedtaksperiodeMedBegrunnelserP
 
 const StyledHeading = styled(Heading)`
     display: flex;
-    margin-top: 1rem;
+    margin-bottom: 0.5rem;
 `;
 
 const StyledHelpText = styled(HelpText)`
@@ -26,6 +26,12 @@ const StyledHelpText = styled(HelpText)`
     & + .navds-popover {
         max-width: 20rem;
     }
+`;
+
+const VedtaksperiodeListeWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
 `;
 
 interface IVedtakBegrunnelserTabell {
@@ -90,8 +96,8 @@ const VedtaksperiodeListe: React.FC<{
     }
 
     return (
-        <>
-            <StyledHeading level="2" size="small" spacing>
+        <VedtaksperiodeListeWrapper>
+            <StyledHeading level="2" size="small">
                 {overskrift}
                 <StyledHelpText placement="right">{hjelpetekst}</StyledHelpText>
             </StyledHeading>
@@ -108,7 +114,7 @@ const VedtaksperiodeListe: React.FC<{
                     </VedtaksperiodeMedBegrunnelserProvider>
                 )
             )}
-        </>
+        </VedtaksperiodeListeWrapper>
     );
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Kun styling endringer for å fikse spacing mellom elementer på vedtakssiden [Tea-10318](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10318)

Prøvde å flytte spacingen slik at den styres av en flex-div ytterst i stedet for å settes på hver komponent

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Syns det ser ut som det er mer spacing enn hva det er på skissene. Har brukt rem som beskrevet i oppgaven, men mulig de burde halveres. 

OBS: Ser ut som at mye er endret i `OppsummeringVedtak` men er kun prettier som har slått inn når alt har havnet et hakk inn av å bli wrappet i en div. Har kommentert hva som faktisk er endringen. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
| Før        | Etter           | 
| ------------- |:-------------:| 
| <img width="688" alt="image" src="https://user-images.githubusercontent.com/46678893/209180039-be10a73f-3d3c-46f0-a2fa-8da762ca0f80.png">   | <img width="688" alt="image" src="https://user-images.githubusercontent.com/46678893/209179532-b1679e45-cab8-40f0-9e91-0c32884e59f1.png"> |
