### PR TITLE
Filtreringsregel mor har ikke opphørt barnetrygd

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -116,8 +116,8 @@ const KompetanseTabellRadEndre: React.FC<IProps> = ({
                 />
                 {erAnnenForelderOmfattetAvNorskLovgivning && (
                     <StyledAlert variant="info" inline>
-                        Annen forelder er omfattet av norsk lovgivning og har selvstendig rett i
-                        perioden
+                        Annen forelder er omfattet av norsk lovgivning og søker har selvstendig rett
+                        i perioden
                     </StyledAlert>
                 )}
                 <StyledFamilieSelect

--- a/src/frontend/typer/fødselshendelser.ts
+++ b/src/frontend/typer/fødselshendelser.ts
@@ -19,6 +19,7 @@ export enum Filtreringsregel {
     LØPER_IKKE_BARNETRYGD_FOR_BARNET = 'LØPER_IKKE_BARNETRYGD_FOR_BARNET',
     FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT = 'FAGSAK_IKKE_MIGRERT_UT_AV_INFOTRYGD_ETTER_BARN_FØDT',
     MOR_HAR_IKKE_OPPFYLT_UTVIDET_VILKÅR_VED_FØDSELSDATO = 'MOR_HAR_IKKE_OPPFYLT_UTVIDET_VILKÅR_VED_FØDSELSDATO',
+    MOR_HAR_IKKE_OPPHØRT_BARNETRYGD = 'MOR_HAR_IKKE_OPPHØRT_BARNETRYGD',
 }
 
 export const filtreringsregler: Record<Filtreringsregel, string> = {
@@ -37,4 +38,5 @@ export const filtreringsregler: Record<Filtreringsregel, string> = {
         'Fagsaken har ikke blitt migrert fra infotrygd etter barn ble født',
     MOR_HAR_IKKE_OPPFYLT_UTVIDET_VILKÅR_VED_FØDSELSDATO:
         'Mor oppfyller ikke vilkår for utvidet barnetrygd',
+    MOR_HAR_IKKE_OPPHØRT_BARNETRYGD: 'Mor har ikke opphørt barnetrgyd',
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Favrokort: [NAV-12150](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12150)

Legger til ny filtreringsregel på fødselshendelser:

Mor har ikke opphørt barnetrygd
Dersom svaret er ja, fortsetter behandlingen.
Dersom svaret er nei, henlegges behandlingen og det opprettes "vurder livshendelse" oppgave.
Tekst i vurder livshendelse oppgave: Fødselshendelse: Mor har vedtak om opphørt barnetrygd.

PR for BA-sak: https://github.com/navikt/familie-ba-sak/pull/3975

![Screenshot 2023-09-20 at 09 54 02](https://github.com/navikt/familie-ba-sak-frontend/assets/8656966/bf774132-0f2a-4346-9e05-067de78de216)


