### PR TITLE
Fjerner underkategori INSTITUSJON fra kontrakt, siden denne ikke brukes i backend

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/BehandlingstemaSelect.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/BehandlingstemaSelect.tsx
@@ -5,11 +5,7 @@ import type { IFamilieSelectProps } from '@navikt/familie-form-elements/src/sele
 import type { Felt } from '@navikt/familie-skjema';
 
 import type { Behandlingstema, IBehandlingstema } from '../../typer/behandlingstema';
-import {
-    BehandlingKategori,
-    behandlingstemaer,
-    BehandlingUnderkategori,
-} from '../../typer/behandlingstema';
+import { BehandlingKategori, behandlingstemaer } from '../../typer/behandlingstema';
 import { FagsakType } from '../../typer/fagsak';
 
 interface EgneProps {
@@ -53,7 +49,7 @@ export const BehandlingstemaSelect = ({
                 </option>
             )}
             {Object.values(behandlingstemaer)
-                .filter(it => it.underkategori !== BehandlingUnderkategori.INSTITUSJON)
+                .filter(it => it.id !== 'NASJONAL_INSTITUSJON')
                 .filter(
                     it =>
                         it.kategori !== BehandlingKategori.EØS ||

--- a/src/frontend/typer/behandlingstema.ts
+++ b/src/frontend/typer/behandlingstema.ts
@@ -10,7 +10,6 @@ export enum BehandlingKategori {
 export enum BehandlingUnderkategori {
     ORDINÆR = 'ORDINÆR',
     UTVIDET = 'UTVIDET',
-    INSTITUSJON = 'INSTITUSJON',
 }
 
 export enum Behandlingstema {
@@ -32,7 +31,6 @@ export const behandlingKategori: Record<BehandlingKategori, string> = {
 export const behandlingUnderkategori: Record<BehandlingUnderkategori, string> = {
     ORDINÆR: 'Ordinær',
     UTVIDET: 'Utvidet',
-    INSTITUSJON: 'Institusjon',
 };
 
 export interface IBehandlingstema {
@@ -57,7 +55,7 @@ export const behandlingstemaer: Record<Behandlingstema, IBehandlingstema> = {
     },
     NASJONAL_INSTITUSJON: {
         kategori: BehandlingKategori.NASJONAL,
-        underkategori: BehandlingUnderkategori.INSTITUSJON,
+        underkategori: BehandlingUnderkategori.ORDINÆR,
         navn: 'Nasjonal institusjon',
         id: 'NASJONAL_INSTITUSJON',
     },


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
NAV-12183
Fjerner INSTITUSJON som en underkategori, og endrer til ORDINÆR, siden man på institusjon bruker fagsakType

Denne må ut før man kan slette fra backend

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

Testet endre behandlingstema, endret enhet, opprett og revurdering av institusjonsak.
  
### 👀 Screen shots
Ingen visuelle endringer
