### PR TITLE
Quick-Win: Fikset "Sticky"-header og scrolling i vilkårsvurderingen

### DIFF
--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -19,6 +19,7 @@ const VenstremenyContainer = styled.div`
 `;
 
 const HovedinnholdContainer = styled.div`
+    height: calc(100vh - 6rem);
     flex: 1;
     overflow: auto;
 `;

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -14,6 +15,11 @@ import Dokumentutsending from './Dokumentutsending/Dokumentutsending';
 import JournalpostListe from './journalposter/JournalpostListe';
 import Personlinje from './Personlinje/Personlinje';
 import Saksoversikt from './Saksoversikt/Saksoversikt';
+
+const HovedInnhold = styled.div`
+    height: calc(100vh - 6rem);
+    overflow: auto;
+`;
 
 const FagsakContainer: React.FunctionComponent = () => {
     const { fagsakId } = useSakOgBehandlingParams();
@@ -55,33 +61,43 @@ const FagsakContainer: React.FunctionComponent = () => {
                     return (
                         <>
                             <Personlinje bruker={bruker.data} minimalFagsak={minimalFagsak.data} />
+                            <HovedInnhold>
+                                <Routes>
+                                    <Route
+                                        path="/saksoversikt"
+                                        element={
+                                            <Saksoversikt minimalFagsak={minimalFagsak.data} />
+                                        }
+                                    />
 
-                            <Routes>
-                                <Route
-                                    path="/saksoversikt"
-                                    element={<Saksoversikt minimalFagsak={minimalFagsak.data} />}
-                                />
+                                    <Route
+                                        path="/dokumentutsending"
+                                        element={
+                                            <DokumentutsendingProvider
+                                                fagsakId={minimalFagsak.data.id}
+                                            >
+                                                <Dokumentutsending />
+                                            </DokumentutsendingProvider>
+                                        }
+                                    />
 
-                                <Route
-                                    path="/dokumentutsending"
-                                    element={
-                                        <DokumentutsendingProvider fagsakId={minimalFagsak.data.id}>
-                                            <Dokumentutsending />
-                                        </DokumentutsendingProvider>
-                                    }
-                                />
+                                    <Route
+                                        path="/dokumenter"
+                                        element={<JournalpostListe bruker={bruker.data} />}
+                                    />
 
-                                <Route
-                                    path="/dokumenter"
-                                    element={<JournalpostListe bruker={bruker.data} />}
-                                />
-
-                                <Route path="/:behandlingId/*" element={<BehandlingContainer />} />
-                                <Route
-                                    path="/"
-                                    element={<Navigate to={`/fagsak/${fagsakId}/saksoversikt`} />}
-                                />
-                            </Routes>
+                                    <Route
+                                        path="/:behandlingId/*"
+                                        element={<BehandlingContainer />}
+                                    />
+                                    <Route
+                                        path="/"
+                                        element={
+                                            <Navigate to={`/fagsak/${fagsakId}/saksoversikt`} />
+                                        }
+                                    />
+                                </Routes>
+                            </HovedInnhold>
                         </>
                     );
                 case RessursStatus.FEILET:

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import styled from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -15,11 +14,6 @@ import Dokumentutsending from './Dokumentutsending/Dokumentutsending';
 import JournalpostListe from './journalposter/JournalpostListe';
 import Personlinje from './Personlinje/Personlinje';
 import Saksoversikt from './Saksoversikt/Saksoversikt';
-
-const Hovedinnhold = styled.div`
-    height: calc(100vh - 6rem);
-    overflow: auto;
-`;
 
 const FagsakContainer: React.FunctionComponent = () => {
     const { fagsakId } = useSakOgBehandlingParams();
@@ -62,43 +56,32 @@ const FagsakContainer: React.FunctionComponent = () => {
                         <>
                             <Personlinje bruker={bruker.data} minimalFagsak={minimalFagsak.data} />
 
-                            <Hovedinnhold>
-                                <Routes>
-                                    <Route
-                                        path="/saksoversikt"
-                                        element={
-                                            <Saksoversikt minimalFagsak={minimalFagsak.data} />
-                                        }
-                                    />
+                            <Routes>
+                                <Route
+                                    path="/saksoversikt"
+                                    element={<Saksoversikt minimalFagsak={minimalFagsak.data} />}
+                                />
 
-                                    <Route
-                                        path="/dokumentutsending"
-                                        element={
-                                            <DokumentutsendingProvider
-                                                fagsakId={minimalFagsak.data.id}
-                                            >
-                                                <Dokumentutsending />
-                                            </DokumentutsendingProvider>
-                                        }
-                                    />
+                                <Route
+                                    path="/dokumentutsending"
+                                    element={
+                                        <DokumentutsendingProvider fagsakId={minimalFagsak.data.id}>
+                                            <Dokumentutsending />
+                                        </DokumentutsendingProvider>
+                                    }
+                                />
 
-                                    <Route
-                                        path="/dokumenter"
-                                        element={<JournalpostListe bruker={bruker.data} />}
-                                    />
+                                <Route
+                                    path="/dokumenter"
+                                    element={<JournalpostListe bruker={bruker.data} />}
+                                />
 
-                                    <Route
-                                        path="/:behandlingId/*"
-                                        element={<BehandlingContainer />}
-                                    />
-                                    <Route
-                                        path="/"
-                                        element={
-                                            <Navigate to={`/fagsak/${fagsakId}/saksoversikt`} />
-                                        }
-                                    />
-                                </Routes>
-                            </Hovedinnhold>
+                                <Route path="/:behandlingId/*" element={<BehandlingContainer />} />
+                                <Route
+                                    path="/"
+                                    element={<Navigate to={`/fagsak/${fagsakId}/saksoversikt`} />}
+                                />
+                            </Routes>
                         </>
                     );
                 case RessursStatus.FEILET:


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11990

### 💰 Hva forsøker du å løse i denne PR'en
Når man scroller i vilkårsvurderingen skal `PersonHeader` for personen man fyller ut vilkårsvurderingskjema for, være "sticky" på toppen av siden. Scrolling for ventremeny, hovedinnhold og høyremeny vil også skje uavhengig av hverandre.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Selve sticky-funksjonaliteten lå egentlig inne fra før, men hadde sluttet å virke etter en liten omstrukturering av `FagsakContainer` og `BehandlingContainer`,  så denne PR'en sørger bare for at det fungerer igjen.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/70642183/226592022-dcb552f7-2ecf-4031-9513-2cadaa94a575.png)
