### PR TITLE
NAV-10332 Legg til teksten: "(Valgfri)" bak teksten: "Utdypende vilkår"

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -9,6 +9,7 @@ import type { FeltState } from '@navikt/familie-skjema';
 
 import type { PersonType } from '../../../../typer/person';
 import {
+    Regelverk,
     UtdypendeVilkårsvurderingDeltBosted,
     UtdypendeVilkårsvurderingEøsBarnBorMedSøker,
     UtdypendeVilkårsvurderingEøsBarnBosattIRiket,
@@ -168,7 +169,11 @@ export const UtdypendeVilkårsvurderingMultiselect: React.FC<Props> = ({
     return (
         <StyledFamilieReactSelect
             id="UtdypendeVilkarsvurderingMultiselect"
-            label="Utdypende vilkårsvurdering"
+            label={
+                redigerbartVilkår.verdi.vurderesEtter === Regelverk.NASJONALE_REGLER
+                    ? 'Utdypende vilkårsvurdering (valgfri)'
+                    : 'Utdypende vilkårsvurdering'
+            }
             value={redigerbartVilkår.verdi.utdypendeVilkårsvurderinger.verdi.map(
                 mapUtdypendeVilkårsvurderingTilOption
             )}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-10332

### 💰 Hva forsøker du å løse i denne PR'en
Label-tekst for "Utdypende vilkårsvurdering" skal ha teksten "(valgfri)" bak - for vilkår som vurderes etter nasjonalt regelverk



### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tester anses unødvendig for betinget tekstendring


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Før: Label teksten "Utdypende vilkårsvurdering" var statisk uavhengig av regler som vilkår vurderes etter
Etter:
![etter_nasjonale_regler_utdypende_vilkårsvurdering](https://user-images.githubusercontent.com/126786453/228744949-34c5333f-3ef5-4354-94bf-f258dc580de7.png)
![etter_eoes_regler_utdypende_vilkårsvurdering](https://user-images.githubusercontent.com/126786453/228744970-7ee39ee1-506f-4b87-87ca-1f53d4690274.png)

