### PR TITLE
Forbedring: hentFagsakerForPerson gjrøes kun når den trengs, og ikke hver gang ma…

### DIFF
--- a/src/frontend/context/OppgaverContext.tsx
+++ b/src/frontend/context/OppgaverContext.tsx
@@ -38,7 +38,7 @@ import { erIsoStringGyldig } from '../utils/kalender';
 import { hentFnrFraOppgaveIdenter } from '../utils/oppgave';
 import { hentFrontendFeilmelding } from '../utils/ressursUtils';
 import { useApp } from './AppContext';
-import { useFagsakContext } from './fagsak/FagsakContext';
+import { useHentFagsakerForPerson } from './fagsak/useHentFagsakerForPerson';
 import type { IOppgaveRad } from './OppgaverContextUtils';
 import { kolonner, mapIOppgaverTilOppgaveRad } from './OppgaverContextUtils';
 
@@ -199,7 +199,7 @@ const [OppgaverProvider, useOppgaver] = createUseContext(() => {
         settOppgaveFelter(initialOppgaveFelter(innloggetSaksbehandler));
     };
 
-    const { hentFagsakerForPerson } = useFagsakContext();
+    const { hentFagsakerForPerson } = useHentFagsakerForPerson();
 
     const gåTilFagsakEllerVisFeilmelding = async (personident: string): Promise<void> => {
         const fagsaker = await hentFagsakerForPerson(personident);

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -14,8 +14,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
-import type { IBaseFagsak, IInternstatistikk, IMinimalFagsak } from '../../typer/fagsak';
-import { mapMinimalFagsakTilBaseFagsak } from '../../typer/fagsak';
+import type { IInternstatistikk, IMinimalFagsak } from '../../typer/fagsak';
 import type { IKlagebehandling } from '../../typer/klage';
 import type { IPersonInfo } from '../../typer/person';
 import { sjekkTilgangTilPerson } from '../../utils/commons';
@@ -27,7 +26,6 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
     );
 
     const [bruker, settBruker] = React.useState<Ressurs<IPersonInfo>>(byggTomRessurs());
-    const [fagsakerPåBruker, settFagsakerPåBruker] = React.useState<IBaseFagsak[]>();
     const [internstatistikk, settInternstatistikk] = React.useState<Ressurs<IInternstatistikk>>(
         byggTomRessurs()
     );
@@ -84,13 +82,6 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
         }).then((hentetPerson: Ressurs<IPersonInfo>) => {
             const brukerEtterTilgangssjekk = sjekkTilgangTilPerson(hentetPerson);
             settBruker(brukerEtterTilgangssjekk);
-            if (brukerEtterTilgangssjekk.status === RessursStatus.SUKSESS) {
-                hentFagsakerForPerson(personIdent).then((fagsaker: Ressurs<IMinimalFagsak[]>) => {
-                    if (fagsaker.status === RessursStatus.SUKSESS) {
-                        settFagsakerPåBruker(fagsaker.data.map(mapMinimalFagsakTilBaseFagsak));
-                    }
-                });
-            }
         });
     };
 
@@ -106,18 +97,6 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
             .catch(() => {
                 settInternstatistikk(byggFeiletRessurs('Feil ved lasting av internstatistikk'));
             });
-    };
-
-    const hentFagsakerForPerson = async (personId: string) => {
-        return request<{ personIdent: string }, IMinimalFagsak[]>({
-            method: 'POST',
-            url: `/familie-ba-sak/api/fagsaker/hent-fagsaker-paa-person`,
-            data: {
-                personIdent: personId,
-            },
-        }).then((fagsaker: Ressurs<IMinimalFagsak[]>) => {
-            return fagsaker;
-        });
     };
 
     const oppdaterKlagebehandlingerPåFagsak = () => {
@@ -149,14 +128,12 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
 
     return {
         bruker,
-        fagsakerPåBruker,
         hentInternstatistikk,
         hentMinimalFagsak,
         internstatistikk,
         minimalFagsak,
         settMinimalFagsak,
         hentBruker,
-        hentFagsakerForPerson,
         klagebehandlinger,
         oppdaterKlagebehandlingerPåFagsak,
         oppdaterGjeldendeFagsak,

--- a/src/frontend/context/fagsak/useHentFagsakerForPerson.ts
+++ b/src/frontend/context/fagsak/useHentFagsakerForPerson.ts
@@ -1,0 +1,23 @@
+import { useHttp } from '@navikt/familie-http';
+import type { Ressurs } from '@navikt/familie-typer';
+
+import type { IMinimalFagsak } from '../../typer/fagsak';
+
+export const useHentFagsakerForPerson = () => {
+    const { request } = useHttp();
+    const hentFagsakerForPerson = async (personId: string) => {
+        return request<{ personIdent: string }, IMinimalFagsak[]>({
+            method: 'POST',
+            url: `/familie-ba-sak/api/fagsaker/hent-fagsaker-paa-person`,
+            data: {
+                personIdent: personId,
+            },
+        }).then((fagsaker: Ressurs<IMinimalFagsak[]>) => {
+            return fagsaker;
+        });
+    };
+
+    return {
+        hentFagsakerForPerson,
+    };
+};

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettFagsak/OpprettFagsak.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettFagsak/OpprettFagsak.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { Dropdown } from '@navikt/ds-react-internal';
 
-import { useFagsakContext } from '../../../../../context/fagsak/FagsakContext';
 import type { IPersonInfo } from '../../../../../typer/person';
 import OpprettFagsakModal from '../../../../Felleskomponenter/HeaderMedSøk/OpprettFagsakModal';
 
@@ -12,7 +11,6 @@ interface IProps {
 
 const OpprettFagsak: React.FC<IProps> = ({ personInfo }) => {
     const [visModal, settVisModal] = React.useState(false);
-    const { fagsakerPåBruker } = useFagsakContext();
 
     return (
         <>
@@ -22,7 +20,6 @@ const OpprettFagsak: React.FC<IProps> = ({ personInfo }) => {
             {visModal && (
                 <OpprettFagsakModal
                     personInfo={personInfo}
-                    fagsakerPåBruker={fagsakerPåBruker}
                     lukkModal={() => {
                         settVisModal(false);
                     }}

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -53,7 +53,7 @@ export interface IGrunnlagPerson {
 export interface IPersonInfo {
     kommunenummer: string;
     adressebeskyttelseGradering: Adressebeskyttelsegradering;
-    harTilgang?: boolean;
+    harTilgang: boolean;
     forelderBarnRelasjon: IForelderBarnRelasjon[];
     forelderBarnRelasjonMaskert: IForelderBarnRelasjonMaskert[];
     fødselsdato: string;


### PR DESCRIPTION
…n henter en bruker

* Tatt ut hentFagsakerForPerson i egen fil
* Modalen henter kun fagsaker fra saksoversikten idag, og har beholdt det

### 💰 Hva forsøker du å løse i denne PR'en
Det gjøres idag kall for å "hente fagsaker for person" hver gang man henter bruker fra FagsakContext, som er unødvendig då den kun brukes for opprettFagsak fra saksoversikten, som skjer veldig skjeldent.
Har i stedet flyttet den til modalen og at den hentes når det trengs.
Viser modalen når fagsakene er hentet. 

Idag henter man ikke fagsaker når man søker etter en person, og har beholdt det. Litt usikker på om det egentlige er en bug eller feature. 
