### PR TITLE
Fix etterbetaling korrigering 0 kroner bug

### DIFF
--- a/src/frontend/context/KorrigertEtterbetaling/ValideringKorrigertEtterbetaling.ts
+++ b/src/frontend/context/KorrigertEtterbetaling/ValideringKorrigertEtterbetaling.ts
@@ -15,7 +15,7 @@ export const erÅrsakForKorrigeringGyldig = (felt: FeltState<string>) => {
 };
 
 export const erEtterbetalingsbeløpGyldig = (felt: FeltState<string>) => {
-    return !isEmpty(felt.verdi) && erPositivtHeltall(felt.verdi)
+    return !isEmpty(felt.verdi) && (erPositivtHeltall(felt.verdi) || Number(felt.verdi) === 0)
         ? ok(felt)
         : feil(felt, 'Skriv inn etterbetalingsbeløp. Desimaltall støttes ikke.');
 };

--- a/src/frontend/context/KorrigertEtterbetaling/ValideringKorrigertEtterbetaling.ts
+++ b/src/frontend/context/KorrigertEtterbetaling/ValideringKorrigertEtterbetaling.ts
@@ -3,7 +3,7 @@ import { feil, ok } from '@navikt/familie-skjema';
 
 import { KorrigertEtterbetalingÅrsak } from '../../typer/vedtak';
 import { isEmpty } from '../../utils/eøsValidators';
-import { erPositivtHeltall } from '../../utils/validators';
+import { erLik0, erPositivtHeltall } from '../../utils/validators';
 
 export const erÅrsakForKorrigeringGyldig = (felt: FeltState<string>) => {
     if (isEmpty(felt.verdi)) {
@@ -15,7 +15,7 @@ export const erÅrsakForKorrigeringGyldig = (felt: FeltState<string>) => {
 };
 
 export const erEtterbetalingsbeløpGyldig = (felt: FeltState<string>) => {
-    return !isEmpty(felt.verdi) && (erPositivtHeltall(felt.verdi) || Number(felt.verdi) === 0)
+    return !isEmpty(felt.verdi) && (erPositivtHeltall(felt.verdi) || erLik0(felt.verdi))
         ? ok(felt)
         : feil(felt, 'Skriv inn etterbetalingsbeløp. Desimaltall støttes ikke.');
 };

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -274,3 +274,9 @@ export const erPositivtHeltall = (string: string) => {
 
     return Number.isInteger(tall) && tall > 0;
 };
+
+export const erLik0 = (string: string) => {
+    const tall = Number(string);
+
+    return Number.isInteger(tall) && tall === 0;
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etterbetaling korrigering må også tillate verdi === 0 i tillegg til positive heltall.
Endringer må også gjøres i backend. Se: https://github.com/navikt/familie-ba-sak/pull/3218

### 👀 Screen shots
Før:

https://user-images.githubusercontent.com/110383605/214021777-b2124a31-1976-4bd3-ba69-2e876a1e535e.mov


Etter:

https://user-images.githubusercontent.com/110383605/214021792-11302bdd-fab0-4046-8f4b-9bb87ff4f0c4.mov

