### PR TITLE
Hent vedtaksperioder på nytt når vi oppdaterer endringstidspunkt

### DIFF
--- a/src/frontend/context/behandlingContext/useVedtaksperioder.ts
+++ b/src/frontend/context/behandlingContext/useVedtaksperioder.ts
@@ -33,5 +33,6 @@ export const [VedtaksperioderProvider, useVedtaksperioder] = constate(() => {
     return {
         vedtaksperioderMedBegrunnelserRessurs,
         settVedtaksperioderMedBegrunnelserRessurs,
+        hentVedtaksperioder,
     };
 });

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/endringstidspunkt/UseEndringstidspunkt.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/endringstidspunkt/UseEndringstidspunkt.tsx
@@ -11,7 +11,7 @@ import {
 } from '@navikt/familie-typer';
 
 import { useOppdaterEndringstidspunktSkjema } from './useOppdaterEndringstidspunktSkjema';
-import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
+import { useVedtaksperioder } from '../../../../../context/behandlingContext/useVedtaksperioder';
 import type { IBehandling } from '../../../../../typer/behandling';
 
 interface IProps {
@@ -21,7 +21,6 @@ interface IProps {
 }
 
 export function useEndringstidspunkt({ behandlingId, visModal, lukkModal }: IProps) {
-    const { settÅpenBehandling } = useBehandling();
     const { request } = useHttp();
     const [endringstidspunktRessurs, settEndringstidspunktRessurs] = useState(
         byggHenterRessurs<ISODateString | undefined>()
@@ -41,6 +40,8 @@ export function useEndringstidspunkt({ behandlingId, visModal, lukkModal }: IPro
         visModal
     );
 
+    const { hentVedtaksperioder } = useVedtaksperioder();
+
     const oppdaterEndringstidspunkt = () => {
         if (kanSendeSkjema()) {
             onSubmit(
@@ -56,7 +57,7 @@ export function useEndringstidspunkt({ behandlingId, visModal, lukkModal }: IPro
                 (response: Ressurs<IBehandling>) => {
                     if (response.status === RessursStatus.SUKSESS) {
                         lukkModal();
-                        settÅpenBehandling(response);
+                        hentVedtaksperioder();
                         settEndringstidspunktRessurs(
                             byggSuksessRessurs(skjema.felter.endringstidspunkt.verdi)
                         );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter at vi splitta ut vedtaksperioder fra IBehandling blir ikke lenger vedtaksperiodene oppdatert når vi endrer endringstidspunktet siden vi oppdaterer IBehandling og ikke vedtaksperiodene når kallet er gjort. 

Gjør så vedtaksperiodene blir oppdatert når vi endrer endringstidspunktet

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Her er det rom for å forbedre ytelse ved å få ba-sak til å returnere vedtaksperiodene direkte når man kaller `familie-ba-sak/api/vedtaksperioder/endringstidspunkt`, men dette gjør man så sjeldent at jeg ønsker ikke bruke tid på det enn så lenge. 
