### PR TITLE
Vis mottaker i send brev i høyremeny

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -6,7 +6,7 @@ import type { ISODateString } from '@navikt/familie-form-elements';
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer';
+import { RessursStatus, hentDataFraRessurs } from '@navikt/familie-typer';
 
 import type { ISelectOptionMedBrevtekst } from '../komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
 import { Brevmal } from '../komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
@@ -120,21 +120,20 @@ export const mottakersMålformImplementering = (
           })?.målform) ?? Målform.NB;
 
 const [BrevModulProvider, useBrevModul] = createUseContext(() => {
-    const { åpenBehandling } = useBehandling();
-    const { minimalFagsak } = useFagsakContext();
+    const { åpenBehandling: åpenBehandlingRessurs } = useBehandling();
+    const { minimalFagsak: minimalFagsakRessurs } = useFagsakContext();
 
     const maksAntallKulepunkter = 20;
     const makslengdeFritekst = 220;
 
-    const behandlingKategori =
-        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.kategori : undefined;
+    const åpenBehandling = hentDataFraRessurs(åpenBehandlingRessurs);
+    const minimalFagsak = hentDataFraRessurs(minimalFagsakRessurs);
 
-    const personer =
-        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.personer : [];
-    const brevmottakere =
-        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.brevmottakere : [];
-    const institusjon =
-        minimalFagsak.status === RessursStatus.SUKSESS ? minimalFagsak.data.institusjon : undefined;
+    const behandlingKategori = åpenBehandling?.kategori;
+
+    const personer = åpenBehandling?.personer ?? [];
+    const brevmottakere = åpenBehandling?.brevmottakere ?? [];
+    const institusjon = minimalFagsak?.institusjon;
 
     const mottakerIdent = useFelt({
         verdi: institusjon
@@ -350,7 +349,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         );
 
     const hentMuligeBrevMaler = (): Brevmal[] =>
-        hentMuligeBrevmalerImplementering(åpenBehandling, !!institusjon);
+        hentMuligeBrevmalerImplementering(åpenBehandlingRessurs, !!institusjon);
 
     const leggTilFritekst = (valideringsmelding?: string) => {
         skjema.felter.fritekster.validerOgSettFelt([

--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -129,8 +129,17 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
     const behandlingKategori =
         åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.kategori : undefined;
 
+    const personer =
+        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.personer : [];
+    const brevmottakere =
+        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.brevmottakere : [];
+    const institusjon =
+        minimalFagsak.status === RessursStatus.SUKSESS ? minimalFagsak.data.institusjon : undefined;
+
     const mottakerIdent = useFelt({
-        verdi: '',
+        verdi: institusjon
+            ? institusjon.orgNummer
+            : personer.find(person => person.type === PersonType.SØKER)?.personIdent || '',
         valideringsfunksjon: (felt: FeltState<string>) =>
             felt.verdi.length >= 1 ? ok(felt) : feil(felt, 'Du må velge en mottaker'),
     });
@@ -333,18 +342,12 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         skjema.felter.mottakerlandSed.nullstill();
     }, [skjema.felter.brevmal.verdi]);
 
-    const personer =
-        åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.personer : [];
-
     const mottakersMålform = (): Målform =>
         mottakersMålformImplementering(
             personer,
             skjema.felter.mottakerIdent.valideringsstatus,
             skjema.felter.mottakerIdent.verdi
         );
-
-    const institusjon =
-        minimalFagsak.status === RessursStatus.SUKSESS ? minimalFagsak.data.institusjon : undefined;
 
     const hentMuligeBrevMaler = (): Brevmal[] =>
         hentMuligeBrevmalerImplementering(åpenBehandling, !!institusjon);
@@ -454,6 +457,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         settVisfeilmeldinger,
         erBrevmalMedObligatoriskFritekst,
         institusjon,
+        brevmottakere,
     };
 });
 

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import type { IInstitusjon } from '../../../../typer/institusjon-og-verge';
+import { type IGrunnlagPerson, PersonType } from '../../../../typer/person';
+import { formaterIdent, lagPersonLabel } from '../../../../utils/formatter';
+import {
+    type IRestBrevmottaker,
+    Mottaker,
+} from '../../../Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker';
+
+interface IProps {
+    personer: IGrunnlagPerson[];
+    institusjon: IInstitusjon | undefined;
+    brevmottakere: IRestBrevmottaker[];
+}
+
+const BrevmottakerListe: React.FC<IProps> = ({ personer, institusjon, brevmottakere }) => {
+    const skalViseInstitusjon = !!institusjon;
+    const harUtenlandskAdresse = brevmottakere.some(
+        mottaker => mottaker.type === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
+    );
+    const harFullmektig = brevmottakere.some(mottaker => mottaker.type === Mottaker.FULLMEKTIG);
+    const harVerge = brevmottakere.some(mottaker => mottaker.type === Mottaker.VERGE);
+    const harManuellDødsboadresse = brevmottakere.some(
+        mottaker => mottaker.type === Mottaker.DØDSBO
+    );
+
+    const søker = personer.find(person => person.type === PersonType.SØKER);
+    const skalViseSøker =
+        søker && !institusjon && !harManuellDødsboadresse && !harUtenlandskAdresse;
+
+    return (
+        <ul>
+            {skalViseSøker && (
+                <li key="søker">{lagPersonLabel(søker.personIdent || '', personer)}</li>
+            )}
+            {skalViseInstitusjon && (
+                <li>{`Institusjon | ${institusjon.navn?.concat(' |') || ''} ${formaterIdent(
+                    institusjon.orgNummer
+                )}`}</li>
+            )}
+            {harUtenlandskAdresse && !harFullmektig && søker && (
+                <li key="utenlandsk-adresse">
+                    {lagPersonLabel(søker.personIdent, personer)} | Utenlandsk adresse
+                </li>
+            )}
+            {harUtenlandskAdresse && harFullmektig && søker && (
+                <li key="kort-utenlandsk-adresse">
+                    {søker.navn} | {formaterIdent(søker.personIdent)} | Utenlandsk adresse
+                </li>
+            )}
+            {harManuellDødsboadresse && søker && <li>{søker.navn} | Dødsbo</li>}
+            {harFullmektig &&
+                brevmottakere
+                    .filter(mottaker => mottaker.type === Mottaker.FULLMEKTIG)
+                    .map(mottaker => <li>{mottaker.navn} | Fullmektig</li>)}
+            {harVerge &&
+                brevmottakere
+                    .filter(mottaker => mottaker.type === Mottaker.VERGE)
+                    .map(mottaker => <li>{mottaker.navn} | Verge</li>)}
+        </ul>
+    );
+};
+
+export default BrevmottakerListe;

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
@@ -35,9 +35,9 @@ const BrevmottakerListe: React.FC<IProps> = ({ personer, institusjon, brevmottak
                 <li key="søker">{lagPersonLabel(søker.personIdent || '', personer)}</li>
             )}
             {skalViseInstitusjon && (
-                <li>{`Institusjon | ${institusjon.navn?.concat(' |') || ''} ${formaterIdent(
-                    institusjon.orgNummer
-                )}`}</li>
+                <li key="institusjon">{`Institusjon | ${
+                    institusjon.navn?.concat(' |') || ''
+                } ${formaterIdent(institusjon.orgNummer)}`}</li>
             )}
             {harUtenlandskAdresse && !harFullmektig && søker && (
                 <li key="utenlandsk-adresse">
@@ -49,15 +49,17 @@ const BrevmottakerListe: React.FC<IProps> = ({ personer, institusjon, brevmottak
                     {søker.navn} | {formaterIdent(søker.personIdent)} | Utenlandsk adresse
                 </li>
             )}
-            {harManuellDødsboadresse && søker && <li>{søker.navn} | Dødsbo</li>}
+            {harManuellDødsboadresse && søker && <li key="dødsbo">{søker.navn} | Dødsbo</li>}
             {harFullmektig &&
                 brevmottakere
                     .filter(mottaker => mottaker.type === Mottaker.FULLMEKTIG)
-                    .map(mottaker => <li>{mottaker.navn} | Fullmektig</li>)}
+                    .map(mottaker => (
+                        <li key={`fullmektig-${mottaker.id}`}>{mottaker.navn} | Fullmektig</li>
+                    ))}
             {harVerge &&
                 brevmottakere
                     .filter(mottaker => mottaker.type === Mottaker.VERGE)
-                    .map(mottaker => <li>{mottaker.navn} | Verge</li>)}
+                    .map(mottaker => <li key={`verge-${mottaker.id}`}>{mottaker.navn} | Verge</li>)}
         </ul>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -27,7 +27,6 @@ import type { IGrunnlagPerson } from '../../../../typer/person';
 import { PersonType } from '../../../../typer/person';
 import type { IBarnMedOpplysninger } from '../../../../typer/søknad';
 import { målform } from '../../../../typer/søknad';
-import { formaterIdent, lagPersonLabel } from '../../../../utils/formatter';
 import type { IFritekstFelt } from '../../../../utils/fritekstfelter';
 import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import { FamilieDatovelgerWrapper } from '../../../../utils/skjema/FamilieDatovelgerWrapper';
@@ -197,44 +196,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 legend="Send brev"
                 hideLegend
             >
-                <StyledFamilieSelect
-                    {...skjema.felter.mottakerIdent.hentNavInputProps(skjema.visFeilmeldinger)}
-                    label={'Velg mottaker'}
-                    placeholder={'Velg mottaker'}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>): void => {
-                        skjema.felter.mottakerIdent.onChange(event.target.value);
-                    }}
-                >
-                    <option value={''}>Velg</option>
-                    {personer
-                        .filter((person: IGrunnlagPerson) => person.type !== PersonType.BARN)
-                        .map((person, index) => {
-                            return (
-                                <option
-                                    aria-selected={
-                                        person.personIdent === skjema.felter.mottakerIdent.verdi
-                                    }
-                                    key={`${index}_${person.fødselsdato}`}
-                                    value={person.personIdent}
-                                >
-                                    {lagPersonLabel(person.personIdent, personer)}
-                                </option>
-                            );
-                        })}
-                    {institusjon && (
-                        <option
-                            aria-selected={
-                                institusjon.orgNummer === skjema.felter.mottakerIdent.verdi
-                            }
-                            key={`institusjon_${institusjon.orgNummer}`}
-                            value={institusjon.orgNummer}
-                        >
-                            {`Institusjon | ${institusjon.navn?.concat(' |') || ''} ${formaterIdent(
-                                institusjon.orgNummer
-                            )}`}
-                        </option>
-                    )}
-                </StyledFamilieSelect>
+                <Label>Brev sendes til</Label>
                 <StyledFamilieSelect
                     {...skjema.felter.brevmal.hentNavInputProps(skjema.visFeilmeldinger)}
                     label={

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -36,6 +36,7 @@ import { useSamhandlerRequest } from '../../../Fagsak/InstitusjonOgVerge/useSamh
 import Knapperekke from '../../Knapperekke';
 import PdfVisningModal from '../../PdfVisningModal/PdfVisningModal';
 import BarnBrevetGjelder from './BarnBrevetGjelder';
+import BrevmottakerListe from './BrevmottakerListe';
 import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
 import {
     Brevmal,
@@ -123,6 +124,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
         settVisfeilmeldinger,
         erBrevmalMedObligatoriskFritekst,
         institusjon,
+        brevmottakere,
     } = useBrevModul();
 
     const [visForhåndsvisningModal, settForhåndsviningModal] = useState(false);
@@ -197,6 +199,11 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 hideLegend
             >
                 <Label>Brev sendes til</Label>
+                <BrevmottakerListe
+                    personer={personer}
+                    institusjon={institusjon}
+                    brevmottakere={brevmottakere}
+                />
                 <StyledFamilieSelect
                     {...skjema.felter.brevmal.hentNavInputProps(skjema.visFeilmeldinger)}
                     label={

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -3,10 +3,8 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { SkjemaGruppe } from 'nav-frontend-skjema';
-
 import { AddCircle, Delete, FileContent } from '@navikt/ds-icons';
-import { Button, Label, Tag } from '@navikt/ds-react';
+import { Button, Fieldset, Label, Tag } from '@navikt/ds-react';
 import { AGray100, AGray600 } from '@navikt/ds-tokens/dist/tokens';
 import {
     FamilieInput,
@@ -38,7 +36,6 @@ import DeltBostedSkjema from '../../../Fagsak/Dokumentutsending/DeltBosted/DeltB
 import { useSamhandlerRequest } from '../../../Fagsak/InstitusjonOgVerge/useSamhandler';
 import Knapperekke from '../../Knapperekke';
 import PdfVisningModal from '../../PdfVisningModal/PdfVisningModal';
-import SkjultLegend from '../../SkjultLegend';
 import BarnBrevetGjelder from './BarnBrevetGjelder';
 import type { BrevtypeSelect, ISelectOptionMedBrevtekst } from './typer';
 import {
@@ -141,6 +138,8 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
         settForhåndsviningModal(false);
     }, []);
 
+    const erLesevisning = vurderErLesevisning();
+
     const brevMaler = hentMuligeBrevMaler();
     const skjemaErLåst =
         skjema.submitRessurs.status === RessursStatus.HENTER ||
@@ -149,7 +148,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
     const behandlingId =
         åpenBehandling.status === RessursStatus.SUKSESS && åpenBehandling.data.behandlingId;
 
-    const skjemaGruppeId = 'Fritekster-brev';
+    const fritekstSkjemaGruppeId = 'Fritekster-brev';
     const erMaksAntallKulepunkter = skjema.felter.fritekster.verdi.length >= maksAntallKulepunkter;
 
     const behandlingSteg =
@@ -190,13 +189,14 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 onRequestClose={() => settForhåndsviningModal(false)}
                 pdfdata={hentetDokument}
             />
-            <SkjemaGruppe
-                feil={
+            <Fieldset
+                error={
                     hentFrontendFeilmelding(skjema.submitRessurs) ||
                     hentFrontendFeilmelding(hentetDokument)
                 }
+                legend="Send brev"
+                hideLegend
             >
-                <SkjultLegend>Send brev</SkjultLegend>
                 <StyledFamilieSelect
                     {...skjema.felter.mottakerIdent.hentNavInputProps(skjema.visFeilmeldinger)}
                     label={'Velg mottaker'}
@@ -277,7 +277,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                         {...skjema.felter.dokumenter.hentNavInputProps(skjema.visFeilmeldinger)}
                         label={<Label>Velg dokumenter</Label>}
                         creatable={false}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         isMulti={true}
                         onChange={valgteOptions => {
                             skjema.felter.dokumenter.onChange(
@@ -295,9 +295,9 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                 )}
                 {skjema.felter.fritekster.erSynlig && (
                     <FritekstWrapper>
-                        <Label htmlFor={skjemaGruppeId}>Legg til kulepunkt</Label>
-                        {vurderErLesevisning() ? (
-                            <StyledList id={skjemaGruppeId}>
+                        <Label htmlFor={fritekstSkjemaGruppeId}>Legg til kulepunkt</Label>
+                        {erLesevisning ? (
+                            <StyledList id={fritekstSkjemaGruppeId}>
                                 {skjema.felter.fritekster.verdi.map(
                                     (fritekst: FeltState<IFritekstFelt>) => (
                                         <li>{fritekst.verdi.tekst}</li>
@@ -306,9 +306,11 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                             </StyledList>
                         ) : (
                             <>
-                                <SkjemaGruppe
-                                    id={skjemaGruppeId}
-                                    feil={
+                                <Fieldset
+                                    legend="Legg til kulepunkt"
+                                    hideLegend
+                                    id={fritekstSkjemaGruppeId}
+                                    error={
                                         skjema.visFeilmeldinger &&
                                         hentFrontendFeilmelding(skjema.submitRessurs)
                                     }
@@ -372,20 +374,19 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                                             );
                                         }
                                     )}
-                                </SkjemaGruppe>
+                                </Fieldset>
 
-                                {!erMaksAntallKulepunkter &&
-                                    (!vurderErLesevisning() ? (
-                                        <Button
-                                            variant={'tertiary'}
-                                            onClick={() => leggTilFritekst()}
-                                            id={`legg-til-fritekst`}
-                                            size={'small'}
-                                            icon={<AddCircle />}
-                                        >
-                                            {'Legg til kulepunkt'}
-                                        </Button>
-                                    ) : null)}
+                                {!erMaksAntallKulepunkter && !erLesevisning && (
+                                    <Button
+                                        variant={'tertiary'}
+                                        onClick={() => leggTilFritekst()}
+                                        id={`legg-til-fritekst`}
+                                        size={'small'}
+                                        icon={<AddCircle />}
+                                    >
+                                        {'Legg til kulepunkt'}
+                                    </Button>
+                                )}
                             </>
                         )}
                     </FritekstWrapper>
@@ -471,9 +472,9 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                             }
                         />
                     )}
-            </SkjemaGruppe>
+            </Fieldset>
             <Knapperekke>
-                {!vurderErLesevisning() && (
+                {!erLesevisning && (
                     <Button
                         variant={'tertiary'}
                         id={'forhandsvis-vedtaksbrev'}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [Tea-10541](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-10541)

Endrer fra at SB kan velge mottaker brevet skal sendes til (som regel har man bare ett valg..) til at vi lister opp mottakeren(e). Hvis det eksisterer manuelle brevmottakeradresser skal disse vises i stedet for eller i tillegg til søker, avhengig av mottakertype.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Skjemafeltet for mottaker kan snart fjernes fra skjemaet, men backend er ikke klar ennå så vi må fremdeles sende ned en hardkodet verdi. Når backend er klar kan vi fjerne hele skjemafeltet. I mellomtiden hardkoder vi verdien som man har måttet velge til nå, altså søker eller institusjon.


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?

Les commit for commit - aller først kommer en commit som gjør litt robustgjøring og oppgradering

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_

#### Før
![image](https://user-images.githubusercontent.com/2379098/218075326-193100f4-b7c9-4022-a782-f9bdfb519238.png)
![image](https://user-images.githubusercontent.com/2379098/218075365-bcb25826-030d-4e57-a8f3-d5b9f3e20461.png)

#### Etter
![image](https://user-images.githubusercontent.com/2379098/218075412-036b8d24-a839-48a1-a83b-a046188e513f.png)
