### PR TITLE
Chore: valider at valutakursdato er gyldig iso streng

### DIFF
--- a/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
+++ b/src/frontend/context/Valutakurs/ValutakursSkjemaContext.tsx
@@ -17,7 +17,7 @@ import {
     tellAntallDesimaler,
 } from '../../utils/eøsValidators';
 import type { IYearMonthPeriode } from '../../utils/kalender';
-import { sammenlignDatoer } from '../../utils/kalender';
+import { erIsoStringGyldig, sammenlignDatoer } from '../../utils/kalender';
 import { nyYearMonthPeriode } from '../../utils/kalender';
 import { useBehandling } from '../behandlingContext/BehandlingContext';
 import {
@@ -27,8 +27,14 @@ import {
 
 const erValutakursDatoGyldig = (
     felt: FeltState<string | undefined>
-): FeltState<string | undefined> =>
-    !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Valutakursdato er påkrevd, men mangler input');
+): FeltState<string | undefined> => {
+    if (isEmpty(felt.verdi)) {
+        return feil(felt, 'Valutakursdato er påkrevd, men mangler input');
+    } else if (!erIsoStringGyldig(felt.verdi)) {
+        return feil(felt, 'Ugyldig format på valutakursdato');
+    }
+    return ok(felt);
+};
 const erValutakursGyldig = (
     felt: FeltState<string | undefined>,
     skalValideres: boolean


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi har fått inn noen feil av denne typen i sentry:
![image](https://user-images.githubusercontent.com/25459913/227550735-7a44c0a9-68e8-4bee-8d13-fee8f59404ff.png)

Legger på validering som sikrer at valutakursdato er gyldig iso streng før vi kaller backend.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei
### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har sjekket manuelt at det funker

### 🤷‍♀ ️Hvor er det lurt å starte?
Er bare 1, så samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
