### PR TITLE
Varsel dersom vi kun får andeler med 0 kr i kalkulert utbetalingsbeløp

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -30,6 +30,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
     const { request } = useHttp();
     const { fagsakId } = useSakOgBehandlingParams();
     const vedtak = åpenBehandling.vedtak;
+    const personerMedAndelerTilkjentYtelse = åpenBehandling.personerMedAndelerTilkjentYtelse;
     const [simuleringsresultat, settSimuleringresultat] = useState<Ressurs<ISimuleringDTO>>({
         status: RessursStatus.HENTER,
     });
@@ -108,6 +109,12 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
     const harManuellePosteringer = simResultat?.perioder.some(
         periode => periode.manuellPostering && periode.manuellPostering > 0
     );
+
+    const behandlingErMigreringFraInfotrygdMedKun0Utbetalinger =
+        erMigreringFraInfotrygd &&
+        !personerMedAndelerTilkjentYtelse.some(
+            personMedAndelerTilkjentYtelse => personMedAndelerTilkjentYtelse.beløp !== 0
+        );
 
     const harMaks1KroneIAvvikPerBarn = (perioderesultater: number[]) => {
         const antallBarn = åpenBehandling.personer.filter(
@@ -259,6 +266,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
         behandlingErMigreringMedManuellePosteringer,
+        behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -45,6 +45,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
         behandlingErMigreringMedManuellePosteringer,
+        behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
 
@@ -89,11 +90,19 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             maxWidthStyle={'80rem'}
             steg={BehandlingSteg.VURDER_TILBAKEKREVING}
         >
+            {behandlingErMigreringFraInfotrygdMedKun0Utbetalinger && (
+                <StyledAlert variant={'warning'}>
+                    Migrering av denne saken gir ingen utbetaling for periodene etter
+                    migreringsdato. Når behandlingsresultatet blir 0 kr i alle perioder, får vi ikke
+                    simulert mot økonomi for å se eventuelle avvik. Det er derfor viktig at du selv
+                    sjekker at det ikke har vært noen utbetalinger fra Infotrygd i disse periodene.
+                </StyledAlert>
+            )}
             {simuleringsresultat?.status === RessursStatus.SUKSESS ? (
                 simuleringsresultat.data.perioder.length === 0 ? (
-                    <Alert variant="info">
+                    <StyledAlert variant="info">
                         Det er ingen etterbetaling, feilutbetaling eller neste utbetaling
-                    </Alert>
+                    </StyledAlert>
                 ) : (
                     <>
                         <SimuleringPanel simulering={simuleringsresultat.data} />


### PR DESCRIPTION
Favro: [NAV-12557](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12557)

### 💰 Hva forsøker du å løse i denne PR'en
Når man migrerer "EØS sekundærland"-saker kan det skje at kalkulert utbetalingsbeløp blir 0 kr som følge av differanseberegning mellom norsk sats og hva som er utbetalt i annet land. Når man kun får andeler med 0 kr i utbetalingsbeløp simulerer vi ikke mot økonomi og vi sender/iverksetter heller ikke noe mot økonomi.

Fordi vi ikke simulerer får vi heller ikke se om migreringen fører til avvik fra det Infotrygd har utbetalt. Altså kan det skje at vi migrerer over en sak og ved en feil (feil valuta, kurs) setter alle andelene til 0 kr, selv om saken egentlig hadde utbetaling i Infotrygd. Utbetalingene vil da fortsatt løpe fra Oppdrag, men BA-sak har på sett og vis ikke "overtatt" saken.

For å hjelpe saksbehandler til å selv oppdage feilen vil det nå dukke opp et varsel for alle migreringssaker hvor alle andeler har 0 kr i kalkulert utbetalingsbeløp.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/70642183/1ca168aa-ed13-44aa-a2df-02db07925941)
