### PR TITLE
Valider at fra og med dato på barnas vilkår ikke er før fødselsdato 

### DIFF
--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -108,17 +108,15 @@ export const erPeriodeGyldig = (
             return feil(felt, 'Ugyldig t.o.m.');
         }
 
-        if (!erEksplisittAvslagPåSøknad) {
-            if (person && person.type === PersonType.BARN) {
-                if (finnesDatoFørFødselsdato(person, fom, tom)) {
-                    return feil(felt, 'Du kan ikke legge til periode før barnets fødselsdato');
-                }
-                if (er18ÅrsVilkår && finnesDatoEtterFødselsdatoPluss18(person, fom, tom)) {
-                    return feil(
-                        felt,
-                        'Du kan ikke legge til periode på dette vilkåret fra barnet har fylt 18 år'
-                    );
-                }
+        if (person && person.type === PersonType.BARN) {
+            if (finnesDatoFørFødselsdato(person, fom, tom)) {
+                return feil(felt, 'Du kan ikke legge til periode før barnets fødselsdato');
+            }
+            if (er18ÅrsVilkår && finnesDatoEtterFødselsdatoPluss18(person, fom, tom)) {
+                return feil(
+                    felt,
+                    'Du kan ikke legge til periode på dette vilkåret fra barnet har fylt 18 år'
+                );
             }
         }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Tidligere validerte vi kun på fom-dato på barnas vilkår hvis det _ikke_ var eksplisitt avslag. Dette stemmer ikke overens med valideringen backend som sjekker fom-dato etter eller lik barnas fødselsdato uansett resultat. Etter prat med Anna har vi konkludert med at det ikke gir mening å sette fom-dato **før** barnets fødselsdato uansett om vilkåret er avslått eller ikke.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Har ikke skrevet tester, men testet det manuelt

### 🤷‍♀ ️Hvor er det lurt å starte?
Er bare 1 commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei