### PR TITLE
Rett opp toggle med motsatt oppførsel enn ønsket

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
@@ -83,8 +83,8 @@ const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjem
                 size="small"
                 label={
                     toggles[ToggleNavn.feilutbetaltValutaPerMåned]
-                        ? 'Feilutbetalt beløp'
-                        : 'Feilutbetalt beløp per måned'
+                        ? 'Feilutbetalt beløp per måned'
+                        : 'Feilutbetalt beløp'
                 }
                 value={skjema.felter.feilutbetaltBeløp.verdi}
                 type="number"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I #2681 har det gått litt fort i svingene og den ene toggle guarden min er "opp ned" 😬 🤦‍♀️ 
`hvis (toggle er på): vis gammel tekst, ellers: vis ny tekst`
Det funker jo litt dårlig. Nå får de ny tekst her i i prod selv om resten av feature ligger togglet AV i prod. Og det gjør at SB misforstår hva de skal føre opp som beløp i skjemaet. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
