### PR TITLE
Fjern mottakerident og mottakernavn fra manuelle brev

### DIFF
--- a/src/frontend/context/DokumentutsendingContext.ts
+++ b/src/frontend/context/DokumentutsendingContext.ts
@@ -159,11 +159,9 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
                 const barnIBrev = skjema.felter.barnMedDeltBosted.verdi.filter(barn => barn.merket);
 
                 return {
-                    mottakerIdent: bruker.data.personIdent,
                     multiselectVerdier: barnIBrev.flatMap(hentDeltBostedMulitiselectVerdierForBarn),
                     barnIBrev: barnIBrev.map(barn => barn.ident),
                     mottakerMålform: målform,
-                    mottakerNavn: bruker.data.navn,
                     brevmal: Informasjonsbrev.INFORMASJONSBREV_DELT_BOSTED,
                 };
             } else {
@@ -185,11 +183,9 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
                 });
 
                 return {
-                    mottakerIdent: bruker.data.personIdent,
                     multiselectVerdier: dokumenter.concat(fritekster),
                     barnIBrev: [],
                     mottakerMålform: målform,
-                    mottakerNavn: bruker.data.navn,
                     brevmal: Informasjonsbrev.INFORMASJONSBREV_KAN_SØKE,
                 };
             } else {

--- a/src/frontend/context/test/BrevModulContext.test.ts
+++ b/src/frontend/context/test/BrevModulContext.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
 
@@ -89,24 +88,17 @@ describe('BrevmodulContext', () => {
 
     describe('mottakersMålformImplementering', () => {
         const personIdent = '12345678930';
-        const orgNummer = '123456789';
         const personerNB = [mockBarn, mockSøker({ målform: Målform.NB, personIdent })];
         const personerNN = [mockBarn, mockSøker({ målform: Målform.NN, personIdent })];
         test('Skal returnere NB når søkers målform er NB', () => {
-            expect(
-                mottakersMålformImplementering(personerNB, Valideringsstatus.OK, personIdent)
-            ).toEqual(Målform.NB);
+            expect(mottakersMålformImplementering(personerNB, false)).toEqual(Målform.NB);
         });
 
         test('Skal returnere NN når søkers målform er NN', () => {
-            expect(
-                mottakersMålformImplementering(personerNN, Valideringsstatus.OK, personIdent)
-            ).toEqual(Målform.NN);
+            expect(mottakersMålformImplementering(personerNN, false)).toEqual(Målform.NN);
         });
         test('Skal returnere målformen registrert på barnet når mottakeren er en institusjon', () => {
-            expect(
-                mottakersMålformImplementering([mockBarn], Valideringsstatus.OK, orgNummer)
-            ).toEqual(mockBarn.målform);
+            expect(mottakersMålformImplementering([mockBarn], true)).toEqual(mockBarn.målform);
         });
     });
 });

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/Informasjonsbrev/enkeltInformasjonsbrevUtils.ts
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/Informasjonsbrev/enkeltInformasjonsbrevUtils.ts
@@ -19,11 +19,9 @@ export const hentEnkeltInformasjonsbrevRequest = ({
 }: IHentEnkeltInformasjonsbrevRequestInput): IManueltBrevRequestPåFagsak => {
     if (bruker.status === RessursStatus.SUKSESS) {
         return {
-            mottakerIdent: bruker.data.personIdent,
             multiselectVerdier: [],
             barnIBrev: [],
             mottakerMålform: målform,
-            mottakerNavn: bruker.data.navn,
             brevmal: brevmal,
         };
     } else {

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandling.ts
@@ -3,10 +3,8 @@ import { useState } from 'react';
 import type { FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
-import { useFagsakContext } from '../../../../../context/fagsak/FagsakContext';
 import type { HenleggÅrsak, IBehandling } from '../../../../../typer/behandling';
 import type { IManueltBrevRequestPåBehandling } from '../../../../../typer/dokument';
 import { Brevmal } from '../../../../Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
@@ -16,7 +14,6 @@ const useHenleggBehandling = (lukkModal: () => void) => {
     const [begrunnelse, settBegrunnelse] = useState('');
     const [årsak, settÅrsak] = useState('');
     const { settÅpenBehandling } = useBehandling();
-    const { minimalFagsak } = useFagsakContext();
 
     const { onSubmit, skjema, nullstillSkjema } = useSkjema<
         {
@@ -67,10 +64,6 @@ const useHenleggBehandling = (lukkModal: () => void) => {
     };
 
     const hentSkjemaData = (): IManueltBrevRequestPåBehandling => ({
-        mottakerIdent:
-            minimalFagsak.status === RessursStatus.SUKSESS
-                ? minimalFagsak.data.søkerFødselsnummer
-                : '',
         multiselectVerdier: [],
         brevmal: Brevmal.HENLEGGE_TRUKKET_SØKNAD,
         barnIBrev: [],

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -156,7 +156,6 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
         åpenBehandling.status === RessursStatus.SUKSESS ? åpenBehandling.data.steg : undefined;
 
     if (institusjon) {
-        skjema.felter.mottakerIdent.validerOgSettFelt(institusjon.orgNummer);
         if (!institusjon.navn && samhandlerRessurs.status === RessursStatus.IKKE_HENTET) {
             hentOgSettSamhandler(institusjon.orgNummer);
         }

--- a/src/frontend/typer/dokument.ts
+++ b/src/frontend/typer/dokument.ts
@@ -6,7 +6,6 @@ import type { BehandlingKategori } from './behandlingstema';
 import type { Målform } from './søknad';
 
 export interface IManueltBrevRequestPåBehandling {
-    mottakerIdent: string;
     multiselectVerdier: string[];
     barnIBrev: string[];
     brevmal: Brevmal;
@@ -15,16 +14,13 @@ export interface IManueltBrevRequestPåBehandling {
     behandlingKategori?: BehandlingKategori | undefined;
     antallUkerSvarfrist?: number;
     mottakerMålform?: Målform;
-    mottakerNavn?: string;
     mottakerlandSed?: string;
 }
 
 export interface IManueltBrevRequestPåFagsak {
-    mottakerIdent: string;
     multiselectVerdier: string[];
     barnIBrev: string[];
     mottakerMålform: Målform;
-    mottakerNavn: string;
     brevmal: Brevmal | Informasjonsbrev;
     datoAvtale?: string;
     behandlingKategori?: undefined;

--- a/src/frontend/utils/brevmal.ts
+++ b/src/frontend/utils/brevmal.ts
@@ -1,4 +1,3 @@
-import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -9,7 +8,6 @@ import { BehandlingKategori } from '../typer/behandlingstema';
 import type { IGrunnlagPerson } from '../typer/person';
 import { PersonType } from '../typer/person';
 import { Målform } from '../typer/søknad';
-import { erOrgNr } from './formatter';
 
 export const hentMuligeBrevmalerImplementering = (
     åpenBehandling: Ressurs<IBehandling>,
@@ -90,15 +88,9 @@ const brevmalKanVelgesForBehandling = (brevmal: Brevmal, åpenBehandling: IBehan
 
 export const mottakersMålformImplementering = (
     personer: IGrunnlagPerson[],
-    skjemaValideringsStatus: Valideringsstatus,
-    mottakerIdent: string | readonly string[] | number
+    erInstitusjon: boolean
 ) =>
-    (erOrgNr(mottakerIdent.toString())
+    erInstitusjon
         ? personer[0]?.målform
-        : personer.find((person: IGrunnlagPerson) => {
-              if (skjemaValideringsStatus === Valideringsstatus.OK) {
-                  return person.personIdent === mottakerIdent;
-              } else {
-                  return person.type === PersonType.SØKER;
-              }
-          })?.målform) ?? Målform.NB;
+        : personer.find((person: IGrunnlagPerson) => person.type === PersonType.SØKER)?.målform ??
+          Målform.NB;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter #2514 lar vi ikke lenger SB velge mottaker av manuelt brev. Derfor utleder vi det nå i backend https://github.com/navikt/familie-ba-sak/pull/3364 og trenger ikke lenger å sende ned ident og navn på søker/institusjon

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har oppdatert eksisterende test

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
