### PR TITLE
Ikke sjekk om tom er før fom hvis fom er ugyldig

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
@@ -60,12 +60,14 @@ const validerTom = (felt: FeltState<FamilieIsoDate>, fom: FamilieIsoDate) => {
         return feil(felt, 'T.o.m. kan ikke være senere enn inneværende måned');
     }
 
-    const fomKalenderDato = kalenderDatoMedFallback(fom, TIDENES_MORGEN);
-    const tomKalenderDato = kalenderDatoMedFallback(tom, TIDENES_ENDE);
-    const fomDatoErFørTomDato = erFør(fomKalenderDato, tomKalenderDato);
+    if (erIsoStringGyldig(fom)) {
+        const fomKalenderDato = kalenderDatoMedFallback(fom, TIDENES_MORGEN);
+        const tomKalenderDato = kalenderDatoMedFallback(tom, TIDENES_ENDE);
+        const fomDatoErFørTomDato = erFør(fomKalenderDato, tomKalenderDato);
 
-    if (!fomDatoErFørTomDato) {
-        return feil(felt, 'T.o.m. må være senere enn f.o.m');
+        if (!fomDatoErFørTomDato) {
+            return feil(felt, 'T.o.m. må være senere enn f.o.m');
+        }
     }
 
     return ok(felt);


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Har fått feil av denne typen i sentry:
![image](https://user-images.githubusercontent.com/25459913/227556937-c3b83609-f6eb-4842-b486-a91e92130adb.png)
Dette gjør at nettsiden krasjer for saksbehandler.

Feilen skyldes saksbehandler som har puttet inn en ugyldig fom-dato, og når man putter inn tom-datoen så prøver man å sjekke om tom er etter fom. Siden fom er ugyldig vil "kalenderDatoMedFallback" kaste en feil fordi fom ikke er gyldig. Ønsker derfor ikke å sjekke tom mot fom hvis ikke både tom og fom er gyldig. 
Når man til slutt har både gyldig fom og tom vil man sjekke at tom er etter fom, så det er ingen validering som går tapt.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Unødvendig 🤷‍♂️

### 🤷‍♀ ️Hvor er det lurt å starte?
Er bare 1!

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://user-images.githubusercontent.com/25459913/227556870-3d89a7ba-ce53-41ea-b248-24a07ab87d2b.png)
