### PR TITLE
Oppdaterer SimuleringTabell til å bruke nye farger. Fjerner import av nav frontend tabell style

### DIFF
--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
@@ -2,11 +2,14 @@ import * as React from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
-import 'nav-frontend-tabell-style';
-
-import navFarger from 'nav-frontend-core';
 
 import { Alert, BodyShort, Label } from '@navikt/ds-react';
+import {
+    ABorderDefault,
+    ATextDanger,
+    ATextDefault,
+    AGreen700,
+} from '@navikt/ds-tokens/dist/tokens';
 
 import { useApp } from '../../../context/AppContext';
 import type { ISimuleringDTO, ISimuleringPeriode } from '../../../typer/simulering';
@@ -38,7 +41,7 @@ const HøyrestiltTh = styled.th`
 `;
 
 const BodyshortMedFarge = styled(BodyShort)`
-    color: ${(props: { farge?: string }) => (props.farge ? props.farge : navFarger.navMorkGra)};
+    color: ${(props: { farge?: string }) => (props.farge ? props.farge : ATextDefault)};
 `;
 
 const VenstreKolonne = styled.col`
@@ -60,7 +63,7 @@ const Skillelinje = styled.td`
 
     hr {
         border: none;
-        border-right: 1px dashed ${navFarger.navGra60};
+        border-right: 1px dashed ${ABorderDefault};
         height: ${(props: { erHeader?: boolean }) => (props.erHeader ? '3.875rem' : '3.25rem')};
         position: absolute;
         top: -0.375rem;
@@ -75,7 +78,7 @@ const SimuleringTabellOverskrift = styled.div`
 `;
 
 const LabelMedFarge = styled(Label)`
-    color: ${(props: { farge?: string }) => (props.farge ? props.farge : navFarger.navMorkGra)};
+    color: ${(props: { farge?: string }) => (props.farge ? props.farge : ATextDefault)};
 `;
 
 interface ISimuleringProps {
@@ -245,8 +248,8 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
                                         <LabelMedFarge
                                             farge={
                                                 periode.resultat && periode.resultat < 0
-                                                    ? navFarger.navRod
-                                                    : navFarger.navGronnDarken40
+                                                    ? ATextDanger
+                                                    : AGreen700
                                             }
                                         >
                                             {formaterBeløpUtenValutakode(periode.resultat)}
@@ -255,8 +258,8 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
                                         <BodyshortMedFarge
                                             farge={
                                                 periode.resultat && periode.resultat < 0
-                                                    ? navFarger.navRod
-                                                    : navFarger.navMorkGra
+                                                    ? ATextDanger
+                                                    : ATextDefault
                                             }
                                         >
                                             {formaterBeløpUtenValutakode(periode.resultat)}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12232

Oppdaterer SimuleringTabell til å bruke nye farger. Fjerner import av nav frontend tabell style.

Før:
<img width="446" alt="Screenshot 2023-03-22 at 12 44 49" src="https://user-images.githubusercontent.com/110383605/226894432-a39d196a-9f2b-4596-aeb9-211c0ed95bc5.png">

Etter:
<img width="407" alt="Screenshot 2023-03-22 at 12 44 26" src="https://user-images.githubusercontent.com/110383605/226894481-e779fc9e-cd07-482b-a61f-a90e6236d9ce.png">
