### PR TITLE
Gå bort ifra set output og save state

### DIFF
--- a/.github/yarn-cache/action.yml
+++ b/.github/yarn-cache/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
     - uses: actions/cache@v2
       id: yarn-cache

--- a/.github/yarn-cache/action.yml
+++ b/.github/yarn-cache/action.yml
@@ -8,7 +8,7 @@ runs:
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
@@ -113,9 +113,9 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
         periode => periode.manuellPostering && periode.manuellPostering !== 0
     );
 
-    const erPeriodeMedKorrigertResultat = perioder.some(
-        periode => periode.resultat !== periode.korrigertResultat
-    );
+    const erPeriodeMedKorrigertResultat = perioder.some(periode => {
+        return (periode.resultat ?? 0) !== (periode.korrigertResultat ?? 0);
+    });
 
     const TabellSkillelinje = (props: { erHeader?: boolean }) => (
         <Skillelinje erHeader={props.erHeader}>
@@ -215,35 +215,6 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
                                 )
                         )}
                     </tr>
-                    {erManuellPosteringIBehandling && (
-                        <tr>
-                            <td>Manuell postering</td>
-                            {perioder.map(
-                                periode =>
-                                    periodeSkalVisesITabell(periode) && (
-                                        <React.Fragment key={'manuell postering - ' + periode.fom}>
-                                            {erNestePeriode(periode) && <TabellSkillelinje />}
-                                            <HøyrestiltTd>
-                                                <BodyShort>
-                                                    <LabelMedFarge
-                                                        farge={
-                                                            periode.manuellPostering &&
-                                                            periode.manuellPostering < 0
-                                                                ? navFarger.navRod
-                                                                : navFarger.navGronnDarken40
-                                                        }
-                                                    >
-                                                        {formaterBeløpUtenValutakode(
-                                                            periode.manuellPostering
-                                                        )}
-                                                    </LabelMedFarge>
-                                                </BodyShort>
-                                            </HøyrestiltTd>
-                                        </React.Fragment>
-                                    )
-                            )}
-                        </tr>
-                    )}
                     <tr>
                         <td>Tidligere utbetalt</td>
                         {perioder.map(
@@ -296,6 +267,26 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
                                 )
                         )}
                     </tr>
+                    {erManuellPosteringIBehandling && (
+                        <tr>
+                            <td>Manuell postering</td>
+                            {perioder.map(
+                                periode =>
+                                    periodeSkalVisesITabell(periode) && (
+                                        <React.Fragment key={'manuell postering - ' + periode.fom}>
+                                            {erNestePeriode(periode) && <TabellSkillelinje />}
+                                            <HøyrestiltTd>
+                                                <BodyShort>
+                                                    {formaterBeløpUtenValutakode(
+                                                        periode.manuellPostering
+                                                    )}
+                                                </BodyShort>
+                                            </HøyrestiltTd>
+                                        </React.Fragment>
+                                    )
+                            )}
+                        </tr>
+                    )}
                     {erPeriodeMedKorrigertResultat && (
                         <tr>
                             <td>Korrigert resultat</td>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi ønsker å gå bort ifra set-output og save-state kommandoene vi bruker per i dag.
Dette er fordi de er deprecated og ikke vil være tilgjengelig etter 31 mai 2023.

Se https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Jeg bumper til cache v3 da cachev2 brukte save-state kommandoen.

Endringen er gjort for ks-sak-frontend, så jeg overfører den bare til ba her.
https://github.com/navikt/familie-ks-sak-frontend/pull/175

Før:
![befff](https://user-images.githubusercontent.com/110383605/217212390-cd670c42-2214-4b3f-ba1b-709853cc330a.png)

Etter:

![afterr](https://user-images.githubusercontent.com/110383605/217212401-a6012848-871a-4f7c-b306-cb2de3ec6a61.png)
