### PR TITLE
Fjern "Gjennomfør satsendring"-knappen når man har startet en satsendring

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -8,7 +8,6 @@ import { Home, Search } from '@navikt/ds-icons';
 import { Alert, Heading, Tabs } from '@navikt/ds-react';
 import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingStatus, erBehandlingHenlagt } from '../../../typer/behandling';
@@ -19,7 +18,6 @@ import {
 } from '../../../typer/behandlingstema';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakStatus } from '../../../typer/fagsak';
-import { ToggleNavn } from '../../../typer/toggles';
 import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../../utils/fagsak';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
@@ -73,7 +71,6 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
     const { kanKjøreSatsendring } = useSatsendringsknapp({
         fagsakId: minimalFagsak.id,
     });
-    const { toggles } = useApp();
 
     React.useEffect(() => {
         settÅpenBehandling(byggTomRessurs(), false);
@@ -207,9 +204,7 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
                 <SaksoversiktWrapper>
                     <Heading size={'large'} level={'1'} children={'Saksoversikt'} />
 
-                    {toggles[ToggleNavn.kanKjøreSatsendringManuelt] && kanKjøreSatsendring && (
-                        <SatsendringKnapp fagsakId={minimalFagsak.id} />
-                    )}
+                    {kanKjøreSatsendring && <SatsendringKnapp fagsakId={minimalFagsak.id} />}
 
                     <FagsakLenkepanel minimalFagsak={minimalFagsak} />
                     {minimalFagsak.status === FagsakStatus.LØPENDE && (

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/SatsendringKnapp.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/SatsendringKnapp.tsx
@@ -29,7 +29,7 @@ interface IProps {
 
 export const SatsendringKnapp: React.FunctionComponent<IProps> = ({ fagsakId }) => {
     const { request } = useHttp();
-    const { oppdaterKanKjøreSatsendring } = useSatsendringsknapp({
+    const { settKanKjøreSatsendringTilFalse } = useSatsendringsknapp({
         fagsakId,
     });
     const { oppdaterGjeldendeFagsak } = useFagsakContext();
@@ -46,7 +46,7 @@ export const SatsendringKnapp: React.FunctionComponent<IProps> = ({ fagsakId }) 
             settKjørSatsendringRessurs(kjørSatsendringRessurs);
 
             if (kjørSatsendringRessurs.status === RessursStatus.SUKSESS) {
-                oppdaterKanKjøreSatsendring();
+                settKanKjøreSatsendringTilFalse();
                 oppdaterGjeldendeFagsak();
             }
         });

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/useSatsendringsknapp.ts
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/useSatsendringsknapp.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
-import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+import { byggSuksessRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
 interface IProps {
     fagsakId: number;
@@ -29,12 +29,15 @@ export const useSatsendringsknapp = ({ fagsakId }: IProps) => {
         oppdaterKanKjøreSatsendring();
     }, [fagsakId]);
 
+    const settKanKjøreSatsendringTilFalse = () =>
+        settKanKjøreSatsendringRessurs(byggSuksessRessurs(false));
+
     const kanKjøreSatsendring =
         kanKjøreSatsendringRessurs.status === RessursStatus.SUKSESS &&
         kanKjøreSatsendringRessurs.data;
 
     return {
         kanKjøreSatsendring,
-        oppdaterKanKjøreSatsendring,
+        settKanKjøreSatsendringTilFalse,
     };
 };

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -14,7 +14,6 @@ export enum ToggleNavn {
     endreMottakerEndringsårsaker = 'familie-ba-sak.behandling.endringsperiode.endre-mottaker-aarsaker.utgivelse',
     kanBehandleKlage = 'familie-ba-sak.klage',
     støtterEnsligMindreårig = 'familie-ba-sak.behandling.enslig-mindreaarig',
-    kanKjøreSatsendringManuelt = 'familie-ba-sak.kan-kjore-satsendring-manuelt',
     manuellPostering = 'familie-ba-sak.manuell-postering',
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når vi har trykket på "Gjennomfør satsendring"-knappen og backend har respondert med suksess har vi gjort en ny sjekk på om vi kan gjennomføre satsendring. Problemet er at da har ikke satsendringen rukket å kjøre lenge nok til at backend svarer false og `kanKjøreSatsendring` blir derfor ikke satt til false. 

Siden en suksess-respons betyr at vi har laget en satsendringsbehandling skal derfor alltid `kanKjøreSatsendring` være false om vi får det svaret. 

Endrer så `kanKjøreSatsendring` alltid blir satt til false når `kjor-satsendring-synkront`-endepunktet returnerer suksess. 

Fjerner også en gammel toggle 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
