### PR TITLE
skjul satsendring knapp

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -66,10 +66,7 @@ const StyledAlert = styled(Alert)`
 
 const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
     const { settÅpenBehandling } = useBehandling();
-    const { kanKjøreSatsendring } = useSatsendringsknapp({
-        fagsakStatus: minimalFagsak.status,
-        fagsakId: minimalFagsak.id,
-    });
+    const { kanKjøreSatsendring } = useSatsendringsknapp({ minimalFagsak });
 
     React.useEffect(() => {
         settÅpenBehandling(byggTomRessurs(), false);
@@ -207,7 +204,7 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
                 <SaksoversiktWrapper>
                     <Heading size={'large'} level={'1'} children={'Saksoversikt'} />
 
-                    {kanKjøreSatsendring && <SatsendringKnapp fagsakId={minimalFagsak.id} />}
+                    {kanKjøreSatsendring && <SatsendringKnapp minimalFagsak={minimalFagsak} />}
 
                     <FagsakLenkepanel minimalFagsak={minimalFagsak} />
                     {minimalFagsak.status === FagsakStatus.LØPENDE && (

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -67,6 +67,7 @@ const StyledAlert = styled(Alert)`
 const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
     const { settÅpenBehandling } = useBehandling();
     const { kanKjøreSatsendring } = useSatsendringsknapp({
+        fagsakStatus: minimalFagsak.status,
         fagsakId: minimalFagsak.id,
     });
 

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/SatsendringKnapp.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/SatsendringKnapp.tsx
@@ -10,6 +10,7 @@ import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useSatsendringsknapp } from './useSatsendringsknapp';
 import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
+import type { IMinimalFagsak } from '../../../typer/fagsak';
 
 const StyledAlert = styled(Alert)`
     margin-top: 2rem;
@@ -24,13 +25,13 @@ const StyledErrorMessage = styled(ErrorMessage)`
 `;
 
 interface IProps {
-    fagsakId: number;
+    minimalFagsak: IMinimalFagsak;
 }
 
-export const SatsendringKnapp: React.FunctionComponent<IProps> = ({ fagsakId }) => {
+export const SatsendringKnapp: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
     const { request } = useHttp();
     const { settKanKjøreSatsendringTilFalse } = useSatsendringsknapp({
-        fagsakId,
+        minimalFagsak,
     });
     const { oppdaterGjeldendeFagsak } = useFagsakContext();
     const [kjørSatsendringRessurs, settKjørSatsendringRessurs] = useState<Ressurs<void>>(
@@ -40,7 +41,7 @@ export const SatsendringKnapp: React.FunctionComponent<IProps> = ({ fagsakId }) 
     const oppdaterFagsakMedSatsendring = () => {
         request<undefined, undefined>({
             method: 'PUT',
-            url: `/familie-ba-sak/api/satsendring/${fagsakId}/kjor-satsendring-synkront`,
+            url: `/familie-ba-sak/api/satsendring/${minimalFagsak.id}/kjor-satsendring-synkront`,
             påvirkerSystemLaster: true,
         }).then((kjørSatsendringRessurs: Ressurs<undefined>) => {
             settKjørSatsendringRessurs(kjørSatsendringRessurs);

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/useSatsendringsknapp.ts
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/useSatsendringsknapp.ts
@@ -4,14 +4,14 @@ import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggSuksessRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
+import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakStatus } from '../../../typer/fagsak';
 
 interface IProps {
-    fagsakStatus: FagsakStatus;
-    fagsakId: number;
+    minimalFagsak: IMinimalFagsak;
 }
 
-export const useSatsendringsknapp = ({ fagsakId, fagsakStatus }: IProps) => {
+export const useSatsendringsknapp = ({ minimalFagsak }: IProps) => {
     const { request } = useHttp();
 
     const [kanKjøreSatsendringRessurs, settKanKjøreSatsendringRessurs] = useState<Ressurs<boolean>>(
@@ -19,11 +19,11 @@ export const useSatsendringsknapp = ({ fagsakId, fagsakStatus }: IProps) => {
     );
 
     const oppdaterKanKjøreSatsendring = () => {
-        if (fagsakStatus !== FagsakStatus.LØPENDE) return false;
+        if (minimalFagsak.status !== FagsakStatus.LØPENDE) return false;
 
         request<undefined, boolean>({
             method: 'GET',
-            url: `/familie-ba-sak/api/satsendring/${fagsakId}/kan-kjore-satsendring`,
+            url: `/familie-ba-sak/api/satsendring/${minimalFagsak.id}/kan-kjore-satsendring`,
             påvirkerSystemLaster: true,
         }).then((ressurs: Ressurs<boolean>) => {
             settKanKjøreSatsendringRessurs(ressurs);
@@ -32,7 +32,7 @@ export const useSatsendringsknapp = ({ fagsakId, fagsakStatus }: IProps) => {
 
     useEffect(() => {
         oppdaterKanKjøreSatsendring();
-    }, [fagsakId]);
+    }, [minimalFagsak.id]);
 
     const settKanKjøreSatsendringTilFalse = () =>
         settKanKjøreSatsendringRessurs(byggSuksessRessurs(false));

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/useSatsendringsknapp.ts
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/useSatsendringsknapp.ts
@@ -4,11 +4,14 @@ import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggSuksessRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
+import { FagsakStatus } from '../../../typer/fagsak';
+
 interface IProps {
+    fagsakStatus: FagsakStatus;
     fagsakId: number;
 }
 
-export const useSatsendringsknapp = ({ fagsakId }: IProps) => {
+export const useSatsendringsknapp = ({ fagsakId, fagsakStatus }: IProps) => {
     const { request } = useHttp();
 
     const [kanKjøreSatsendringRessurs, settKanKjøreSatsendringRessurs] = useState<Ressurs<boolean>>(
@@ -16,6 +19,8 @@ export const useSatsendringsknapp = ({ fagsakId }: IProps) => {
     );
 
     const oppdaterKanKjøreSatsendring = () => {
+        if (fagsakStatus !== FagsakStatus.LØPENDE) return false;
+
         request<undefined, boolean>({
             method: 'GET',
             url: `/familie-ba-sak/api/satsendring/${fagsakId}/kan-kjore-satsendring`,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12430

To små forbedringer:

1. Vi gjør bare kall mot backend hvis det er løpende fagsak. Per i dag så skjer dette hver gang man går inn i fagsaken, uavhengig om det er nylig opprettet fagsak eller avsluttet.
2. Vi viser bare satsendring knapp for løpende fagsaker.