### PR TITLE
Bug: Kopier ident og orgnr uten formattering

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@navikt/familie-skjema": "7.0.3",
     "@navikt/familie-tidslinje": "6.0.0",
     "@navikt/familie-typer": "8.0.0",
-    "@navikt/familie-visittkort": "11.0.1",
+    "@navikt/familie-visittkort": "11.0.2",
     "@navikt/flagg-ikoner": "3.2.7",
     "@navikt/fnrvalidator": "^1.3.1",
     "@navikt/hoykontrast": "^3.1.0",

--- a/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -54,7 +54,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskr
                         <Heading level="2" size="medium" as="span">
                             {formattertIdent}
                         </Heading>
-                        <CopyButton size="small" copyText={formattertIdent} />
+                        <CopyButton size="small" copyText={person.personIdent} />
                     </FlexBox>
                     <Heading level="2" size="medium" as="span">
                         &ensp;|&ensp;
@@ -106,7 +106,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskr
                     <BodyShort>&ensp;|&ensp;</BodyShort>
                     <FlexBox>
                         <BodyShort>{formattertIdent}</BodyShort>
-                        <CopyButton size="small" copyText={formattertIdent} />
+                        <CopyButton size="small" copyText={person.personIdent} />
                     </FlexBox>
                     <BodyShort>&ensp;|&ensp;</BodyShort>
                     <BodyShort>{`${personTypeMap[person.type]} `}</BodyShort>

--- a/src/frontend/komponenter/Felleskomponenter/SamhandlerInformasjon/SamhandlerInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/SamhandlerInformasjon/SamhandlerInformasjon.tsx
@@ -44,7 +44,7 @@ const SamhandlerInformasjon: React.FunctionComponent<IProps> = ({
     somOverskrift = false,
 }) => {
     const navn = samhandler.navn;
-    const formattertIdent = formaterIdent(samhandler.orgNummer);
+    const formattertOrgNummer = formaterIdent(samhandler.orgNummer);
     return (
         <FlexDiv>
             {somOverskrift && (
@@ -58,9 +58,9 @@ const SamhandlerInformasjon: React.FunctionComponent<IProps> = ({
                     </Heading>
                     <FlexBox>
                         <Heading level="2" size="medium" as="span">
-                            {formattertIdent}
+                            {formattertOrgNummer}
                         </Heading>
-                        <CopyButton size={'small'} copyText={formattertIdent} />
+                        <CopyButton size={'small'} copyText={samhandler.orgNummer} />
                     </FlexBox>
                     <Heading level="2" size="medium" as="span">
                         &ensp;|&ensp;
@@ -83,8 +83,8 @@ const SamhandlerInformasjon: React.FunctionComponent<IProps> = ({
                     </BodyShort>
                     <BodyShort>&ensp;|&ensp;</BodyShort>
                     <FlexBox>
-                        <BodyShort>{formattertIdent}</BodyShort>
-                        <CopyButton size={'small'} copyText={formattertIdent} />
+                        <BodyShort>{formattertOrgNummer}</BodyShort>
+                        <CopyButton size={'small'} copyText={samhandler.orgNummer} />
                     </FlexBox>
                     <BodyShort>&ensp;|&ensp;</BodyShort>
                     <BodyShort>Institusjon</BodyShort>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,10 +2114,10 @@
   resolved "https://npm.pkg.github.com/download/@navikt/familie-validering/5.0.2/b890a334ca5f5aa5aeba6873f3fb00aff30be759#b890a334ca5f5aa5aeba6873f3fb00aff30be759"
   integrity sha512-S8C3egFMHC97auVFOlWMmG2Z84X1mwtVAvmp3ACEpFFRtzKQ2CD25ZJV7Sqf3IqHZLLAzGEaYCeMtYIAPwp3ag==
 
-"@navikt/familie-visittkort@11.0.1":
-  version "11.0.1"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-visittkort/11.0.1/8f160ace684cf3b779ac738903c75d30fb8653cb#8f160ace684cf3b779ac738903c75d30fb8653cb"
-  integrity sha512-gqNYHA7qhq9/LKsqA22POyvKVlRyVp3H36lrB+ajFpbEbdbK+Wu71eHYBUIT4vbRgfZD5AZycdlV6us0qKTZIg==
+"@navikt/familie-visittkort@11.0.2":
+  version "11.0.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-visittkort/11.0.2/87876bff6515e6e7cdcd6ef265921bfc288596a2#87876bff6515e6e7cdcd6ef265921bfc288596a2"
+  integrity sha512-UwFYLGXMTVBBN6vP389VIQc+qZp3ugQFeaqHVzv7n8Lz9BjY5hiq78GCtZnWvCdRa5TNoQJ+BitiIrMvGFPGUQ==
   dependencies:
     "@navikt/familie-ikoner" "^7.0.1"
     "@navikt/familie-typer" "^8.0.1"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Retter opp bug jeg introduserte her (https://github.com/navikt/familie-ba-sak-frontend/pull/2778) hvor ident/orgnr som ble kopiert var formattert. Ønsker ikke at det som kopieres skal ha formattering (altså et mellomrom).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Tenker det er unødvendig, har testet manuelt

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  