### PR TITLE
Lagt til ny filtreringsregel for fødselshendelser

### DIFF
--- a/src/frontend/typer/fødselshendelser.ts
+++ b/src/frontend/typer/fødselshendelser.ts
@@ -18,7 +18,7 @@ export enum Filtreringsregel {
     MOR_HAR_IKKE_LØPENDE_EØS_BARNETRYGD = 'MOR_HAR_IKKE_LØPENDE_EØS_BARNETRYGD',
     LØPER_IKKE_BARNETRYGD_FOR_BARNET = 'LØPER_IKKE_BARNETRYGD_FOR_BARNET',
     FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT = 'FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT',
-    MOR_OPPFYLLER_IKKE_VILKÅR_FOR_UTVIDET_BARNETRYGD_VED_FØDSELSDATO = 'MOR_OPPFYLLER_IKKE_VILKÅR_FOR_UTVIDET_BARNETRYGD_VED_FØDSELSDATO',
+    MOR_HAR_IKKE_OPPFYLT_UTVIDET_VILKÅR_VED_FØDSELSDATO = 'MOR_HAR_IKKE_OPPFYLT_UTVIDET_VILKÅR_VED_FØDSELSDATO',
 }
 
 export const filtreringsregler: Record<Filtreringsregel, string> = {
@@ -35,6 +35,6 @@ export const filtreringsregler: Record<Filtreringsregel, string> = {
         'Det er ikke utbetalt barnetrygd for barnet til annen mottaker',
     FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT:
         'Fagsaken har ikke blitt migrert fra infotrygd etter barn ble født',
-    MOR_OPPFYLLER_IKKE_VILKÅR_FOR_UTVIDET_BARNETRYGD_VED_FØDSELSDATO:
+    MOR_HAR_IKKE_OPPFYLT_UTVIDET_VILKÅR_VED_FØDSELSDATO:
         'Mor oppfyller ikke vilkår for utvidet barnetrygd',
 };

--- a/src/frontend/typer/fødselshendelser.ts
+++ b/src/frontend/typer/fødselshendelser.ts
@@ -18,6 +18,7 @@ export enum Filtreringsregel {
     MOR_HAR_IKKE_LØPENDE_EØS_BARNETRYGD = 'MOR_HAR_IKKE_LØPENDE_EØS_BARNETRYGD',
     LØPER_IKKE_BARNETRYGD_FOR_BARNET = 'LØPER_IKKE_BARNETRYGD_FOR_BARNET',
     FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT = 'FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT',
+    MOR_OPPFYLLER_IKKE_VILKÅR_FOR_UTVIDET_BARNETRYGD_VED_FØDSELSDATO = 'MOR_OPPFYLLER_IKKE_VILKÅR_FOR_UTVIDET_BARNETRYGD_VED_FØDSELSDATO',
 }
 
 export const filtreringsregler: Record<Filtreringsregel, string> = {
@@ -34,4 +35,6 @@ export const filtreringsregler: Record<Filtreringsregel, string> = {
         'Det er ikke utbetalt barnetrygd for barnet til annen mottaker',
     FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT:
         'Fagsaken har ikke blitt migrert fra infotrygd etter barn ble født',
+    MOR_OPPFYLLER_IKKE_VILKÅR_FOR_UTVIDET_BARNETRYGD_VED_FØDSELSDATO:
+        'Mor oppfyller ikke vilkår for utvidet barnetrygd',
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Støtte for visning av ny filtreringsregel for fødselshendelser. `MOR_OPPFYLLER_IKKE_VILKÅR_FOR_UTVIDET_BARNETRYGD_VED_FØDSELSDATO`
  
### 👀 Screen shots
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/70642183/00e74316-2d52-4988-accd-c4f229ce756f)

