### PR TITLE
Lagt til Switch for å skru av og på visning av manuelle posteringer

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -105,6 +105,10 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
     const erMigreringFraInfotrygdMedAvvik =
         erMigreringFraInfotrygd && erAvvikISimuleringForBehandling;
 
+    const harManuellePosteringer = simResultat?.perioder.some(
+        periode => periode.manuellPostering && periode.manuellPostering > 0
+    );
+
     const harMaks1KroneIAvvikPerBarn = (perioderesultater: number[]) => {
         const antallBarn = åpenBehandling.personer.filter(
             person => person.type === PersonType.BARN
@@ -124,6 +128,9 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
 
     const behandlingErMigreringMedAvvikUtenforBeløpsgrenser =
         erMigreringFraInfotrygdMedAvvik && !behandlingErMigreringMedAvvikInnenforBeløpsgrenser;
+
+    const behandlingErMigreringMedManuellePosteringer =
+        erMigreringFraInfotrygd && harManuellePosteringer;
 
     const tilbakekrevingsvalg = useFelt<Tilbakekrevingsvalg | undefined>({
         verdi: åpenBehandling.tilbakekreving?.valg,
@@ -251,6 +258,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         erMigreringFraInfotrygdMedAvvik,
         behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
+        behandlingErMigreringMedManuellePosteringer,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -44,6 +44,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         erFeilutbetaling,
         behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
+        behandlingErMigreringMedManuellePosteringer,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
 
@@ -98,7 +99,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                         <SimuleringPanel simulering={simuleringsresultat.data} />
                         <SimuleringTabell simulering={simuleringsresultat.data} />
                         {(behandlingErMigreringMedAvvikInnenforBeløpsgrenser ||
-                            behandlingErMigreringMedAvvikUtenforBeløpsgrenser) && (
+                            behandlingErMigreringMedAvvikUtenforBeløpsgrenser ||
+                            behandlingErMigreringMedManuellePosteringer) && (
                             <>
                                 {behandlingErMigreringMedAvvikInnenforBeløpsgrenser && (
                                     <StyledBeløpsgrenseAlert variant="warning" size="medium">
@@ -109,7 +111,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                         kravgrunnlag.
                                     </StyledBeløpsgrenseAlert>
                                 )}
-                                {behandlingErMigreringMedAvvikUtenforBeløpsgrenser && (
+                                {behandlingErMigreringMedAvvikUtenforBeløpsgrenser ? (
                                     <StyledBeløpsgrenseAlert variant="warning" size="medium">
                                         Simuleringen viser en feilutbetaling eller etterbetaling.
                                         Hvis du velger å gå videre i behandlingen kreves det
@@ -120,7 +122,13 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                         dette behandles i en egen revurderingsbehandling med
                                         vedtaksbrev til bruker.
                                     </StyledBeløpsgrenseAlert>
-                                )}
+                                ) : behandlingErMigreringMedManuellePosteringer ? (
+                                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                        Det finnes manuelle posteringer tilknyttet tidligere
+                                        behandling. Hvis du velger å gå videre i behandlingen kreves
+                                        det to-trinnskontroll.
+                                    </StyledBeløpsgrenseAlert>
+                                ) : null}
                             </>
                         )}
                         {erFeilutbetaling && (

--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
@@ -7,6 +7,7 @@ import { Alert, BodyShort, Label, Switch } from '@navikt/ds-react';
 import {
     ABorderDefault,
     AGreen700,
+    ASurfaceSubtle,
     ATextDanger,
     ATextDefault,
 } from '@navikt/ds-tokens/dist/tokens';
@@ -75,19 +76,17 @@ const SimuleringTabellOverskrift = styled.div`
     margin-bottom: 1rem;
 `;
 
+const ManuellPosteringRad = styled.tr`
+    background-color: ${ASurfaceSubtle};
+`;
+
 const LabelMedFarge = styled(Label)`
     color: ${(props: { farge?: string }) => (props.farge ? props.farge : ATextDefault)};
 `;
 
 const StyledSwitch = styled(Switch)`
-    float: right;
+    width: fit-content;
 `;
-
-const TableContainer = styled.div(
-    (props: { bredde: number }) => `
-    width: ${props.bredde}rem;
-`
-);
 
 interface ISimuleringProps {
     simulering: ISimuleringDTO;
@@ -109,8 +108,20 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
     } = simulering;
     const perioder = hentPeriodelisteMedTommePerioder(perioderUtenTommeSimuleringer);
     const årISimuleringen = hentÅrISimuleringen(perioder);
+
     const [indexFramvistÅr, settIndexFramvistÅr] = useState(årISimuleringen.length - 1);
-    const [visManuellePosteringer, setVisManuellePosteringer] = useState(false);
+
+    const erManuellPosteringSamtidigSomResultatIkkeErNull = perioder.some(
+        periode =>
+            periode.manuellPostering &&
+            periode.manuellPostering !== 0 &&
+            periode.resultat &&
+            periode.resultat !== 0
+    );
+    const [visManuellePosteringer, setVisManuellePosteringer] = useState(
+        erManuellPosteringSamtidigSomResultatIkkeErNull
+    );
+
     const aktueltÅr = årISimuleringen[indexFramvistÅr];
     const erMerEnn12MånederISimulering = perioder.length > 12;
 
@@ -135,18 +146,6 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
 
     const erNestePeriode = (periode: ISimuleringPeriode) => periode.fom === fomDatoNestePeriode;
 
-    const finnesManuellePosteringer = perioder.some(
-        periode => periode.manuellPostering && periode.manuellPostering !== 0
-    );
-
-    const erManuellPosteringSamtidigSomResultatIkkeErNull = perioder.some(
-        periode =>
-            periode.manuellPostering &&
-            periode.manuellPostering !== 0 &&
-            periode.resultat &&
-            periode.resultat !== 0
-    );
-
     const tilOgFraDatoForSimulering = `${periodeToString({
         fom,
         tom: tomDatoNestePeriode ?? tomSisteUtbetaling,
@@ -169,146 +168,143 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
                         : `perioden ${tilOgFraDatoForSimulering}`}
                 </Label>
             </SimuleringTabellOverskrift>
-            <TableContainer bredde={tabellbredde}>
-                <StyledSwitch
-                    checked={visManuellePosteringer}
-                    onChange={() => setVisManuellePosteringer(!visManuellePosteringer)}
-                >
-                    Vis manuelle posteringer
-                </StyledSwitch>
-                <StyledTable
-                    aria-label={`Simuleringsresultat for ${
-                        erMerEnn12MånederISimulering
-                            ? aktueltÅr
-                            : `perioden ${tilOgFraDatoForSimulering}`
-                    }`}
-                    className="tabell"
-                    bredde={tabellbredde}
-                >
-                    <colgroup>
-                        <VenstreKolonne />
-                        {perioderSomSkalVisesITabellen.map(periode =>
-                            fomDatoNestePeriode === periode.fom ? (
-                                <React.Fragment key={'col - ' + periode.fom}>
-                                    <SkillelinjeKolonne />
-                                    <DataKolonne />
-                                </React.Fragment>
-                            ) : (
-                                <DataKolonne key={'col - ' + periode.fom} />
-                            )
-                        )}
-                    </colgroup>
 
-                    <thead>
-                        <tr>
-                            <td>
-                                {erMerEnn12MånederISimulering && (
-                                    <Årsvelger
-                                        settIndexFramvistÅr={settIndexFramvistÅr}
-                                        indexFramvistÅr={indexFramvistÅr}
-                                        erISisteÅrAvPerioden={erISisteÅrAvPerioden}
-                                        aktueltÅr={aktueltÅr}
-                                        årISimuleringen={årISimuleringen}
-                                    />
-                                )}
-                            </td>
-                            {perioderSomSkalVisesITabellen.map(periode => (
-                                <React.Fragment key={'måned - ' + periode.fom}>
-                                    {erNestePeriode(periode) && <TabellSkillelinje erHeader />}
-                                    <HøyrestiltTh>
-                                        <Label>
-                                            {kapitaliserTekst(
-                                                formaterIsoDato(periode.fom, datoformat.MÅNED_NAVN)
-                                            )}
-                                        </Label>
-                                    </HøyrestiltTh>
-                                </React.Fragment>
-                            ))}
-                        </tr>
-                    </thead>
+            <StyledSwitch
+                checked={visManuellePosteringer}
+                onChange={() => setVisManuellePosteringer(!visManuellePosteringer)}
+                position="right"
+                size="small"
+            >
+                Vis manuelle posteringer
+            </StyledSwitch>
+            <StyledTable
+                aria-label={`Simuleringsresultat for ${
+                    erMerEnn12MånederISimulering
+                        ? aktueltÅr
+                        : `perioden ${tilOgFraDatoForSimulering}`
+                }`}
+                className="tabell"
+                bredde={tabellbredde}
+            >
+                <colgroup>
+                    <VenstreKolonne />
+                    {perioderSomSkalVisesITabellen.map(periode =>
+                        fomDatoNestePeriode === periode.fom ? (
+                            <React.Fragment key={'col - ' + periode.fom}>
+                                <SkillelinjeKolonne />
+                                <DataKolonne />
+                            </React.Fragment>
+                        ) : (
+                            <DataKolonne key={'col - ' + periode.fom} />
+                        )
+                    )}
+                </colgroup>
 
-                    <tbody>
-                        <tr>
-                            <td>Nytt beløp</td>
-                            {perioderSomSkalVisesITabellen.map(periode => (
-                                <React.Fragment key={'nytt beløp - ' + periode.fom}>
+                <thead>
+                    <tr>
+                        <td>
+                            {erMerEnn12MånederISimulering && (
+                                <Årsvelger
+                                    settIndexFramvistÅr={settIndexFramvistÅr}
+                                    indexFramvistÅr={indexFramvistÅr}
+                                    erISisteÅrAvPerioden={erISisteÅrAvPerioden}
+                                    aktueltÅr={aktueltÅr}
+                                    årISimuleringen={årISimuleringen}
+                                />
+                            )}
+                        </td>
+                        {perioderSomSkalVisesITabellen.map(periode => (
+                            <React.Fragment key={'måned - ' + periode.fom}>
+                                {erNestePeriode(periode) && <TabellSkillelinje erHeader />}
+                                <HøyrestiltTh>
+                                    <Label>
+                                        {kapitaliserTekst(
+                                            formaterIsoDato(periode.fom, datoformat.MÅNED_NAVN)
+                                        )}
+                                    </Label>
+                                </HøyrestiltTh>
+                            </React.Fragment>
+                        ))}
+                    </tr>
+                </thead>
+
+                <tbody>
+                    <tr>
+                        <td>Nytt beløp</td>
+                        {perioderSomSkalVisesITabellen.map(periode => (
+                            <React.Fragment key={'nytt beløp - ' + periode.fom}>
+                                {erNestePeriode(periode) && <TabellSkillelinje />}
+                                <HøyrestiltTd>
+                                    <BodyShort>
+                                        {formaterBeløpUtenValutakode(periode.nyttBeløp)}
+                                    </BodyShort>
+                                </HøyrestiltTd>
+                            </React.Fragment>
+                        ))}
+                    </tr>
+                    <tr>
+                        <td>Tidligere utbetalt</td>
+                        {perioderSomSkalVisesITabellen.map(periode => {
+                            return (
+                                <React.Fragment key={'tidligere utbetalt - ' + periode.fom}>
                                     {erNestePeriode(periode) && <TabellSkillelinje />}
                                     <HøyrestiltTd>
                                         <BodyShort>
-                                            {formaterBeløpUtenValutakode(periode.nyttBeløp)}
+                                            {formaterBeløpUtenValutakode(periode.tidligereUtbetalt)}
+                                        </BodyShort>
+                                    </HøyrestiltTd>
+                                </React.Fragment>
+                            );
+                        })}
+                    </tr>
+                    <tr>
+                        <td>Resultat</td>
+                        {perioderSomSkalVisesITabellen.map(periode => (
+                            <React.Fragment key={'resultat - ' + periode.fom}>
+                                {erNestePeriode(periode) && <TabellSkillelinje />}
+                                <HøyrestiltTd>
+                                    {fomDatoNestePeriode === periode.fom ? (
+                                        <LabelMedFarge
+                                            farge={
+                                                periode.resultat && periode.resultat < 0
+                                                    ? ATextDanger
+                                                    : AGreen700
+                                            }
+                                        >
+                                            {formaterBeløpUtenValutakode(periode.resultat)}
+                                        </LabelMedFarge>
+                                    ) : (
+                                        <BodyshortMedFarge
+                                            farge={
+                                                periode.resultat && periode.resultat < 0
+                                                    ? ATextDanger
+                                                    : ATextDefault
+                                            }
+                                        >
+                                            {formaterBeløpUtenValutakode(periode.resultat)}
+                                        </BodyshortMedFarge>
+                                    )}
+                                </HøyrestiltTd>
+                            </React.Fragment>
+                        ))}
+                    </tr>
+                    {visManuellePosteringer && (
+                        <ManuellPosteringRad>
+                            <td>Manuell postering</td>
+                            {perioderSomSkalVisesITabellen.map(periode => (
+                                <React.Fragment key={'manuell postering - ' + periode.fom}>
+                                    {erNestePeriode(periode) && <TabellSkillelinje />}
+                                    <HøyrestiltTd>
+                                        <BodyShort>
+                                            {formaterBeløpUtenValutakode(periode.manuellPostering)}
                                         </BodyShort>
                                     </HøyrestiltTd>
                                 </React.Fragment>
                             ))}
-                        </tr>
-                        <tr>
-                            <td>Tidligere utbetalt</td>
-                            {perioderSomSkalVisesITabellen.map(periode => {
-                                return (
-                                    <React.Fragment key={'tidligere utbetalt - ' + periode.fom}>
-                                        {erNestePeriode(periode) && <TabellSkillelinje />}
-                                        <HøyrestiltTd>
-                                            <BodyShort>
-                                                {formaterBeløpUtenValutakode(
-                                                    periode.tidligereUtbetalt
-                                                )}
-                                            </BodyShort>
-                                        </HøyrestiltTd>
-                                    </React.Fragment>
-                                );
-                            })}
-                        </tr>
-                        <tr>
-                            <td>Resultat</td>
-                            {perioderSomSkalVisesITabellen.map(periode => (
-                                <React.Fragment key={'resultat - ' + periode.fom}>
-                                    {erNestePeriode(periode) && <TabellSkillelinje />}
-                                    <HøyrestiltTd>
-                                        {fomDatoNestePeriode === periode.fom ? (
-                                            <LabelMedFarge
-                                                farge={
-                                                    periode.resultat && periode.resultat < 0
-                                                        ? ATextDanger
-                                                        : AGreen700
-                                                }
-                                            >
-                                                {formaterBeløpUtenValutakode(periode.resultat)}
-                                            </LabelMedFarge>
-                                        ) : (
-                                            <BodyshortMedFarge
-                                                farge={
-                                                    periode.resultat && periode.resultat < 0
-                                                        ? ATextDanger
-                                                        : ATextDefault
-                                                }
-                                            >
-                                                {formaterBeløpUtenValutakode(periode.resultat)}
-                                            </BodyshortMedFarge>
-                                        )}
-                                    </HøyrestiltTd>
-                                </React.Fragment>
-                            ))}
-                        </tr>
-                        {finnesManuellePosteringer && visManuellePosteringer && (
-                            <tr>
-                                <td>Manuell postering</td>
-                                {perioderSomSkalVisesITabellen.map(periode => (
-                                    <React.Fragment key={'manuell postering - ' + periode.fom}>
-                                        {erNestePeriode(periode) && <TabellSkillelinje />}
-                                        <HøyrestiltTd>
-                                            <BodyShort>
-                                                {formaterBeløpUtenValutakode(
-                                                    periode.manuellPostering
-                                                )}
-                                            </BodyShort>
-                                        </HøyrestiltTd>
-                                    </React.Fragment>
-                                ))}
-                            </tr>
-                        )}
-                    </tbody>
-                </StyledTable>
-            </TableContainer>
+                        </ManuellPosteringRad>
+                    )}
+                </tbody>
+            </StyledTable>
         </>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
@@ -12,7 +12,9 @@ import {
     ATextDefault,
 } from '@navikt/ds-tokens/dist/tokens';
 
+import { useApp } from '../../../context/AppContext';
 import type { ISimuleringDTO, ISimuleringPeriode } from '../../../typer/simulering';
+import { ToggleNavn } from '../../../typer/toggles';
 import { datoformat, formaterIsoDato } from '../../../utils/formatter';
 import { erEtter, kalenderDato, periodeToString } from '../../../utils/kalender';
 import { hentPeriodelisteMedTommePerioder, hentÅrISimuleringen } from '../../../utils/simulering';
@@ -124,6 +126,8 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
 
     const aktueltÅr = årISimuleringen[indexFramvistÅr];
     const erMerEnn12MånederISimulering = perioder.length > 12;
+    const { toggles } = useApp();
+    const erManuelPosteringTogglePå = toggles[ToggleNavn.manuellPostering];
 
     const periodeErEtterNesteUtbetalingsPeriode = (periode: ISimuleringPeriode) =>
         fomDatoNestePeriode &&
@@ -153,7 +157,7 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
 
     return (
         <>
-            {erManuellPosteringSamtidigSomResultatIkkeErNull && (
+            {erManuelPosteringTogglePå && erManuellPosteringSamtidigSomResultatIkkeErNull && (
                 <StyledAlert variant={'warning'}>
                     Det finnes manuelle posteringer på den forrige behandlingen. Du må mest
                     sannsynlig sende en oppgave til NØS og be dem gjøre manuelle posteringer
@@ -288,7 +292,7 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
                             </React.Fragment>
                         ))}
                     </tr>
-                    {visManuellePosteringer && (
+                    {erManuelPosteringTogglePå && visManuellePosteringer && (
                         <ManuellPosteringRad>
                             <td>Manuell postering</td>
                             {perioderSomSkalVisesITabellen.map(periode => (

--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
@@ -113,6 +113,10 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
 
     const [indexFramvistÅr, settIndexFramvistÅr] = useState(årISimuleringen.length - 1);
 
+    const finnesManuellePosteringer = perioder.some(
+        periode => periode.manuellPostering && periode.manuellPostering !== 0
+    );
+
     const erManuellPosteringSamtidigSomResultatIkkeErNull = perioder.some(
         periode =>
             periode.manuellPostering &&
@@ -173,14 +177,16 @@ const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulerin
                 </Label>
             </SimuleringTabellOverskrift>
 
-            <StyledSwitch
-                checked={visManuellePosteringer}
-                onChange={() => setVisManuellePosteringer(!visManuellePosteringer)}
-                position="right"
-                size="small"
-            >
-                Vis manuelle posteringer
-            </StyledSwitch>
+            {erManuelPosteringTogglePå && finnesManuellePosteringer && (
+                <StyledSwitch
+                    checked={visManuellePosteringer}
+                    onChange={() => setVisManuellePosteringer(!visManuellePosteringer)}
+                    position="right"
+                    size="small"
+                >
+                    Vis manuelle posteringer
+                </StyledSwitch>
+            )}
             <StyledTable
                 aria-label={`Simuleringsresultat for ${
                     erMerEnn12MånederISimulering


### PR DESCRIPTION
Favro: [NAV-12443](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12443)

### 💰 Hva forsøker du å løse i denne PR'en
Legger til `<Switch/>` for å kunne styre visning av manuelle posteringer på simuleringssiden. Bryteren vil kun dukke opp dersom det eksisterer manuelle posteringer. Ved å toggle den på dukker det opp en ekstra rad i tabellen som viser en summert fremstilling av manuelle posteringer innenfor bestemt periode. Dersom det finnes kolonner med noe annet enn 0 i resultatraden vil bryter være "på" som default, ellers vil den være "av".

Har også lagt til varsel om at behandling vil gå til to-trinnskontroll dersom det finnes manuelle posteringer. Vises kun dersom det ikke er avvik (etterbetaling eller feilutbetaling) i tillegg.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Switch skrudd av:
![image](https://user-images.githubusercontent.com/70642183/237022580-d441e5c1-f1b2-4d0d-9cc9-83882008961c.png)

Switch skrudd på:
![image](https://user-images.githubusercontent.com/70642183/237022493-11617b5e-7091-41b3-a923-bc602e993606.png)


