### PR TITLE
Fiks landvelger i brevskjema med tom ekskluderingsliste

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -119,7 +119,7 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ lukkModal }) => {
                     eksluderLand={
                         skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
                             ? ['NO']
-                            : []
+                            : undefined
                     }
                     feil={
                         skjema.visFeilmeldinger &&


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter #2560 sender vi ekskluderingslisten videre til den underliggende landvelgeren uansett om listen er tom. Tidligere sendte vi den kun videre om den hadde lengde > 0. Ser ut til at denne endringen skaper en feil i prod, se skjermbilde:
![image](https://user-images.githubusercontent.com/2379098/224075809-d6e51b0f-847c-4c5a-b90b-8a8234bdfc99.png)
<img width="597" alt="image" src="https://user-images.githubusercontent.com/2379098/224076081-6535e7ae-11b4-45f9-8fc8-8561fb57385a.png">

Etter endringen i denne PR-en blir det riktig igjen:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/2379098/224076345-9f359e18-bbd6-4919-a762-47da00c5732d.png">

Norge er fremdeles ekskludert for mottakertype "Bruker med utenlandsk adresse"
<img width="585" alt="image" src="https://user-images.githubusercontent.com/2379098/224076507-a35a5fba-5085-4027-b201-92b1afcc1170.png">


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Jeg har sjekket at ikke denne propen er i bruk (på feil måte) flere steder i koden

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
