### PR TITLE
Bruk nye komponenter i behandlingsresultat og tilbakekrevingskjema

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -4,10 +4,8 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Feiloppsummering } from 'nav-frontend-skjema';
-
 import { Edit } from '@navikt/ds-icons';
-import { Alert, Button, ErrorMessage, Label } from '@navikt/ds-react';
+import { Alert, Button, ErrorMessage, ErrorSummary, Label } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import { RessursStatus } from '@navikt/familie-typer';
 import type { Ressurs } from '@navikt/familie-typer';
@@ -54,7 +52,7 @@ const StyledAlert = styled(Alert)`
     margin-bottom: 1rem;
 `;
 
-const StyledFeiloppsummering = styled(Feiloppsummering)`
+const StyledErrorSummary = styled(ErrorSummary)`
     margin-top: 5rem;
 `;
 
@@ -254,9 +252,8 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
                 />
             )}
             {visFeilmeldinger && !erEøsInformasjonGyldig() && (
-                <StyledFeiloppsummering
-                    tittel={'For å gå videre må du rette opp følgende:'}
-                    feil={[
+                <StyledErrorSummary heading={'For å gå videre må du rette opp følgende:'}>
+                    {[
                         ...hentKompetanserMedFeil().map((kompetanse: IRestKompetanse) => ({
                             feilmelding: `Kompetanse barn: ${kompetanse.barnIdenter}, f.o.m.: ${kompetanse.fom} er ikke fullstendig.`,
                             skjemaelementId: kompetanseFeilmeldingId(kompetanse),
@@ -272,8 +269,12 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
                             feilmelding: `Valutakurs barn: ${valutakurs.barnIdenter}, f.o.m.: ${valutakurs.fom} er ikke fullstendig.`,
                             skjemaelementId: valutakursFeilmeldingId(valutakurs),
                         })),
-                    ]}
-                />
+                    ].map(item => (
+                        <ErrorSummary.Item href={`#${item.skjemaelementId}`}>
+                            {item.feilmelding}
+                        </ErrorSummary.Item>
+                    ))}
+                </StyledErrorSummary>
             )}
         </Skjemasteg>
     );

--- a/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { ExternalLink } from '@navikt/ds-icons';
+import { ExternalLink, FileContent } from '@navikt/ds-icons';
 import {
     Alert,
     BodyLong,
@@ -26,7 +26,6 @@ import { useBehandling } from '../../../context/behandlingContext/BehandlingCont
 import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
 import { useSimulering } from '../../../context/SimuleringContext';
 import useDokument from '../../../hooks/useDokument';
-import { DokumentIkon } from '../../../ikoner/DokumentIkon';
 import { Tilbakekrevingsvalg, visTilbakekrevingsvalg } from '../../../typer/simulering';
 import type { Målform } from '../../../typer/søknad';
 import { målform } from '../../../typer/søknad';
@@ -41,6 +40,10 @@ const ForhåndsvisVarselKnappContainer = styled.div`
 
 const FritekstVarsel = styled.div`
     margin-left: 2rem;
+
+    label {
+        width: 100%;
+    }
 `;
 
 const FritektsVarselLabel = styled.div`
@@ -161,7 +164,10 @@ const TilbakekrevingSkjema: React.FC<{
                 pdfdata={hentetDokument}
             />
 
-            <TilbakekrevingFieldset legend="Tilbakekreving">
+            <TilbakekrevingFieldset legend="Tilbakekreving" hideLegend>
+                <Heading level="2" size="medium">
+                    Tilbakekreving
+                </Heading>
                 <FamilieTextarea
                     label={
                         <FlexDiv>
@@ -362,7 +368,7 @@ const TilbakekrevingSkjema: React.FC<{
                                                     hentetDokument.status === RessursStatus.HENTER
                                                 }
                                                 size={'small'}
-                                                icon={<DokumentIkon />}
+                                                icon={<FileContent />}
                                             >
                                                 {'Forhåndsvis varsel'}
                                             </Button>

--- a/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
@@ -91,6 +91,14 @@ const StyledLabel = styled(Label)`
     margin-top: 4rem;
 `;
 
+const HeadingMedEkstraLuft = styled(Heading)`
+    margin-bottom: 2rem;
+`;
+
+const TextareaMedEkstraLuft = styled(FamilieTextarea)`
+    margin-bottom: 2rem;
+`;
+
 interface IForhåndsvisTilbakekrevingsvarselbrevRequest {
     fritekst: string;
 }
@@ -165,10 +173,10 @@ const TilbakekrevingSkjema: React.FC<{
             />
 
             <TilbakekrevingFieldset legend="Tilbakekreving" hideLegend>
-                <Heading level="2" size="medium">
+                <HeadingMedEkstraLuft level="2" size="medium">
                     Tilbakekreving
-                </Heading>
-                <FamilieTextarea
+                </HeadingMedEkstraLuft>
+                <TextareaMedEkstraLuft
                     label={
                         <FlexDiv>
                             Årsak til feilutbetaling og videre behandling

--- a/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
@@ -2,22 +2,22 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import navFarger from 'nav-frontend-core';
-import Lenke from 'nav-frontend-lenker';
-import { Feiloppsummering, SkjemaGruppe } from 'nav-frontend-skjema';
-
 import { ExternalLink } from '@navikt/ds-icons';
 import {
     Alert,
     BodyLong,
     BodyShort,
     Button,
+    ErrorSummary,
+    Fieldset,
+    Link,
     Heading,
     Label,
     Radio,
     RadioGroup,
     Tag,
 } from '@navikt/ds-react';
+import { AGray100, AGray600 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieTextarea, FlexDiv } from '@navikt/familie-form-elements';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -66,16 +66,16 @@ const StyledHelpTextContainer = styled.div`
 
 const StyledTag = styled(Tag)`
     margin-left: auto;
-    background-color: ${navFarger.navLysGra};
-    border-color: ${navFarger.navGra60};
+    background-color: ${AGray100};
+    border-color: ${AGray600};
 `;
 
-const TilbakekrevingSkjemaGruppe = styled(SkjemaGruppe)`
+const TilbakekrevingFieldset = styled(Fieldset)`
     margin-top: 4rem;
     width: 90%;
     max-width: 40rem;
 
-    .radiogruppe {
+    .navds-radio-group {
         margin-top: 2rem;
     }
 `;
@@ -161,7 +161,7 @@ const TilbakekrevingSkjema: React.FC<{
                 pdfdata={hentetDokument}
             />
 
-            <TilbakekrevingSkjemaGruppe legend="Tilbakekreving">
+            <TilbakekrevingFieldset legend="Tilbakekreving">
                 <FamilieTextarea
                     label={
                         <FlexDiv>
@@ -315,7 +315,7 @@ const TilbakekrevingSkjema: React.FC<{
                                                                     allerede utbetalt barnetrygd for
                                                                     perioden (Fom dato - Tom dato).
                                                                 </BodyLong>
-                                                                <Lenke
+                                                                <Link
                                                                     href="https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Språk.aspx"
                                                                     target="_blank"
                                                                 >
@@ -324,7 +324,7 @@ const TilbakekrevingSkjema: React.FC<{
                                                                         klarspråk:
                                                                     </span>
                                                                     <ExternalLink />
-                                                                </Lenke>
+                                                                </Link>
                                                             </StyledHelpTextContainer>
                                                         </StyledHelpText>
                                                     </FlexRad>
@@ -396,12 +396,15 @@ const TilbakekrevingSkjema: React.FC<{
                 )}
 
                 {tilbakekrevingSkjema.visFeilmeldinger && hentFeilTilOppsummering().length > 0 && (
-                    <Feiloppsummering
-                        tittel={'For å gå videre må du rette opp følgende:'}
-                        feil={hentFeilTilOppsummering()}
-                    />
+                    <ErrorSummary heading={'For å gå videre må du rette opp følgende:'}>
+                        {hentFeilTilOppsummering().map(item => (
+                            <ErrorSummary.Item href={`#${item.skjemaelementId}`}>
+                                {item.feilmelding}
+                            </ErrorSummary.Item>
+                        ))}
+                    </ErrorSummary>
                 )}
-            </TilbakekrevingSkjemaGruppe>
+            </TilbakekrevingFieldset>
         </>
     );
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Trukket ut fra #2485 
Robustgjøring for å forberede at vi trygt kan oppgradere React og designsystemet.

Tar i bruk nytt [ErrorSummary](https://aksel.nav.no/komponenter/core/errorsummary) fra Aksel, og rydder opp visuelt i tilbakekrevingsskjemaet (quick-win i samarbeid med Gunn - [Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10786))

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Begge deler skal være ryddig

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<details>
<summary>Behandlingsresultat</summary>
<strong>Før</strong>
<img src="https://user-images.githubusercontent.com/2379098/213175092-079924bc-a4e8-41cb-b552-39456b69a6d2.png"/>
<strong>Etter</strong>
<img src="https://user-images.githubusercontent.com/2379098/213175280-8f0be1c6-5f5e-42fd-a757-025acd9b8a06.png">

</details>
<details>
<summary>Tilbakekreving</summary>
<strong>Før</strong>
<img src="https://user-images.githubusercontent.com/2379098/216559619-727bbcb6-b16e-4285-9a91-53272224a181.png">
<img src="https://user-images.githubusercontent.com/2379098/216559667-ae6f5763-745e-46f6-b893-6767aee7dedf.png">

<strong>Etter</strong>
<img width="709" alt="image" src="https://user-images.githubusercontent.com/2379098/216584444-e65ca3af-d26b-473a-ada4-ca976cc9aaa2.png">

<img width="719" alt="image" src="https://user-images.githubusercontent.com/2379098/216569241-1fa12618-1135-48fb-97fe-1d8aaa173b4c.png">

</details>