### PR TITLE
Ikke fjern alle opphørsperioder utenom den siste ved resultatet er opphør

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -33,7 +33,6 @@ const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
 
     const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
         åpenBehandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
-        åpenBehandling.resultat,
         åpenBehandling.status
     );
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/test/VedtakBegrunnelserContext.test.ts
@@ -1,4 +1,4 @@
-import { BehandlingResultat, BehandlingStatus } from '../../../../../typer/behandling';
+import { BehandlingStatus } from '../../../../../typer/behandling';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import {
@@ -9,7 +9,6 @@ import {
     sisteDagIInneværendeMåned,
 } from '../../../../../utils/kalender';
 import {
-    mockAvslagsperiode,
     mockOpphørsperiode,
     mockUtbetalingsperiode,
 } from '../../../../../utils/test/vedtak/vedtaksperiode.mock';
@@ -29,7 +28,6 @@ describe('VedtakBegrunnelserContext', () => {
                 ];
                 const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
                     vedtaksperioder,
-                    BehandlingResultat.INNVILGET_OG_OPPHØRT,
                     BehandlingStatus.AVSLUTTET
                 );
                 expect(perioder.length).toBe(1);
@@ -56,7 +54,6 @@ describe('VedtakBegrunnelserContext', () => {
                             tom: serializeIso8601String(enMndFremITidTom),
                         }),
                     ],
-                    BehandlingResultat.INNVILGET,
                     BehandlingStatus.UTREDES
                 );
                 expect(perioder.length).toBe(1);
@@ -80,24 +77,9 @@ describe('VedtakBegrunnelserContext', () => {
                             tom: serializeIso8601String(toMndFremITidTom),
                         }),
                     ],
-                    BehandlingResultat.INNVILGET,
                     BehandlingStatus.UTREDES
                 );
                 expect(perioder.length).toBe(0);
-            });
-            test(`Test at opphør kun gir én periode`, () => {
-                const vedtaksperioder: IVedtaksperiodeMedBegrunnelser[] = [
-                    mockOpphørsperiode({ fom: opphørFom }),
-                    mockUtbetalingsperiode({ fom: fom, tom: tom }),
-                    mockAvslagsperiode({ fom: fom, tom: tom }),
-                ];
-                const perioder = filtrerOgSorterPerioderMedBegrunnelseBehov(
-                    vedtaksperioder,
-                    BehandlingResultat.OPPHØRT,
-                    BehandlingStatus.UTREDES
-                );
-                expect(perioder.length).toBe(1);
-                expect(perioder[0].type).toBe(Vedtaksperiodetype.OPPHØR);
             });
         });
     });

--- a/src/frontend/utils/vedtakUtils.ts
+++ b/src/frontend/utils/vedtakUtils.ts
@@ -16,7 +16,6 @@ import { BehandlingResultat, BehandlingStatus } from '../typer/behandling';
 import type { IRestVedtakBegrunnelseTilknyttetVilkår, VedtakBegrunnelse } from '../typer/vedtak';
 import { VedtakBegrunnelseType } from '../typer/vedtak';
 import type { IVedtaksperiodeMedBegrunnelser } from '../typer/vedtaksperiode';
-import { Vedtaksperiodetype } from '../typer/vedtaksperiode';
 import type { VedtaksbegrunnelseTekster } from '../typer/vilkår';
 import {
     førsteDagIInneværendeMåned,
@@ -30,27 +29,15 @@ import {
 
 export const filtrerOgSorterPerioderMedBegrunnelseBehov = (
     vedtaksperioder: IVedtaksperiodeMedBegrunnelser[],
-    behandlingResultat: BehandlingResultat,
     behandlingStatus: BehandlingStatus
 ): IVedtaksperiodeMedBegrunnelser[] => {
-    const sorterteOgFiltrertePerioder = vedtaksperioder
-        .slice()
-        .filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
-            if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
-                return harPeriodeBegrunnelse(vedtaksperiode);
-            } else {
-                return erPeriodeFomMindreEnn2MndFramITid(vedtaksperiode);
-            }
-        });
-
-    if (
-        behandlingResultat === BehandlingResultat.OPPHØRT ||
-        behandlingResultat === BehandlingResultat.FORTSATT_OPPHØRT
-    ) {
-        return hentSisteOpphørsperiode(sorterteOgFiltrertePerioder);
-    } else {
-        return sorterteOgFiltrertePerioder;
-    }
+    return vedtaksperioder.slice().filter((vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
+        if (behandlingStatus === BehandlingStatus.AVSLUTTET) {
+            return harPeriodeBegrunnelse(vedtaksperiode);
+        } else {
+            return erPeriodeFomMindreEnn2MndFramITid(vedtaksperiode);
+        }
+    });
 };
 
 const erPeriodeFomMindreEnn2MndFramITid = (vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
@@ -63,16 +50,6 @@ const erPeriodeFomMindreEnn2MndFramITid = (vedtaksperiode: IVedtaksperiodeMedBeg
 
 const harPeriodeBegrunnelse = (vedtaksperiode: IVedtaksperiodeMedBegrunnelser) => {
     return !!vedtaksperiode.begrunnelser.length || !!vedtaksperiode.fritekster.length;
-};
-
-const hentSisteOpphørsperiode = (sortertePerioder: IVedtaksperiodeMedBegrunnelser[]) => {
-    const sorterteOgFiltrerteOpphørsperioder = sortertePerioder.filter(
-        (vedtaksperiode: IVedtaksperiodeMedBegrunnelser) =>
-            vedtaksperiode.type === Vedtaksperiodetype.OPPHØR
-    );
-    const sisteOpphørsPeriode =
-        sorterteOgFiltrerteOpphørsperioder[sorterteOgFiltrerteOpphørsperioder.length - 1];
-    return sisteOpphørsPeriode ? [sisteOpphørsPeriode] : [];
 };
 
 export const finnVedtakBegrunnelseType = (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Tidligere har vi fjerna alle vedtaksperioder utenom den siste opphørsperioden dersom behandlingsresultatet er Opphør. 

Tror denne funksjonen fin er moden for å fjernes, nå som vi har mer filtrering backend med endringstidspunkt. Den skaper i alle fall feil sik det er nå.

Endrer så vi ikke filterer bort periodene. 
