### PR TITLE
Benytt annet retur objekt for oppdater vedtaksperiode med fritekst

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -80,7 +80,7 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
                 periode: IPeriode;
                 fritekster: FeltState<IFritekstFelt>[];
             },
-            IBehandling
+            IVedtaksperiodeMedBegrunnelser[]
         >({
             felter: {
                 periode,
@@ -238,10 +238,10 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
                     },
                 }).then(vedtaksperioderMedBegrunnelserRessurs => {
                     if (vedtaksperioderMedBegrunnelserRessurs.status === RessursStatus.SUKSESS) {
-                        settStandardBegrunnelserPut(byggTomRessurs());
                         settVedtaksperioderMedBegrunnelserRessurs(
                             vedtaksperioderMedBegrunnelserRessurs
                         );
+                        onPanelClose(false);
                     } else if (
                         vedtaksperioderMedBegrunnelserRessurs.status ===
                         RessursStatus.FUNKSJONELL_FEIL


### PR DESCRIPTION
Favrokort: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543

Vi har en bug der vi ikke oppdaterer state korrekt etter at vi splittet ut vedtaksperioder fra behandling responsen.


Endrer til at i returnerer bare det relevante ved oppdatering av fritekst og oppdater state i henhold til dette i frontend.
Backend PR: https://github.com/navikt/familie-ba-sak/pull/3928

