### PR TITLE
Ekskluder Norge fra landvelger for utenlandsk adresse

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -116,6 +116,11 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ lukkModal }) => {
                     label={'Land'}
                     medFlag
                     utenMargin
+                    eksluderLand={
+                        skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
+                            ? ['NO']
+                            : []
+                    }
                     feil={
                         skjema.visFeilmeldinger &&
                         skjema.felter.land.valideringsstatus === Valideringsstatus.FEIL


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ønske fra Eivind. For brevmottaker "Bruker med utenlandsk adresse" skal man ikke kunne oppgi en adresse i Norge

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<img width="599" alt="image" src="https://user-images.githubusercontent.com/2379098/218679878-349f14e2-b8d8-4458-a043-3c90d49f5066.png">
