### PR TITLE
Legger til aktivertTidspunkt for sortering av behandlinger etter at e…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -13,7 +13,7 @@ import type { Saksoversiktsbehandling } from './utils';
 import {
     hentBehandlingerTilSaksoversikten,
     hentBehandlingId,
-    hentOpprettetTidspunkt,
+    hentTidspunktforSortering,
     skalRadVises,
 } from './utils';
 
@@ -87,8 +87,8 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
                             .filter(behandling => skalRadVises(behandling, visHenlagteBehandlinger))
                             .sort((a, b) =>
                                 kalenderDiff(
-                                    new Date(hentOpprettetTidspunkt(b)),
-                                    new Date(hentOpprettetTidspunkt(a))
+                                    new Date(hentTidspunktforSortering(b)),
+                                    new Date(hentTidspunktforSortering(a))
                                 )
                             )
                             .map((behandling: Saksoversiktsbehandling) => (

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/utils.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/utils.tsx
@@ -66,6 +66,17 @@ export const hentOpprettetTidspunkt = (saksoversiktsbehandling: Saksoversiktsbeh
     }
 };
 
+export const hentTidspunktforSortering = (saksoversiktsbehandling: Saksoversiktsbehandling) => {
+    switch (saksoversiktsbehandling.saksoversiktbehandlingstype) {
+        case Saksoversiktbehandlingstype.BARNETRYGD:
+            return saksoversiktsbehandling.aktivertTidspunkt;
+        case Saksoversiktbehandlingstype.TILBAKEBETALING:
+            return saksoversiktsbehandling.opprettetTidspunkt;
+        case Saksoversiktbehandlingstype.KLAGE:
+            return saksoversiktsbehandling.opprettet;
+    }
+};
+
 export const hentBehandlingId = (saksoversiktsbehandling: Saksoversiktsbehandling) => {
     switch (saksoversiktsbehandling.saksoversiktbehandlingstype) {
         case Saksoversiktbehandlingstype.BARNETRYGD:

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/visningBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/visningBehandling.ts
@@ -10,6 +10,7 @@ export interface VisningBehandling {
     aktiv: boolean;
     behandlingId: number | string;
     opprettetTidspunkt: string;
+    aktivertTidspunkt: string;
     resultat?: BehandlingResultat;
     status: BehandlingStatus;
     type: Behandlingstype;

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -175,8 +175,9 @@ export const hentStegNummer = (steg: BehandlingSteg): number => {
 };
 
 export enum BehandlingStatus {
-    OPPRETTET = 'OPPRETTET',
     UTREDES = 'UTREDES',
+    SATT_PÅ_VENT = 'SATT_PÅ_VENT',
+    SATT_PÅ_MASKINELL_VENT = 'SATT_PÅ_MASKINELL_VENT',
     FATTER_VEDTAK = 'FATTER_VEDTAK',
     IVERKSETTER_VEDTAK = 'IVERKSETTER_VEDTAK',
     AVSLUTTET = 'AVSLUTTET',
@@ -391,13 +392,15 @@ export const behandlingsstatuser: Record<
     BehandlingStatus | Behandlingsstatus | KlageStatus,
     string
 > = {
-    OPPRETTET: 'Opprettet',
     UTREDES: 'Utredes',
+    SATT_PÅ_VENT: 'Satt på vent',
+    SATT_PÅ_MASKINELL_VENT: 'Satt på maskinell vent',
     FATTER_VEDTAK: 'Fatter vedtak',
     IVERKSETTER_VEDTAK: 'Iverksetter vedtak',
     AVSLUTTET: 'Avsluttet',
 
     /** For klagebehandlinger: **/
+    OPPRETTET: 'Opprettet',
     VENTER: 'Venter',
     FERDIGSTILT: 'Ferdigstilt',
 };

--- a/src/frontend/utils/test/behandling/behandling.mock.ts
+++ b/src/frontend/utils/test/behandling/behandling.mock.ts
@@ -112,6 +112,7 @@ export const mockVisningBehandling = ({
         type: type,
         resultat: resultat,
         opprettetTidspunkt,
+        aktivertTidspunkt: opprettetTidspunkt,
         kategori: BehandlingKategori.NASJONAL,
         underkategori: BehandlingUnderkategori.ORDINÆR,
         status,


### PR DESCRIPTION
…n behandling kan ha sniket i køen

### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12540
For å åpne opp for å kunne i snike i køen så har vi lagt til en "aktivertTidspunkt" på en behandling. 
Hvis en behandling blir satt på maskinell vent og en annen sniker i køen, så vill behandlingen som vært på vent få en oppdatert aktivertTidspunkt når den blir reaktivert, sånn at det er behandlingen som har eldste opprettetTid som er siste behandlingen. 



### 🔎️ Er det noe spesielt du ønsker å fremheve?
Merges ETTER
* https://github.com/navikt/familie-ba-sak/pull/3630

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Satsendring kjøres:
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/937168/69bdfb03-c32f-43f4-bc9a-bb374d6e4897)

Etter satsendring så behandlingen som vært på maskinell vent reaktivert
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/937168/25b035d5-080f-4be2-931d-fc4f1d3726d1)


