### PR TITLE
Feat/hent vedtaksperioder fra endepunkt

### DIFF
--- a/src/frontend/context/behandlingContext/BehandlingContext.ts
+++ b/src/frontend/context/behandlingContext/BehandlingContext.ts
@@ -8,6 +8,7 @@ import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/famil
 
 import useBehandlingApi from './useBehandlingApi';
 import useBehandlingssteg from './useBehandlingssteg';
+import { useVedtaksperioder } from './useVedtaksperioder';
 import { saksbehandlerHarKunLesevisning } from './util';
 import useSakOgBehandlingParams from '../../hooks/useSakOgBehandlingParams';
 import type { ISide, ITrinn, SideId } from '../../komponenter/Felleskomponenter/Venstremeny/sider';
@@ -64,6 +65,8 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         åpenBehandling,
         settÅpenBehandling
     );
+
+    const { vedtaksperioderMedBegrunnelserRessurs } = useVedtaksperioder();
 
     const {
         harInnloggetSaksbehandlerSkrivetilgang,
@@ -264,6 +267,7 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         gjelderInstitusjon,
         samhandlerOrgnr,
         gjelderEnsligMindreårig,
+        vedtaksperioderMedBegrunnelserRessurs,
     };
 });
 

--- a/src/frontend/context/behandlingContext/BehandlingContext.ts
+++ b/src/frontend/context/behandlingContext/BehandlingContext.ts
@@ -8,7 +8,6 @@ import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/famil
 
 import useBehandlingApi from './useBehandlingApi';
 import useBehandlingssteg from './useBehandlingssteg';
-import { useVedtaksperioder } from './useVedtaksperioder';
 import { saksbehandlerHarKunLesevisning } from './util';
 import useSakOgBehandlingParams from '../../hooks/useSakOgBehandlingParams';
 import type { ISide, ITrinn, SideId } from '../../komponenter/Felleskomponenter/Venstremeny/sider';
@@ -65,8 +64,6 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         åpenBehandling,
         settÅpenBehandling
     );
-
-    const { vedtaksperioderMedBegrunnelserRessurs } = useVedtaksperioder();
 
     const {
         harInnloggetSaksbehandlerSkrivetilgang,
@@ -267,7 +264,6 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         gjelderInstitusjon,
         samhandlerOrgnr,
         gjelderEnsligMindreårig,
-        vedtaksperioderMedBegrunnelserRessurs,
     };
 });
 

--- a/src/frontend/context/behandlingContext/useVedtaksperioder.ts
+++ b/src/frontend/context/behandlingContext/useVedtaksperioder.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+import { useHttp } from '@navikt/familie-http';
+import type { Ressurs } from '@navikt/familie-typer';
+import { byggTomRessurs } from '@navikt/familie-typer';
+
+import useSakOgBehandlingParams from '../../hooks/useSakOgBehandlingParams';
+import type { IVedtaksperiodeMedBegrunnelser } from '../../typer/vedtaksperiode';
+
+export const useVedtaksperioder = () => {
+    const { behandlingId } = useSakOgBehandlingParams();
+    const { request } = useHttp();
+
+    useEffect(() => {
+        if (behandlingId) {
+            request<void, IVedtaksperiodeMedBegrunnelser[]>({
+                method: 'GET',
+                url: `/familie-ba-sak/api/vedtaksperioder/behandling/${behandlingId}/hent-vedtaksperioder`,
+                påvirkerSystemLaster: false,
+            }).then(settVedtaksperioderMedBegrunnelserRessurs);
+        }
+    }, [behandlingId]);
+
+    const [vedtaksperioderMedBegrunnelserRessurs, settVedtaksperioderMedBegrunnelserRessurs] =
+        useState<Ressurs<IVedtaksperiodeMedBegrunnelser[]>>(byggTomRessurs());
+
+    return { vedtaksperioderMedBegrunnelserRessurs };
+};

--- a/src/frontend/komponenter/Fagsak/BehandlingRouter.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingRouter.tsx
@@ -13,6 +13,7 @@ import RegistrerSøknad from './Søknad/RegistrerSøknad';
 import OppsummeringVedtak from './Vedtak/OppsummeringVedtak';
 import Vilkårsvurdering from './Vilkårsvurdering/Vilkårsvurdering';
 import { useBehandling } from '../../context/behandlingContext/BehandlingContext';
+import { VedtaksperioderProvider } from '../../context/behandlingContext/useVedtaksperioder';
 import { EøsProvider } from '../../context/Eøs/EøsContext';
 import { InstitusjonOgVergeProvider } from '../../context/InstitusjonOgVergeContext';
 import { SimuleringProvider } from '../../context/SimuleringContext';
@@ -93,7 +94,9 @@ const BehandlingRouter: React.FunctionComponent = () => {
                         path="/vedtak"
                         element={
                             <SimuleringProvider åpenBehandling={åpenBehandling.data}>
-                                <OppsummeringVedtak åpenBehandling={åpenBehandling.data} />
+                                <VedtaksperioderProvider>
+                                    <OppsummeringVedtak åpenBehandling={åpenBehandling.data} />
+                                </VedtaksperioderProvider>
                             </SimuleringProvider>
                         }
                     />

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -50,8 +50,12 @@ export const BehandlingKorrigertAlert = styled(Alert)`
 const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehandling }) => {
     const { hentSaksbehandlerRolle } = useApp();
     const { fagsakId } = useSakOgBehandlingParams();
-    const { vurderErLesevisning, sendTilBeslutterNesteOnClick, behandlingsstegSubmitressurs } =
-        useBehandling();
+    const {
+        vurderErLesevisning,
+        sendTilBeslutterNesteOnClick,
+        behandlingsstegSubmitressurs,
+        vedtaksperioderMedBegrunnelserRessurs,
+    } = useBehandling();
 
     const { behandlingErMigreringMedAvvikUtenforBeløpsgrenser } = useSimulering();
 
@@ -119,7 +123,8 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
         sendTilBeslutterNesteOnClick(
             (visModal: boolean) => settVisModal(visModal),
             erUlagretNyFeilutbetaltValutaPeriode,
-            erUlagretNyRefusjonEøsPeriode
+            erUlagretNyRefusjonEøsPeriode,
+            vedtaksperioderMedBegrunnelserRessurs
         );
     };
 
@@ -208,6 +213,9 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
                                 <VedtaksbegrunnelseTeksterProvider>
                                     <VedtaksperioderMedBegrunnelser
                                         åpenBehandling={åpenBehandling}
+                                        vedtaksperioderMedBegrunnelserRessurs={
+                                            vedtaksperioderMedBegrunnelserRessurs
+                                        }
                                     />
                                 </VedtaksbegrunnelseTeksterProvider>
                                 {visFeilutbetaltValuta && (

--- a/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/OppsummeringVedtak.tsx
@@ -15,6 +15,7 @@ import VedtaksperioderMedBegrunnelser from './VedtakBegrunnelserTabell/Vedtakspe
 import Vedtaksmeny from './Vedtaksmeny';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
+import { useVedtaksperioder } from '../../../context/behandlingContext/useVedtaksperioder';
 import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
 import { useSimulering } from '../../../context/SimuleringContext';
 import useDokument from '../../../hooks/useDokument';
@@ -50,12 +51,10 @@ export const BehandlingKorrigertAlert = styled(Alert)`
 const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehandling }) => {
     const { hentSaksbehandlerRolle } = useApp();
     const { fagsakId } = useSakOgBehandlingParams();
-    const {
-        vurderErLesevisning,
-        sendTilBeslutterNesteOnClick,
-        behandlingsstegSubmitressurs,
-        vedtaksperioderMedBegrunnelserRessurs,
-    } = useBehandling();
+    const { vurderErLesevisning, sendTilBeslutterNesteOnClick, behandlingsstegSubmitressurs } =
+        useBehandling();
+
+    const { vedtaksperioderMedBegrunnelserRessurs } = useVedtaksperioder();
 
     const { behandlingErMigreringMedAvvikUtenforBeløpsgrenser } = useSimulering();
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -37,8 +37,8 @@ interface IProps {
     åpenBehandling: IBehandling;
 }
 
-const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] = constate(
-    ({ åpenBehandling, vedtaksperiodeMedBegrunnelser }: IProps) => {
+const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnelserPanel] =
+    constate(({ åpenBehandling, vedtaksperiodeMedBegrunnelser }: IProps) => {
         const { request } = useHttp();
         const { settÅpenBehandling } = useBehandling();
         const [erPanelEkspandert, settErPanelEkspandert] = useState(
@@ -255,7 +255,6 @@ const [VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser] 
             standardBegrunnelserPut,
             genererteBrevbegrunnelser,
         };
-    }
-);
+    });
 
-export { VedtaksperiodeMedBegrunnelserProvider, useVedtaksperiodeMedBegrunnelser };
+export { VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnelserPanel };

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -16,6 +16,7 @@ import {
 } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
+import { useVedtaksperioder } from '../../../../../context/behandlingContext/useVedtaksperioder';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { Behandlingstype } from '../../../../../typer/behandling';
 import type { VedtakBegrunnelse } from '../../../../../typer/vedtak';
@@ -50,6 +51,7 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
         const [genererteBrevbegrunnelser, settGenererteBrevbegrunnelser] = useState<
             Ressurs<string[]>
         >(byggTomRessurs());
+        const { hentVedtaksperioder } = useVedtaksperioder();
 
         const maksAntallKulepunkter =
             vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.FORTSATT_INNVILGET ? 1 : 3;
@@ -158,10 +160,10 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
                 method: 'PUT',
                 url: `/familie-ba-sak/api/vedtaksperioder/standardbegrunnelser/${vedtaksperiodeMedBegrunnelser.id}`,
                 data: { standardbegrunnelser },
-            }).then((behandling: Ressurs<IBehandling>) => {
+            }).then((behandling: Ressurs<IBehandling | IVedtaksperiodeMedBegrunnelser[]>) => {
                 if (behandling.status === RessursStatus.SUKSESS) {
-                    settÅpenBehandling(behandling);
                     settStandardBegrunnelserPut(byggTomRessurs());
+                    hentVedtaksperioder();
                 } else if (behandling.status === RessursStatus.FUNKSJONELL_FEIL) {
                     settStandardBegrunnelserPut(byggFeiletRessurs(behandling.frontendFeilmelding));
                 } else {

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/BegrunnelserMultiselect.tsx
@@ -23,7 +23,7 @@ import {
     hentBorderfarge,
 } from '../../../../../utils/vedtakUtils';
 import { useVedtaksbegrunnelseTekster } from '../Context/VedtaksbegrunnelseTeksterContext';
-import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBegrunnelserContext';
+import { useVedtaksperiodeMedBegrunnelserPanel } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 import { mapBegrunnelserTilSelectOptions } from '../Hooks/useVedtaksbegrunnelser';
 
 interface IProps {
@@ -46,7 +46,7 @@ const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
         standardBegrunnelserPut,
         vedtaksperiodeMedBegrunnelser,
         genererteBrevbegrunnelser,
-    } = useVedtaksperiodeMedBegrunnelser();
+    } = useVedtaksperiodeMedBegrunnelserPanel();
     const { vedtaksbegrunnelseTekster } = useVedtaksbegrunnelseTekster();
 
     const [standardbegrunnelser, settStandardbegrunnelser] = useState<ISelectOption[]>([]);

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/FritekstVedtakbegrunnelser.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { PlusCircleIcon, TrashIcon, ExternalLinkIcon } from '@navikt/aksel-icons';
-import { BodyLong, Button, Fieldset, Heading, Link, Tag, Label, HelpText } from '@navikt/ds-react';
+import { ExternalLinkIcon, PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
+import { BodyLong, Button, Fieldset, Heading, HelpText, Label, Link, Tag } from '@navikt/ds-react';
 import { FamilieKnapp, FamilieTextarea } from '@navikt/familie-form-elements';
 import type { FeltState } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -13,7 +13,7 @@ import { målform } from '../../../../../typer/søknad';
 import type { IFritekstFelt } from '../../../../../utils/fritekstfelter';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import Knapperekke from '../../../../Felleskomponenter/Knapperekke';
-import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBegrunnelserContext';
+import { useVedtaksperiodeMedBegrunnelserPanel } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 
 const FritekstContainer = styled.div`
     padding: 1rem;
@@ -78,7 +78,7 @@ const FritekstVedtakbegrunnelser: React.FC = () => {
         onPanelClose,
         putVedtaksperiodeMedFritekster,
         vedtaksperiodeMedBegrunnelser,
-    } = useVedtaksperiodeMedBegrunnelser();
+    } = useVedtaksperiodeMedBegrunnelserPanel();
 
     const erMaksAntallKulepunkter = skjema.felter.fritekster.verdi.length >= maksAntallKulepunkter;
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/Personvelger.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/Personvelger.tsx
@@ -9,12 +9,12 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import { personTypeMap } from '../../../../../typer/person';
-import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBegrunnelserContext';
+import { useVedtaksperiodeMedBegrunnelserPanel } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 
 const Personvelger: React.FC = () => {
     const { vurderErLesevisning } = useBehandling();
     const erLesevisning = vurderErLesevisning();
-    const { skjema, åpenBehandling, id } = useVedtaksperiodeMedBegrunnelser();
+    const { skjema, åpenBehandling, id } = useVedtaksperiodeMedBegrunnelserPanel();
 
     const personIdenter = useFelt({
         verdi: [],

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -9,7 +9,7 @@ import FritekstVedtakbegrunnelser from './FritekstVedtakbegrunnelser';
 import { Standardbegrunnelse, VedtakBegrunnelseType } from '../../../../../typer/vedtak';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
-import { useVedtaksperiodeMedBegrunnelser } from '../Context/VedtaksperiodeMedBegrunnelserContext';
+import { useVedtaksperiodeMedBegrunnelserPanel } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 import Utbetalingsresultat from '../Felles/Utbetalingsresultat';
 
 interface IProps {
@@ -20,7 +20,7 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
     vedtaksperiodeMedBegrunnelser,
 }) => {
     const { erPanelEkspandert, onPanelClose, genererteBrevbegrunnelser } =
-        useVedtaksperiodeMedBegrunnelser();
+        useVedtaksperiodeMedBegrunnelserPanel();
 
     const ugyldigeReduksjonsteksterForÅTriggeFritekst = [
         Standardbegrunnelse.REDUKSJON_SATSENDRING,

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -15,7 +15,7 @@ import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import { partition } from '../../../../../utils/commons';
 import { filtrerOgSorterPerioderMedBegrunnelseBehov } from '../../../../../utils/vedtakUtils';
 import { useVedtaksbegrunnelseTekster } from '../Context/VedtaksbegrunnelseTeksterContext';
-import { VedtaksperiodeMedBegrunnelserProvider } from '../Context/VedtaksperiodeMedBegrunnelserContext';
+import { VedtaksperiodeMedBegrunnelserPanelProvider } from '../Context/VedtaksperiodeMedBegrunnelserContext';
 
 const StyledHeading = styled(Heading)`
     display: flex;
@@ -111,7 +111,7 @@ const VedtaksperiodeListe: React.FC<{
             </StyledHeading>
             {vedtaksperioderMedBegrunnelser.map(
                 (vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (
-                    <VedtaksperiodeMedBegrunnelserProvider
+                    <VedtaksperiodeMedBegrunnelserPanelProvider
                         key={vedtaksperiodeMedBegrunnelser.id}
                         åpenBehandling={åpenBehandling}
                         vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
@@ -119,7 +119,7 @@ const VedtaksperiodeListe: React.FC<{
                         <VedtaksperiodeMedBegrunnelserPanel
                             vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
                         />
-                    </VedtaksperiodeMedBegrunnelserProvider>
+                    </VedtaksperiodeMedBegrunnelserPanelProvider>
                 )
             )}
         </>

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperioderMedBegrunnelser.tsx
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react';
 import styled from 'styled-components';
 
 import { Alert, Heading } from '@navikt/ds-react';
+import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import VedtaksperiodeMedBegrunnelserPanel from './VedtaksperiodeMedBegrunnelserPanel';
@@ -21,27 +22,48 @@ const StyledHeading = styled(Heading)`
     margin-top: 1rem;
 `;
 
+const StyledAlert = styled(Alert)`
+    margin-bottom: 1rem;
+`;
+
 interface IVedtakBegrunnelserTabell {
     åpenBehandling: IBehandling;
+    vedtaksperioderMedBegrunnelserRessurs: Ressurs<IVedtaksperiodeMedBegrunnelser[]>;
 }
 
 const VedtaksperioderMedBegrunnelser: React.FC<IVedtakBegrunnelserTabell> = ({
     åpenBehandling,
+    vedtaksperioderMedBegrunnelserRessurs,
 }) => {
     const { toggles } = useApp();
     const { vedtaksbegrunnelseTekster } = useVedtaksbegrunnelseTekster();
-
-    const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
-        åpenBehandling.vedtak?.vedtaksperioderMedBegrunnelser ?? [],
-        åpenBehandling.status
-    );
 
     if (
         vedtaksbegrunnelseTekster.status === RessursStatus.FEILET ||
         vedtaksbegrunnelseTekster.status === RessursStatus.FUNKSJONELL_FEIL
     ) {
-        return <Alert variant="error">Klarte ikke å hente inn begrunnelser for vedtak.</Alert>;
+        return (
+            <StyledAlert variant="error">
+                Klarte ikke å hente inn begrunnelser for vedtak.
+            </StyledAlert>
+        );
     }
+
+    if (
+        vedtaksperioderMedBegrunnelserRessurs.status === RessursStatus.FEILET ||
+        vedtaksperioderMedBegrunnelserRessurs.status === RessursStatus.FUNKSJONELL_FEIL
+    ) {
+        return <StyledAlert variant="error">Klarte ikke å hente inn vedtaksperiodene.</StyledAlert>;
+    }
+
+    if (vedtaksperioderMedBegrunnelserRessurs.status !== RessursStatus.SUKSESS) {
+        return null;
+    }
+
+    const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
+        vedtaksperioderMedBegrunnelserRessurs.data ?? [],
+        åpenBehandling.status
+    );
 
     const avslagOgResterende = partition(
         vedtaksperiode =>

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -1,10 +1,9 @@
-import type { IVedtaksperiodeMedBegrunnelser, Vedtaksperiodetype } from './vedtaksperiode';
+import type { Vedtaksperiodetype } from './vedtaksperiode';
 import type { VilkårType } from './vilkår';
 
 export interface IVedtakForBehandling {
     aktiv: boolean;
     vedtaksdato: string;
-    vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     id: number;
 }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Hører til https://github.com/navikt/familie-ba-sak/pull/3869 og må bli merget etter den.

[Denne behandlingen](https://barnetrygd.intern.nav.no/fagsak/1921845/3780399) stopper helt opp fordi vi ikke klarer å utlede vedtaksperiodene. Det er ikke mulig å se på noe annet data siden all data i behandlingen som sendes til frontend finnes på samme objekt som vi nå ikke klarer å lage. 

Gjør så vi splitter ut vedtaksperiodene fra `IBehandling` (`RestUtvidetBehandling` backend). 
* Første steg er å gi med vedtaksperiodene i både `RestUtvidetBehandling` og eget endtepunkt. https://github.com/navikt/familie-ba-sak/pull/3869
* Så må frontend gå over til å ta imot fra det nye endepunktet. (Denne PRen)
* Til slutt kan vi fjerne vedtaksperiodene fra `RestUtvidetBehandling`.

![image](https://github.com/navikt/familie-ba-sak/assets/17828446/2dafc883-e8c2-4f10-9da7-29e71b6dbc55)

Splitter hentingen av vedtaksperiodene på eget endepunkt slik at vi kan begrense feilmeldingen til der det feiler:
![image](https://github.com/navikt/familie-ba-sak/assets/17828446/077220fe-1659-4f65-88ab-fee987957f25)
