### PR TITLE
Åpner for at saker som er flyttet tilbake til infotrygd kan migreres over på nytt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -61,7 +61,8 @@ const erOpprettBehandlingSkjema = (
 ): skjema is ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling> =>
     Object.hasOwn(skjema, 'valgteBarn');
 
-const erTekniskEndringMedOpphør = (behandling?: VisningBehandling) => {
+const forrigeBehandlingVarTekniskEndringMedOpphør = (minimalFagsak?: IMinimalFagsak) => {
+    const behandling = hentSisteIkkeHenlagteBehandling(minimalFagsak);
     return (
         behandling?.årsak === BehandlingÅrsak.TEKNISK_ENDRING &&
         behandling.resultat === BehandlingResultat.OPPHØRT
@@ -127,7 +128,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
     const aktivBehandling: VisningBehandling | undefined = minimalFagsak
         ? hentAktivBehandlingPåMinimalFagsak(minimalFagsak)
         : undefined;
-    const sisteBehandling = hentSisteIkkeHenlagteBehandling(minimalFagsak);
 
     const kanOppretteBehandling =
         !aktivBehandling || aktivBehandling?.status === BehandlingStatus.AVSLUTTET;
@@ -150,7 +150,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
         skjema.felter.behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
     const kanOpprettMigreringsbehandlingMedHelmanuellMigrering =
         kanOppretteMigreringFraInfotrygd &&
-        (!kanOppretteRevurdering || erTekniskEndringMedOpphør(sisteBehandling));
+        (!kanOppretteRevurdering || forrigeBehandlingVarTekniskEndringMedOpphør(minimalFagsak));
     const kanOppretteMigreringsbehandlingMedEndreMigreringsdato =
         kanOppretteMigreringFraInfotrygd && !kanOpprettMigreringsbehandlingMedHelmanuellMigrering;
 

--- a/src/frontend/utils/fagsak.ts
+++ b/src/frontend/utils/fagsak.ts
@@ -37,8 +37,8 @@ export const hentSisteIkkeHenlagteBehandling = (
     if (filtrerteBehandlinger.length === 0) {
         return undefined;
     } else {
-        return filtrerteBehandlinger.sort(
-            (a, b) => Number(b.behandlingId) - Number(a.behandlingId)
+        return filtrerteBehandlinger.sort((a, b) =>
+            kalenderDiff(new Date(b.opprettetTidspunkt), new Date(a.opprettetTidspunkt))
         )[0];
     }
 };

--- a/src/frontend/utils/fagsak.ts
+++ b/src/frontend/utils/fagsak.ts
@@ -1,4 +1,5 @@
 import type { VisningBehandling } from '../komponenter/Fagsak/Saksoversikt/visningBehandling';
+import { erBehandlingHenlagt } from '../typer/behandling';
 import type { IMinimalFagsak } from '../typer/fagsak';
 import { fagsakStatus } from '../typer/fagsak';
 import { kalenderDiff } from './kalender';
@@ -26,4 +27,18 @@ export const hentAktivBehandlingPåMinimalFagsak = (
     minimalFagsak: IMinimalFagsak
 ): VisningBehandling | undefined => {
     return minimalFagsak.behandlinger.find((behandling: VisningBehandling) => behandling.aktiv);
+};
+
+export const hentSisteIkkeHenlagteBehandling = (
+    fagsak?: IMinimalFagsak
+): VisningBehandling | undefined => {
+    const filtrerteBehandlinger =
+        fagsak?.behandlinger.filter(behandling => !erBehandlingHenlagt(behandling.resultat)) || [];
+    if (filtrerteBehandlinger.length === 0) {
+        return undefined;
+    } else {
+        return filtrerteBehandlinger.sort(
+            (a, b) => Number(b.behandlingId) - Number(a.behandlingId)
+        )[0];
+    }
 };

--- a/src/frontend/utils/test/behandling/behandling.mock.ts
+++ b/src/frontend/utils/test/behandling/behandling.mock.ts
@@ -23,6 +23,7 @@ interface IMockBehandling {
     type?: Behandlingstype;
     skalBehandlesAutomatisk?: boolean;
     stegTilstand?: IRestStegTilstand[];
+    resultat?: BehandlingResultat;
 }
 
 export const mockBehandling = ({
@@ -101,12 +102,13 @@ export const mockVisningBehandling = ({
     aktiv = true,
     årsak = BehandlingÅrsak.SØKNAD,
     type = Behandlingstype.FØRSTEGANGSBEHANDLING,
+    resultat = BehandlingResultat.INNVILGET,
 }: IMockBehandling = {}): VisningBehandling => {
     return {
         behandlingId,
         aktiv,
         type: type,
-        resultat: BehandlingResultat.INNVILGET,
+        resultat: resultat,
         opprettetTidspunkt,
         kategori: BehandlingKategori.NASJONAL,
         underkategori: BehandlingUnderkategori.ORDINÆR,

--- a/src/frontend/utils/test/fagsak.test.ts
+++ b/src/frontend/utils/test/fagsak.test.ts
@@ -7,11 +7,18 @@ describe('fagsak utils tester', () => {
     test('hent siste ikke-henlagte behandling', () => {
         const minimalFagsak = mockMinimalFagsak({
             behandlinger: [
-                mockVisningBehandling({ behandlingId: 1 }),
-                mockVisningBehandling({ behandlingId: 2 }),
+                mockVisningBehandling({
+                    behandlingId: 1,
+                    opprettetTidspunkt: '2023-01-06T16:11:59.065',
+                }),
+                mockVisningBehandling({
+                    behandlingId: 2,
+                    opprettetTidspunkt: '2023-01-06T16:21:59.065',
+                }),
                 mockVisningBehandling({
                     behandlingId: 3,
                     resultat: BehandlingResultat.HENLAGT_FEILAKTIG_OPPRETTET,
+                    opprettetTidspunkt: '2023-01-06T16:31:59.065',
                 }),
             ],
         });

--- a/src/frontend/utils/test/fagsak.test.ts
+++ b/src/frontend/utils/test/fagsak.test.ts
@@ -1,0 +1,20 @@
+import { BehandlingResultat } from '../../typer/behandling';
+import { hentSisteIkkeHenlagteBehandling } from '../fagsak';
+import { mockVisningBehandling } from './behandling/behandling.mock';
+import { mockMinimalFagsak } from './minimalFagsak/minimalFagsak.mock';
+
+describe('fagsak utils tester', () => {
+    test('hent siste ikke-henlagte behandling', () => {
+        const minimalFagsak = mockMinimalFagsak({
+            behandlinger: [
+                mockVisningBehandling({ behandlingId: 1 }),
+                mockVisningBehandling({ behandlingId: 2 }),
+                mockVisningBehandling({
+                    behandlingId: 3,
+                    resultat: BehandlingResultat.HENLAGT_FEILAKTIG_OPPRETTET,
+                }),
+            ],
+        });
+        expect(hentSisteIkkeHenlagteBehandling(minimalFagsak)?.behandlingId).toBe(2);
+    });
+});


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10733)
Gjør behandlingsvalget for helmanuell migrering tilgjengelig dersom den siste behandlingen var en teknisk endring med opphør.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/47184872/211335057-1f0c9b7e-4f2d-4654-8b3c-63262c7ffcd9.png)

