### PR TITLE
Totrinnskontroll for avvik over 1kr per barn

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -133,8 +133,9 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
     const harStoppetMigreringAvvikInnenforBeløpsgrenser =
         erMigreringMedStoppISimulering &&
         harKunNegativeEllerKunPositiveAvvik(perioderesultaterFørMars2023) &&
-        harMaks1KroneIAvvikPerBarn(perioderesultaterFørMars2023) &&
         harTotaltAvvikUnderBeløpsgrense(perioderesultaterFørMars2023);
+
+    const erMaks1KroneIAvvikPerBarn = harMaks1KroneIAvvikPerBarn(perioderesultaterFørMars2023);
 
     const tilbakekrevingsvalg = useFelt<Tilbakekrevingsvalg | undefined>({
         verdi: åpenBehandling.tilbakekreving?.valg,
@@ -266,6 +267,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         harÅpenTilbakekrevingRessurs,
         erMigreringMedStoppISimulering,
         harStoppetMigreringAvvikInnenforBeløpsgrenser,
+        erMaks1KroneIAvvikPerBarn,
     };
 });
 

--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -100,9 +100,10 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
 
     const erMigreringFraInfotrygd = åpenBehandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
 
-    const erAvvikIBehandling = erFeilutbetaling || erEtterutbetaling;
+    const erAvvikISimuleringForBehandling = erFeilutbetaling || erEtterutbetaling;
 
-    const erMigreringFraInfotrygdMedAvvik = erMigreringFraInfotrygd && erAvvikIBehandling;
+    const erMigreringFraInfotrygdMedAvvik =
+        erMigreringFraInfotrygd && erAvvikISimuleringForBehandling;
 
     const harMaks1KroneIAvvikPerBarn = (perioderesultater: number[]) => {
         const antallBarn = åpenBehandling.personer.filter(

--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -123,9 +123,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         harTotaltAvvikUnderBeløpsgrense(perioderesultaterFørMars2023);
 
     const behandlingErMigreringMedAvvikUtenforBeløpsgrenser =
-        erMigreringFraInfotrygdMedAvvik &&
-        (!harMaks1KroneIAvvikPerBarn(perioderesultaterFørMars2023) ||
-            !harTotaltAvvikUnderBeløpsgrense(perioderesultaterFørMars2023));
+        erMigreringFraInfotrygdMedAvvik && !behandlingErMigreringMedAvvikInnenforBeløpsgrenser;
 
     const tilbakekrevingsvalg = useFelt<Tilbakekrevingsvalg | undefined>({
         verdi: åpenBehandling.tilbakekreving?.valg,

--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -250,7 +250,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         hentSkjemadata,
         maksLengdeTekst,
         harÅpenTilbakekrevingRessurs,
-        erMigreringFraInfotrygdMedAvvik: erMigreringFraInfotrygdMedAvvik,
+        erMigreringFraInfotrygdMedAvvik,
         behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
     };

--- a/src/frontend/komponenter/Fagsak/BehandlingRouter.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingRouter.tsx
@@ -91,7 +91,11 @@ const BehandlingRouter: React.FunctionComponent = () => {
                     />
                     <Route
                         path="/vedtak"
-                        element={<OppsummeringVedtak åpenBehandling={åpenBehandling.data} />}
+                        element={
+                            <SimuleringProvider åpenBehandling={åpenBehandling.data}>
+                                <OppsummeringVedtak åpenBehandling={åpenBehandling.data} />
+                            </SimuleringProvider>
+                        }
                     />
                 </Routes>
             );

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -46,6 +46,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         erMigreringMedStoppISimulering,
         erFeilutbetaling,
         harStoppetMigreringAvvikInnenforBeløpsgrenser,
+        erMaks1KroneIAvvikPerBarn,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
     const { toggles } = useApp();
@@ -111,14 +112,27 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                             harStoppetMigreringAvvikInnenforBeløpsgrenser ||
                             skalIkkeStoppeMigreringsbehandlinger) && (
                             <>
-                                {harStoppetMigreringAvvikInnenforBeløpsgrenser && (
-                                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                        Behandlingen medfører avvik i simulering. Ved avvik på
-                                        mindre enn totalt 100 kroner, kan du gå videre i
-                                        behandlingen. Du må huske å sende oppgave til NØS om at det
-                                        ikke skal etterbetales / opprettes kravgrunnlag.
-                                    </StyledBeløpsgrenseAlert>
-                                )}
+                                {harStoppetMigreringAvvikInnenforBeløpsgrenser &&
+                                    (erMaks1KroneIAvvikPerBarn ? (
+                                        <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                            Behandlingen medfører avvik i simulering. Ved avvik på
+                                            mindre enn totalt 100 kroner, kan du gå videre i
+                                            behandlingen. Du må huske å sende oppgave til NØS om at
+                                            det ikke skal etterbetales / opprettes kravgrunnlag.
+                                        </StyledBeløpsgrenseAlert>
+                                    ) : (
+                                        <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                            Simuleringen viser en feilutbetaling eller
+                                            etterbetaling. Hvis du velger å gå videre i behandlingen
+                                            kreves det to-trinnskontroll. Det må sendes manuell
+                                            oppgave til NØS for å sikre at det ikke går ut
+                                            etterbetaling eller blir opprettet feilutbetalingssak i
+                                            migreringsbehandlingen. Hvis bruker skal ha en
+                                            etterbetaling eller feilutbetaling, må dette behandles i
+                                            en egen revurderingsbehandling med vedtaksbrev til
+                                            bruker.
+                                        </StyledBeløpsgrenseAlert>
+                                    ))}
                                 {erFeilutbetaling && (
                                     <TilbakekrevingSkjema
                                         søkerMålform={hentSøkersMålform(åpenBehandling)}

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -7,14 +7,12 @@ import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 import type { Ressurs } from '@navikt/familie-typer';
 
-import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useSimulering } from '../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingSteg } from '../../../typer/behandling';
 import type { ITilbakekreving } from '../../../typer/simulering';
-import { ToggleNavn } from '../../../typer/toggles';
 import { hentSøkersMålform } from '../../../utils/behandling';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
 import SimuleringPanel from './SimuleringPanel';
@@ -43,15 +41,11 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         simuleringsresultat,
         tilbakekrevingSkjema,
         harÅpenTilbakekrevingRessurs,
-        erMigreringMedStoppISimulering,
         erFeilutbetaling,
-        harStoppetMigreringAvvikInnenforBeløpsgrenser,
-        erMaks1KroneIAvvikPerBarn,
+        behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
+        behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
-    const { toggles } = useApp();
-    const skalIkkeStoppeMigreringsbehandlinger =
-        toggles[ToggleNavn.skalIkkeStoppeMigreringsbehandlig];
 
     const nesteOnClick = () => {
         if (vurderErLesevisning()) {
@@ -92,11 +86,6 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             forrigeOnClick={forrigeOnClick}
             nesteOnClick={nesteOnClick}
             maxWidthStyle={'80rem'}
-            skalViseNesteKnapp={
-                !erMigreringMedStoppISimulering ||
-                harStoppetMigreringAvvikInnenforBeløpsgrenser ||
-                skalIkkeStoppeMigreringsbehandlinger
-            }
             steg={BehandlingSteg.VURDER_TILBAKEKREVING}
         >
             {simuleringsresultat?.status === RessursStatus.SUKSESS ? (
@@ -108,31 +97,30 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                     <>
                         <SimuleringPanel simulering={simuleringsresultat.data} />
                         <SimuleringTabell simulering={simuleringsresultat.data} />
-                        {(!erMigreringMedStoppISimulering ||
-                            harStoppetMigreringAvvikInnenforBeløpsgrenser ||
-                            skalIkkeStoppeMigreringsbehandlinger) && (
+                        {(behandlingErMigreringMedAvvikInnenforBeløpsgrenser ||
+                            behandlingErMigreringMedAvvikUtenforBeløpsgrenser) && (
                             <>
-                                {harStoppetMigreringAvvikInnenforBeløpsgrenser &&
-                                    (erMaks1KroneIAvvikPerBarn ? (
-                                        <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                            Behandlingen medfører avvik i simulering. Ved avvik på
-                                            mindre enn totalt 100 kroner, kan du gå videre i
-                                            behandlingen. Du må huske å sende oppgave til NØS om at
-                                            det ikke skal etterbetales / opprettes kravgrunnlag.
-                                        </StyledBeløpsgrenseAlert>
-                                    ) : (
-                                        <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                            Simuleringen viser en feilutbetaling eller
-                                            etterbetaling. Hvis du velger å gå videre i behandlingen
-                                            kreves det to-trinnskontroll. Det må sendes manuell
-                                            oppgave til NØS for å sikre at det ikke går ut
-                                            etterbetaling eller blir opprettet feilutbetalingssak i
-                                            migreringsbehandlingen. Hvis bruker skal ha en
-                                            etterbetaling eller feilutbetaling, må dette behandles i
-                                            en egen revurderingsbehandling med vedtaksbrev til
-                                            bruker.
-                                        </StyledBeløpsgrenseAlert>
-                                    ))}
+                                {behandlingErMigreringMedAvvikInnenforBeløpsgrenser && (
+                                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                        Behandlingen medfører avvik i simulering. Ved avvik på
+                                        mindre enn totalt 100 kroner, kan du gå videre i
+                                        behandlingen uten totrinnskontroll. Du må huske å sende
+                                        oppgave til NØS om at det ikke skal etterbetales / opprettes
+                                        kravgrunnlag.
+                                    </StyledBeløpsgrenseAlert>
+                                )}
+                                {behandlingErMigreringMedAvvikUtenforBeløpsgrenser && (
+                                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                        Simuleringen viser en feilutbetaling eller etterbetaling.
+                                        Hvis du velger å gå videre i behandlingen kreves det
+                                        to-trinnskontroll. Det må sendes manuell oppgave til NØS for
+                                        å sikre at det ikke går ut etterbetaling eller blir
+                                        opprettet feilutbetalingssak i migreringsbehandlingen. Hvis
+                                        bruker skal ha en etterbetaling eller feilutbetaling, må
+                                        dette behandles i en egen revurderingsbehandling med
+                                        vedtaksbrev til bruker.
+                                    </StyledBeløpsgrenseAlert>
+                                )}
                                 {erFeilutbetaling && (
                                     <TilbakekrevingSkjema
                                         søkerMålform={hentSøkersMålform(åpenBehandling)}
@@ -141,15 +129,6 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                 )}
                             </>
                         )}
-                        {erMigreringMedStoppISimulering &&
-                            !harStoppetMigreringAvvikInnenforBeløpsgrenser && (
-                                <Alert variant="error">
-                                    Utbetalingen må være lik utbetalingen i Infotrygd.
-                                    <br />
-                                    Du må tilbake og gjøre nødvendige endringer for å komme videre i
-                                    behandlingen
-                                </Alert>
-                            )}
                     </>
                 )
             ) : (

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -10,6 +10,7 @@ import { hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
+import { useSimulering } from '../../../context/SimuleringContext';
 import useDokument from '../../../hooks/useDokument';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../typer/behandling';
@@ -50,6 +51,10 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
     const { fagsakId } = useSakOgBehandlingParams();
     const { vurderErLesevisning, sendTilBeslutterNesteOnClick, behandlingsstegSubmitressurs } =
         useBehandling();
+
+    const { harStoppetMigreringAvvikInnenforBeløpsgrenser, erMaks1KroneIAvvikPerBarn } =
+        useSimulering();
+
     const erLesevisning = vurderErLesevisning();
 
     const { minimalFagsak: minimalFagsakRessurs } = useFagsakContext();
@@ -131,7 +136,13 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                 navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/simulering`)
             }
             nesteOnClick={visSubmitKnapp ? sendTilBeslutter : undefined}
-            nesteKnappTittel={erMigreringFraInfotrygd ? 'Bekreft migrering' : 'Til godkjenning'}
+            nesteKnappTittel={
+                erMigreringFraInfotrygd &&
+                harStoppetMigreringAvvikInnenforBeløpsgrenser &&
+                !erMaks1KroneIAvvikPerBarn
+                    ? 'Bekreft migrering'
+                    : 'Til godkjenning'
+            }
             senderInn={behandlingsstegSubmitressurs.status === RessursStatus.HENTER}
             maxWidthStyle="54rem"
             className={'vedtak'}

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -52,8 +52,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
     const { vurderErLesevisning, sendTilBeslutterNesteOnClick, behandlingsstegSubmitressurs } =
         useBehandling();
 
-    const { harStoppetMigreringAvvikInnenforBeløpsgrenser, erMaks1KroneIAvvikPerBarn } =
-        useSimulering();
+    const { behandlingErMigreringMedAvvikUtenforBeløpsgrenser } = useSimulering();
 
     const erLesevisning = vurderErLesevisning();
 
@@ -137,9 +136,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
             }
             nesteOnClick={visSubmitKnapp ? sendTilBeslutter : undefined}
             nesteKnappTittel={
-                erMigreringFraInfotrygd &&
-                harStoppetMigreringAvvikInnenforBeløpsgrenser &&
-                !erMaks1KroneIAvvikPerBarn
+                erMigreringFraInfotrygd && !behandlingErMigreringMedAvvikUtenforBeløpsgrenser
                     ? 'Bekreft migrering'
                     : 'Til godkjenning'
             }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12102

Det er ønskelig med nye regler for migreringsbehandlinger som har avvik i simulering.

- Migreringsbehandlinger skal ikke lenger stoppes i simuleringssteget ved avvik.
- Ved ingen avvik i simulering så dukker det ikke opp noe alertboks, og man kan ferdigstille behandling uten totrinnskontroll.
- Ved avvik på maks 1 krone per barn opptil 100 kroner, så skal behandlingen gå videre uten totrinnskontroll. Det vises separat alertboks for dette scenarioet.
- Ved avvik på over 1 krone per barn, så skal behandlingen gå videre til totrinnskontroll. Det vises separat alertboks for dette scenarioet.

![over beløpsgrense](https://user-images.githubusercontent.com/110383605/225332240-12b2953f-1805-4b7f-82a8-54ae6c79bfa9.png)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Siden jeg måtte ha tilgang til useSimulering så brukte jeg SimuleringProvider for OppsummeringVedtak.
Det var raskeste vei til mål, men SimuleringContext bør på sikt skrives om da den kanskje ikke trenger provider i det hele tatt?
