### PR TITLE
NAV-11431 Validering: strengt fortrolig adresser skal ikke kombineres med manuelle brevmottakere

### DIFF
--- a/build_n_deploy/naiserator/azure-ad-app-lokal.yaml
+++ b/build_n_deploy/naiserator/azure-ad-app-lokal.yaml
@@ -25,3 +25,4 @@ spec:
       - id: "d21e00a4-969d-4b28-8782-dc818abfae65"  # SAKSBEHANDLER_ROLLE
       - id: "9449c153-5a1e-44a7-84c6-7cc7a8867233"  # BESLUTTER_ROLLE
       - id: "314fa714-f13c-4cdc-ac5c-e13ce08e241c"  # SUPERBRUKER_ROLLE
+      - id: "5ef775f2-61f8-4283-bf3d-8d03f428aa14"  # 0000-GA-Strengt_Fortrolig_Adresse

--- a/build_n_deploy/naiserator/gcp-dev.yaml
+++ b/build_n_deploy/naiserator/gcp-dev.yaml
@@ -36,6 +36,8 @@ spec:
           - id: "d21e00a4-969d-4b28-8782-dc818abfae65"  # SAKSBEHANDLER_ROLLE
           - id: "9449c153-5a1e-44a7-84c6-7cc7a8867233"  # BESLUTTER_ROLLE
           - id: "314fa714-f13c-4cdc-ac5c-e13ce08e241c"  # SUPERBRUKER_ROLLE
+          - id: "5ef775f2-61f8-4283-bf3d-8d03f428aa14"  # 0000-GA-Strengt_Fortrolig_Adresse
+
   resources:
     limits:
       cpu: 2000m

--- a/build_n_deploy/naiserator/gcp-prod.yaml
+++ b/build_n_deploy/naiserator/gcp-prod.yaml
@@ -41,6 +41,7 @@ spec:
           - id: "9cd89ac3-5587-46ba-b571-a625f2af481d"  # MEDLEM: 4833 NAV Familie- og pensjonsytelser Oslo 1
           - id: "7af5f216-6a5e-4228-9c99-687658c5b957"  # MEDLEM: 4842 NAV Familie- og pensjonsytelser Stord
           - id: "0feaea21-ada1-48c0-9300-3f6aec36b993"  # MEDLEM: 4817 NAV Familie- og pensjonsytelser Steinkjer
+          - id: "ad7b87a6-9180-467c-affc-20a566b0fec0"  # 0000-GA-Strengt_Fortrolig_Adresse
   resources:
     limits:
       cpu: 2000m

--- a/src/frontend/context/SøknadContext.ts
+++ b/src/frontend/context/SøknadContext.ts
@@ -40,8 +40,8 @@ const [SøknadProvider, useSøknad] = createUseContext(
         const {
             bruker,
             minimalFagsak,
-            skjemaHarValgtFortroligBarn,
-            settSkjemaHarValgtFortroligBarn,
+            søknadsskjemaHarValgtStrengtFortroligBarn,
+            settSøknadsskjemaHarValgtStrengtFortroligBarn,
         } = useFagsakContext();
         const [visBekreftModal, settVisBekreftModal] = useState<boolean>(false);
 
@@ -57,7 +57,7 @@ const [SøknadProvider, useSøknad] = createUseContext(
             brukerData?.adressebeskyttelseGradering ===
                 Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND;
 
-        const sjekkAtBarnIkkeErFortrolig = (person: IBarnMedOpplysninger) => {
+        const sjekkAtBarnIkkeErStrengtFortrolig = (person: IBarnMedOpplysninger) => {
             return !brukerData?.forelderBarnRelasjon.some(
                 barn =>
                     barn.personIdent === person.ident &&
@@ -86,7 +86,7 @@ const [SøknadProvider, useSøknad] = createUseContext(
                     'Brevmottaker(e) er manuelt registrert og må fjernes da brukeren har diskresjonskode.'
                 );
             }
-            if (avhengigheter?.antallBrevmottakere && avhengigheter?.finnesFortroligBarn) {
+            if (avhengigheter?.antallBrevmottakere && avhengigheter?.finnesStrengtFortroligBarn) {
                 return feil(
                     felt,
                     'Brevmottaker(e) er manuelt registrert og må fjernes før du kan velge barn med diskresjonskode.'
@@ -118,7 +118,7 @@ const [SøknadProvider, useSøknad] = createUseContext(
                         barnMedLøpendeUtbetaling,
                         antallBrevmottakere: åpenBehandling.brevmottakere.length,
                         erBrukerStrengtFortrolig,
-                        finnesFortroligBarn: skjemaHarValgtFortroligBarn,
+                        finnesStrengtFortroligBarn: søknadsskjemaHarValgtStrengtFortroligBarn,
                     },
                 }),
                 endringAvOpplysningerBegrunnelse: useFelt<string>({
@@ -208,10 +208,10 @@ const [SøknadProvider, useSøknad] = createUseContext(
             const merkedeBarn = skjema.felter.barnaMedOpplysninger.verdi.filter(
                 barn => barn.merket
             );
-            const finnesFortroligMerkedeBarn = !merkedeBarn.every(person =>
-                sjekkAtBarnIkkeErFortrolig(person)
+            const finnesStrengtFortroligMerkedeBarn = !merkedeBarn.every(person =>
+                sjekkAtBarnIkkeErStrengtFortrolig(person)
             );
-            settSkjemaHarValgtFortroligBarn(finnesFortroligMerkedeBarn);
+            settSøknadsskjemaHarValgtStrengtFortroligBarn(finnesStrengtFortroligMerkedeBarn);
         }, [skjema.felter.barnaMedOpplysninger.verdi]);
 
         const nesteAction = (bekreftEndringerViaFrontend: boolean) => {

--- a/src/frontend/context/SøknadContext.ts
+++ b/src/frontend/context/SøknadContext.ts
@@ -75,22 +75,21 @@ const [SøknadProvider, useSøknad] = createUseContext(
                 felt.verdi.some((barn: IBarnMedOpplysninger) => barn.merket) ||
                 (avhengigheter?.barnMedLøpendeUtbetaling.size ?? []) > 0
             ) {
-                if (avhengigheter?.antallBrevmottakere && avhengigheter?.erBrukerFortrolig) {
-                    return feil(
-                        felt,
-                        'Brevmottaker(e) er manuelt registrert og må fjernes da brukeren har diskresjonskode.'
-                    );
-                }
-                if (avhengigheter?.antallBrevmottakere && avhengigheter?.finnesFortroligBarn) {
-                    return feil(
-                        felt,
-                        'Brevmottaker(e) er manuelt registrert og må fjernes før du kan velge barn med diskresjonskode.'
-                    );
-                }
-                return ok(felt);
-            } else {
                 return feil(felt, 'Ingen av barna er valgt.');
             }
+            if (avhengigheter?.antallBrevmottakere && avhengigheter?.erBrukerFortrolig) {
+                return feil(
+                    felt,
+                    'Brevmottaker(e) er manuelt registrert og må fjernes da brukeren har diskresjonskode.'
+                );
+            }
+            if (avhengigheter?.antallBrevmottakere && avhengigheter?.finnesFortroligBarn) {
+                return feil(
+                    felt,
+                    'Brevmottaker(e) er manuelt registrert og må fjernes før du kan velge barn med diskresjonskode.'
+                );
+            }
+            return ok(felt);
         };
 
         const { skjema, nullstillSkjema, onSubmit, hentFeilTilOppsummering } = useSkjema<

--- a/src/frontend/context/SøknadContext.ts
+++ b/src/frontend/context/SøknadContext.ts
@@ -51,7 +51,7 @@ const [SøknadProvider, useSøknad] = createUseContext(
                 : new Set();
 
         const brukerData = hentDataFraRessurs(bruker);
-        const erBrukerFortrolig =
+        const erBrukerStrengtFortrolig =
             brukerData?.adressebeskyttelseGradering ===
                 Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
             brukerData?.adressebeskyttelseGradering ===
@@ -80,7 +80,7 @@ const [SøknadProvider, useSøknad] = createUseContext(
             ) {
                 return feil(felt, 'Ingen av barna er valgt.');
             }
-            if (avhengigheter?.antallBrevmottakere && avhengigheter?.erBrukerFortrolig) {
+            if (avhengigheter?.antallBrevmottakere && avhengigheter?.erBrukerStrengtFortrolig) {
                 return feil(
                     felt,
                     'Brevmottaker(e) er manuelt registrert og må fjernes da brukeren har diskresjonskode.'
@@ -117,7 +117,7 @@ const [SøknadProvider, useSøknad] = createUseContext(
                     avhengigheter: {
                         barnMedLøpendeUtbetaling,
                         antallBrevmottakere: åpenBehandling.brevmottakere.length,
-                        erBrukerFortrolig,
+                        erBrukerStrengtFortrolig,
                         finnesFortroligBarn: skjemaHarValgtFortroligBarn,
                     },
                 }),

--- a/src/frontend/context/SøknadContext.ts
+++ b/src/frontend/context/SøknadContext.ts
@@ -72,8 +72,10 @@ const [SøknadProvider, useSøknad] = createUseContext(
             avhengigheter?: Avhengigheter
         ) => {
             if (
-                felt.verdi.some((barn: IBarnMedOpplysninger) => barn.merket) ||
-                (avhengigheter?.barnMedLøpendeUtbetaling.size ?? []) > 0
+                !(
+                    felt.verdi.some((barn: IBarnMedOpplysninger) => barn.merket) ||
+                    (avhengigheter?.barnMedLøpendeUtbetaling.size ?? []) > 0
+                )
             ) {
                 return feil(felt, 'Ingen av barna er valgt.');
             }

--- a/src/frontend/context/SøknadContext.ts
+++ b/src/frontend/context/SøknadContext.ts
@@ -56,7 +56,8 @@ const [SøknadProvider, useSøknad] = createUseContext(
                 Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
             brukerData?.adressebeskyttelseGradering ===
                 Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND;
-        function sjekkAtBarnIkkeErFortrolig(person: IBarnMedOpplysninger) {
+
+        const sjekkAtBarnIkkeErFortrolig = (person: IBarnMedOpplysninger) => {
             return !brukerData?.forelderBarnRelasjon.some(
                 barn =>
                     barn.personIdent === person.ident &&
@@ -65,7 +66,7 @@ const [SøknadProvider, useSøknad] = createUseContext(
                         Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND ===
                             barn.adressebeskyttelseGradering)
             );
-        }
+        };
 
         const validerBrukerOgBarnaMedOpplysninger = (
             felt: FeltState<IBarnMedOpplysninger[]>,

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -34,8 +34,10 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
 
     const [klagebehandlinger, settKlagebehandlinger] = useState<IKlagebehandling[]>([]);
 
-    const [skjemaHarValgtFortroligBarn, settSkjemaHarValgtFortroligBarn] =
-        React.useState<boolean>(false);
+    const [
+        søknadsskjemaHarValgtStrengtFortroligBarn,
+        settSøknadsskjemaHarValgtStrengtFortroligBarn,
+    ] = React.useState<boolean>(false);
 
     const { request } = useHttp();
 
@@ -163,8 +165,8 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
         klagebehandlinger,
         oppdaterKlagebehandlingerPåFagsak,
         oppdaterGjeldendeFagsak,
-        skjemaHarValgtFortroligBarn,
-        settSkjemaHarValgtFortroligBarn,
+        søknadsskjemaHarValgtStrengtFortroligBarn,
+        settSøknadsskjemaHarValgtStrengtFortroligBarn,
     };
 });
 

--- a/src/frontend/context/fagsak/FagsakContext.tsx
+++ b/src/frontend/context/fagsak/FagsakContext.tsx
@@ -34,6 +34,9 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
 
     const [klagebehandlinger, settKlagebehandlinger] = useState<IKlagebehandling[]>([]);
 
+    const [skjemaHarValgtFortroligBarn, settSkjemaHarValgtFortroligBarn] =
+        React.useState<boolean>(false);
+
     const { request } = useHttp();
 
     const hentMinimalFagsak = (fagsakId: string | number, påvirkerSystemLaster = true): void => {
@@ -160,6 +163,8 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
         klagebehandlinger,
         oppdaterKlagebehandlingerPåFagsak,
         oppdaterGjeldendeFagsak,
+        skjemaHarValgtFortroligBarn,
+        settSkjemaHarValgtFortroligBarn,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -7,7 +7,7 @@ import '@navikt/ds-css-internal';
 import { ExpandFilled } from '@navikt/ds-icons';
 import { Button } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react-internal';
-import { Adressebeskyttelsegradering, hentDataFraRessurs } from '@navikt/familie-typer';
+import { hentDataFraRessurs } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import useSakOgBehandlingParams from '../../../../hooks/useSakOgBehandlingParams';
@@ -45,21 +45,7 @@ const Behandlingsmeny: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
 
     const erLesevisning = vurderErLesevisning();
     const åpenBehandling = hentDataFraRessurs(åpenBehandlingRessurs);
-
     const erPåBehandling = !!behandlingIdFraURL && !!åpenBehandling;
-
-    const brukerEllerBarnHarStrengtFortroligAdresse =
-        bruker &&
-        (bruker.adressebeskyttelseGradering === Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
-            bruker.adressebeskyttelseGradering ===
-                Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND ||
-            bruker.forelderBarnRelasjonMaskert.some(
-                relasjon =>
-                    relasjon.adressebeskyttelseGradering ===
-                        Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
-                    relasjon.adressebeskyttelseGradering ===
-                        Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND
-            ));
 
     return (
         <Dropdown>
@@ -109,8 +95,7 @@ const Behandlingsmeny: React.FC<IProps> = ({ bruker, minimalFagsak }) => {
                     {erPåBehandling && åpenBehandling.aktivSettPåVent && (
                         <TaBehandlingAvVent behandling={åpenBehandling} />
                     )}
-                    {!brukerEllerBarnHarStrengtFortroligAdresse &&
-                        erPåBehandling &&
+                    {erPåBehandling &&
                         minimalFagsak.fagsakType !== FagsakType.INSTITUSJON &&
                         (!erLesevisning || åpenBehandling.brevmottakere.length > 0) &&
                         (åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING ||

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -52,24 +52,26 @@ const MottakerSelect = styled(FamilieSelect)`
 interface IProps {
     lukkModal: () => void;
     åpenBehandling: IBehandling;
-    erBrukerFortrolig: boolean;
-    finnesFortroligBarnIBehandling: boolean;
-    skjemaHarValgtFortroligBarn: boolean;
+    erBrukerStrengtFortrolig: boolean;
+    finnesStrengtFortroligBarnIBehandling: boolean;
+    søknadsskjemaHarValgtStrengtFortroligBarn: boolean;
 }
 
 const BrevmottakerSkjema: React.FC<IProps> = ({
     lukkModal,
     åpenBehandling,
-    erBrukerFortrolig,
-    finnesFortroligBarnIBehandling,
-    skjemaHarValgtFortroligBarn,
+    erBrukerStrengtFortrolig,
+    finnesStrengtFortroligBarnIBehandling,
+    søknadsskjemaHarValgtStrengtFortroligBarn,
 }) => {
     const { skjema, lagreMottaker, valideringErOk, navnErPreutfylt } =
         useLeggTilFjernBrevmottaker();
     const { vurderErLesevisning } = useBehandling();
     const erLesevisning = vurderErLesevisning();
     const deaktiverSkjema =
-        erBrukerFortrolig || finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
+        erBrukerStrengtFortrolig ||
+        finnesStrengtFortroligBarnIBehandling ||
+        søknadsskjemaHarValgtStrengtFortroligBarn;
 
     return (
         <>
@@ -186,9 +188,11 @@ const BrevmottakerSkjema: React.FC<IProps> = ({
 
             <BrevmottakerValideringAlert
                 åpenBehandling={åpenBehandling}
-                erBrukerFortrolig={erBrukerFortrolig}
-                finnesFortroligBarnIBehandling={finnesFortroligBarnIBehandling}
-                skjemaHarValgtFortroligBarn={skjemaHarValgtFortroligBarn}
+                erBrukerStrengtFortrolig={erBrukerStrengtFortrolig}
+                finnesStrengtFortroligBarnIBehandling={finnesStrengtFortroligBarnIBehandling}
+                søknadsskjemaHarValgtStrengtFortroligBarn={
+                    søknadsskjemaHarValgtStrengtFortroligBarn
+                }
             />
         </>
     );

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -52,6 +52,7 @@ const MottakerSelect = styled(FamilieSelect)`
 interface IProps {
     lukkModal: () => void;
     åpenBehandling: IBehandling;
+    erBrukerFortrolig: boolean;
     finnesFortroligBarnIBehandling: boolean;
     skjemaHarValgtFortroligBarn: boolean;
 }
@@ -59,6 +60,7 @@ interface IProps {
 const BrevmottakerSkjema: React.FC<IProps> = ({
     lukkModal,
     åpenBehandling,
+    erBrukerFortrolig,
     finnesFortroligBarnIBehandling,
     skjemaHarValgtFortroligBarn,
 }) => {
@@ -66,7 +68,8 @@ const BrevmottakerSkjema: React.FC<IProps> = ({
         useLeggTilFjernBrevmottaker();
     const { vurderErLesevisning } = useBehandling();
     const erLesevisning = vurderErLesevisning();
-    const deaktiverSkjema = finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
+    const deaktiverSkjema =
+        erBrukerFortrolig || finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
 
     return (
         <>
@@ -183,6 +186,7 @@ const BrevmottakerSkjema: React.FC<IProps> = ({
 
             <BrevmottakerValideringAlert
                 åpenBehandling={åpenBehandling}
+                erBrukerFortrolig={erBrukerFortrolig}
                 finnesFortroligBarnIBehandling={finnesFortroligBarnIBehandling}
                 skjemaHarValgtFortroligBarn={skjemaHarValgtFortroligBarn}
             />

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerValideringAlert.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerValideringAlert.tsx
@@ -11,24 +11,32 @@ const StyledAlert = styled(Alert)`
 `;
 interface IProps {
     åpenBehandling: IBehandling;
+    erBrukerFortrolig: boolean;
     finnesFortroligBarnIBehandling: boolean;
     skjemaHarValgtFortroligBarn: boolean;
 }
 
 const BrevmottakerValideringAlert: React.FC<IProps> = ({
     åpenBehandling,
+    erBrukerFortrolig,
     finnesFortroligBarnIBehandling,
     skjemaHarValgtFortroligBarn,
 }) => {
-    const deaktiverSkjema = finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
+    const deaktiverSkjema =
+        erBrukerFortrolig || finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
     return (
         <>
             {deaktiverSkjema && (
                 <StyledAlert variant={åpenBehandling.brevmottakere.length ? 'error' : 'warning'}>
-                    Enkelte personer
-                    {finnesFortroligBarnIBehandling
-                        ? ' lagt til i behandlingen '
-                        : ' valgt i behandlingen '}
+                    {erBrukerFortrolig ? (
+                        <>Brukeren i behandlingen </>
+                    ) : (
+                        <>
+                            {finnesFortroligBarnIBehandling
+                                ? 'Barn lagt til i behandlingen '
+                                : 'Barn valgt i behandlingen '}
+                        </>
+                    )}
                     har diskresjonskode som innebærer at det ikke er tillatt med manuelle
                     brevmottakere.
                     {åpenBehandling.brevmottakere.length > 0 && (

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerValideringAlert.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerValideringAlert.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Alert } from '@navikt/ds-react';
+
+import type { IBehandling } from '../../../../../typer/behandling';
+
+const StyledAlert = styled(Alert)`
+    margin: 1rem 0 0;
+`;
+interface IProps {
+    åpenBehandling: IBehandling;
+    finnesFortroligBarnIBehandling: boolean;
+    skjemaHarValgtFortroligBarn: boolean;
+}
+
+const BrevmottakerValideringAlert: React.FC<IProps> = ({
+    åpenBehandling,
+    finnesFortroligBarnIBehandling,
+    skjemaHarValgtFortroligBarn,
+}) => {
+    const deaktiverSkjema = finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
+    return (
+        <>
+            {deaktiverSkjema && (
+                <StyledAlert variant={åpenBehandling.brevmottakere.length ? 'error' : 'warning'}>
+                    Enkelte personer
+                    {finnesFortroligBarnIBehandling
+                        ? ' lagt til i behandlingen '
+                        : ' valgt i behandlingen '}
+                    har diskresjonskode som innebærer at det ikke er tillatt med manuelle
+                    brevmottakere.
+                    {åpenBehandling.brevmottakere.length > 0 && (
+                        <span>
+                            <br />
+                            <b>
+                                Brevmottaker(e) er manuelt registrert og må fjernes før du kan velge
+                                bruker eller barn med diskresjonskode.
+                            </b>
+                        </span>
+                    )}
+                </StyledAlert>
+            )}
+        </>
+    );
+};
+export default BrevmottakerValideringAlert;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerValideringAlert.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerValideringAlert.tsx
@@ -11,28 +11,30 @@ const StyledAlert = styled(Alert)`
 `;
 interface IProps {
     åpenBehandling: IBehandling;
-    erBrukerFortrolig: boolean;
-    finnesFortroligBarnIBehandling: boolean;
-    skjemaHarValgtFortroligBarn: boolean;
+    erBrukerStrengtFortrolig: boolean;
+    finnesStrengtFortroligBarnIBehandling: boolean;
+    søknadsskjemaHarValgtStrengtFortroligBarn: boolean;
 }
 
 const BrevmottakerValideringAlert: React.FC<IProps> = ({
     åpenBehandling,
-    erBrukerFortrolig,
-    finnesFortroligBarnIBehandling,
-    skjemaHarValgtFortroligBarn,
+    erBrukerStrengtFortrolig,
+    finnesStrengtFortroligBarnIBehandling,
+    søknadsskjemaHarValgtStrengtFortroligBarn,
 }) => {
     const deaktiverSkjema =
-        erBrukerFortrolig || finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
+        erBrukerStrengtFortrolig ||
+        finnesStrengtFortroligBarnIBehandling ||
+        søknadsskjemaHarValgtStrengtFortroligBarn;
     return (
         <>
             {deaktiverSkjema && (
                 <StyledAlert variant={åpenBehandling.brevmottakere.length ? 'error' : 'warning'}>
-                    {erBrukerFortrolig ? (
+                    {erBrukerStrengtFortrolig ? (
                         <>Brukeren i behandlingen </>
                     ) : (
                         <>
-                            {finnesFortroligBarnIBehandling
+                            {finnesStrengtFortroligBarnIBehandling
                                 ? 'Barn lagt til i behandlingen '
                                 : 'Barn valgt i behandlingen '}
                         </>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -60,6 +60,10 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
     const heading = utledHeading(åpenBehandling.brevmottakere.length, erLesevisning);
 
     const brukerData = hentDataFraRessurs(bruker);
+    const erBrukerFortrolig =
+        brukerData?.adressebeskyttelseGradering === Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
+        brukerData?.adressebeskyttelseGradering ===
+            Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND;
     function sjekkAtBarnIkkeErFortrolig(person: IGrunnlagPerson) {
         return !brukerData?.forelderBarnRelasjon.some(
             barn =>
@@ -74,7 +78,8 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
     const finnesFortroligBarnIBehandling = !åpenBehandling.personer.every(person =>
         sjekkAtBarnIkkeErFortrolig(person)
     );
-    const deaktiverSkjema = finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
+    const deaktiverSkjema =
+        erBrukerFortrolig || finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
 
     const [visSkjemaNårDetErÉnBrevmottaker, settVisSkjemaNårDetErÉnBrevmottaker] = useState(false);
 
@@ -114,6 +119,7 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
                         <BrevmottakerSkjema
                             lukkModal={lukkModalOgSkjema}
                             åpenBehandling={åpenBehandling}
+                            erBrukerFortrolig={erBrukerFortrolig}
                             finnesFortroligBarnIBehandling={finnesFortroligBarnIBehandling}
                             skjemaHarValgtFortroligBarn={skjemaHarValgtFortroligBarn}
                         />
@@ -134,6 +140,7 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
 
                         <BrevmottakerValideringAlert
                             åpenBehandling={åpenBehandling}
+                            erBrukerFortrolig={erBrukerFortrolig}
                             finnesFortroligBarnIBehandling={finnesFortroligBarnIBehandling}
                             skjemaHarValgtFortroligBarn={skjemaHarValgtFortroligBarn}
                         />

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -64,7 +64,7 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
         brukerData?.adressebeskyttelseGradering === Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
         brukerData?.adressebeskyttelseGradering ===
             Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND;
-    function sjekkAtBarnIkkeErFortrolig(person: IGrunnlagPerson) {
+    const sjekkAtBarnIkkeErFortrolig = (person: IGrunnlagPerson) => {
         return !brukerData?.forelderBarnRelasjon.some(
             barn =>
                 barn.personIdent === person.personIdent &&
@@ -73,7 +73,7 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
                     Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND ===
                         barn.adressebeskyttelseGradering)
         );
-    }
+    };
 
     const finnesFortroligBarnIBehandling = !åpenBehandling.personer.every(person =>
         sjekkAtBarnIkkeErFortrolig(person)

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -54,13 +54,13 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
     åpenBehandling,
 }: Props) => {
     const { vurderErLesevisning } = useBehandling();
-    const { bruker, skjemaHarValgtFortroligBarn } = useFagsakContext();
+    const { bruker, søknadsskjemaHarValgtStrengtFortroligBarn } = useFagsakContext();
     const erLesevisning = vurderErLesevisning();
 
     const heading = utledHeading(åpenBehandling.brevmottakere.length, erLesevisning);
 
     const brukerData = hentDataFraRessurs(bruker);
-    const erBrukerFortrolig =
+    const erBrukerStrengtFortrolig =
         brukerData?.adressebeskyttelseGradering === Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
         brukerData?.adressebeskyttelseGradering ===
             Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND;
@@ -75,11 +75,13 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
         );
     };
 
-    const finnesFortroligBarnIBehandling = !åpenBehandling.personer.every(person =>
+    const finnesStrengtFortroligBarnIBehandling = !åpenBehandling.personer.every(person =>
         sjekkAtBarnIkkeErStrengtFortrolig(person)
     );
     const deaktiverSkjema =
-        erBrukerFortrolig || finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;
+        erBrukerStrengtFortrolig ||
+        finnesStrengtFortroligBarnIBehandling ||
+        søknadsskjemaHarValgtStrengtFortroligBarn;
 
     const [visSkjemaNårDetErÉnBrevmottaker, settVisSkjemaNårDetErÉnBrevmottaker] = useState(false);
 
@@ -119,9 +121,13 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
                         <BrevmottakerSkjema
                             lukkModal={lukkModalOgSkjema}
                             åpenBehandling={åpenBehandling}
-                            erBrukerFortrolig={erBrukerFortrolig}
-                            finnesFortroligBarnIBehandling={finnesFortroligBarnIBehandling}
-                            skjemaHarValgtFortroligBarn={skjemaHarValgtFortroligBarn}
+                            erBrukerStrengtFortrolig={erBrukerStrengtFortrolig}
+                            finnesStrengtFortroligBarnIBehandling={
+                                finnesStrengtFortroligBarnIBehandling
+                            }
+                            søknadsskjemaHarValgtStrengtFortroligBarn={
+                                søknadsskjemaHarValgtStrengtFortroligBarn
+                            }
                         />
                     </>
                 ) : (
@@ -140,9 +146,13 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
 
                         <BrevmottakerValideringAlert
                             åpenBehandling={åpenBehandling}
-                            erBrukerFortrolig={erBrukerFortrolig}
-                            finnesFortroligBarnIBehandling={finnesFortroligBarnIBehandling}
-                            skjemaHarValgtFortroligBarn={skjemaHarValgtFortroligBarn}
+                            erBrukerStrengtFortrolig={erBrukerStrengtFortrolig}
+                            finnesStrengtFortroligBarnIBehandling={
+                                finnesStrengtFortroligBarnIBehandling
+                            }
+                            søknadsskjemaHarValgtStrengtFortroligBarn={
+                                søknadsskjemaHarValgtStrengtFortroligBarn
+                            }
                         />
 
                         <div>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -64,7 +64,7 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
         brukerData?.adressebeskyttelseGradering === Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
         brukerData?.adressebeskyttelseGradering ===
             Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND;
-    const sjekkAtBarnIkkeErFortrolig = (person: IGrunnlagPerson) => {
+    const sjekkAtBarnIkkeErStrengtFortrolig = (person: IGrunnlagPerson) => {
         return !brukerData?.forelderBarnRelasjon.some(
             barn =>
                 barn.personIdent === person.personIdent &&
@@ -76,7 +76,7 @@ export const LeggTilBrevmottakerModal: React.FC<Props> = ({
     };
 
     const finnesFortroligBarnIBehandling = !åpenBehandling.personer.every(person =>
-        sjekkAtBarnIkkeErFortrolig(person)
+        sjekkAtBarnIkkeErStrengtFortrolig(person)
     );
     const deaktiverSkjema =
         erBrukerFortrolig || finnesFortroligBarnIBehandling || skjemaHarValgtFortroligBarn;

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -143,6 +143,17 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
         nullstillRegistrerBarnSkjema();
     };
 
+    const harBrevMottakereOgHarStrengtFortroligAdressebeskyttelse = (
+        adressebeskyttelsegradering: Adressebeskyttelsegradering,
+        antallBrevmottakere: number
+    ): boolean => {
+        return (
+            (adressebeskyttelsegradering === Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
+                adressebeskyttelsegradering ===
+                    Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND) &&
+            antallBrevmottakere > 0
+        );
+    };
     const leggTilOnClick = () => {
         const erSkjemaOk = kanSendeSkjema();
         if (
@@ -187,11 +198,10 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                                 settSubmitRessurs(hentetPerson);
                                 if (hentetPerson.status === RessursStatus.SUKSESS) {
                                     if (
-                                        (ressurs.data.adressebeskyttelsegradering ===
-                                            Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
-                                            ressurs.data.adressebeskyttelsegradering ===
-                                                Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND) &&
-                                        åpenBehandling?.brevmottakere.length
+                                        harBrevMottakereOgHarStrengtFortroligAdressebeskyttelse(
+                                            ressurs.data.adressebeskyttelsegradering,
+                                            åpenBehandling?.brevmottakere.length ?? 0
+                                        )
                                     ) {
                                         settSubmitRessurs(
                                             byggFeiletRessurs(

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -68,26 +68,9 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
     const { request } = useHttp();
     const { logg, åpenBehandling: åpenBehandlingRessurs } = useBehandling();
     const åpenBehandling = hentDataFraRessurs(åpenBehandlingRessurs);
-
-    const getDiskresjonskodeNavn = (diskresjonskode: string) => {
-        if (Adressebeskyttelsegradering.UGRADERT === diskresjonskode) {
-            return '"UGRADERT"';
-        } else if (Adressebeskyttelsegradering.FORTROLIG === diskresjonskode) {
-            return '"Fortrolig"';
-        } else if (Adressebeskyttelsegradering.STRENGT_FORTROLIG === diskresjonskode) {
-            return '"Strengt fortrolig"';
-        } else if (Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND === diskresjonskode) {
-            return '"Strengt fortrolig utland"';
-        } else {
-            return '"UGYLDIG KODE: ' + diskresjonskode + '"';
-        }
-    };
-
     const [visModal, settVisModal] = useState<boolean>(false);
     const [fnrInputNode, settFnrInputNode] = useState<HTMLInputElement | null>(null);
-
     const [kanLeggeTilUregistrerteBarn, settKanLeggeTilUregistrerteBarn] = useState(true);
-
     const fnrInputRef = React.useCallback((inputNode: HTMLInputElement | null) => {
         inputNode?.focus();
         settFnrInputNode(inputNode);
@@ -204,17 +187,19 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                                 settSubmitRessurs(hentetPerson);
                                 if (hentetPerson.status === RessursStatus.SUKSESS) {
                                     if (
-                                        (hentetPerson.data.adressebeskyttelseGradering ===
+                                        (ressurs.data.adressebeskyttelsegradering ===
                                             Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
-                                            hentetPerson.data.adressebeskyttelseGradering ===
+                                            ressurs.data.adressebeskyttelsegradering ===
                                                 Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND) &&
                                         åpenBehandling?.brevmottakere.length
                                     ) {
                                         settSubmitRessurs(
                                             byggFeiletRessurs(
-                                                `Barnet du prøver å legge til har diskresjonskode: ${getDiskresjonskodeNavn(
-                                                    hentetPerson.data.adressebeskyttelseGradering
-                                                )}. Brevmottaker(e) er endret og må fjernes før du kan legge til barnet.`
+                                                `Barnet du prøver å legge til har diskresjonskode: "${
+                                                    adressebeskyttelsestyper[
+                                                        ressurs.data.adressebeskyttelsegradering
+                                                    ] ?? 'ukjent'
+                                                }". Brevmottaker(e) er endret og må fjernes før du kan legge til barnet.`
                                             )
                                         );
                                     } else {


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11431
Løsning avviker noe fra favro-kortet i samråd med Tor og Daphne.

### 💰 Hva forsøker du å løse i denne PR'en
 Validering av at bruker/barn med “STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND adressebeskyttelse” ikke kan legges til dersom det foreligger manuelle brevmottakere.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Følgende steder er det lagt til validering for at ikke fortrolig personer skal kombineres med manuelle brevmottakere:
* Validering i “Legg til barn” (at barn ikke er fortrolig)
* Validering i skjema (Registrer søknad) (at bruker/barn ikke er fortrolig)
* Validering i “Legg til brevmottaker” (at bruker/barn ikke er fortrolig)

Endring innebærer at “Legg til brevmottaker”-menypunktet ikke lenger skjules pga fortrolig person(er) - slik at man kan fjerne ev brevmottakere dersom en endring i “fotrolig status” skulle tilsi at man bør slette manuelle brevmottakere. Dette var ikke mulig tidligere da hele meny ble skjult. 
Det blir i stedet ikke mulig å opprette nye (kun slette + feilmelding) dersom fortrolig-adresse-validering tilsier det.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
Testet manuelt.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![NAV-11431-legg_til_barn](https://github.com/navikt/familie-ba-sak-frontend/assets/126786453/3d8764b5-6f4b-4e0d-9f92-5355f1907243)
![NAV-11431-skjema](https://github.com/navikt/familie-ba-sak-frontend/assets/126786453/e3cd090e-f33f-4ea8-a32c-7fd1aa20bf35)
![NAV-11431-legg_til_brevmottaker_1](https://github.com/navikt/familie-ba-sak-frontend/assets/126786453/e2accd33-861a-4902-a293-a7091d00b2d2)
![NAV-11431-legg_til_brevmottaker_2](https://github.com/navikt/familie-ba-sak-frontend/assets/126786453/065c7f1c-69f4-42d1-aad8-12d30b1aca16)


