### PR TITLE
Håndter tom liste som input ved å legge til initiell verdi i reduce

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -117,7 +117,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
     };
 
     const harTotaltAvvikUnderBeløpsgrense = (perioderesultater: number[]) => {
-        const totaltAvvik = Math.abs(perioderesultater.reduce((acc, val) => acc + val));
+        const totaltAvvik = Math.abs(perioderesultater.reduce((acc, val) => acc + val, 0));
         return totaltAvvik <= maksgrenseForAvvikIBeløpVedMigrering;
     };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: NAV-12686

Vi får en feil i en prodsak som er en migrering fra infotrygd. Vi prøver å beregne om totalt avvik er under beløpsgrense ved å se på perioderesultater før mars 2023. Her er det ingen perioderesultater før mars 2023 og inputlisten til `harTotaltAvvikUnderBeløpsgrense` er derfor tom. I det tilfellet klarer ikke reduce å beregne en verdi uten å ha en initiell verdi. Legger til en initiell verdi slik at vi kan håndtere tomme lister.

![image](https://github.com/navikt/familie-ba-sak-frontend/assets/2379098/336ffcf1-753d-4326-b8f4-eec9a66d2a77)


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Jeg har lyst til å flytte disse funksjonene til `utils/simulering.ts` og legge til tester men tar det i en egen PR så dette kan løses i prod først 😇 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
