### PR TITLE
Valider skjemafelter for brevmottaker

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Button, Fieldset } from '@navikt/ds-react';
 import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieInput, FamilieSelect } from '@navikt/familie-form-elements';
+import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
@@ -19,6 +20,13 @@ const PostnummerOgStedContainer = styled.div`
     display: grid;
     grid-gap: 1rem;
     grid-template-columns: 8rem 24rem;
+
+    &:has(.navds-text-field--error) {
+        .navds-form-field .navds-form-field__error {
+            height: 3rem;
+            display: initial;
+        }
+    }
 `;
 
 const StyledFieldset = styled(Fieldset)`
@@ -108,6 +116,12 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ lukkModal }) => {
                     label={'Land'}
                     medFlag
                     utenMargin
+                    feil={
+                        skjema.visFeilmeldinger &&
+                        skjema.felter.land.valideringsstatus === Valideringsstatus.FEIL
+                            ? skjema.felter.land.feilmelding?.toString()
+                            : ''
+                    }
                     erLesevisning={erLesevisning}
                     onChange={land => {
                         skjema.felter.land.validerOgSettFelt(land.value);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
@@ -1,4 +1,4 @@
-import { useSkjema, useFelt } from '@navikt/familie-skjema';
+import { useSkjema, useFelt, ok, feil } from '@navikt/familie-skjema';
 import { type Ressurs, RessursStatus, byggHenterRessurs } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
@@ -38,24 +38,40 @@ const useLeggTilFjernBrevmottaker = (lukkModal: () => void) => {
 
     const mottaker = useFelt<Mottaker | ''>({
         verdi: '',
+        valideringsfunksjon: felt =>
+            felt.verdi !== '' ? ok(felt) : feil(felt, 'Feltet er påkrevd'),
     });
     const navn = useFelt<string>({
         verdi: '',
+        valideringsfunksjon: felt =>
+            felt.verdi !== ''
+                ? ok(felt)
+                : feil(felt, 'Navn på person eller organisasjon er påkrevd'),
     });
     const adresselinje1 = useFelt<string>({
         verdi: '',
+        valideringsfunksjon: felt =>
+            felt.verdi !== '' ? ok(felt) : feil(felt, 'Feltet er påkrevd'),
     });
     const adresselinje2 = useFelt<string>({
         verdi: '',
     });
     const postnummer = useFelt<string>({
         verdi: '',
+        valideringsfunksjon: felt =>
+            felt.verdi !== '' ? ok(felt) : feil(felt, 'Feltet er påkrevd'),
     });
     const poststed = useFelt<string>({
         verdi: '',
+        valideringsfunksjon: felt =>
+            felt.verdi !== '' ? ok(felt) : feil(felt, 'Feltet er påkrevd'),
     });
     const land = useFelt<string>({
         verdi: '',
+        valideringsfunksjon: felt =>
+            felt.verdi !== ''
+                ? ok(felt)
+                : feil(felt, 'Feltet er påkrevd. Velg Norge dersom brevet skal sendes innenlands.'),
     });
 
     const {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [Tea-10561](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10561)
Dette er en del av featuren manuell brevmottaker og ligger bak feature toggle
Legger til validering av skjemafeltene, og spesialhåndtering av feltene som skal ligge side om side slik at de ligger jevnt selv når minst ett av dem har valideringsfeil

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots

Knappen er secondary før skjemaet er ferdig utfylt, primary når alt er OK
![image](https://user-images.githubusercontent.com/2379098/216059238-78c7527f-00f7-4e95-9a23-4e32e9c089a5.png)
<img width="599" alt="Screenshot 2023-02-01 at 14 38 21" src="https://user-images.githubusercontent.com/2379098/216059264-f8d8b854-5d6c-4db3-90e2-ab7af72362fd.png">
