### PR TITLE
Oppgrader til node 16 i CI og dockerimage

### DIFF
--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache

--- a/.github/workflows/build_n_deploy_rett_i_prod.yaml
+++ b/.github/workflows/build_n_deploy_rett_i_prod.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache

--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/node-express:16-alpine
+FROM ghcr.io/navikt/baseimages/node-express:16-alpine
 USER root
 USER apprunner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/node-express:14-alpine
+FROM navikt/node-express:16-alpine
 USER root
 USER apprunner
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Generelt vedlikehold. Vi er på node 14, men LTS (long time support, hovedversjonen som er anbefalt i bruk) er node 18 (obs legg merke til at partallsversjoner av node regnes som stabile og brukes som LTS, oddetallsversjoner er mellomversjoner). Vi bør i alle fall gå opp til node 16 og så teste node 18 deretter. 

#### Node release schedule: 
[Se docs](https://github.com/nodejs/release#release-schedule)
<img width="863" alt="image" src="https://github.com/navikt/familie-ba-sak-frontend/assets/2379098/5fbb7cbc-b3c6-4ede-965c-a917478fef02">


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Typiske risikoer ved oppgradering av node engine er inkompabilitet i våre avhengigheter. Node 16 regner jeg som ganske trygt å ta i bruk ettersom mange av utviklerne har bygget og kjørt med node 16 ved lokal utvikling over lang tid nå. Tipper at det blir mer aktuelt å teste grundig for node 18. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testes ved å kontrollere funksjonaliteten i miljø

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei

