### PR TITLE
Chore/oppdater "barn brevet gjelder"-checkboxgroup

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -13,6 +13,7 @@ import type { IBehandling } from '../typer/behandling';
 import { BehandlingKategori } from '../typer/behandlingstema';
 import type { IManueltBrevRequestPåBehandling } from '../typer/dokument';
 import { FagsakType } from '../typer/fagsak';
+import type { IGrunnlagPerson } from '../typer/person';
 import { PersonType } from '../typer/person';
 import type { IBarnMedOpplysninger } from '../typer/søknad';
 import type { Målform } from '../typer/søknad';
@@ -182,6 +183,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
             ].includes(avhengigheter?.brevmal.verdi);
         },
         avhengigheter: { brevmal },
+        nullstillVedAvhengighetEndring: false,
     });
 
     const mottakerlandSed = useFelt<string[]>({
@@ -244,6 +246,22 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
     const [navigerTilOpplysningsplikt, settNavigerTilOpplysningsplikt] =
         React.useState<boolean>(false);
 
+    const nullstillBarnBrevetGjelder = () => {
+        const barn = personer
+            .filter(person => person.type === PersonType.BARN)
+            .map(
+                (person: IGrunnlagPerson): IBarnMedOpplysninger => ({
+                    ident: person.personIdent,
+                    fødselsdato: person.fødselsdato,
+                    navn: person.navn,
+                    merket: false,
+                    manueltRegistrert: false,
+                    erFolkeregistrert: true,
+                })
+            );
+        skjema.felter.barnBrevetGjelder.validerOgSettFelt(barn);
+    };
+
     /**
      * Nullstill enkelte felter i skjemaet ved oppdatering av åpenbehandling i staten.
      * Dette fordi at man kan ha gjort endring på målform
@@ -251,11 +269,13 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
     useEffect(() => {
         skjema.felter.dokumenter.nullstill();
         nullstillDeltBosted();
+        nullstillBarnBrevetGjelder();
     }, [åpenBehandling]);
 
     useEffect(() => {
         nullstillDeltBosted();
         skjema.felter.mottakerlandSed.nullstill();
+        nullstillBarnBrevetGjelder();
     }, [skjema.felter.brevmal.verdi]);
 
     const mottakersMålform = (): Målform =>

--- a/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
@@ -30,7 +30,7 @@ const BarnaWrapper = styled.div`
     margin: 1rem 0;
 `;
 
-const StyledCheckboxGruppe = styled(CheckboxGroup)`
+const StyledCheckboxGroup = styled(CheckboxGroup)`
     min-width: 0;
 `;
 
@@ -103,7 +103,7 @@ const Barna: React.FunctionComponent = () => {
             )}
 
             <br />
-            <StyledCheckboxGruppe
+            <StyledCheckboxGroup
                 {...skjema.felter.barnaMedOpplysninger.hentNavBaseSkjemaProps(
                     skjema.visFeilmeldinger
                 )}
@@ -138,7 +138,7 @@ const Barna: React.FunctionComponent = () => {
                 {!lesevisning && !gjelderInstitusjon && !gjelderEnsligMindreårig && (
                     <LeggTilBarn barnaMedOpplysninger={skjema.felter.barnaMedOpplysninger} />
                 )}
-            </StyledCheckboxGruppe>
+            </StyledCheckboxGroup>
         </BarnaWrapper>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
@@ -34,39 +34,35 @@ interface IProps {
     behandlingsSteg?: BehandlingSteg;
     visFeilmeldinger: boolean;
     settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
-    alternativer: IBarnMedOpplysninger[];
 }
 
 const BarnBrevetGjelder = (props: IProps) => {
-    const {
-        barnBrevetGjelderFelt,
-        behandlingsSteg,
-        visFeilmeldinger,
-        settVisFeilmeldinger,
-        alternativer,
-    } = props;
+    const { barnBrevetGjelderFelt, behandlingsSteg, visFeilmeldinger, settVisFeilmeldinger } =
+        props;
 
     const skalViseVarselOmManglendeBarn =
         behandlingsSteg &&
         hentStegNummer(behandlingsSteg) <= hentStegNummer(BehandlingSteg.REGISTRERE_SØKNAD) &&
-        alternativer.length === 0;
+        barnBrevetGjelderFelt.verdi.length === 0;
 
-    alternativer.sort((a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
-        if (!a.fødselsdato || a.fødselsdato === '') {
-            return 1;
+    const sorterteBarn = barnBrevetGjelderFelt.verdi.sort(
+        (a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
+            if (!a.fødselsdato || a.fødselsdato === '') {
+                return 1;
+            }
+
+            if (!b.fødselsdato || b.fødselsdato === '') {
+                return -1;
+            }
+
+            return !a.ident
+                ? 1
+                : kalenderDiff(
+                      kalenderDatoTilDate(kalenderDato(b.fødselsdato)),
+                      kalenderDatoTilDate(kalenderDato(a.fødselsdato))
+                  );
         }
-
-        if (!b.fødselsdato || b.fødselsdato === '') {
-            return -1;
-        }
-
-        return !a.ident
-            ? 1
-            : kalenderDiff(
-                  kalenderDatoTilDate(kalenderDato(b.fødselsdato)),
-                  kalenderDatoTilDate(kalenderDato(a.fødselsdato))
-              );
-    });
+    );
 
     const oppdaterBarnMedNyMerketStatus = (barnaSomErMerket: string[]) => {
         barnBrevetGjelderFelt.validerOgSettFelt(
@@ -89,7 +85,7 @@ const BarnBrevetGjelder = (props: IProps) => {
                 settVisFeilmeldinger(false);
             }}
         >
-            {alternativer.map((barn: IBarnMedOpplysninger, index: number) => {
+            {sorterteBarn.map((barn: IBarnMedOpplysninger, index: number) => {
                 const barnLabel = lagBarnLabel(barn);
                 return (
                     <StyledCheckbox value={barn.ident} key={'barn-' + index}>

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BarnBrevetGjelder.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { CheckboxGruppe } from 'nav-frontend-skjema';
-
-import { Alert, Checkbox } from '@navikt/ds-react';
+import { Alert, Checkbox, CheckboxGroup } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
@@ -70,39 +68,31 @@ const BarnBrevetGjelder = (props: IProps) => {
               );
     });
 
+    const oppdaterBarnMedNyMerketStatus = (barnaSomErMerket: string[]) => {
+        barnBrevetGjelderFelt.validerOgSettFelt(
+            barnBrevetGjelderFelt.verdi.map((barnMedOpplysninger: IBarnMedOpplysninger) => ({
+                ...barnMedOpplysninger,
+                merket: barnaSomErMerket.includes(barnMedOpplysninger.ident),
+            }))
+        );
+    };
+
     return (
-        <CheckboxGruppe
+        <CheckboxGroup
             {...barnBrevetGjelderFelt.hentNavBaseSkjemaProps(visFeilmeldinger)}
             legend={'Hvilke barn gjelder brevet?'}
+            value={barnBrevetGjelderFelt.verdi
+                .filter((barn: IBarnMedOpplysninger) => barn.merket)
+                .map((barn: IBarnMedOpplysninger) => barn.ident)}
+            onChange={(barnaSomErMerket: string[]) => {
+                oppdaterBarnMedNyMerketStatus(barnaSomErMerket);
+                settVisFeilmeldinger(false);
+            }}
         >
             {alternativer.map((barn: IBarnMedOpplysninger, index: number) => {
                 const barnLabel = lagBarnLabel(barn);
                 return (
-                    <StyledCheckbox
-                        value={
-                            <LabelContent>
-                                <LabelTekst title={barnLabel}>{barnLabel}</LabelTekst>
-                            </LabelContent>
-                        }
-                        checked={barn.merket}
-                        key={'barn-' + index}
-                        onChange={event => {
-                            const barnSkalMerkes = event.target.checked;
-                            if (barnSkalMerkes) {
-                                barnBrevetGjelderFelt.validerOgSettFelt([
-                                    ...barnBrevetGjelderFelt.verdi,
-                                    { ...barn, merket: true },
-                                ]);
-                            } else {
-                                barnBrevetGjelderFelt.validerOgSettFelt(
-                                    barnBrevetGjelderFelt.verdi.filter(
-                                        it => it.ident !== barn.ident
-                                    )
-                                );
-                            }
-                            settVisFeilmeldinger(false);
-                        }}
-                    >
+                    <StyledCheckbox value={barn.ident} key={'barn-' + index}>
                         <LabelContent>
                             <LabelTekst title={barnLabel}>{barnLabel}</LabelTekst>
                         </LabelContent>
@@ -117,7 +107,7 @@ const BarnBrevetGjelder = (props: IProps) => {
                     inline
                 />
             )}
-        </CheckboxGruppe>
+        </CheckboxGroup>
     );
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -24,9 +24,6 @@ import useDokument from '../../../../hooks/useDokument';
 import type { IBehandling } from '../../../../typer/behandling';
 import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
 import type { IManueltBrevRequestPåBehandling } from '../../../../typer/dokument';
-import type { IGrunnlagPerson } from '../../../../typer/person';
-import { PersonType } from '../../../../typer/person';
-import type { IBarnMedOpplysninger } from '../../../../typer/søknad';
 import { målform } from '../../../../typer/søknad';
 import type { IFritekstFelt } from '../../../../utils/fritekstfelter';
 import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
@@ -369,21 +366,6 @@ const Brevskjema = ({ onSubmitSuccess }: IProps) => {
                         behandlingsSteg={behandlingSteg}
                         visFeilmeldinger={skjema.visFeilmeldinger}
                         settVisFeilmeldinger={settVisfeilmeldinger}
-                        alternativer={personer
-                            .filter(person => person.type === PersonType.BARN)
-                            .map(
-                                (person: IGrunnlagPerson): IBarnMedOpplysninger => ({
-                                    ident: person.personIdent,
-                                    fødselsdato: person.fødselsdato,
-                                    navn: person.navn,
-                                    merket:
-                                        skjema.felter.barnBrevetGjelder.verdi.find(
-                                            markertFelt => markertFelt.ident === person.personIdent
-                                        )?.merket ?? false,
-                                    manueltRegistrert: false,
-                                    erFolkeregistrert: true,
-                                })
-                            )}
                     />
                 )}
                 {skjema.felter.brevmal.verdi ===


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12232

Oppdaterer til ny CheckboxGroup i "send brev"-fanen inne på en behandling. Dette innebærer å flytte value og onChange fra checkbox-komponentene til checkbox-gruppen. Måtte også endre til å la skjemafeltet barnBrevetGjelderFelt inneholde alle barna som det er mulig å velge (med merket = false), så man slipper å sende med egen alternativer-parameter.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ta gjerne en ekstra titt på commit 354e1e6 (commit nummer 2)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testet manuelt

### 🤷‍♀ ️Hvor er det lurt å starte?
Kan nok være fint å se commit for commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  