### PR TITLE
Velg og vis mottakere av manuelle brev for EM-saker

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -12,6 +12,7 @@ import { Brevmal } from '../komponenter/Felleskomponenter/Hendelsesoversikt/Brev
 import type { IBehandling } from '../typer/behandling';
 import { BehandlingKategori } from '../typer/behandlingstema';
 import type { IManueltBrevRequestPåBehandling } from '../typer/dokument';
+import { FagsakType } from '../typer/fagsak';
 import { PersonType } from '../typer/person';
 import type { IBarnMedOpplysninger } from '../typer/søknad';
 import type { Målform } from '../typer/søknad';
@@ -41,11 +42,20 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
     const personer = åpenBehandling?.personer ?? [];
     const brevmottakere = åpenBehandling?.brevmottakere ?? [];
     const institusjon = minimalFagsak?.institusjon;
+    const fagsakType = minimalFagsak?.fagsakType;
+
+    const velgMottaker = (): string | undefined => {
+        if (minimalFagsak?.fagsakType === FagsakType.INSTITUSJON && institusjon) {
+            return institusjon.orgNummer;
+        }
+        if (minimalFagsak?.fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
+            return personer[0].personIdent;
+        }
+        return personer.find(person => person.type === PersonType.SØKER)?.personIdent;
+    };
 
     const mottakerIdent = useFelt({
-        verdi: institusjon
-            ? institusjon.orgNummer
-            : personer.find(person => person.type === PersonType.SØKER)?.personIdent || '',
+        verdi: velgMottaker() || '',
         valideringsfunksjon: (felt: FeltState<string>) =>
             felt.verdi.length >= 1 ? ok(felt) : feil(felt, 'Du må velge en mottaker'),
     });
@@ -364,6 +374,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         erBrevmalMedObligatoriskFritekst,
         institusjon,
         brevmottakere,
+        fagsakType,
     };
 });
 

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { FagsakType } from '../../../../typer/fagsak';
 import type { IInstitusjon } from '../../../../typer/institusjon-og-verge';
 import { type IGrunnlagPerson, PersonType } from '../../../../typer/person';
 import { formaterIdent, lagPersonLabel } from '../../../../utils/formatter';
@@ -12,9 +13,15 @@ interface IProps {
     personer: IGrunnlagPerson[];
     institusjon: IInstitusjon | undefined;
     brevmottakere: IRestBrevmottaker[];
+    fagsakType?: FagsakType;
 }
 
-const BrevmottakerListe: React.FC<IProps> = ({ personer, institusjon, brevmottakere }) => {
+const BrevmottakerListe: React.FC<IProps> = ({
+    personer,
+    institusjon,
+    brevmottakere,
+    fagsakType,
+}) => {
     const skalViseInstitusjon = !!institusjon;
     const harUtenlandskAdresse = brevmottakere.some(
         mottaker => mottaker.type === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
@@ -29,10 +36,24 @@ const BrevmottakerListe: React.FC<IProps> = ({ personer, institusjon, brevmottak
     const skalViseSøker =
         søker && !institusjon && !harManuellDødsboadresse && !harUtenlandskAdresse;
 
+    const skalViseEnsligMindreårig = fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG;
+
     return (
         <ul>
             {skalViseSøker && (
                 <li key="søker">{lagPersonLabel(søker.personIdent || '', personer)}</li>
+            )}
+            {skalViseEnsligMindreårig && (
+                <>
+                    <li key="barnet">
+                        {lagPersonLabel(
+                            personer.find(person => person.type === PersonType.BARN)?.personIdent ||
+                                '',
+                            personer
+                        )}
+                    </li>
+                    <li key="verge">Registrert verge</li>
+                </>
             )}
             {skalViseInstitusjon && (
                 <li key="institusjon">{`Institusjon | ${

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -125,6 +125,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
         erBrevmalMedObligatoriskFritekst,
         institusjon,
         brevmottakere,
+        fagsakType,
     } = useBrevModul();
 
     const [visForhåndsvisningModal, settForhåndsviningModal] = useState(false);
@@ -203,6 +204,7 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                     personer={personer}
                     institusjon={institusjon}
                     brevmottakere={brevmottakere}
+                    fagsakType={fagsakType}
                 />
                 <StyledFamilieSelect
                     {...skjema.felter.brevmal.hentNavInputProps(skjema.visFeilmeldinger)}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Forhåpentligvis en midlertidig løsning på å evaluere og vise mottakere av manuelle brev for enslig mindreårig-saker.

Usikker på om dette er noe vi har lyst til å gjøre. Men dette er en minimal løsning frem til vi får forbedret løsningen i backend som skissert under:

- Egentlig ønsker vi å fjerne hele `mottakerIdent`-feltet fra brevskjemaet og populere denne verdien i backend: #2539  https://github.com/navikt/familie-ba-sak/pull/3364
- I tillegg ønsker vi egentlig at backend evaluerer hvem som er brevmottaker manuelle brev og forteller dette til frontend som kun viser mottakerne. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
1: Får en feil i backend (i `OppgaveService.oppdaterOppgave`) ved sending av manuelt brev (innhenting av opplysninger) på EM-sak. Den typen brev skal føre til at oppgaven blir satt på vent, men det feiler. Usikker på om det er pga andre endringer som kreves i backend for EM-saker eller om det er relatert til denne endringen

2: I saken jeg tester på i preprod klarer jeg ikke å lese ut noe data om verge, selv om det er registrert verge på barnet. Derfor viser jeg bare "Registrert verge" som mottaker enn så lenge, men tar gjerne en prat om dette

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
