### PR TITLE
Endret validering for manuell migrering ifm. satsendring

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -92,7 +92,7 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                                     visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
                                     etikett={'Ny migreringsdato'}
                                     begrensninger={{
-                                        maxDate: maksdatoForMigrering().toISOString(),
+                                        maxDate: maksdatoForMigrering.toISOString(),
                                     }}
                                 />
                             )}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -111,12 +111,9 @@ const useOpprettBehandling = (
     const migreringsdato = useFelt<FamilieIsoDate>({
         verdi: '',
         valideringsfunksjon: (felt: FeltState<FamilieIsoDate>) =>
-            felt.verdi && erIsoStringGyldig(felt.verdi) && erDatoFørForrigeMåned(felt.verdi)
+            felt.verdi && erIsoStringGyldig(felt.verdi) && erDatoMindreEllerLikMaksdato(felt.verdi)
                 ? ok(felt)
-                : feil(
-                      felt,
-                      'Du må velge en migreringsdato som er før inneværende eller forrige måned'
-                  ),
+                : feil(felt, 'Du må velge 01.01.23 eller tidligere som migreringsdato'),
         avhengigheter: { behandlingstype, behandlingsårsak },
         skalFeltetVises: avhengigheter => {
             const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;
@@ -189,8 +186,8 @@ const useOpprettBehandling = (
         return Date.parse(dato.toString()) > new Date().getTime();
     };
 
-    const erDatoFørForrigeMåned = (dato: FamilieIsoDate): boolean => {
-        return Date.parse(dato.toString()) <= dagenførForrigeMånedStartet().getTime();
+    const erDatoMindreEllerLikMaksdato = (dato: FamilieIsoDate): boolean => {
+        return Date.parse(dato.toString()) <= maksdatoForMigrering().getTime();
     };
 
     const valgteBarn = useFelt({
@@ -330,11 +327,8 @@ const useOpprettBehandling = (
         nullstillSkjema();
     };
 
-    const dagenførForrigeMånedStartet = () => {
-        const dato = new Date();
-        dato.setMonth(dato.getMonth() - 1);
-        dato.setDate(0);
-        return dato;
+    const maksdatoForMigrering = () => {
+        return new Date('2023-01-01');
     };
 
     return {
@@ -342,7 +336,7 @@ const useOpprettBehandling = (
         opprettBehandlingSkjema: skjema,
         nullstillSkjemaStatus,
         bruker,
-        maksdatoForMigrering: dagenførForrigeMånedStartet,
+        maksdatoForMigrering,
         valideringErOk,
     };
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -187,7 +187,7 @@ const useOpprettBehandling = (
     };
 
     const erDatoMindreEllerLikMaksdato = (dato: FamilieIsoDate): boolean => {
-        return Date.parse(dato.toString()) <= maksdatoForMigrering().getTime();
+        return Date.parse(dato.toString()) <= MAKSDATO_FOR_MIGRERING.getTime();
     };
 
     const valgteBarn = useFelt({
@@ -327,16 +327,14 @@ const useOpprettBehandling = (
         nullstillSkjema();
     };
 
-    const maksdatoForMigrering = () => {
-        return new Date('2023-01-01');
-    };
+    const MAKSDATO_FOR_MIGRERING = new Date('2023-01-01');
 
     return {
         onBekreft,
         opprettBehandlingSkjema: skjema,
         nullstillSkjemaStatus,
         bruker,
-        maksdatoForMigrering,
+        maksdatoForMigrering: MAKSDATO_FOR_MIGRERING,
         valideringErOk,
     };
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-11429) (med tilhørende backend-PR her: https://github.com/navikt/familie-ba-sak/pull/3361)
- Validering som sier at saksbehandler må velge 01.01.23 eller tidligere dato som migreringsdato.
- Filtrerer vekk simuleringsperioder senere enn februar 2023 ved validering av etterbetaling/feilutbetaling, slik at det fortsatt skal fungere å migrere etter satsendring.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

testet manuelt


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/47184872/219666665-76e465fa-bf5a-40f8-9a6c-b476d20fe35a.png)
