### PR TITLE
NAV-13868 Lagt til feilmelding i brevmottakerskjema for validerings-feilmelding fra backend

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -9,6 +9,7 @@ import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
+import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import { ModalKnapperad } from '../../../../Felleskomponenter/Modal/ModalKnapperad';
 import { FamilieLandvelger } from '../../../Behandlingsresultat/EøsPeriode/FamilieLandvelger';
 import useLeggTilFjernBrevmottaker, {
@@ -50,7 +51,11 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ lukkModal }) => {
     const erLesevisning = vurderErLesevisning();
     return (
         <>
-            <StyledFieldset legend="Skjema for å legge til eller fjerne brevmottaker" hideLegend>
+            <StyledFieldset
+                legend="Skjema for å legge til eller fjerne brevmottaker"
+                hideLegend
+                error={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
+            >
                 <MottakerSelect
                     {...skjema.felter.mottaker.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                     erLesevisning={erLesevisning}


### PR DESCRIPTION


### 💰 Hva forsøker du å løse i denne PR'en
Det er lagt til støtte for feilmelding i brevmottakerskjema - for validerings-feilmelding som kommer fra backend ved oppretting av manuell brevmottaker (egen PR backend) - dersom behandlingen inneholder fortrolig(e) person(er) (har adresebeskyttelse: STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett. En linje (+ import)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots

![Screenshot 2023-07-11 at 11 14 15](https://github.com/navikt/familie-ba-sak-frontend/assets/126786453/15aa152c-89d5-49c8-8b69-d56947c95a04)
