### PR TITLE
NAV-12298 - Reduser kall internt i komponenter til vurderErLesevisning()

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -110,6 +110,8 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
         hentValutakurserMedFeil,
     } = useEøs();
 
+    const erLesevisning = vurderErLesevisning();
+
     useEffect(() => {
         hentPersonerMedUgyldigEtterbetalingsperiode();
     }, [åpenBehandling]);
@@ -176,7 +178,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
             className="behandlingsresultat"
             forrigeOnClick={forrigeOnClick}
             nesteOnClick={() => {
-                if (vurderErLesevisning()) {
+                if (erLesevisning) {
                     navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/simulering`);
                 } else if (harEøs && !erEøsInformasjonGyldig()) {
                     settVisFeilmeldinger(true);
@@ -206,7 +208,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
                 tidslinjePersoner={tidslinjePersoner}
                 fagsakType={minimalFagsak?.fagsakType}
             />
-            {!vurderErLesevisning() && (
+            {!erLesevisning && (
                 <EndretUtbetalingAndel>
                     <Button
                         variant="tertiary"

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -85,6 +85,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
     const { request } = useHttp();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
     const { toggles } = useApp();
+    const erLesevisning = vurderErLesevisning();
 
     const {
         endretUtbetalingAndel,
@@ -187,7 +188,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         onChange={(event): void => {
                             skjema.felter.person.validerOgSettFelt(event.target.value);
                         }}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                     >
                         <option value={undefined}>Velg person</option>
                         {åpenBehandling.personer
@@ -223,7 +224,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                     skjema.felter.fom.validerOgSettFelt(dato);
                                 }
                             }}
-                            lesevisning={vurderErLesevisning()}
+                            lesevisning={erLesevisning}
                         />
                     </Feltmargin>
                     <MånedÅrVelger
@@ -239,7 +240,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 skjema.felter.tom.validerOgSettFelt(dato);
                             }
                         }}
-                        lesevisning={vurderErLesevisning()}
+                        lesevisning={erLesevisning}
                     />
                 </Feltmargin>
 
@@ -254,7 +255,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 event.target.value as IEndretUtbetalingAndelÅrsak
                             );
                         }}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         lesevisningVerdi={
                             skjema.felter.årsak.verdi ? årsakTekst[skjema.felter.årsak.verdi] : ''
                         }
@@ -269,7 +270,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 </Feltmargin>
 
                 <Feltmargin>
-                    {vurderErLesevisning() ? (
+                    {erLesevisning ? (
                         <>
                             <Label>Utbetaling</Label>
                             <BodyShort>
@@ -318,7 +319,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         onChange={(dato?: ISODateString) =>
                             skjema.felter.søknadstidspunkt.validerOgSettFelt(dato)
                         }
-                        erLesesvisning={vurderErLesevisning()}
+                        erLesesvisning={erLesevisning}
                     />
                 </Feltmargin>
 
@@ -342,7 +343,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                             onChange={(dato?: ISODateString) =>
                                 skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(dato)
                             }
-                            erLesesvisning={vurderErLesevisning()}
+                            erLesesvisning={erLesevisning}
                         />
                         {skjema.felter.avtaletidspunktDeltBosted.feilmelding &&
                             skjema.visFeilmeldinger && (
@@ -391,7 +392,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 <Feltmargin>
                     <StyledFamilieTextarea
                         {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         label={'Begrunnelse'}
                         resize
                         value={
@@ -405,7 +406,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         }}
                     />
                 </Feltmargin>
-                {!vurderErLesevisning() && (
+                {!erLesevisning && (
                     <Knapperekke>
                         <KnapperekkeVenstre>
                             <StyledFerdigKnapp
@@ -425,7 +426,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 Avbryt
                             </Button>
                         </KnapperekkeVenstre>
-                        {!vurderErLesevisning() ? (
+                        {!erLesevisning ? (
                             <Button
                                 variant={'tertiary'}
                                 id={`sletteknapp-endret-utbetaling-andel-${endretUtbetalingAndel.id}`}

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -158,6 +158,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
 }) => {
     const { request } = useHttp();
     const { settÅpenBehandling, åpenBehandling, vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const { settToast } = useApp();
     const { settAktivEtikett } = useTidslinje();
 
@@ -340,7 +341,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                 variant={'tertiary'}
                                 size={'xsmall'}
                                 loading={justererSmåbarnstillegg}
-                                disabled={justererSmåbarnstillegg || vurderErLesevisning()}
+                                disabled={justererSmåbarnstillegg || erLesevisning}
                                 onClick={() =>
                                     fjernSmåbarnstilleggFraMåned(småbarnstilleggKorrigering)
                                 }
@@ -356,7 +357,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                 variant={'tertiary'}
                                 size={'xsmall'}
                                 loading={justererSmåbarnstillegg}
-                                disabled={justererSmåbarnstillegg || vurderErLesevisning()}
+                                disabled={justererSmåbarnstillegg || erLesevisning}
                                 onClick={() =>
                                     leggSmåbarnstilleggTilIMåned(småbarnstilleggKorrigering)
                                 }

--- a/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/RegistrerMottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/InstitusjonOgVerge/RegistrerMottaker.tsx
@@ -25,6 +25,7 @@ const RegistrerMottaker: React.FC = () => {
     const { fagsakType, fagsakFeilmelding, onSubmitMottaker, submitFeilmelding } =
         useInstitusjonOgVerge();
     const { behandlingsstegSubmitressurs, vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     return (
         <>
@@ -33,14 +34,14 @@ const RegistrerMottaker: React.FC = () => {
                     className={'mottaker'}
                     tittel={'Registrer mottaker'}
                     nesteOnClick={onSubmitMottaker}
-                    nesteKnappTittel={vurderErLesevisning() ? 'Neste' : 'Bekreft og fortsett'}
+                    nesteKnappTittel={erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
                     senderInn={behandlingsstegSubmitressurs.status === RessursStatus.HENTER}
                     steg={BehandlingSteg.REGISTRERE_INSTITUSJON_OG_VERGE}
                 >
                     {fagsakType === FagsakType.INSTITUSJON ? (
                         <Institusjon />
                     ) : (
-                        <Verge erLesevisning={vurderErLesevisning()} />
+                        <Verge erLesevisning={erLesevisning} />
                     )}
                     {submitFeilmelding && <Alert variant="error" children={submitFeilmelding} />}
                 </StyledSkjemasteg>

--- a/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/TilbakekrevingSkjema.tsx
@@ -139,7 +139,7 @@ const TilbakekrevingSkjema: React.FC<{
     if (
         harÅpenTilbakekrevingRessurs.status === RessursStatus.SUKSESS &&
         harÅpenTilbakekrevingRessurs.data &&
-        !vurderErLesevisning()
+        !erLesevisning
     ) {
         return (
             <>
@@ -152,7 +152,7 @@ const TilbakekrevingSkjema: React.FC<{
         );
     }
 
-    if (vurderErLesevisning() && !tilbakekrevingSkjema.felter.tilbakekrevingsvalg.verdi) {
+    if (erLesevisning && !tilbakekrevingSkjema.felter.tilbakekrevingsvalg.verdi) {
         return (
             <>
                 <StyledLabel>Tilbakekrevingsvalg</StyledLabel>
@@ -225,7 +225,7 @@ const TilbakekrevingSkjema: React.FC<{
                         tilbakekrevingSkjema.visFeilmeldinger ||
                             begrunnelse.verdi.length > maksLengdeTekst
                     )}
-                    erLesevisning={vurderErLesevisning()}
+                    erLesevisning={erLesevisning}
                     maxLength={maksLengdeTekst}
                     description="Hva er årsaken til feilutbetaling? Hvordan og når ble feilutbetalingen oppdaget? Begrunn hvordan feilutbetalingen skal behandles videre."
                 />
@@ -351,7 +351,7 @@ const TilbakekrevingSkjema: React.FC<{
                                                 tilbakekrevingSkjema.visFeilmeldinger ||
                                                     fritekstVarsel.verdi.length > maksLengdeTekst
                                             )}
-                                            erLesevisning={vurderErLesevisning()}
+                                            erLesevisning={erLesevisning}
                                             maxLength={maksLengdeTekst}
                                         />
 
@@ -401,11 +401,11 @@ const TilbakekrevingSkjema: React.FC<{
                         </Radio>
                     </RadioGroup>
                 )}
-                {vurderErLesevisning() && fritekstVarsel.erSynlig && (
+                {erLesevisning && fritekstVarsel.erSynlig && (
                     <FamilieTextarea
                         label="Fritekst i varselet"
                         {...fritekstVarsel.hentNavInputProps(tilbakekrevingSkjema.visFeilmeldinger)}
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                     />
                 )}
 

--- a/src/frontend/komponenter/Fagsak/Søknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/BarnMedOpplysninger.tsx
@@ -45,7 +45,7 @@ const FjernBarnKnapp = styled(Button)`
 const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
     const { skjema, barnMedLøpendeUtbetaling } = useSøknad();
     const { vurderErLesevisning, gjelderInstitusjon, gjelderEnsligMindreårig } = useBehandling();
-
+    const erLesevisning = vurderErLesevisning();
     const barnetHarLøpendeUtbetaling = barnMedLøpendeUtbetaling.has(barn.ident);
 
     const navnOgIdentTekst = `${barn.navn ?? 'Navn ukjent'} (${hentAlderSomString(
@@ -68,7 +68,7 @@ const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
 
     return (
         <CheckboxOgSlettknapp>
-            {vurderErLesevisning() || gjelderInstitusjon || gjelderEnsligMindreårig ? (
+            {erLesevisning || gjelderInstitusjon || gjelderEnsligMindreårig ? (
                 barn.merket ? (
                     <BodyShort
                         className={classNames('skjemaelement', 'lese-felt')}
@@ -97,7 +97,7 @@ const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
                     </LabelContent>
                 </StyledCheckbox>
             )}
-            {barn.manueltRegistrert && !vurderErLesevisning() && (
+            {barn.manueltRegistrert && !erLesevisning && (
                 <FjernBarnKnapp
                     variant={'tertiary'}
                     id={`fjern__${barn.ident}`}

--- a/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/RegistrerSøknad.tsx
@@ -28,6 +28,7 @@ const StyledSkjemasteg = styled(Skjemasteg)`
 
 const RegistrerSøknad: React.FC = () => {
     const { vurderErLesevisning, gjelderInstitusjon } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const {
         hentFeilTilOppsummering,
@@ -45,11 +46,11 @@ const RegistrerSøknad: React.FC = () => {
             nesteOnClick={() => {
                 nesteAction(false);
             }}
-            nesteKnappTittel={vurderErLesevisning() ? 'Neste' : 'Bekreft og fortsett'}
+            nesteKnappTittel={erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
             senderInn={skjema.submitRessurs.status === RessursStatus.HENTER}
             steg={BehandlingSteg.REGISTRERE_SØKNAD}
         >
-            {søknadErLastetFraBackend && !vurderErLesevisning() && (
+            {søknadErLastetFraBackend && !erLesevisning && (
                 <>
                     <br />
                     <Alert
@@ -69,7 +70,7 @@ const RegistrerSøknad: React.FC = () => {
             <MålformVelger
                 målformFelt={skjema.felter.målform}
                 visFeilmeldinger={skjema.visFeilmeldinger}
-                erLesevisning={vurderErLesevisning()}
+                erLesevisning={erLesevisning}
             />
 
             <Annet />

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/Personvelger.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/Personvelger.tsx
@@ -14,6 +14,7 @@ import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBe
 
 const Personvelger: React.FC = () => {
     const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const { skjema, åpenBehandling, id } = useVedtaksperiodeMedBegrunnelser();
 
     const personIdenter = useFelt({
@@ -49,13 +50,11 @@ const Personvelger: React.FC = () => {
             id={`personvelger-${id}`}
             value={personIdenter.verdi}
             placeholder={`Velg`}
-            isDisabled={
-                vurderErLesevisning() || skjema.submitRessurs.status === RessursStatus.HENTER
-            }
+            isDisabled={erLesevisning || skjema.submitRessurs.status === RessursStatus.HENTER}
             feil={skjema.visFeilmeldinger ? personIdenter.feilmelding : undefined}
             label={`Velg de begrunnelsene gjelder for`}
             creatable={false}
-            erLesevisning={vurderErLesevisning()}
+            erLesevisning={erLesevisning}
             isMulti={true}
             formatOptionLabel={(option: ISelectOption) => {
                 return (

--- a/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksmeny.tsx
@@ -36,6 +36,7 @@ const Vedtaksmeny: React.FunctionComponent<IVedtakmenyProps> = ({
     visFeilutbetaltValuta,
 }) => {
     const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const kanIkkeKorrigereVedtak =
         åpenBehandling.type === Behandlingstype.REVURDERING &&
@@ -57,13 +58,13 @@ const Vedtaksmeny: React.FunctionComponent<IVedtakmenyProps> = ({
                     {erBehandlingMedVedtaksbrevutsending && (
                         <>
                             <KorrigerEtterbetaling
-                                erLesevisning={vurderErLesevisning()}
+                                erLesevisning={erLesevisning}
                                 korrigertEtterbetaling={åpenBehandling.korrigertEtterbetaling}
                                 behandlingId={åpenBehandling.behandlingId}
                             />
                             {(!kanIkkeKorrigereVedtak || åpenBehandling.korrigertVedtak) && (
                                 <KorrigerVedtak
-                                    erLesevisning={vurderErLesevisning()}
+                                    erLesevisning={erLesevisning}
                                     korrigertVedtak={åpenBehandling.korrigertVedtak}
                                     behandlingId={åpenBehandling.behandlingId}
                                 />

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -44,6 +44,7 @@ const AvslagBegrunnelseMultiselect: React.FC<IProps> = ({
     regelverk,
 }) => {
     const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const { vedtaksbegrunnelseTekster } = useVedtaksbegrunnelseTekster();
     const { vilkårSubmit } = useVilkårsvurdering();
 
@@ -108,8 +109,8 @@ const AvslagBegrunnelseMultiselect: React.FC<IProps> = ({
             creatable={false}
             placeholder={'Velg begrunnelse(r)'}
             isLoading={vilkårSubmit !== VilkårSubmit.NONE}
-            isDisabled={vurderErLesevisning() || vilkårSubmit !== VilkårSubmit.NONE}
-            erLesevisning={vurderErLesevisning()}
+            isDisabled={erLesevisning || vilkårSubmit !== VilkårSubmit.NONE}
+            erLesevisning={erLesevisning}
             isMulti={true}
             onChange={(_, action: ActionMeta<ISelectOption>) => {
                 onChangeBegrunnelse(action);

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -51,6 +51,7 @@ const GeneriskVilkår: React.FC<IProps> = ({
     generiskVilkårKey,
 }) => {
     const { vurderErLesevisning, settÅpenBehandling, erMigreringsbehandling } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
     const { settVilkårSubmit, postVilkår, vilkårSubmit } = useVilkårsvurdering();
 
     const [visFeilmeldingerForVilkår, settVisFeilmeldingerForVilkår] = useState(false);
@@ -90,7 +91,7 @@ const GeneriskVilkår: React.FC<IProps> = ({
     };
 
     const skalViseLeggTilKnapp = () => {
-        if (vurderErLesevisning()) {
+        if (erLesevisning) {
             return false;
         }
         const uvurdertPeriodePåVilkår = vilkårResultater.find(
@@ -100,7 +101,7 @@ const GeneriskVilkår: React.FC<IProps> = ({
     };
 
     const skalViseFjernUtvidetBarnetrygdKnapp = () => {
-        if (vurderErLesevisning()) {
+        if (erLesevisning) {
             return false;
         }
         const utvidetVilkår = vilkårResultater.filter(

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -59,9 +59,10 @@ const VilkårTabellRad: React.FC<IProps> = ({
     settFokusPåKnapp,
 }) => {
     const { vurderErLesevisning, åpenBehandling, aktivSettPåVent } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const hentInitiellEkspandering = () =>
-        vurderErLesevisning() || vilkårResultat.verdi.resultat.verdi === Resultat.IKKE_VURDERT;
+        erLesevisning || vilkårResultat.verdi.resultat.verdi === Resultat.IKKE_VURDERT;
 
     const [ekspandertVilkår, settEkspandertVilkår] = useState(hentInitiellEkspandering());
     const [redigerbartVilkår, settRedigerbartVilkår] =
@@ -100,7 +101,7 @@ const VilkårTabellRad: React.FC<IProps> = ({
                     settRedigerbartVilkår={settRedigerbartVilkår}
                     settEkspandertVilkår={settEkspandertVilkår}
                     settFokusPåKnapp={settFokusPåKnapp}
-                    lesevisning={vurderErLesevisning()}
+                    lesevisning={erLesevisning}
                 />
             }
         >

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -64,6 +64,7 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
         aktivSettPåVent,
         åpenBehandling,
     } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
 
     const kanLeggeTilUtvidetVilkår =
         erMigreringsbehandling ||
@@ -82,7 +83,7 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
             (personMapEkspandert, personResultat) => ({
                 ...personMapEkspandert,
                 [personResultat.personIdent]:
-                    vurderErLesevisning() || personHarIkkevurdertVilkår(personResultat),
+                    erLesevisning || personHarIkkevurdertVilkår(personResultat),
             }),
             {}
         );
@@ -121,13 +122,13 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
                         <PersonHeader>
                             <PersonInformasjon person={personResultat.person} somOverskrift />
 
-                            {!vurderErLesevisning() &&
+                            {!erLesevisning &&
                                 personErEkspandert[personResultat.personIdent] &&
                                 personResultat.person.type === PersonType.SØKER &&
                                 !harUtvidet &&
                                 kanLeggeTilUtvidetVilkår && (
                                     <VilkårDiv>
-                                        {!vurderErLesevisning() ? (
+                                        {!erLesevisning ? (
                                             <Button
                                                 variant={'tertiary'}
                                                 id={`${index}_${personResultat.person.fødselsdato}__legg-til-vilkår-utvidet`}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -67,6 +67,8 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ åpenBehandling })
         behandlingsstegSubmitressurs,
     } = useBehandling();
 
+    const erLesevisning = vurderErLesevisning();
+
     const registeropplysningerHentetTidpsunkt =
         vilkårsvurdering[0]?.person?.registerhistorikk?.hentetTidspunkt;
 
@@ -103,7 +105,7 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ åpenBehandling })
                 }
             }}
             nesteOnClick={() => {
-                if (vurderErLesevisning()) {
+                if (erLesevisning) {
                     navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/tilkjent-ytelse`);
                 } else if (erVilkårsvurderingenGyldig()) {
                     vilkårsvurderingNesteOnClick();
@@ -153,7 +155,7 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ åpenBehandling })
                         loading={hentOpplysningerRessurs.status === RessursStatus.HENTER}
                         variant="tertiary"
                         size="xsmall"
-                        erLesevisning={vurderErLesevisning()}
+                        erLesevisning={erLesevisning}
                         icon={
                             <Refresh style={{ fontSize: '1.5rem' }} role="img" focusable="false" />
                         }


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12298

### 💰 Hva forsøker du å løse i denne PR'en
Begrense kall til vurderErLesevisning() ved å opprette en lokal variabel i relevante komponent (som kaller fra mer enn 1 sted) og benytte den lokale variabelen i stedet for å kalle metoden direkte.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Usikker på om det i alle tilfeller er greit å benytte "lokal variabel" - som beskrevet i oppgaven - eller om det i spesielle tilfeller kan være påkrevd å kalle metoden direkte..

### ✅ Checklist
_Har du husket alle punktene i listen?_
Testet lokalt etter beste evne..

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Dette skal ikke medføre visuelle endringer
