### PR TITLE
Visning av brevmottakere i tabell

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -106,7 +106,7 @@ const Behandlingsmeny: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
                         åpenBehandling.data.status === BehandlingStatus.UTREDES &&
                         (åpenBehandling.data.type === Behandlingstype.FØRSTEGANGSBEHANDLING ||
                             åpenBehandling.data.type === Behandlingstype.REVURDERING) && (
-                            <LeggTilEllerFjernBrevmottakere />
+                            <LeggTilEllerFjernBrevmottakere åpenBehandling={åpenBehandling.data} />
                         )}
                 </Dropdown.Menu.List>
             </StyletDropdownMenu>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -44,7 +44,7 @@ interface IProps {
 }
 
 const BrevmottakerSkjema: React.FC<IProps> = ({ lukkModal }) => {
-    const { skjema, lagreMottaker, valideringErOk } = useLeggTilFjernBrevmottaker(lukkModal);
+    const { skjema, lagreMottaker, valideringErOk } = useLeggTilFjernBrevmottaker();
     const { vurderErLesevisning } = useBehandling();
     const erLesevisning = vurderErLesevisning();
     return (

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Delete } from '@navikt/ds-icons';
+import { AddCircle, Delete } from '@navikt/ds-icons';
 import { Table, BodyShort, Heading, Button } from '@navikt/ds-react';
 import CountryData from '@navikt/land-verktoy';
 
+import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import useLeggTilFjernBrevmottaker, { mottakerVisningsnavn } from './useLeggTilFjernBrevmottaker';
 import type { IRestBrevmottaker } from './useLeggTilFjernBrevmottaker';
 
@@ -14,8 +15,12 @@ const FlexDiv = styled.div`
     justify-content: space-between;
 `;
 
-const StyledButton = styled(Button)`
+const FjernKnapp = styled(Button)`
     float: right;
+`;
+
+const LeggTilKnapp = styled(Button)`
+    margin-top: 1rem;
 `;
 
 const StyledBodyShort = styled(BodyShort)`
@@ -28,24 +33,31 @@ const StyledDiv = styled.div`
 
 interface IProps {
     mottaker: IRestBrevmottaker;
+    visLeggTilKnapp: boolean;
+    leggTilOnClick: () => void;
 }
-const BrevmottakerTabell: React.FC<IProps> = ({ mottaker }) => {
+const BrevmottakerTabell: React.FC<IProps> = ({ mottaker, visLeggTilKnapp, leggTilOnClick }) => {
     const { fjernMottaker } = useLeggTilFjernBrevmottaker();
+    const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const land = CountryData.getCountryInstance('nb').findByValue(mottaker.landkode);
+
     return (
         <StyledDiv>
             <FlexDiv>
                 <Heading size="medium" children={mottakerVisningsnavn[mottaker.type]} />
-                <StyledButton
-                    variant={'tertiary'}
-                    onClick={() => fjernMottaker(mottaker.id)}
-                    loading={false}
-                    disabled={false}
-                    size={'small'}
-                    icon={<Delete />}
-                >
-                    {'Fjern'}
-                </StyledButton>
+                {!erLesevisning && (
+                    <FjernKnapp
+                        variant={'tertiary'}
+                        onClick={() => fjernMottaker(mottaker.id)}
+                        loading={false}
+                        disabled={false}
+                        size={'small'}
+                        icon={<Delete />}
+                    >
+                        {'Fjern'}
+                    </FjernKnapp>
+                )}
             </FlexDiv>
             <FlexDiv role="grid" aria-colcount={2} aria-rowcount={6}>
                 <Table>
@@ -117,6 +129,16 @@ const BrevmottakerTabell: React.FC<IProps> = ({ mottaker }) => {
                     </Table.Body>
                 </Table>
             </FlexDiv>
+            {!erLesevisning && visLeggTilKnapp && (
+                <LeggTilKnapp
+                    variant="tertiary"
+                    size="small"
+                    icon={<AddCircle />}
+                    onClick={leggTilOnClick}
+                >
+                    Legg til ny mottaker
+                </LeggTilKnapp>
+            )}
         </StyledDiv>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Delete } from '@navikt/ds-icons';
+import { Table, BodyShort, Heading, Button } from '@navikt/ds-react';
+import CountryData from '@navikt/land-verktoy';
+
+import useLeggTilFjernBrevmottaker, { mottakerVisningsnavn } from './useLeggTilFjernBrevmottaker';
+import type { IRestBrevmottaker } from './useLeggTilFjernBrevmottaker';
+
+const FlexDiv = styled.div`
+    display: flex;
+    justify-content: space-between;
+`;
+
+const StyledButton = styled(Button)`
+    float: right;
+`;
+
+const StyledBodyShort = styled(BodyShort)`
+    font-weight: 600;
+`;
+
+interface IProps {
+    mottaker: IRestBrevmottaker;
+}
+export const BrevmottakerTabell: React.FC<IProps> = ({ mottaker }) => {
+    const { fjernMottaker } = useLeggTilFjernBrevmottaker(undefined);
+    const land = CountryData.getCountryInstance('nb').findByValue(mottaker.landkode);
+    return (
+        <>
+            <FlexDiv>
+                <Heading size="medium" children={mottakerVisningsnavn[mottaker.type]} />
+                <StyledButton
+                    variant={'tertiary'}
+                    onClick={() => fjernMottaker(mottaker.id)}
+                    loading={false}
+                    disabled={false}
+                    size={'small'}
+                    icon={<Delete />}
+                >
+                    {'Fjern'}
+                </StyledButton>
+            </FlexDiv>
+            <FlexDiv role="grid" aria-colcount={2} aria-rowcount={6}>
+                <Table>
+                    <Table.Header>
+                        <Table.Row role="row" aria-rowindex={1}>
+                            <Table.HeaderCell role="columnheader" aria-colindex={1}>
+                                <BodyShort>Navn</BodyShort>
+                            </Table.HeaderCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={2}>
+                            <Table.HeaderCell role="columnheader" aria-colindex={1}>
+                                <BodyShort>Adresselinje 1</BodyShort>
+                            </Table.HeaderCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={3}>
+                            <Table.HeaderCell role="columnheader" aria-colindex={1}>
+                                <BodyShort>Adresselinje 2</BodyShort>
+                            </Table.HeaderCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={4}>
+                            <Table.HeaderCell role="columnheader" aria-colindex={1}>
+                                <BodyShort>Postnummer</BodyShort>
+                            </Table.HeaderCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={5}>
+                            <Table.HeaderCell role="columnheader" aria-colindex={1}>
+                                <BodyShort>Poststed</BodyShort>
+                            </Table.HeaderCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={6}>
+                            <Table.HeaderCell role="columnheader" aria-colindex={1}>
+                                <BodyShort>Land</BodyShort>
+                            </Table.HeaderCell>
+                        </Table.Row>
+                    </Table.Header>
+                </Table>
+                <Table>
+                    <Table.Body>
+                        <Table.Row role="row" aria-rowindex={1}>
+                            <Table.DataCell role="gridcell" aria-colindex={2}>
+                                <StyledBodyShort>{mottaker.navn}</StyledBodyShort>
+                            </Table.DataCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={2}>
+                            <Table.DataCell role="gridcell" aria-colindex={2}>
+                                <StyledBodyShort>{mottaker.adresselinje1}</StyledBodyShort>
+                            </Table.DataCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={3}>
+                            <Table.DataCell role="gridcell" aria-colindex={2}>
+                                <StyledBodyShort>{mottaker.adresselinje2 || '-'}</StyledBodyShort>
+                            </Table.DataCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={4}>
+                            <Table.DataCell role="gridcell" aria-colindex={2}>
+                                <StyledBodyShort>{mottaker.postnummer}</StyledBodyShort>
+                            </Table.DataCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={5}>
+                            <Table.DataCell role="gridcell" aria-colindex={2}>
+                                <StyledBodyShort>{mottaker.poststed}</StyledBodyShort>
+                            </Table.DataCell>
+                        </Table.Row>
+                        <Table.Row role="row" aria-rowindex={6}>
+                            <Table.DataCell role="gridcell" aria-colindex={2}>
+                                <StyledBodyShort>{land.label}</StyledBodyShort>
+                            </Table.DataCell>
+                        </Table.Row>
+                    </Table.Body>
+                </Table>
+            </FlexDiv>
+        </>
+    );
+};

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -36,6 +36,7 @@ interface IProps {
     visLeggTilKnapp: boolean;
     leggTilOnClick: () => void;
 }
+
 const BrevmottakerTabell: React.FC<IProps> = ({ mottaker, visLeggTilKnapp, leggTilOnClick }) => {
     const { fjernMottaker } = useLeggTilFjernBrevmottaker();
     const { vurderErLesevisning } = useBehandling();

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -22,14 +22,18 @@ const StyledBodyShort = styled(BodyShort)`
     font-weight: 600;
 `;
 
+const StyledDiv = styled.div`
+    margin-top: 2.5rem;
+`;
+
 interface IProps {
     mottaker: IRestBrevmottaker;
 }
-export const BrevmottakerTabell: React.FC<IProps> = ({ mottaker }) => {
-    const { fjernMottaker } = useLeggTilFjernBrevmottaker(undefined);
+const BrevmottakerTabell: React.FC<IProps> = ({ mottaker }) => {
+    const { fjernMottaker } = useLeggTilFjernBrevmottaker();
     const land = CountryData.getCountryInstance('nb').findByValue(mottaker.landkode);
     return (
-        <>
+        <StyledDiv>
             <FlexDiv>
                 <Heading size="medium" children={mottakerVisningsnavn[mottaker.type]} />
                 <StyledButton
@@ -113,6 +117,8 @@ export const BrevmottakerTabell: React.FC<IProps> = ({ mottaker }) => {
                     </Table.Body>
                 </Table>
             </FlexDiv>
-        </>
+        </StyledDiv>
     );
 };
+
+export default BrevmottakerTabell;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { AddCircle, Delete } from '@navikt/ds-icons';
 import { Table, BodyShort, Heading, Button } from '@navikt/ds-react';
+import { AFontWeightBold } from '@navikt/ds-tokens/dist/tokens';
 import CountryData from '@navikt/land-verktoy';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
@@ -15,16 +16,12 @@ const FlexDiv = styled.div`
     justify-content: space-between;
 `;
 
-const FjernKnapp = styled(Button)`
-    float: right;
-`;
-
 const LeggTilKnapp = styled(Button)`
     margin-top: 1rem;
 `;
 
 const StyledBodyShort = styled(BodyShort)`
-    font-weight: 600;
+    font-weight: ${AFontWeightBold};
 `;
 
 const StyledDiv = styled.div`
@@ -48,7 +45,7 @@ const BrevmottakerTabell: React.FC<IProps> = ({ mottaker, visLeggTilKnapp, leggT
             <FlexDiv>
                 <Heading size="medium" children={mottakerVisningsnavn[mottaker.type]} />
                 {!erLesevisning && (
-                    <FjernKnapp
+                    <Button
                         variant={'tertiary'}
                         onClick={() => fjernMottaker(mottaker.id)}
                         loading={false}
@@ -57,7 +54,7 @@ const BrevmottakerTabell: React.FC<IProps> = ({ mottaker, visLeggTilKnapp, leggT
                         icon={<Delete />}
                     >
                         {'Fjern'}
-                    </FjernKnapp>
+                    </Button>
                 )}
             </FlexDiv>
             <FlexDiv role="grid" aria-colcount={2} aria-rowcount={6}>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
@@ -1,13 +1,14 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, Heading, Modal } from '@navikt/ds-react';
+import { AddCircle } from '@navikt/ds-icons';
+import { Alert, Button, Heading, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
 
 import type { IBehandling } from '../../../../../typer/behandling';
 import BrevmottakerSkjema from './BrevmottakerSkjema';
-import { BrevmottakerTabell } from './BrevmottakerTabell';
+import BrevmottakerTabell from './BrevmottakerTabell';
 
 const StyledModal = styled(Modal)`
     width: 35rem;
@@ -17,17 +18,31 @@ const StyledAlert = styled(Alert)`
     margin: 1rem 0 2.5rem;
 `;
 
+const LeggTilKnapp = styled(Button)`
+    margin-top: 1rem;
+`;
+
+const LukkKnapp = styled(Button)`
+    margin-top: 2.5rem;
+`;
+
 interface IProps {
     åpenBehandling: IBehandling;
 }
 
 const LeggTilEllerFjernBrevmottakere: React.FC<IProps> = ({ åpenBehandling }) => {
     const [visModal, settVisModal] = useState(false);
-    const [visSkjema] = useState(åpenBehandling.brevmottakere.length === 0);
+    const [visSkjema, settVisSkjema] = useState(true);
 
     const lukkModal = () => {
         settVisModal(false);
+        settVisSkjema(åpenBehandling.brevmottakere.length === 0);
     };
+
+    useEffect(() => {
+        settVisSkjema(åpenBehandling.brevmottakere.length === 0);
+    }, [åpenBehandling]);
+
     return (
         <>
             <Dropdown.Menu.List.Item onClick={() => settVisModal(true)}>
@@ -51,9 +66,28 @@ const LeggTilEllerFjernBrevmottakere: React.FC<IProps> = ({ åpenBehandling }) =
                     {visSkjema ? (
                         <BrevmottakerSkjema lukkModal={lukkModal} />
                     ) : (
-                        åpenBehandling.brevmottakere.map(mottaker => (
-                            <BrevmottakerTabell mottaker={mottaker} />
-                        ))
+                        <>
+                            {åpenBehandling.brevmottakere.length === 1 ? (
+                                <div>
+                                    <BrevmottakerTabell
+                                        mottaker={åpenBehandling.brevmottakere[0]}
+                                    />
+                                    <LeggTilKnapp
+                                        variant="tertiary"
+                                        size="small"
+                                        icon={<AddCircle />}
+                                        onClick={() => settVisSkjema(true)}
+                                    >
+                                        Legg til ny mottaker
+                                    </LeggTilKnapp>
+                                </div>
+                            ) : (
+                                åpenBehandling.brevmottakere.map(mottaker => (
+                                    <BrevmottakerTabell mottaker={mottaker} />
+                                ))
+                            )}
+                            <LukkKnapp onClick={lukkModal}>Lukk vindu</LukkKnapp>
+                        </>
                     )}
                 </Modal.Content>
             </StyledModal>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
@@ -62,12 +62,10 @@ const LeggTilEllerFjernBrevmottakere: React.FC<IProps> = ({ åpenBehandling }) =
                         <BrevmottakerSkjema lukkModal={lukkModal} />
                     ) : (
                         <>
-                            {åpenBehandling.brevmottakere.map((mottaker, index) => (
+                            {åpenBehandling.brevmottakere.map(mottaker => (
                                 <BrevmottakerTabell
                                     mottaker={mottaker}
-                                    visLeggTilKnapp={
-                                        index === 0 && åpenBehandling.brevmottakere.length === 1
-                                    }
+                                    visLeggTilKnapp={åpenBehandling.brevmottakere.length === 1}
                                     leggTilOnClick={() => settVisSkjema(true)}
                                 />
                             ))}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { AddCircle } from '@navikt/ds-icons';
 import { Alert, Button, Heading, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
 
@@ -16,10 +15,6 @@ const StyledModal = styled(Modal)`
 
 const StyledAlert = styled(Alert)`
     margin: 1rem 0 2.5rem;
-`;
-
-const LeggTilKnapp = styled(Button)`
-    margin-top: 1rem;
 `;
 
 const LukkKnapp = styled(Button)`
@@ -67,25 +62,15 @@ const LeggTilEllerFjernBrevmottakere: React.FC<IProps> = ({ åpenBehandling }) =
                         <BrevmottakerSkjema lukkModal={lukkModal} />
                     ) : (
                         <>
-                            {åpenBehandling.brevmottakere.length === 1 ? (
-                                <div>
-                                    <BrevmottakerTabell
-                                        mottaker={åpenBehandling.brevmottakere[0]}
-                                    />
-                                    <LeggTilKnapp
-                                        variant="tertiary"
-                                        size="small"
-                                        icon={<AddCircle />}
-                                        onClick={() => settVisSkjema(true)}
-                                    >
-                                        Legg til ny mottaker
-                                    </LeggTilKnapp>
-                                </div>
-                            ) : (
-                                åpenBehandling.brevmottakere.map(mottaker => (
-                                    <BrevmottakerTabell mottaker={mottaker} />
-                                ))
-                            )}
+                            {åpenBehandling.brevmottakere.map((mottaker, index) => (
+                                <BrevmottakerTabell
+                                    mottaker={mottaker}
+                                    visLeggTilKnapp={
+                                        index === 0 && åpenBehandling.brevmottakere.length === 1
+                                    }
+                                    leggTilOnClick={() => settVisSkjema(true)}
+                                />
+                            ))}
                             <LukkKnapp onClick={lukkModal}>Lukk vindu</LukkKnapp>
                         </>
                     )}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakere.tsx
@@ -5,7 +5,9 @@ import styled from 'styled-components';
 import { Alert, Heading, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
 
+import type { IBehandling } from '../../../../../typer/behandling';
 import BrevmottakerSkjema from './BrevmottakerSkjema';
+import { BrevmottakerTabell } from './BrevmottakerTabell';
 
 const StyledModal = styled(Modal)`
     width: 35rem;
@@ -15,8 +17,13 @@ const StyledAlert = styled(Alert)`
     margin: 1rem 0 2.5rem;
 `;
 
-const LeggTilEllerFjernBrevmottakere: React.FC = () => {
+interface IProps {
+    åpenBehandling: IBehandling;
+}
+
+const LeggTilEllerFjernBrevmottakere: React.FC<IProps> = ({ åpenBehandling }) => {
     const [visModal, settVisModal] = useState(false);
+    const [visSkjema] = useState(åpenBehandling.brevmottakere.length === 0);
 
     const lukkModal = () => {
         settVisModal(false);
@@ -41,7 +48,13 @@ const LeggTilEllerFjernBrevmottakere: React.FC = () => {
                         kanal. Legg til mottaker dersom brev skal sendes til utenlandsk adresse,
                         fullmektig, verge eller dødsbo.
                     </StyledAlert>
-                    <BrevmottakerSkjema lukkModal={lukkModal} />
+                    {visSkjema ? (
+                        <BrevmottakerSkjema lukkModal={lukkModal} />
+                    ) : (
+                        åpenBehandling.brevmottakere.map(mottaker => (
+                            <BrevmottakerTabell mottaker={mottaker} />
+                        ))
+                    )}
                 </Modal.Content>
             </StyledModal>
         </>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
@@ -43,7 +43,7 @@ export interface IRestBrevmottaker {
     landkode: string;
 }
 
-const useLeggTilFjernBrevmottaker = (lukkModal?: () => void) => {
+const useLeggTilFjernBrevmottaker = () => {
     const { settToast } = useApp();
     const { settÅpenBehandling } = useBehandling();
     const { behandlingId } = useSakOgBehandlingParams();
@@ -132,7 +132,6 @@ const useLeggTilFjernBrevmottaker = (lukkModal?: () => void) => {
                 (response: Ressurs<IBehandling>) => {
                     if (response.status === RessursStatus.SUKSESS) {
                         nullstillSkjema();
-                        lukkModal && lukkModal();
                         settToast(ToastTyper.BREVMOTTAKER_LAGRET, {
                             alertType: AlertType.SUCCESS,
                             tekst: 'Mottaker ble lagret',

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
@@ -1,4 +1,5 @@
-import { useSkjema, useFelt } from '@navikt/familie-skjema';
+import { useHttp } from '@navikt/familie-http';
+import { useFelt, useSkjema } from '@navikt/familie-skjema';
 import { type Ressurs, RessursStatus, byggHenterRessurs } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
@@ -31,10 +32,22 @@ export interface ILeggTilFjernBrevmottakerSkjema {
     land: string;
 }
 
-const useLeggTilFjernBrevmottaker = (lukkModal: () => void) => {
+export interface IRestBrevmottaker {
+    id: number;
+    type: Mottaker;
+    navn: string;
+    adresselinje1: string;
+    adresselinje2?: string;
+    postnummer: string;
+    poststed: string;
+    landkode: string;
+}
+
+const useLeggTilFjernBrevmottaker = (lukkModal?: () => void) => {
     const { settToast } = useApp();
     const { settÅpenBehandling } = useBehandling();
     const { behandlingId } = useSakOgBehandlingParams();
+    const { request } = useHttp();
 
     const mottaker = useFelt<Mottaker | ''>({
         verdi: '',
@@ -103,7 +116,7 @@ const useLeggTilFjernBrevmottaker = (lukkModal: () => void) => {
                 (response: Ressurs<IBehandling>) => {
                     if (response.status === RessursStatus.SUKSESS) {
                         nullstillSkjema();
-                        lukkModal();
+                        lukkModal && lukkModal();
                         settToast(ToastTyper.BREVMOTTAKER_LAGRET, {
                             alertType: AlertType.SUCCESS,
                             tekst: 'Mottaker ble lagret',
@@ -117,10 +130,23 @@ const useLeggTilFjernBrevmottaker = (lukkModal: () => void) => {
         }
     };
 
+    const fjernMottaker = (mottakerId: number) => {
+        return request<void, IBehandling>({
+            method: 'DELETE',
+            url: `/familie-ba-sak/api/brevmottaker/${behandlingId}/${mottakerId}`,
+            påvirkerSystemLaster: false,
+        }).then((response: Ressurs<IBehandling>) => {
+            if (response.status === RessursStatus.SUKSESS) {
+                settÅpenBehandling(response);
+            }
+        });
+    };
+
     return {
         skjema,
         lagreMottaker,
         valideringErOk,
+        fjernMottaker,
     };
 };
 

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -1,5 +1,6 @@
 import type { ISODateString } from '@navikt/familie-form-elements';
 
+import type { IRestBrevmottaker } from '../komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker';
 import type { BehandlingKategori, BehandlingUnderkategori } from './behandlingstema';
 import type { IPersonMedAndelerTilkjentYtelse } from './beregning';
 import type { INøkkelPar } from './common';
@@ -267,6 +268,7 @@ export interface IBehandling {
     korrigertEtterbetaling?: IRestKorrigertEtterbetaling;
     korrigertVedtak?: IRestKorrigertVedtak;
     feilutbetaltValuta: IRestFeilutbetaltValuta[];
+    brevmottakere: IRestBrevmottaker[];
 }
 
 export interface IArbeidsfordelingPåBehandling {

--- a/src/frontend/utils/test/behandling/behandling.mock.ts
+++ b/src/frontend/utils/test/behandling/behandling.mock.ts
@@ -92,6 +92,7 @@ export const mockBehandling = ({
         utenlandskePeriodebeløp: [],
         valutakurser: [],
         feilutbetaltValuta: [],
+        brevmottakere: [],
     };
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10539)

- Visning av lagrede brevmottakere i tabellform, etter at man har trykket "Lagre" i modalen.
- "Fjern"-knapp og "Legg til ny mottaker"-knapp

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Oppgaven inneholdt en kommentar fra UU, med et ønske om at første kolonne i tabellen kodes som table header. Prøvde å google meg frem til hva det innebærer og fant denne blogg-posten som jeg har forsøkt å følge oppskriften til: [Tutorial: How To Build an Accessible React Table](https://www.telerik.com/blogs/tutorial-how-to-build-accessible-react-table-data-grid)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Har testet implementasjonen manuelt


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/47184872/216537703-c52de16b-971d-4a07-be13-5b9297b21953.png)

![image](https://user-images.githubusercontent.com/47184872/216537610-575a27a4-3878-43fd-b909-564f7e788844.png)

Lesevisning:
![image](https://user-images.githubusercontent.com/47184872/216537807-06beab7b-522c-4114-914b-4ed430238500.png)
