### PR TITLE
Avslag uten fom og tom kommer i eget panel bak toggle. Sorter opphør …

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartVedtaksbegrunnelsePanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/EkspanderbartVedtaksbegrunnelsePanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useApp } from '../../../../../context/AppContext';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../typer/vedtaksperiode';
 import { hentVedtaksperiodeTittel, Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import { summer } from '../../../../../utils/formatter';
@@ -17,6 +18,7 @@ const EkspanderbartVedtaksbegrunnelsePanel: React.FC<IEkspanderbartBegrunnelsePa
     onClick,
     children,
 }) => {
+    const { toggles } = useApp();
     const periode = {
         fom: vedtaksperiodeMedBegrunnelser.fom,
         tom: vedtaksperiodeMedBegrunnelser.tom,
@@ -41,7 +43,7 @@ const EkspanderbartVedtaksbegrunnelsePanel: React.FC<IEkspanderbartBegrunnelsePa
                     )
                 )
             }
-            tittel={hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser)}
+            tittel={hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser, toggles)}
         />
     );
 };

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, Heading, HelpText } from '@navikt/ds-react';
+import { Alert, Heading } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
@@ -19,15 +19,6 @@ import VedtaksperiodeMedBegrunnelserPanel from './VedtaksperiodeMedBegrunnelserP
 const StyledHeading = styled(Heading)`
     display: flex;
     margin-top: 1rem;
-`;
-
-const StyledHelpText = styled(HelpText)`
-    margin-top: 0.1rem;
-    margin-left: 0.6rem;
-
-    & + .navds-popover {
-        max-width: 20rem;
-    }
 `;
 
 interface IVedtakBegrunnelserTabell {
@@ -71,11 +62,6 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
             <VedtaksperiodeListe
                 vedtaksperioderMedBegrunnelser={avslagOgResterende[1]}
                 overskrift={'Begrunnelser i vedtaksbrev'}
-                hjelpetekst={
-                    toggles[ToggleNavn.organiserAvslag]
-                        ? 'Her skal du sette begrunnelsestekster for innvilgelse, reduksjon, opphør og avslag med start- eller sluttdato.'
-                        : 'Her skal du sette begrunnelsestekster for innvilgelse, reduksjon og opphør.'
-                }
                 åpenBehandling={åpenBehandling}
             />
             <VedtaksperiodeListe
@@ -84,11 +70,6 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
                     toggles[ToggleNavn.organiserAvslag]
                         ? 'Generelle avslagsbegrunnelser'
                         : 'Begrunnelser for avslag i vedtaksbrev'
-                }
-                hjelpetekst={
-                    toggles[ToggleNavn.organiserAvslag]
-                        ? 'Her har vi hentet begrunnelsestekster for avslag som ikke har en start- eller sluttdato.'
-                        : 'Her har vi hentet begrunnelsestekster for avslag som du har satt i vilkårsvurderingen.'
                 }
                 åpenBehandling={åpenBehandling}
             />
@@ -101,9 +82,8 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
 const VedtaksperiodeListe: React.FC<{
     vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     overskrift: string;
-    hjelpetekst: string;
     åpenBehandling: IBehandling;
-}> = ({ vedtaksperioderMedBegrunnelser, overskrift, hjelpetekst, åpenBehandling }) => {
+}> = ({ vedtaksperioderMedBegrunnelser, overskrift, åpenBehandling }) => {
     if (vedtaksperioderMedBegrunnelser.length === 0) {
         return <></>;
     }
@@ -112,7 +92,6 @@ const VedtaksperiodeListe: React.FC<{
         <>
             <StyledHeading level="2" size="small" spacing>
                 {overskrift}
-                <StyledHelpText placement="right">{hjelpetekst}</StyledHelpText>
             </StyledHeading>
             {vedtaksperioderMedBegrunnelser.map(
                 (vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -21,23 +21,6 @@ describe('VedtakBegrunnelserContext', () => {
         const tom = '2020-02-28';
         const opphørFom = '2020-03-01';
 
-        test(`Test at returnerte perioder er sortert på fom-dato.`, () => {
-            const vedtaksperioder: IVedtaksperiodeMedBegrunnelser[] = [
-                mockOpphørsperiode({ fom: opphørFom }),
-                mockUtbetalingsperiode({ fom: fom, tom: tom }),
-                mockAvslagsperiode({ fom: fom, tom: tom }),
-            ];
-            const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
-                vedtaksperioder,
-                BehandlingResultat.AVSLÅTT_ENDRET_OG_OPPHØRT,
-                BehandlingStatus.UTREDES
-            );
-            expect(perioder.length).toBe(3);
-            expect(perioder[0].type).toBe(Vedtaksperiodetype.UTBETALING);
-            expect(perioder[1].type).toBe(Vedtaksperiodetype.AVSLAG);
-            expect(perioder[2].type).toBe(Vedtaksperiodetype.OPPHØR);
-        });
-
         describe('Test lesevisning', () => {
             test(`Test at ubegrunnede perioder ikke returneres ved avsluttet behandling`, () => {
                 const vedtaksperioder: IVedtaksperiodeMedBegrunnelser[] = [

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -16,6 +16,7 @@ export enum ToggleNavn {
     støtterEnsligMindreårig = 'familie-ba-sak.behandling.enslig-mindreaarig',
     manuellPostering = 'familie-ba-sak.manuell-postering',
     støtterRefusjonEøs = 'familie-ba-sak.behandling.refusjon-eos',
+    organiserAvslag = 'familie-ba-sak-frontend.vedtaksperiode-organisering',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -1,6 +1,8 @@
 import type { FamilieIsoDate } from '../utils/kalender';
 import { ytelsetype, YtelseType } from './beregning';
 import type { IGrunnlagPerson } from './person';
+import type { IToggles } from './toggles';
+import { ToggleNavn } from './toggles';
 import type { VedtakBegrunnelse, VedtakBegrunnelseType } from './vedtak';
 
 export interface IVedtaksperiodeMedBegrunnelser {
@@ -77,7 +79,8 @@ export interface IUtbetalingsperiodeDetalj {
 }
 
 export const hentVedtaksperiodeTittel = (
-    vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser
+    vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser,
+    toggles: IToggles
 ) => {
     const { type, utbetalingsperiodeDetaljer } = vedtaksperiodeMedBegrunnelser;
 
@@ -110,9 +113,9 @@ export const hentVedtaksperiodeTittel = (
         case Vedtaksperiodetype.ENDRET_UTBETALING:
             return 'Endret utbetalingsperiode';
         case Vedtaksperiodetype.OPPHØR:
-            return 'Opphør';
+            return toggles[ToggleNavn.organiserAvslag] ? 'Ingen utbetaling' : 'Opphør';
         case Vedtaksperiodetype.AVSLAG:
-            return 'Avslag';
+            return toggles[ToggleNavn.organiserAvslag] ? 'Ingen utbetaling' : 'Avslag';
         default:
             return '';
     }

--- a/src/frontend/utils/vedtakUtils.ts
+++ b/src/frontend/utils/vedtakUtils.ts
@@ -40,17 +40,7 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
                 kalenderDatoTilDate(kalenderDatoMedFallback(a.fom, TIDENES_MORGEN)),
                 kalenderDatoTilDate(kalenderDatoMedFallback(b.fom, TIDENES_MORGEN))
             );
-            if (diff === 0) {
-                if (a.type === Vedtaksperiodetype.AVSLAG) {
-                    return 1;
-                } else if (b.type === Vedtaksperiodetype.AVSLAG) {
-                    return -1;
-                } else {
-                    return diff;
-                }
-            } else {
-                return diff;
-            }
+            return sorterAvslagNederst(diff, a, b);
         })
         .filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
             if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
@@ -67,6 +57,24 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
         return hentSisteOpphørsperiode(sorterteOgFiltrertePerioder);
     } else {
         return sorterteOgFiltrertePerioder;
+    }
+
+    function sorterAvslagNederst(
+        diff: number | number,
+        a: IVedtaksperiodeMedBegrunnelser,
+        b: IVedtaksperiodeMedBegrunnelser
+    ) {
+        if (diff === 0) {
+            if (a.type === Vedtaksperiodetype.AVSLAG) {
+                return 1;
+            } else if (b.type === Vedtaksperiodetype.AVSLAG) {
+                return -1;
+            } else {
+                return diff;
+            }
+        } else {
+            return diff;
+        }
     }
 };
 

--- a/src/frontend/utils/vedtakUtils.ts
+++ b/src/frontend/utils/vedtakUtils.ts
@@ -1,13 +1,13 @@
 import {
-    AGreen100,
-    ARed50,
-    AOrange100,
-    AGray100,
     ABlue100,
-    AGreen500,
-    ARed600,
-    AOrange600,
+    AGray100,
     AGray600,
+    AGreen100,
+    AGreen500,
+    AOrange100,
+    AOrange600,
+    ARed50,
+    ARed600,
 } from '@navikt/ds-tokens/dist/tokens';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -35,12 +35,23 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
 ): IVedtaksperiodeMedBegrunnelser[] => {
     const sorterteOgFiltrertePerioder = vedtaksperioder
         .slice()
-        .sort((a, b) =>
-            kalenderDiff(
+        .sort((a, b) => {
+            const diff = kalenderDiff(
                 kalenderDatoTilDate(kalenderDatoMedFallback(a.fom, TIDENES_MORGEN)),
                 kalenderDatoTilDate(kalenderDatoMedFallback(b.fom, TIDENES_MORGEN))
-            )
-        )
+            );
+            if (diff === 0) {
+                if (a.type === Vedtaksperiodetype.AVSLAG) {
+                    return 1;
+                } else if (b.type === Vedtaksperiodetype.AVSLAG) {
+                    return -1;
+                } else {
+                    return diff;
+                }
+            } else {
+                return diff;
+            }
+        })
         .filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
             if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
                 return harPeriodeBegrunnelse(vedtaksperiode);

--- a/src/frontend/utils/vedtakUtils.ts
+++ b/src/frontend/utils/vedtakUtils.ts
@@ -35,13 +35,6 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
 ): IVedtaksperiodeMedBegrunnelser[] => {
     const sorterteOgFiltrertePerioder = vedtaksperioder
         .slice()
-        .sort((a, b) => {
-            const diff = kalenderDiff(
-                kalenderDatoTilDate(kalenderDatoMedFallback(a.fom, TIDENES_MORGEN)),
-                kalenderDatoTilDate(kalenderDatoMedFallback(b.fom, TIDENES_MORGEN))
-            );
-            return sorterAvslagNederst(diff, a, b);
-        })
         .filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
             if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
                 return harPeriodeBegrunnelse(vedtaksperiode);
@@ -57,24 +50,6 @@ export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
         return hentSisteOpphørsperiode(sorterteOgFiltrertePerioder);
     } else {
         return sorterteOgFiltrertePerioder;
-    }
-
-    function sorterAvslagNederst(
-        diff: number | number,
-        a: IVedtaksperiodeMedBegrunnelser,
-        b: IVedtaksperiodeMedBegrunnelser
-    ) {
-        if (diff === 0) {
-            if (a.type === Vedtaksperiodetype.AVSLAG) {
-                return 1;
-            } else if (b.type === Vedtaksperiodetype.AVSLAG) {
-                return -1;
-            } else {
-                return diff;
-            }
-        } else {
-            return diff;
-        }
     }
 };
 


### PR DESCRIPTION
…foran avslag.

### 💰 Hva forsøker du å løse i denne PR'en
Ønsker i fremtiden (bak toggle) at generelle avslag (avslag uten fom og tom) kommer for seg. For avslag med fom og/eller tom skal opphør sorteres foran. Se https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12702


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
