### PR TITLE
NAV-12237 Oppdatert z-index på dropdown i vilkårsvurdering (Vurdering…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -118,6 +118,7 @@ const AvslagBegrunnelseMultiselect: React.FC<IProps> = ({
                 container: provided => ({
                     ...provided,
                     maxWidth: '25rem',
+                    zIndex: 3,
                 }),
                 groupHeading: provided => ({
                     ...provided,

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import navFarger from 'nav-frontend-core';
 
 import { Alert } from '@navikt/ds-react';
+import { AZIndexFocus } from '@navikt/ds-tokens/dist/tokens';
 import type { ActionMeta, ISelectOption } from '@navikt/familie-form-elements';
 import { FamilieReactSelect } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -118,7 +119,7 @@ const AvslagBegrunnelseMultiselect: React.FC<IProps> = ({
                 container: provided => ({
                     ...provided,
                     maxWidth: '25rem',
-                    zIndex: 3,
+                    zIndex: AZIndexFocus.valueOf(),
                 }),
                 groupHeading: provided => ({
                     ...provided,


### PR DESCRIPTION
…en er et avslag -> Velg standardtekst i brev) til: 3, da bakenforliggende datovelgere har z-index:2



### 💰 Hva forsøker du å løse i denne PR'en
At dropdown i vilkårsvurdering (vurderingen er et avslag -> Velg standardtekst i brev)  kommer over datovelger-knappene under i ui. (har høyere z-index)


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det er overflødig med tester for å verifisere at dropdown har høyere z-index i denne konteksten


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Før:
![dropdown-foer](https://user-images.githubusercontent.com/126786453/228214168-b9758b10-3f51-4bf1-91a3-dc8b812099f8.png)

Etter:
![dropdown-etter](https://user-images.githubusercontent.com/126786453/228214189-0c25b027-1632-40db-af90-46846a3cb0b8.png)

