### PR TITLE
Legg til registrer dødsfall modal

### DIFF
--- a/src/frontend/context/RegistrerDødsfallDato/RegistrerDødsfallDatoSkjemaContext.ts
+++ b/src/frontend/context/RegistrerDødsfallDato/RegistrerDødsfallDatoSkjemaContext.ts
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+
+import type { FeltState } from '@navikt/familie-skjema';
+import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
+import type { Ressurs } from '@navikt/familie-typer';
+import { byggHenterRessurs, RessursStatus } from '@navikt/familie-typer';
+
+import type { IBehandling } from '../../typer/behandling';
+import type { IGrunnlagPerson } from '../../typer/person';
+import { isEmpty } from '../../utils/eøsValidators';
+import { useBehandling } from '../behandlingContext/BehandlingContext';
+
+interface IProps {
+    onSuccess: () => void;
+    person: IGrunnlagPerson;
+}
+
+const erDødsfallDatoFyltUt = (felt: FeltState<string | undefined>): FeltState<string | undefined> =>
+    !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Dato for dødsfall er påkrevd.');
+
+const erBegrunnelseFyltUt = (felt: FeltState<string>): FeltState<string> =>
+    !isEmpty(felt.verdi)
+        ? ok(felt)
+        : feil(felt, 'Begrunnelse for manuell registrering av dødsfall er påkrevd.');
+
+export const useRegistrerDødsfallDatoSkjemaContext = ({ person, onSuccess }: IProps) => {
+    const { åpenBehandling, settÅpenBehandling } = useBehandling();
+    const [restFeil, settRestFeil] = useState<string | undefined>(undefined);
+
+    const {
+        skjema,
+        valideringErOk,
+        kanSendeSkjema,
+        settVisfeilmeldinger,
+        onSubmit,
+        nullstillSkjema,
+        settSubmitRessurs,
+        validerAlleSynligeFelter,
+    } = useSkjema<
+        {
+            dødsfallDato: string | undefined;
+            begrunnelse: string;
+        },
+        IBehandling
+    >({
+        felter: {
+            dødsfallDato: useFelt<string | undefined>({
+                verdi: '',
+                valideringsfunksjon: erDødsfallDatoFyltUt,
+            }),
+            begrunnelse: useFelt<string>({
+                verdi: '',
+                valideringsfunksjon: erBegrunnelseFyltUt,
+            }),
+        },
+        skjemanavn: 'registrer-dødsfall-dato-skjema',
+    });
+
+    const valideringsstatuser = [
+        skjema.felter.dødsfallDato.valideringsstatus,
+        skjema.felter.begrunnelse.valideringsstatus,
+    ];
+
+    useEffect(() => {
+        if (
+            valideringsstatuser.some(
+                valideringsstatus => valideringsstatus === Valideringsstatus.IKKE_VALIDERT
+            )
+        ) {
+            validerAlleSynligeFelter();
+        }
+    }, [valideringsstatuser]);
+
+    const behandlingId =
+        åpenBehandling.status === RessursStatus.SUKSESS && åpenBehandling.data.behandlingId;
+    const korrigertVedtakURL = `/familie-ba-sak/api/person/registrer-manuell-dødsfall/${behandlingId}`;
+
+    const registrerManuellDødsfall = () => {
+        if (kanSendeSkjema()) {
+            settVisfeilmeldinger(false);
+            settSubmitRessurs(byggHenterRessurs());
+            onSubmit(
+                {
+                    method: 'POST',
+                    data: {
+                        dødsfallDato: skjema.felter.dødsfallDato.verdi,
+                        begrunnelse: skjema.felter.begrunnelse.verdi,
+                        personIdent: {
+                            ident: person.personIdent,
+                        },
+                    },
+                    url: korrigertVedtakURL,
+                },
+                (response: Ressurs<IBehandling>) => {
+                    if (response.status === RessursStatus.SUKSESS) {
+                        settRestFeil(undefined);
+                        onSuccess();
+                        nullstillSkjema();
+                        settÅpenBehandling(response);
+                    }
+                },
+                (error: Ressurs<IBehandling>) => {
+                    if (
+                        error.status === RessursStatus.FEILET ||
+                        error.status === RessursStatus.FUNKSJONELL_FEIL
+                    ) {
+                        settRestFeil(error.frontendFeilmelding);
+                    } else {
+                        settRestFeil('Teknisk feil ved lagring av manuell dødsfall dato');
+                    }
+                }
+            );
+        } else {
+            settVisfeilmeldinger(true);
+        }
+    };
+
+    return {
+        skjema,
+        valideringErOk,
+        registrerManuellDødsfall,
+        nullstillSkjema,
+        restFeil,
+        settVisfeilmeldinger,
+        settRestFeil,
+    };
+};

--- a/src/frontend/context/RegistrerDødsfallDato/RegistrerDødsfallDatoSkjemaContext.ts
+++ b/src/frontend/context/RegistrerDødsfallDato/RegistrerDødsfallDatoSkjemaContext.ts
@@ -73,7 +73,7 @@ export const useRegistrerDødsfallDatoSkjemaContext = ({ person, onSuccess }: IP
 
     const behandlingId =
         åpenBehandling.status === RessursStatus.SUKSESS && åpenBehandling.data.behandlingId;
-    const korrigertVedtakURL = `/familie-ba-sak/api/person/registrer-manuell-dødsfall/${behandlingId}`;
+    const korrigertVedtakURL = `/familie-ba-sak/api/person/registrer-manuell-dodsfall/${behandlingId}`;
 
     const registrerManuellDødsfall = () => {
         if (kanSendeSkjema()) {
@@ -85,9 +85,7 @@ export const useRegistrerDødsfallDatoSkjemaContext = ({ person, onSuccess }: IP
                     data: {
                         dødsfallDato: skjema.felter.dødsfallDato.verdi,
                         begrunnelse: skjema.felter.begrunnelse.verdi,
-                        personIdent: {
-                            ident: person.personIdent,
-                        },
+                        personIdent: person.personIdent,
                     },
                     url: korrigertVedtakURL,
                 },

--- a/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
 
-import { BodyShort, Heading } from '@navikt/ds-react';
+import styled from 'styled-components';
+
+import { MenuElipsisHorizontalCircleIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, Dropdown, Heading } from '@navikt/ds-react';
 import Clipboard from '@navikt/familie-clipboard';
 import { FamilieIkonVelger } from '@navikt/familie-ikoner';
 
+import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import type { IGrunnlagPerson } from '../../../typer/person';
 import { personTypeMap } from '../../../typer/person';
 import { hentAlder, formaterIdent } from '../../../utils/formatter';
 import DødsfallTag from '../DødsfallTag';
+import RegistrerDødsfallDato from '../RegistrerDødsfallDato/RegistrerDødsfallDato';
 
 interface IProps {
     person: IGrunnlagPerson;
@@ -15,9 +20,14 @@ interface IProps {
     width?: string;
 }
 
+const StyledDropdownMeny = styled(Dropdown.Menu)`
+    width: 20ch;
+`;
+
 const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskrift = false }) => {
     const alder = hentAlder(person.fødselsdato);
     const navnOgAlder = `${person.navn} (${alder} år)`;
+    const { vurderErLesevisning } = useBehandling();
 
     return (
         <div className={'personinformasjon'}>
@@ -51,6 +61,26 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskr
                                 &ensp;&ensp;
                             </Heading>
                             <DødsfallTag dødsfallDato={person.dødsfallDato} />
+                        </>
+                    )}
+                    {!person.dødsfallDato?.length && (
+                        <>
+                            <Dropdown>
+                                <Button
+                                    aria-label="Åpne valgmeny"
+                                    as={Dropdown.Toggle}
+                                    icon={<MenuElipsisHorizontalCircleIcon aria-hidden />}
+                                    variant="tertiary"
+                                />
+                                <StyledDropdownMeny placement={'right'}>
+                                    <Dropdown.Menu.List>
+                                        <RegistrerDødsfallDato
+                                            erLesevisning={vurderErLesevisning()}
+                                            person={person}
+                                        />
+                                    </Dropdown.Menu.List>
+                                </StyledDropdownMeny>
+                            </Dropdown>
                         </>
                     )}
                 </>

--- a/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -64,24 +64,22 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskr
                         </>
                     )}
                     {!person.dødsfallDato?.length && (
-                        <>
-                            <Dropdown>
-                                <Button
-                                    aria-label="Åpne valgmeny"
-                                    as={Dropdown.Toggle}
-                                    icon={<MenuElipsisHorizontalCircleIcon aria-hidden />}
-                                    variant="tertiary"
-                                />
-                                <StyledDropdownMeny placement={'right'}>
-                                    <Dropdown.Menu.List>
-                                        <RegistrerDødsfallDato
-                                            erLesevisning={vurderErLesevisning()}
-                                            person={person}
-                                        />
-                                    </Dropdown.Menu.List>
-                                </StyledDropdownMeny>
-                            </Dropdown>
-                        </>
+                        <Dropdown>
+                            <Button
+                                aria-label="Åpne valgmeny"
+                                as={Dropdown.Toggle}
+                                icon={<MenuElipsisHorizontalCircleIcon aria-hidden />}
+                                variant="tertiary"
+                            />
+                            <StyledDropdownMeny placement={'right'}>
+                                <Dropdown.Menu.List>
+                                    <RegistrerDødsfallDato
+                                        erLesevisning={vurderErLesevisning()}
+                                        person={person}
+                                    />
+                                </Dropdown.Menu.List>
+                            </StyledDropdownMeny>
+                        </Dropdown>
                     )}
                 </>
             )}

--- a/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDato.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDato.tsx
@@ -79,7 +79,7 @@ const RegistrerDødsfallDato: React.FC<IRegistrerDødsfallDato> = ({ person, erL
             <Modal open={visModal} onClose={lukkModal}>
                 <StyledModalContent>
                     <Heading size="medium" level={'2'} spacing>
-                        Registrere Dødsfall
+                        Registrere dødsdato
                     </Heading>
                     <div>
                         <StyledFamilieDatovelger

--- a/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDato.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDato.tsx
@@ -121,25 +121,19 @@ const RegistrerDødsfallDato: React.FC<IRegistrerDødsfallDato> = ({ person, erL
                     </div>
                     <Knapperad>
                         {!erLesevisning && (
-                            <>
-                                <div>
-                                    <KnappVenstre
-                                        onClick={registrerManuellDødsfall}
-                                        variant={valideringErOk() ? 'primary' : 'secondary'}
-                                        loading={
-                                            skjema.submitRessurs.status === RessursStatus.HENTER
-                                        }
-                                        disabled={
-                                            skjema.submitRessurs.status === RessursStatus.HENTER
-                                        }
-                                    >
-                                        Bekreft
-                                    </KnappVenstre>
-                                    <Button onClick={lukkModal} variant={'tertiary'}>
-                                        Avbryt
-                                    </Button>
-                                </div>
-                            </>
+                            <div>
+                                <KnappVenstre
+                                    onClick={registrerManuellDødsfall}
+                                    variant={valideringErOk() ? 'primary' : 'secondary'}
+                                    loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                    disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                >
+                                    Bekreft
+                                </KnappVenstre>
+                                <Button onClick={lukkModal} variant={'tertiary'}>
+                                    Avbryt
+                                </Button>
+                            </div>
                         )}
                         {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
                     </Knapperad>

--- a/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDato.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDato.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+
+import styled, { css } from 'styled-components';
+
+import { Alert, Button, Heading, Modal } from '@navikt/ds-react';
+import { Dropdown } from '@navikt/ds-react';
+import type { ISODateString } from '@navikt/familie-datovelger';
+import { FamilieDatovelger } from '@navikt/familie-datovelger';
+import { FamilieTextarea } from '@navikt/familie-form-elements';
+import { RessursStatus } from '@navikt/familie-typer';
+
+import { useRegistrerDødsfallDatoSkjemaContext } from '../../../context/RegistrerDødsfallDato/RegistrerDødsfallDatoSkjemaContext';
+import type { IGrunnlagPerson } from '../../../typer/person';
+import { datoformatNorsk } from '../../../utils/formatter';
+
+const Knapperad = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+`;
+
+const KnappVenstre = styled(Button)`
+    margin-right: 1rem;
+`;
+
+const StyledModalContent = styled(Modal.Content)`
+    width: 40rem;
+`;
+
+const baseSkjemaelementStyle = css`
+    margin-bottom: 1.5rem;
+`;
+
+const StyledFamilieDatovelger = styled(FamilieDatovelger)`
+    ${baseSkjemaelementStyle}
+`;
+
+const StyledFamilieTextarea = styled(FamilieTextarea)`
+    ${baseSkjemaelementStyle}
+`;
+
+interface IRegistrerDødsfallDato {
+    person: IGrunnlagPerson;
+    erLesevisning: boolean;
+}
+
+const RegistrerDødsfallDato: React.FC<IRegistrerDødsfallDato> = ({ person, erLesevisning }) => {
+    const [visModal, settVisModal] = React.useState<boolean>(false);
+
+    const {
+        skjema,
+        valideringErOk,
+        registrerManuellDødsfall,
+        nullstillSkjema,
+        settVisfeilmeldinger,
+        settRestFeil,
+        restFeil,
+    } = useRegistrerDødsfallDatoSkjemaContext({
+        onSuccess: () => settVisModal(false),
+        person,
+    });
+
+    const lukkModal = () => {
+        nullstillSkjema();
+        settVisfeilmeldinger(false);
+        settRestFeil(undefined);
+        settVisModal(false);
+    };
+
+    return (
+        <>
+            <Dropdown.Menu.List.Item
+                onClick={() => {
+                    settVisModal(true);
+                }}
+            >
+                Registrer Dødsfall
+            </Dropdown.Menu.List.Item>
+            <Modal open={visModal} onClose={lukkModal}>
+                <StyledModalContent>
+                    <Heading size="medium" level={'2'} spacing>
+                        Registrere Dødsfall
+                    </Heading>
+                    <div>
+                        <StyledFamilieDatovelger
+                            {...skjema.felter.dødsfallDato?.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            id={'registrer-døds-dato'}
+                            label={'Dødsdato'}
+                            erLesesvisning={erLesevisning}
+                            value={
+                                skjema.felter.dødsfallDato?.verdi !== null
+                                    ? skjema.felter.dødsfallDato?.verdi
+                                    : undefined
+                            }
+                            placeholder={datoformatNorsk.DATO}
+                            onChange={(dato?: ISODateString) =>
+                                skjema.felter.dødsfallDato?.validerOgSettFelt(dato)
+                            }
+                        />
+                        <StyledFamilieTextarea
+                            {...skjema.felter.begrunnelse?.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            id={'manuell-dødsdato-begrunnelse'}
+                            label={'Begrunnelse'}
+                            erLesevisning={erLesevisning}
+                            value={skjema.felter.begrunnelse.verdi}
+                            onChange={changeEvent =>
+                                skjema.felter.begrunnelse.validerOgSettFelt(
+                                    changeEvent.target.value
+                                )
+                            }
+                        />
+                        {restFeil && (
+                            <Alert variant="error" style={{ marginBottom: '1.5rem' }} inline>
+                                {restFeil}
+                            </Alert>
+                        )}
+                    </div>
+                    <Knapperad>
+                        {!erLesevisning && (
+                            <>
+                                <div>
+                                    <KnappVenstre
+                                        onClick={registrerManuellDødsfall}
+                                        variant={valideringErOk() ? 'primary' : 'secondary'}
+                                        loading={
+                                            skjema.submitRessurs.status === RessursStatus.HENTER
+                                        }
+                                        disabled={
+                                            skjema.submitRessurs.status === RessursStatus.HENTER
+                                        }
+                                    >
+                                        Bekreft
+                                    </KnappVenstre>
+                                    <Button onClick={lukkModal} variant={'tertiary'}>
+                                        Avbryt
+                                    </Button>
+                                </div>
+                            </>
+                        )}
+                        {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
+                    </Knapperad>
+                </StyledModalContent>
+            </Modal>
+        </>
+    );
+};
+
+export default RegistrerDødsfallDato;


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Vi ønsker å kunne manuelt registrere dødsfall dato i vilkårsvurderingen.
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-4829

Backend PR: https://github.com/navikt/familie-ba-sak/pull/3834

Det er derfor:

- Opprettet modal for å kunne registrere dødsdato med noe validering.

Demonstrasjon fra frontend som viser følgende:
- Ny knapp for å registrere manuell dødsfall
- Validering som skjer dersom feltene ikke fylles ut
- Validering som skjer dersom man forsøker å registrere dødsfall før brukerens fødselsdato
- Registrering av dødsdato
- Endring i vilkår etter registrering av dødsdato
- Historikk innslag etter registrering av dødsdato
- Oppdatering fra PDL som fjerner manuell dødsdato


https://github.com/navikt/familie-ba-sak/assets/110383605/dac53be0-3aeb-49f8-950a-b726d188c06d
