### PR TITLE
Fjernet knapper og logikk for flytting av sak fra Infotrygd til BA-sak

### DIFF
--- a/src/frontend/komponenter/Infotrygd/Infotrygd.tsx
+++ b/src/frontend/komponenter/Infotrygd/Infotrygd.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components';
 
 import { Input } from 'nav-frontend-skjema';
 
-import { Alert, Button, Fieldset, Heading } from '@navikt/ds-react';
+import { Button, Fieldset, Heading } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { hentFrontendFeilmelding } from '../../utils/ressursUtils';
 import { Infotrygdtabeller } from './Infotrygdtabeller';
-import { useInfotrygdSkjema, useInfotrygdMigrering } from './useInfotrygd';
+import { useInfotrygdSkjema } from './useInfotrygd';
 
 const InfotrygdContainer = styled.div`
     padding: 1rem;
@@ -31,16 +31,8 @@ const HentSakerButton = styled(Button)`
     height: 40px;
 `;
 
-const FlyttSakButton = styled(Button)`
-    margin-left: 1rem;
-    margin-top: 30px;
-    margin-bottom: auto;
-    height: 40px;
-`;
-
 export const Infotrygd: React.FC = () => {
     const { ident, onSubmitWrapper, skjema } = useInfotrygdSkjema();
-    const { flyttBrukerTilBaSak, migrerInfotrygdSakRessurs } = useInfotrygdMigrering();
 
     const location = useLocation();
     useEffect(() => {
@@ -52,34 +44,6 @@ export const Infotrygd: React.FC = () => {
     }, []);
 
     const skjemaErLåst = skjema.submitRessurs.status === RessursStatus.HENTER;
-
-    const visFlyttSakKnapp = () => {
-        if (skjema.submitRessurs.status === RessursStatus.SUKSESS) {
-            return (
-                <FlyttSakButton
-                    variant={'secondary'}
-                    size={'small'}
-                    disabled={migrerInfotrygdSakRessurs.status === RessursStatus.HENTER}
-                    onClick={() => {
-                        flyttBrukerTilBaSak(ident);
-                    }}
-                >
-                    Flytt til BA-sak
-                </FlyttSakButton>
-            );
-        }
-    };
-
-    const visFlyttSakAlert = () => {
-        if (
-            migrerInfotrygdSakRessurs.status === RessursStatus.FEILET ||
-            migrerInfotrygdSakRessurs.status === RessursStatus.FUNKSJONELL_FEIL
-        ) {
-            return (
-                <Alert children={migrerInfotrygdSakRessurs.frontendFeilmelding} variant="error" />
-            );
-        }
-    };
 
     return (
         <InfotrygdContainer>
@@ -109,9 +73,7 @@ export const Infotrygd: React.FC = () => {
                 >
                     Hent saker
                 </HentSakerButton>
-                {visFlyttSakKnapp()}
             </HentSakerFlex>
-            {visFlyttSakAlert()}
             {skjema.submitRessurs.status === RessursStatus.SUKSESS ? (
                 <Infotrygdtabeller ident={ident} saker={skjema.submitRessurs.data.saker} />
             ) : undefined}

--- a/src/frontend/komponenter/Infotrygd/Infotrygdtabeller.tsx
+++ b/src/frontend/komponenter/Infotrygd/Infotrygdtabeller.tsx
@@ -2,16 +2,12 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
+import { Alert, Heading } from '@navikt/ds-react';
 
-import { erBehandlingHenlagt } from '../../typer/behandling';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import type { IInfotrygdSak } from '../../typer/infotrygd';
 import { datoformat, formaterIsoDato } from '../../utils/formatter';
-import UIModalWrapper from '../Felleskomponenter/Modal/UIModalWrapper';
 import { Sakstabell } from './Sakstabell';
-import { useInfotrygdMigrering } from './useInfotrygd';
 import { Vedtakstabell } from './Vedtakstabell';
 
 interface InfotrygdtabellerProps {
@@ -30,17 +26,6 @@ const VedtakTekst = styled(Heading)`
     margin-bottom: 1rem;
 `;
 
-const FlyttSakButton = styled(Button)`
-    margin-left: 1rem;
-    margin-top: 30px;
-    margint-bottom: auto;
-    height: 40px;
-`;
-
-const Feilmelding = styled(Alert)`
-    margin-top: 10px;
-`;
-
 const sorterSakerEtterSaksnr = (saker: IInfotrygdSak[]): IInfotrygdSak[] =>
     saker.sort((sakA, sakB) => {
         const saksnrA = sakA.saksnr ? parseInt(sakA.saksnr) : 1000;
@@ -53,76 +38,8 @@ export const Infotrygdtabeller: React.FC<InfotrygdtabellerProps> = ({
     saker,
     minimalFagsak,
 }) => {
-    const {
-        flyttBrukerTilBaSak,
-        migrerInfotrygdSakRessurs,
-        visMigrertModal,
-        gåTilSaksoversiktVedSuksess,
-    } = useInfotrygdMigrering();
-
-    const visFlyttSakAlert = () => {
-        if (
-            migrerInfotrygdSakRessurs.status === RessursStatus.FEILET ||
-            migrerInfotrygdSakRessurs.status === RessursStatus.FUNKSJONELL_FEIL
-        ) {
-            return (
-                <>
-                    <Feilmelding
-                        children={migrerInfotrygdSakRessurs.frontendFeilmelding}
-                        variant="error"
-                    />
-                </>
-            );
-        }
-    };
-
-    const disableMigrerKnapp =
-        migrerInfotrygdSakRessurs.status === RessursStatus.HENTER ||
-        migrerInfotrygdSakRessurs.status === RessursStatus.FEILET ||
-        migrerInfotrygdSakRessurs.status === RessursStatus.FUNKSJONELL_FEIL;
-
     return (
         <>
-            {saker.length > 0 &&
-                minimalFagsak?.behandlinger.filter(
-                    behandling => !erBehandlingHenlagt(behandling.resultat)
-                ).length === 0 && (
-                    <FlyttSakButton
-                        variant={'secondary'}
-                        size={'small'}
-                        disabled={disableMigrerKnapp}
-                        onClick={() => {
-                            ident && flyttBrukerTilBaSak(ident);
-                        }}
-                    >
-                        Flytt til BA-sak
-                    </FlyttSakButton>
-                )}
-            {visFlyttSakAlert()}
-            {visMigrertModal && (
-                <UIModalWrapper
-                    modal={{
-                        tittel: 'Migreringen pågår',
-                        lukkKnapp: false,
-                        visModal: visMigrertModal,
-                        actions: [
-                            <Button
-                                key={'bekreft'}
-                                variant={'secondary'}
-                                size={'small'}
-                                onClick={() => gåTilSaksoversiktVedSuksess(minimalFagsak?.id)}
-                                children={'Gå til saksoversikt'}
-                            />,
-                        ],
-                    }}
-                >
-                    <BodyShort>
-                        Migrering tar 1-2 minutter. Du vil se behandlingen i saksoversikten så fort
-                        migreringen er ferdig.
-                    </BodyShort>
-                </UIModalWrapper>
-            )}
-
             {minimalFagsak?.migreringsdato !== null && (
                 <Alert
                     variant="info"

--- a/src/frontend/komponenter/Infotrygd/useInfotrygd.ts
+++ b/src/frontend/komponenter/Infotrygd/useInfotrygd.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import type { AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
 
 import type { FamilieRequestConfig } from '@navikt/familie-http';
 import { useHttp } from '@navikt/familie-http';
@@ -15,11 +14,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
-import type {
-    IInfotrygdsaker,
-    IInfotrygdsakerRequest,
-    IMigreringResponseDto,
-} from '../../typer/infotrygd';
+import type { IInfotrygdsaker, IInfotrygdsakerRequest } from '../../typer/infotrygd';
 import { Adressebeskyttelsegradering } from '../../typer/person';
 import { identValidator } from '../../utils/validators';
 
@@ -78,49 +73,6 @@ export const useInfotrygdRequest = () => {
     return {
         hentInfotrygdsaker,
         infotrygdsakerRessurs,
-    };
-};
-
-export const useInfotrygdMigrering = () => {
-    const navigate = useNavigate();
-    const { request } = useHttp();
-    const [migrerInfotrygdSakRessurs, settMigrerInfotrygdSakRessurs] = useState<
-        Ressurs<IMigreringResponseDto>
-    >(byggTomRessurs());
-    const [visMigrertModal, settVisMigrertModal] = useState<boolean>(false);
-
-    const flyttBrukerTilBaSak = (ident: string) => {
-        settMigrerInfotrygdSakRessurs(byggHenterRessurs());
-        request<{ ident: string }, IMigreringResponseDto>({
-            method: 'POST',
-            data: { ident },
-            url: `familie-ba-sak/api/migrering`,
-        })
-            .then(ressurs => {
-                if (ressurs.status === RessursStatus.SUKSESS) {
-                    settVisMigrertModal(true);
-                }
-                settMigrerInfotrygdSakRessurs(ressurs);
-            })
-            .catch((_error: AxiosError) => {
-                settMigrerInfotrygdSakRessurs(
-                    byggFeiletRessurs('Ukjent feil ved flytting av bruker til BA-sak')
-                );
-            });
-    };
-
-    const gåTilSaksoversiktVedSuksess = (fagsakId?: number) => {
-        settVisMigrertModal(false);
-        if (fagsakId) {
-            navigate(`/fagsak/${fagsakId}/saksoversikt`);
-        }
-    };
-
-    return {
-        flyttBrukerTilBaSak,
-        migrerInfotrygdSakRessurs,
-        visMigrertModal,
-        gåTilSaksoversiktVedSuksess,
     };
 };
 

--- a/src/frontend/typer/infotrygd.ts
+++ b/src/frontend/typer/infotrygd.ts
@@ -10,12 +10,6 @@ export interface IInfotrygdsakerRequest {
     ident: string;
 }
 
-export interface IInfotrygdstønader {
-    adressebeskyttelsegradering?: Adressebeskyttelsegradering;
-    harTilgang: boolean;
-    stønader: IInfotrygdStønad[];
-}
-
 export interface IInfotrygdSak {
     behenEnhet?: string;
     iverksattdato?: string;
@@ -60,9 +54,4 @@ export interface IDelytelse {
     typeDelytelse?: string;
     oppgjørsordning?: string;
     typeUtbetaling?: string;
-}
-
-export interface IMigreringResponseDto {
-    fagsakId: number;
-    behandlingId: number;
 }


### PR DESCRIPTION
Favro: [NAV-12825](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12825)

### 💰 Hva forsøker du å løse i denne PR'en
Knapp for flytting/migrering av sak fra Infotrygd til BA-sak har skapt en del støy og feil som må rettes opp manuelt. Denne PR'en fjerner knappene og logikk tilknyttet disse.


### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. 

Jeg har ikke skrevet tester fordi: har ikke lagt til noe ny funksjonalitet. Har manuelt testet at eksisterende funksjonalitet for visning av Infotrygd-sak fortsatt fungerer.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 