### PR TITLE
Nav 11431 validering strengt fortrolig adresser ikke manuelle brevmottakere i "legg til barn"

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -182,6 +182,7 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                 nullstillRegistrerBarnSkjema();
             } else {
                 settSubmitRessurs(byggHenterRessurs());
+
                 request<{ brukerIdent: string }, IRestTilgang>({
                     method: 'POST',
                     url: '/familie-ba-sak/api/tilgang',

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -10,7 +10,13 @@ import { useHttp } from '@navikt/familie-http';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Avhengigheter, Felt } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
-import { byggFeiletRessurs, byggHenterRessurs, RessursStatus } from '@navikt/familie-typer';
+import {
+    Adressebeskyttelsegradering,
+    byggFeiletRessurs,
+    byggHenterRessurs,
+    hentDataFraRessurs,
+    RessursStatus,
+} from '@navikt/familie-typer';
 
 import { useBehandling } from '../../context/behandlingContext/BehandlingContext';
 import type { IPersonInfo, IRestTilgang } from '../../typer/person';
@@ -40,6 +46,12 @@ const DrekLenkeContainer = styled.div`
     margin-bottom: 1.25rem;
 `;
 
+const StyledFieldset = styled(Fieldset)`
+    p.navds-error-message.navds-label {
+        max-width: 35rem;
+    }
+`;
+
 export interface IRegistrerBarnSkjema {
     ident: string;
     erFolkeregistrert: boolean;
@@ -54,11 +66,10 @@ interface IProps {
 
 const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
     const { request } = useHttp();
-    const { logg } = useBehandling();
-
+    const { logg, åpenBehandling: åpenBehandlingRessurs } = useBehandling();
+    const åpenBehandling = hentDataFraRessurs(åpenBehandlingRessurs);
     const [visModal, settVisModal] = useState<boolean>(false);
     const [fnrInputNode, settFnrInputNode] = useState<HTMLInputElement | null>(null);
-
     const [kanLeggeTilUregistrerteBarn, settKanLeggeTilUregistrerteBarn] = useState(true);
 
     const fnrInputRef = React.useCallback((inputNode: HTMLInputElement | null) => {
@@ -133,6 +144,18 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
         nullstillRegistrerBarnSkjema();
     };
 
+    const harBrevMottakereOgHarStrengtFortroligAdressebeskyttelse = (
+        adressebeskyttelsegradering: Adressebeskyttelsegradering,
+        antallBrevmottakere: number
+    ): boolean => {
+        return (
+            (adressebeskyttelsegradering === Adressebeskyttelsegradering.STRENGT_FORTROLIG ||
+                adressebeskyttelsegradering ===
+                    Adressebeskyttelsegradering.STRENGT_FORTROLIG_UTLAND) &&
+            antallBrevmottakere > 0
+        );
+    };
+
     const leggTilOnClick = () => {
         const erSkjemaOk = kanSendeSkjema();
         if (
@@ -159,7 +182,6 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                 nullstillRegistrerBarnSkjema();
             } else {
                 settSubmitRessurs(byggHenterRessurs());
-
                 request<{ brukerIdent: string }, IRestTilgang>({
                     method: 'POST',
                     url: '/familie-ba-sak/api/tilgang',
@@ -176,20 +198,37 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                             }).then((hentetPerson: Ressurs<IPersonInfo>) => {
                                 settSubmitRessurs(hentetPerson);
                                 if (hentetPerson.status === RessursStatus.SUKSESS) {
-                                    barnaMedOpplysninger.validerOgSettFelt([
-                                        ...barnaMedOpplysninger.verdi,
-                                        {
-                                            fødselsdato: hentetPerson.data.fødselsdato,
-                                            ident: hentetPerson.data.personIdent,
-                                            merket: true,
-                                            manueltRegistrert: true,
-                                            navn: hentetPerson.data.navn,
-                                            erFolkeregistrert: true,
-                                        },
-                                    ]);
-                                    onSuccess && onSuccess(hentetPerson.data);
+                                    if (
+                                        harBrevMottakereOgHarStrengtFortroligAdressebeskyttelse(
+                                            ressurs.data.adressebeskyttelsegradering,
+                                            åpenBehandling?.brevmottakere.length ?? 0
+                                        )
+                                    ) {
+                                        settSubmitRessurs(
+                                            byggFeiletRessurs(
+                                                `Barnet du prøver å legge til har diskresjonskode: "${
+                                                    adressebeskyttelsestyper[
+                                                        ressurs.data.adressebeskyttelsegradering
+                                                    ] ?? 'ukjent'
+                                                }". Brevmottaker(e) er endret og må fjernes før du kan legge til barnet.`
+                                            )
+                                        );
+                                    } else {
+                                        barnaMedOpplysninger.validerOgSettFelt([
+                                            ...barnaMedOpplysninger.verdi,
+                                            {
+                                                fødselsdato: hentetPerson.data.fødselsdato,
+                                                ident: hentetPerson.data.personIdent,
+                                                merket: true,
+                                                manueltRegistrert: true,
+                                                navn: hentetPerson.data.navn,
+                                                erFolkeregistrert: true,
+                                            },
+                                        ]);
+                                        onSuccess && onSuccess(hentetPerson.data);
 
-                                    settVisModal(false);
+                                        settVisModal(false);
+                                    }
                                 }
                             });
                         } else {
@@ -258,7 +297,7 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                             </BodyLong>
                         </StyledHelpText>
                     </StyledHeading>
-                    <Fieldset
+                    <StyledFieldset
                         error={
                             registrerBarnSkjema.visFeilmeldinger &&
                             (registrerBarnSkjema.submitRessurs.status === RessursStatus.FEILET ||
@@ -326,7 +365,7 @@ const LeggTilBarn: React.FC<IProps> = ({ barnaMedOpplysninger, onSuccess }) => {
                                 children={'Avbryt'}
                             />
                         </ModalKnapperad>
-                    </Fieldset>
+                    </StyledFieldset>
                 </Modal.Content>
             </StyledModal>
         </>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Lagt til validering i "Legg til barn" som tilsier at man ikke får lagt til barn med diskresjonskode (STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND) dersom det er lagt til manuelle brevmottakere
_

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- Testet manuelt


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![Screenshot 2023-05-22 at 09 49 13](https://github.com/navikt/familie-ba-sak-frontend/assets/126786453/4fae9e13-44f1-4f04-8bff-36a7fa23fe1d)
