### PR TITLE
NAV-11474 Manuelle brevmottakere skal ikke være tilgjengelig for institusjon

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -111,6 +111,7 @@ const Behandlingsmeny: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
                     )}
                     {!brukerEllerBarnHarStrengtFortroligAdresse &&
                         erPåBehandling &&
+                        minimalFagsak.fagsakType !== FagsakType.INSTITUSJON &&
                         (!erLesevisning || åpenBehandling.brevmottakere.length > 0) &&
                         (åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING ||
                             åpenBehandling.type === Behandlingstype.REVURDERING) && (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11474)
Fjerner menyvalget for brevmottakere fra behandlingsmenyen på fagsaker av type INSTITUSJON.

### 👀 Screen shots
Før:
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/47184872/2e46bef0-db58-465c-8ccc-43f7d6bdea47)

Etter:
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/47184872/a99f8eaa-88fe-4bf4-9c61-25fcde0d813b)