### PR TITLE
Sørger for at vi ikke kjører `hentEndringstidspunkt` og `simulering` ved opprettelse av ny behandling

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -286,7 +286,6 @@ const useOpprettBehandling = (
                     lukkModal();
                     nullstillSkjema();
 
-                    settÅpenBehandling(response);
                     const behandling: IBehandling | undefined = hentDataFraRessurs(response);
 
                     if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
@@ -300,6 +299,8 @@ const useOpprettBehandling = (
                             `/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`
                         );
                     }
+
+                    settÅpenBehandling(response);
                 }
             }
         );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Dersom man oppretter en ny behandling fra vedtakssiden(`/vedtak`) trigges kall mot `/endringstidspunkt` og `/simulering` for den nye behandlingen. For `/endringstidspunkt` kastes en feil i backend og for `/simulering` kjører vi en unødvendig simulering som også kaster en feil i kontroll av ny utbetlaingsgenerator. Ingen stor konsekvens at vi gjør dette utover unødvendige feil og støy i loggene.

Disse kallene trigges fordi vi oppdaterer behandling i global state før vi navigerer bort fra `/vedtak`. Løser det ved å oppdatere behandling i state etter at vi har navigert bort fra `/vedtak`.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
