### PR TITLE
Oppdaterer SimuleringPanel til å bruke nye farger og panel av navikt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringPanel.tsx
@@ -2,10 +2,8 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import navFarger from 'nav-frontend-core';
-import Panel from 'nav-frontend-paneler';
-
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, Label, Panel } from '@navikt/ds-react';
+import { AGray900, ABorderDefault, ANavRed, AGreen700 } from '@navikt/ds-tokens/dist/tokens';
 
 import type { ISimuleringDTO, ISimuleringPeriode } from '../../../typer/simulering';
 import { datoformat, formaterBeløp, formaterIsoDato } from '../../../utils/formatter';
@@ -36,11 +34,11 @@ const StyledTd = styled.th(
 );
 
 const LabelMedFarge = styled(Label)`
-    color: ${(props: { farge?: string }) => (props.farge ? props.farge : navFarger.navMorkGra)};
+    color: ${(props: { farge?: string }) => (props.farge ? props.farge : AGray900)};
 `;
 
 const StyledHr = styled.hr`
-    border-top: 1px solid ${navFarger.navGra40};
+    border-top: 1px solid ${ABorderDefault};
     margin-left: 0.125rem;
 `;
 
@@ -100,9 +98,7 @@ const SimuleringPanel: React.FunctionComponent<ISimuleringProps> = ({
                             <BodyShort>Feilutbetaling</BodyShort>
                         </StyledTd>
                         <StyledTd erHøyrestilt={true}>
-                            <LabelMedFarge
-                                farge={feilutbetaling > 0 ? navFarger.navRod : navFarger.navMorkGra}
-                            >
+                            <LabelMedFarge farge={feilutbetaling > 0 ? ANavRed : AGray900}>
                                 {formaterBeløpEllerDashOmUndefined(feilutbetaling)}
                             </LabelMedFarge>
                         </StyledTd>
@@ -152,8 +148,8 @@ const SimuleringPanel: React.FunctionComponent<ISimuleringProps> = ({
                                 <LabelMedFarge
                                     farge={
                                         nestePeriode?.resultat && nestePeriode.resultat > 0
-                                            ? navFarger.navGronnDarken40
-                                            : navFarger.navMorkGra
+                                            ? AGreen700
+                                            : AGray900
                                     }
                                 >
                                     {formaterBeløpEllerDashOmUndefined(nestePeriode?.resultat)}

--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringPanel.tsx
@@ -3,7 +3,12 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import { BodyShort, Label, Panel } from '@navikt/ds-react';
-import { AGray900, ABorderDefault, ANavRed, AGreen700 } from '@navikt/ds-tokens/dist/tokens';
+import {
+    ABorderDefault,
+    AGreen700,
+    ATextDefault,
+    ATextDanger,
+} from '@navikt/ds-tokens/dist/tokens';
 
 import type { ISimuleringDTO, ISimuleringPeriode } from '../../../typer/simulering';
 import { datoformat, formaterBeløp, formaterIsoDato } from '../../../utils/formatter';
@@ -34,7 +39,7 @@ const StyledTd = styled.th(
 );
 
 const LabelMedFarge = styled(Label)`
-    color: ${(props: { farge?: string }) => (props.farge ? props.farge : AGray900)};
+    color: ${(props: { farge?: string }) => (props.farge ? props.farge : ATextDefault)};
 `;
 
 const StyledHr = styled.hr`
@@ -98,7 +103,7 @@ const SimuleringPanel: React.FunctionComponent<ISimuleringProps> = ({
                             <BodyShort>Feilutbetaling</BodyShort>
                         </StyledTd>
                         <StyledTd erHøyrestilt={true}>
-                            <LabelMedFarge farge={feilutbetaling > 0 ? ANavRed : AGray900}>
+                            <LabelMedFarge farge={feilutbetaling > 0 ? ATextDanger : ATextDefault}>
                                 {formaterBeløpEllerDashOmUndefined(feilutbetaling)}
                             </LabelMedFarge>
                         </StyledTd>
@@ -149,7 +154,7 @@ const SimuleringPanel: React.FunctionComponent<ISimuleringProps> = ({
                                     farge={
                                         nestePeriode?.resultat && nestePeriode.resultat > 0
                                             ? AGreen700
-                                            : AGray900
+                                            : ATextDefault
                                     }
                                 >
                                     {formaterBeløpEllerDashOmUndefined(nestePeriode?.resultat)}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12232

Oppdaterer SimuleringPanel til å bruke nye farger og panel av navikt

Før:
![før](https://user-images.githubusercontent.com/110383605/226889705-852488ce-b921-4c0a-862c-25203d2b9127.png)

Etter:
![etter](https://user-images.githubusercontent.com/110383605/226889745-bd22756f-fb49-4df1-b13b-7d134a497d55.png)

