### PR TITLE
Unngå å vise endringsloggen hvis vi ikke kjenner innlogget brukers nav-ident

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -124,7 +124,7 @@ const FagsakDeltagerSøk: React.FC = () => {
                 }
             />
 
-            {innloggetSaksbehandler && (
+            {innloggetSaksbehandler?.navIdent && (
                 <Endringslogg
                     userId={innloggetSaksbehandler.navIdent}
                     dataFetchingIntervalSeconds={60 * 15}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi får noen 400-feil mot endringsloggen i prod på at userId mangler, og teorien er det de kommer herfra
`kotlinx.serialization.MissingFieldException: Field 'userId' is required for type with serial name 'no.nav.familie.BrukerData', but it was missing`

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
