### PR TITLE
Erstatt ekspanderbart panel med stylet accordion

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
@@ -28,12 +28,12 @@ const StyledAccordion = styled(Accordion)`
         }
     }
     .navds-accordion__header {
-        padding-left: 1.6rem;
-        padding-right: 2.75rem;
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
         border-bottom: none;
     }
     .navds-accordion__content {
-        padding: 0.5rem 2.75rem 1.5rem 1.6rem;
+        padding: 0.5rem 1.5rem 1.5rem;
         border-bottom: none;
     }
 `;

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartBegrunnelsePanel.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { EkspanderbartpanelBase } from 'nav-frontend-ekspanderbartpanel';
-
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, Label, Accordion } from '@navikt/ds-react';
+import { AGray600, ASpacing1, ASurfaceSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import { formaterBeløp } from '../../../../../utils/formatter';
 import type { IYearMonthPeriode } from '../../../../../utils/kalender';
@@ -16,14 +15,26 @@ import {
     TIDENES_ENDE,
 } from '../../../../../utils/kalender';
 
-const StyledEkspanderbartpanelBase = styled(EkspanderbartpanelBase)`
+const StyledAccordion = styled(Accordion)`
     margin-bottom: 1rem;
-
-    .ekspanderbartPanel__hode {
-        padding: 0 1rem 0 1.6rem;
+    .navds-accordion__item {
+        border: 1px solid ${AGray600};
+        border-radius: ${ASpacing1};
     }
-    .ekspanderbartPanel__innhold {
+    .navds-accordion__item--open {
+        background-color: ${ASurfaceSubtle};
+        & > .navds-accordion__header {
+            background-color: transparent;
+        }
+    }
+    .navds-accordion__header {
+        padding-left: 1.6rem;
+        padding-right: 2.75rem;
+        border-bottom: none;
+    }
+    .navds-accordion__content {
         padding: 0.5rem 2.75rem 1.5rem 1.6rem;
+        border-bottom: none;
     }
 `;
 
@@ -31,7 +42,7 @@ const PanelTittel = styled.div`
     display: grid;
     grid-template-columns: minmax(6rem, 12rem) minmax(6rem, 15rem) auto;
     grid-gap: 0.5rem;
-    margin: 1rem;
+
     margin-left: 0;
 `;
 
@@ -57,29 +68,27 @@ const EkspanderbartBegrunnelsePanel: React.FC<IEkspanderbartBegrunnelsePanelProp
     tittel,
 }) => {
     return (
-        <StyledEkspanderbartpanelBase
-            key={`${periode.fom}_${periode.tom}`}
-            apen={åpen}
-            onClick={onClick}
-            tittel={
-                <PanelTittel>
-                    {periode.fom && (
-                        <Label>
-                            {periodeToString({
-                                fom: periode.fom,
-                                tom: slutterSenereEnnInneværendeMåned(periode.tom)
-                                    ? ''
-                                    : periode.tom,
-                            })}
-                        </Label>
-                    )}
-                    <BodyShort>{tittel}</BodyShort>
-                    {skalViseSum && <BodyShort>{formaterBeløp(summer())}</BodyShort>}
-                </PanelTittel>
-            }
-        >
-            {children}
-        </StyledEkspanderbartpanelBase>
+        <StyledAccordion>
+            <Accordion.Item open={åpen}>
+                <Accordion.Header onClick={onClick}>
+                    <PanelTittel>
+                        {periode.fom && (
+                            <Label>
+                                {periodeToString({
+                                    fom: periode.fom,
+                                    tom: slutterSenereEnnInneværendeMåned(periode.tom)
+                                        ? ''
+                                        : periode.tom,
+                                })}
+                            </Label>
+                        )}
+                        <BodyShort>{tittel}</BodyShort>
+                        {skalViseSum && <BodyShort>{formaterBeløp(summer())}</BodyShort>}
+                    </PanelTittel>
+                </Accordion.Header>
+                <Accordion.Content>{children}</Accordion.Content>
+            </Accordion.Item>
+        </StyledAccordion>
     );
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Skriver om EkspanderbartBegrunnelsePanel fra å bruke `nav-frontend-ekspanderbartpanel` til å bruke Accordion fra `@navikt/ds-react`
Splittet ut fra #2485. Jobber med å robustgjøre koden og komme bort fra de gamle nav-frontend-pakkene.

Åpne paneler har nå en lys gråfarge som bakgrunnsfarge - det er etter ønske fra Gunn

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots

<h3>Før</h3>
<img width="818" alt="image" src="https://user-images.githubusercontent.com/2379098/219046334-5616c489-109d-4ef0-9567-5e694b4e76bd.png">

<h3>Etter</h3>
<img src="https://user-images.githubusercontent.com/2379098/219344239-dcff7a59-000e-4c1a-9a81-042452f7cbe9.png">

