### PR TITLE
Tillater helmanuell migrering dersom det ikke er noe løpende fagsak og man kan migrere fra infotrygd

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -10,14 +10,14 @@ import type { ISkjema } from '@navikt/familie-skjema';
 import { useApp } from '../../../../../context/AppContext';
 import type { ManuellJournalføringSkjemaFelter } from '../../../../../context/ManuellJournalførContext';
 import {
+    BehandlingResultat,
     BehandlingStatus,
     Behandlingstype,
-    BehandlingÅrsak,
     behandlingÅrsak,
+    BehandlingÅrsak,
     erBehandlingHenlagt,
     type IBehandling,
 } from '../../../../../typer/behandling';
-import { BehandlingResultat } from '../../../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../../../typer/fagsak';
 import { FagsakStatus } from '../../../../../typer/fagsak';
 import { Klagebehandlingstype } from '../../../../../typer/klage';
@@ -151,9 +151,11 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
         skjema.felter.behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
     const kanOpprettMigreringsbehandlingMedHelmanuellMigrering =
         kanOppretteMigreringFraInfotrygd &&
-        (!kanOppretteRevurdering || forrigeBehandlingVarTekniskEndringMedOpphør(minimalFagsak));
+        (forrigeBehandlingVarTekniskEndringMedOpphør(minimalFagsak) ||
+            minimalFagsak?.status !== FagsakStatus.LØPENDE);
+
     const kanOppretteMigreringsbehandlingMedEndreMigreringsdato =
-        kanOppretteMigreringFraInfotrygd && !kanOpprettMigreringsbehandlingMedHelmanuellMigrering;
+        kanOppretteMigreringFraInfotrygd && kanOppretteRevurdering;
 
     const barn = bruker?.forelderBarnRelasjon
         .filter(relasjon => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12151

Vi ønsker å tillate helmanuelle migrering selvom det har vært tidligere behandlinger (bortsett fra når det er løpende utbetealing).

Logikken jeg endrer på ble rørt på i https://github.com/navikt/familie-ba-sak-frontend/pull/2473, så jeg reverter litt av det slik at endre migreringsdato ikke er avhengig av helmanuell migreringsvalget.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇