### PR TITLE
Legg inn en validering for om Norge er valgt ulovlig, og vis feilmelding

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
@@ -146,10 +146,18 @@ const useLeggTilFjernBrevmottaker = () => {
     });
     const land = useFelt<string>({
         verdi: '',
-        valideringsfunksjon: felt =>
-            felt.verdi !== ''
+        valideringsfunksjon: (felt, avhengigheter) => {
+            const norgeErUlovligValgt =
+                avhengigheter?.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE &&
+                felt.verdi === 'NO';
+            if (norgeErUlovligValgt) {
+                return feil(felt, 'Norge kan ikke være satt for bruker med utenlandsk adresse');
+            }
+            return felt.verdi !== ''
                 ? ok(felt)
-                : feil(felt, 'Feltet er påkrevd. Velg Norge dersom brevet skal sendes innenlands.'),
+                : feil(felt, 'Feltet er påkrevd. Velg Norge dersom brevet skal sendes innenlands.');
+        },
+        avhengigheter: { mottaker },
     });
 
     useEffect(() => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favrokort: [NAV-12456](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12456)

Det skal ikke være mulig å velge Norge i mottagerliste dersom det er en utenlandsk adresse. Likevel kan Norge velges dersom man f.eks. velger Norge på Verge, men endrer mottager etterpå. Denne PR'en legger inn en fiks for dette slik at dersom man har valgt Norge på ulovligvis vil bruker få en feilmelding.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<img width="576" alt="Screenshot 2023-05-12 at 11 25 42" src="https://github.com/navikt/familie-ba-sak-frontend/assets/8656966/d0e245d5-b82d-48bd-afc5-85d8afb5e649">

