### PR TITLE
Oppdaterer kanSøkeFritekst til å bruke fieldset istedenfor skjemagruppe

### DIFF
--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Label, SkjemaGruppe } from 'nav-frontend-skjema';
-
 import { AddCircle, Delete } from '@navikt/ds-icons';
-import { Button } from '@navikt/ds-react';
+import { Button, Fieldset } from '@navikt/ds-react';
 import { FamilieTextarea } from '@navikt/familie-form-elements';
 import type { FeltState } from '@navikt/familie-skjema';
 
@@ -70,66 +68,64 @@ const KanSøkeFritekst = ({
 
     return (
         <>
-            <Label htmlFor={skjemaGruppeId}>Fritekst til kulepunkt i brev</Label>
-            <>
-                <SkjemaGruppe
-                    id={skjemaGruppeId}
-                    feil={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
+            <Fieldset
+                id={skjemaGruppeId}
+                error={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
+                legend="Fritekst felt til kulepunkt i brev"
+            >
+                {friteksterFelt.verdi.map((fritekst: FeltState<IFritekstFelt>) => {
+                    const fritekstId = fritekst.verdi.id;
+
+                    return (
+                        <StyledFamilieFritekstFelt key={`fritekst-${fritekstId}`}>
+                            <FamilieTextareaBegrunnelseFritekst
+                                erLesevisning={false}
+                                key={`fritekst-${fritekstId}`}
+                                id={`${fritekstId}`}
+                                className={'fritekst-textarea'}
+                                value={fritekst.verdi.tekst}
+                                label={`Kulepunkt ${fritekstId}`}
+                                hideLabel={true}
+                                maxLength={makslengdeFritekst}
+                                onChange={event => onChangeFritekst(event, fritekstId)}
+                                error={skjema.visFeilmeldinger && fritekst.feilmelding}
+                                /* eslint-disable-next-line jsx-a11y/no-autofocus */
+                                autoFocus
+                            />
+
+                            <SletteKnapp
+                                variant={'tertiary'}
+                                onClick={() => {
+                                    friteksterFelt.validerOgSettFelt([
+                                        ...friteksterFelt.verdi.filter(
+                                            mapFritekst =>
+                                                mapFritekst.verdi.id !== fritekst.verdi.id
+                                        ),
+                                    ]);
+                                }}
+                                id={`fjern_fritekst-${fritekstId}`}
+                                size={'small'}
+                                aria-label={'Fjern fritekst'}
+                                icon={<Delete />}
+                            >
+                                {'Fjern'}
+                            </SletteKnapp>
+                        </StyledFamilieFritekstFelt>
+                    );
+                })}
+            </Fieldset>
+
+            {!erMaksAntallKulepunkter && (
+                <Button
+                    variant={'tertiary'}
+                    onClick={leggTilFritekst}
+                    id={`legg-til-fritekst`}
+                    size={'small'}
+                    icon={<AddCircle />}
                 >
-                    {friteksterFelt.verdi.map((fritekst: FeltState<IFritekstFelt>) => {
-                        const fritekstId = fritekst.verdi.id;
-
-                        return (
-                            <StyledFamilieFritekstFelt key={`fritekst-${fritekstId}`}>
-                                <FamilieTextareaBegrunnelseFritekst
-                                    erLesevisning={false}
-                                    key={`fritekst-${fritekstId}`}
-                                    id={`${fritekstId}`}
-                                    className={'fritekst-textarea'}
-                                    value={fritekst.verdi.tekst}
-                                    label={`Kulepunkt ${fritekstId}`}
-                                    hideLabel={true}
-                                    maxLength={makslengdeFritekst}
-                                    onChange={event => onChangeFritekst(event, fritekstId)}
-                                    error={skjema.visFeilmeldinger && fritekst.feilmelding}
-                                    /* eslint-disable-next-line jsx-a11y/no-autofocus */
-                                    autoFocus
-                                />
-
-                                <SletteKnapp
-                                    variant={'tertiary'}
-                                    onClick={() => {
-                                        friteksterFelt.validerOgSettFelt([
-                                            ...friteksterFelt.verdi.filter(
-                                                mapFritekst =>
-                                                    mapFritekst.verdi.id !== fritekst.verdi.id
-                                            ),
-                                        ]);
-                                    }}
-                                    id={`fjern_fritekst-${fritekstId}`}
-                                    size={'small'}
-                                    aria-label={'Fjern fritekst'}
-                                    icon={<Delete />}
-                                >
-                                    {'Fjern'}
-                                </SletteKnapp>
-                            </StyledFamilieFritekstFelt>
-                        );
-                    })}
-                </SkjemaGruppe>
-
-                {!erMaksAntallKulepunkter && (
-                    <Button
-                        variant={'tertiary'}
-                        onClick={leggTilFritekst}
-                        id={`legg-til-fritekst`}
-                        size={'small'}
-                        icon={<AddCircle />}
-                    >
-                        {'Legg til fritekst'}
-                    </Button>
-                )}
-            </>
+                    {'Legg til fritekst'}
+                </Button>
+            )}
         </>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
@@ -71,7 +71,7 @@ const KanSøkeFritekst = ({
             <Fieldset
                 id={skjemaGruppeId}
                 error={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
-                legend="Fritekst felt til kulepunkt i brev"
+                legend="Fritekst til kulepunkt i brev"
             >
                 {friteksterFelt.verdi.map((fritekst: FeltState<IFritekstFelt>) => {
                     const fritekstId = fritekst.verdi.id;


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12232

Oppdaterer kanSøkeFritekst til å bruke fieldset istedenfor skjemagruppe. 
Fjerner bruk av Label og bruker heller legend i fieldset.

Før:
<img width="456" alt="førr" src="https://user-images.githubusercontent.com/110383605/226904811-1c7ac381-c3e5-47c5-9405-201bce514cb2.png">

Etter
<img width="458" alt="etterrr" src="https://user-images.githubusercontent.com/110383605/226906453-9aa86b81-8c49-4c94-a93d-581228c3b4a7.png">
