### PR TITLE
Fjern nav-frontend-typografi og nav-frontend-typografi-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,6 @@
     "nav-frontend-tabell-style": "^2.1.1",
     "nav-frontend-tabs": "^2.0.1",
     "nav-frontend-tabs-style": "^2.0.1",
-    "nav-frontend-typografi": "^4.0.1",
-    "nav-frontend-typografi-style": "^2.0.1",
     "nav-hoykontrast": "^2.1.2",
     "prop-types": "^15.8.1",
     "query-string": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8246,11 +8246,6 @@ nav-frontend-typografi-style@^2.0.1:
   dependencies:
     nav-frontend-core "^6.0.1"
 
-nav-frontend-typografi@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nav-frontend-typografi/-/nav-frontend-typografi-4.0.1.tgz#dee38984be84bc472e1ee3b726fa69b8f0b363b9"
-  integrity sha512-zJrvysIWqZm0HSJqqgc1G5Lqr8bLO16B9Pg/FW7+mJQGGz/iqPhX5vvIFTXqAlXVo95qImoZ72uiWiHHRdGhPQ==
-
 nav-frontend-typografi@^4.0.x:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/nav-frontend-typografi/-/nav-frontend-typografi-4.0.2.tgz#470cc95f4b4ff3a94363dd86eeea45bd9dc6014a"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ser ikke ut som nav-frontend-typografi trenger å ligge i package.json. Den blir kun brukt ett sted som jeg kan se, og det er i yarn.lock filen som en dependency til familie-form-elements. Blir alikevel dratt inn som en avhengighet når jeg fjerner fra package.json, så alt burde være i orden. Jeg har testet og alt ser fint ut i mine øyne 😄

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Fjerner bare en dependency

### 🤷‍♀ ️Hvor er det lurt å starte?
Er bare 1 commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

