### PR TITLE
Ny varselmelding ved avvik for endre migreringsdato behandlinger på simuleringssiden

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -3,14 +3,14 @@ import { useEffect, useState } from 'react';
 import constate from 'constate';
 
 import { useHttp } from '@navikt/familie-http';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Avhengigheter } from '@navikt/familie-skjema';
-import { RessursStatus } from '@navikt/familie-typer';
+import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
+import { RessursStatus } from '@navikt/familie-typer';
 
 import useSakOgBehandlingParams from '../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../typer/behandling';
-import { Behandlingstype } from '../typer/behandling';
+import { Behandlingstype, BehandlingÅrsak } from '../typer/behandling';
 import { PersonType } from '../typer/person';
 import type { ISimuleringDTO, ISimuleringPeriode, ITilbakekreving } from '../typer/simulering';
 import { Tilbakekrevingsvalg } from '../typer/simulering';
@@ -138,6 +138,9 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
 
     const behandlingErMigreringMedManuellePosteringer =
         erMigreringFraInfotrygd && harManuellePosteringer;
+
+    const behandlingErEndreMigreringsdato =
+        åpenBehandling.årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO;
 
     const tilbakekrevingsvalg = useFelt<Tilbakekrevingsvalg | undefined>({
         verdi: åpenBehandling.tilbakekreving?.valg,
@@ -267,6 +270,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
         behandlingErMigreringMedManuellePosteringer,
         behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
+        behandlingErEndreMigreringsdato,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -46,6 +46,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
         behandlingErMigreringMedManuellePosteringer,
         behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
+        behandlingErEndreMigreringsdato,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
 
@@ -107,39 +108,47 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                     <>
                         <SimuleringPanel simulering={simuleringsresultat.data} />
                         <SimuleringTabell simulering={simuleringsresultat.data} />
-                        {(behandlingErMigreringMedAvvikInnenforBeløpsgrenser ||
-                            behandlingErMigreringMedAvvikUtenforBeløpsgrenser ||
-                            behandlingErMigreringMedManuellePosteringer) && (
-                            <>
-                                {behandlingErMigreringMedAvvikInnenforBeløpsgrenser && (
-                                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                        Behandlingen medfører avvik i simulering. Ved avvik på
-                                        mindre enn totalt 100 kroner, kan du gå videre i
-                                        behandlingen uten totrinnskontroll. Du må huske å sende
-                                        oppgave til NØS om at det ikke skal etterbetales / opprettes
-                                        kravgrunnlag.
-                                    </StyledBeløpsgrenseAlert>
-                                )}
-                                {behandlingErMigreringMedAvvikUtenforBeløpsgrenser ? (
-                                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                        Simuleringen viser en feilutbetaling eller etterbetaling.
-                                        Hvis du velger å gå videre i behandlingen kreves det
-                                        to-trinnskontroll. Det må sendes manuell oppgave til NØS for
-                                        å sikre at det ikke går ut etterbetaling eller blir
-                                        opprettet feilutbetalingssak i migreringsbehandlingen. Hvis
-                                        bruker skal ha en etterbetaling eller feilutbetaling, må
-                                        dette behandles i en egen revurderingsbehandling med
-                                        vedtaksbrev til bruker.
-                                    </StyledBeløpsgrenseAlert>
-                                ) : behandlingErMigreringMedManuellePosteringer ? (
-                                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                        Det finnes manuelle posteringer tilknyttet tidligere
-                                        behandling. Hvis du velger å gå videre i behandlingen kreves
-                                        det to-trinnskontroll.
-                                    </StyledBeløpsgrenseAlert>
-                                ) : null}
-                            </>
-                        )}
+                        {behandlingErEndreMigreringsdato &&
+                            (behandlingErMigreringMedAvvikUtenforBeløpsgrenser ||
+                                behandlingErMigreringMedAvvikUtenforBeløpsgrenser) && (
+                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                    Simuleringen viser en feilutbetaling eller etterbetaling. Du
+                                    trenger ikke sende oppgave til NØS, da beløpet ikke sendes til
+                                    oppdrag. Hvis bruker skal ha en etterbetaling eller
+                                    feilutbetaling må dette behandles i en egen
+                                    revurderingsbehandling med vedtaksbrev til bruker.
+                                </StyledBeløpsgrenseAlert>
+                            )}
+                        {!behandlingErEndreMigreringsdato &&
+                            behandlingErMigreringMedAvvikInnenforBeløpsgrenser && (
+                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                    Behandlingen medfører avvik i simulering. Ved avvik på mindre
+                                    enn totalt 100 kroner, kan du gå videre i behandlingen uten
+                                    totrinnskontroll. Du må huske å sende oppgave til NØS om at det
+                                    ikke skal etterbetales / opprettes kravgrunnlag.
+                                </StyledBeløpsgrenseAlert>
+                            )}
+                        {!behandlingErEndreMigreringsdato &&
+                            behandlingErMigreringMedAvvikUtenforBeløpsgrenser && (
+                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                    Simuleringen viser en feilutbetaling eller etterbetaling. Hvis
+                                    du velger å gå videre i behandlingen kreves det
+                                    to-trinnskontroll. Det må sendes manuell oppgave til NØS for å
+                                    sikre at det ikke går ut etterbetaling eller blir opprettet
+                                    feilutbetalingssak i migreringsbehandlingen. Hvis bruker skal ha
+                                    en etterbetaling eller feilutbetaling, må dette behandles i en
+                                    egen revurderingsbehandling med vedtaksbrev til bruker.
+                                </StyledBeløpsgrenseAlert>
+                            )}
+
+                        {!behandlingErEndreMigreringsdato &&
+                            behandlingErMigreringMedManuellePosteringer && (
+                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                                    Det finnes manuelle posteringer tilknyttet tidligere behandling.
+                                    Hvis du velger å gå videre i behandlingen kreves det
+                                    to-trinnskontroll.
+                                </StyledBeløpsgrenseAlert>
+                            )}
                         {erFeilutbetaling && (
                             <TilbakekrevingSkjema
                                 søkerMålform={hentSøkersMålform(åpenBehandling)}


### PR DESCRIPTION
Favro: [NAV-12736](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12736)

### 💰 Hva forsøker du å løse i denne PR'en
Ny varselmelding for "Endre migreringsdato"-behandlinger ved avvik.

Relatert endring i backend: https://github.com/navikt/familie-ba-sak/pull/3716

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/70642183/aa76ccef-70f6-4376-9ed2-a60d7179288e)
