### PR TITLE
Behandlingsresultat&brev: Ikke mulighet til å velge brev med perioder hvis toggle er på

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -189,25 +189,28 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                                 Vedtaket er korrigert etter § 35
                             </BehandlingKorrigertAlert>
                         )}
-                        {åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && (
-                            <FamilieSelect
-                                label="Velg brev med eller uten perioder"
-                                erLesevisning={vurderErLesevisning()}
-                                onChange={(
-                                    event: React.ChangeEvent<FortsattInnvilgetPerioderSelect>
-                                ): void => {
-                                    overstyrFortsattInnvilgetVedtaksperioder(event.target.value);
-                                }}
-                                value={periodetypeIVedtaksbrev}
-                            >
-                                <option value={PeriodetypeIVedtaksbrev.UTEN_PERIODER}>
-                                    Fortsatt innvilget: Uten perioder
-                                </option>
-                                <option value={PeriodetypeIVedtaksbrev.MED_PERIODER}>
-                                    Fortsatt innvilget: Med perioder
-                                </option>
-                            </FamilieSelect>
-                        )}
+                        {åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET &&
+                            !toggles[ToggleNavn.nyMåteÅBeregneBehandlingsresultat] && (
+                                <FamilieSelect
+                                    label="Velg brev med eller uten perioder"
+                                    erLesevisning={vurderErLesevisning()}
+                                    onChange={(
+                                        event: React.ChangeEvent<FortsattInnvilgetPerioderSelect>
+                                    ): void => {
+                                        overstyrFortsattInnvilgetVedtaksperioder(
+                                            event.target.value
+                                        );
+                                    }}
+                                    value={periodetypeIVedtaksbrev}
+                                >
+                                    <option value={PeriodetypeIVedtaksbrev.UTEN_PERIODER}>
+                                        Fortsatt innvilget: Uten perioder
+                                    </option>
+                                    <option value={PeriodetypeIVedtaksbrev.MED_PERIODER}>
+                                        Fortsatt innvilget: Med perioder
+                                    </option>
+                                </FamilieSelect>
+                            )}
                         {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
                         åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
                         åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -14,6 +14,7 @@ export enum ToggleNavn {
     støtterEnsligMindreårig = 'familie-ba-sak.behandling.enslig-mindreaarig',
     kanKjøreSatsendringManuelt = 'familie-ba-sak.kan-kjore-satsendring-manuelt',
     kanAutomatiskSetteVilkår = 'familie-ba-sak.kan-automatisk-sette-vilkaar',
+    nyMåteÅBeregneBehandlingsresultat = 'familie-ba-sak.behandling.behandlingsresultat',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når toggle er skrudd på betyr resultatet FORTSATT_INNVILGET brev med én vedtaksperiode, mens ENDRET_OG_FORTSATT_INNVILGET betyr brev med perioder. Funksjonaliteten for å velge brev med eller uten perioder er derfor unødvendig, og skal ikke brukes med toggle på.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Legger bare kode bak toggle

### 🤷‍♀ ️Hvor er det lurt å starte?
Kun 1 commit.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
