### PR TITLE
Flytt toggle for å vise henlagte behandlinger opp

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -18,7 +18,6 @@ import {
 } from './utlis';
 
 const SwitchHøyre = styled(Switch)`
-    margin-top: 1rem;
     margin-right: 0.275rem;
     float: right;
 `;
@@ -52,7 +51,22 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
 
     return (
         <div className={'saksoversikt__behandlingshistorikk'}>
-            <StyledHeading level="2" size={'medium'} children={'Behandlinger'} spacing />
+            <StyledHeading level="2" size={'medium'} spacing>
+                Behandlinger
+                {finnesRadSomKanFiltreresBort && (
+                    <SwitchHøyre
+                        size="small"
+                        position="left"
+                        id={'vis-henlagte-behandlinger'}
+                        checked={visHenlagteBehandlinger}
+                        onChange={() => {
+                            setVisHenlagteBehandlinger(!visHenlagteBehandlinger);
+                        }}
+                    >
+                        Vis henlagte behandlinger
+                    </SwitchHøyre>
+                )}
+            </StyledHeading>
             {behandlinger.length > 0 ? (
                 <table
                     className={classNames('tabell', 'saksoversikt__behandlingshistorikk__tabell')}
@@ -88,19 +102,6 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
                 </table>
             ) : (
                 <BodyShort children={'Ingen tidligere behandlinger'} />
-            )}
-            {finnesRadSomKanFiltreresBort && (
-                <SwitchHøyre
-                    size="small"
-                    position="left"
-                    id={'vis-henlagte-behandlinger'}
-                    checked={visHenlagteBehandlinger}
-                    onChange={() => {
-                        setVisHenlagteBehandlinger(!visHenlagteBehandlinger);
-                    }}
-                >
-                    Vis henlagte behandlinger
-                </SwitchHøyre>
             )}
         </div>
     );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Anna har funnet en rar liten bug der knappen for å vise/skjule henlagte behandlinger _iblant_ ikke er klikkbar. [Test gjerne i preprod](https://barnetrygd.dev.intern.nav.no/fagsak/200031652/saksoversikt) for å se det selv. Trykk på knappen, før musepekeren utenfor, klikk utenfor, før musepeker frem og tilbake, klikk på knappen og utenfor. Iblant er knappen ikke aktiv/klikkbar når du prøver å aktivere den 🤔 rare greier. Har ikke klart å reprodusere den i dokumentasjonen til Aksel.

Skjønner ikke heeelt hvorfor det skjer, men jeg lurer på om det kan være forårsaket av at knappen blir flyttet på når listen blir lengre eller kortere? Derfor testet jeg å flytte knappen opp i overskriften Behandlinger, og har ikke klart å gjenskape bugen etter at jeg gjorde den endringen. Har tatt avsjekk med Gunn og Anna på at de er fornøyde med endringen. Så får vi håpe at det ikke skjer igjen, for da må jeg gruble mer 😅 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke funksjonell endring

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots - etter endringen
![image](https://user-images.githubusercontent.com/2379098/219665614-5cd87114-8bc0-4529-ad71-f004ecb6ab08.png)
![image](https://user-images.githubusercontent.com/2379098/219665630-8941e09b-a01a-473a-927b-02edfd0b5f86.png)
![image](https://user-images.githubusercontent.com/2379098/219665646-e9e32937-2801-43d4-8d24-ca489818c0b2.png)

