### PR TITLE
Bruk returobjekt for å oppdatere vedtaksperioder når vi oppdaterer begrunnelser

### DIFF
--- a/src/frontend/context/behandlingContext/useVedtaksperioder.ts
+++ b/src/frontend/context/behandlingContext/useVedtaksperioder.ts
@@ -30,5 +30,8 @@ export const [VedtaksperioderProvider, useVedtaksperioder] = constate(() => {
     const [vedtaksperioderMedBegrunnelserRessurs, settVedtaksperioderMedBegrunnelserRessurs] =
         useState<Ressurs<IVedtaksperiodeMedBegrunnelser[]>>(byggTomRessurs());
 
-    return { vedtaksperioderMedBegrunnelserRessurs, hentVedtaksperioder };
+    return {
+        vedtaksperioderMedBegrunnelserRessurs,
+        settVedtaksperioderMedBegrunnelserRessurs,
+    };
 });

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -51,7 +51,7 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
         const [genererteBrevbegrunnelser, settGenererteBrevbegrunnelser] = useState<
             Ressurs<string[]>
         >(byggTomRessurs());
-        const { hentVedtaksperioder } = useVedtaksperioder();
+        const { settVedtaksperioderMedBegrunnelserRessurs } = useVedtaksperioder();
 
         const maksAntallKulepunkter =
             vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.FORTSATT_INNVILGET ? 1 : 3;
@@ -156,16 +156,25 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
 
         const oppdaterStandardbegrunnelser = (standardbegrunnelser: VedtakBegrunnelse[]) => {
             settStandardBegrunnelserPut(byggHenterRessurs());
-            request<{ standardbegrunnelser: VedtakBegrunnelse[] }, IBehandling>({
+            request<
+                { standardbegrunnelser: VedtakBegrunnelse[] },
+                IVedtaksperiodeMedBegrunnelser[]
+            >({
                 method: 'PUT',
                 url: `/familie-ba-sak/api/vedtaksperioder/standardbegrunnelser/${vedtaksperiodeMedBegrunnelser.id}`,
                 data: { standardbegrunnelser },
-            }).then((behandling: Ressurs<IBehandling | IVedtaksperiodeMedBegrunnelser[]>) => {
-                if (behandling.status === RessursStatus.SUKSESS) {
+            }).then(vedtaksperioderMedBegrunnelserRessurs => {
+                if (vedtaksperioderMedBegrunnelserRessurs.status === RessursStatus.SUKSESS) {
                     settStandardBegrunnelserPut(byggTomRessurs());
-                    hentVedtaksperioder();
-                } else if (behandling.status === RessursStatus.FUNKSJONELL_FEIL) {
-                    settStandardBegrunnelserPut(byggFeiletRessurs(behandling.frontendFeilmelding));
+                    settVedtaksperioderMedBegrunnelserRessurs(
+                        vedtaksperioderMedBegrunnelserRessurs
+                    );
+                } else if (
+                    vedtaksperioderMedBegrunnelserRessurs.status === RessursStatus.FUNKSJONELL_FEIL
+                ) {
+                    settStandardBegrunnelserPut(
+                        byggFeiletRessurs(vedtaksperioderMedBegrunnelserRessurs.frontendFeilmelding)
+                    );
                 } else {
                     settStandardBegrunnelserPut(
                         byggFeiletRessurs('Klarte ikke oppdatere standardbegrunnelser')


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Kommer etter denne: https://github.com/navikt/familie-ba-sak/pull/3899

Nå er vedtaksperiodene splittet ut fra behandlingsobjektet og vi returnerer vedtaksperiodene når vi oppdaterer begrunnelsene. Vi kan bruke dette objektet direkte til å sette vedtaksperiodene slik at vi slipper å gjøre et kall mot backend etter at vi har oppdatert begrunnelsene for å få oppdaterte vedtaksperioder