### PR TITLE
Legg til suffix/prefix på dødsbo ved manuell mottaker

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useLeggTilFjernBrevmottaker.ts
@@ -47,6 +47,13 @@ export interface IRestBrevmottaker {
     landkode: string;
 }
 
+const preutfyltNavnFixed = (mottaker: Mottaker | '', land: string, navn: string) => {
+    if (mottaker === Mottaker.DØDSBO) {
+        return !land || land === 'NO' ? `${navn} v/dødsbo` : `Estate of ${navn}`;
+    }
+    return navn;
+};
+
 const useLeggTilFjernBrevmottaker = () => {
     const { settToast } = useApp();
     const { åpenBehandling: åpenBehandlingRessurs, settÅpenBehandling } = useBehandling();
@@ -165,11 +172,15 @@ const useLeggTilFjernBrevmottaker = () => {
             mottaker.verdi === Mottaker.DØDSBO ||
             mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE;
 
-        if (skalNavnVærePreutfylt !== navnErPreutfylt) {
-            settNavnErPreutfylt(skalNavnVærePreutfylt);
-            navn.validerOgSettFelt(skalNavnVærePreutfylt && søker?.navn ? søker.navn : '');
+        if (skalNavnVærePreutfylt || skalNavnVærePreutfylt !== navnErPreutfylt) {
+            navn.validerOgSettFelt(
+                skalNavnVærePreutfylt && søker?.navn
+                    ? preutfyltNavnFixed(mottaker.verdi, land.verdi, søker.navn)
+                    : ''
+            );
         }
-    }, [mottaker.verdi]);
+        settNavnErPreutfylt(skalNavnVærePreutfylt);
+    }, [mottaker.verdi, land.verdi]);
 
     const {
         skjema,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favrokort: [NAV-11463](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11463)

Endringer gjelder på modal for manuelle mottakere. Dersom man velger:
Dødsbo i Norge: Legge til suffix på brukers navn "v/dødsbo"
Dødsbo i utlandet: Legge til prefix før brukers navn "Estate of"

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<img width="548" alt="Screenshot 2023-05-26 at 13 22 46" src="https://github.com/navikt/familie-ba-sak-frontend/assets/8656966/17412b62-a0a2-459e-80cb-a5bae6a83128">

<img width="531" alt="Screenshot 2023-05-26 at 13 23 35" src="https://github.com/navikt/familie-ba-sak-frontend/assets/8656966/f1677d61-1c25-4438-924e-9bf29f8b4fc2">


<img width="376" alt="Screenshot 2023-05-26 at 13 23 48" src="https://github.com/navikt/familie-ba-sak-frontend/assets/8656966/b0dcc629-f6e1-46ca-993b-ce28fc24a74c">

<img width="345" alt="Screenshot 2023-05-26 at 13 23 58" src="https://github.com/navikt/familie-ba-sak-frontend/assets/8656966/dff9ad43-7825-4767-9e50-c59c5a4ea5bd">
