### PR TITLE
Bytter til Google distroless nodejs image

### DIFF
--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache

--- a/.github/workflows/build_n_deploy_rett_i_prod.yaml
+++ b/.github/workflows/build_n_deploy_rett_i_prod.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: npm
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache

--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -21,19 +21,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
-          cache: npm
+          node-version: '18'
+          cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/yarn-cache
       - name: Yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: yarn --prefer-offline --frozen-lockfile
-      - name: Build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE: ${{ github.sha }}
+      - name: Yarn build
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#          SENTRY_RELEASE: ${{ github.sha }}
         run: |
           yarn build
           yarn test

--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -30,10 +30,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: yarn --prefer-offline --frozen-lockfile
       - name: Yarn build
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#          SENTRY_RELEASE: ${{ github.sha }}
         run: |
           yarn build
           yarn test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM ghcr.io/navikt/baseimages/node-express:16-alpine
+FROM gcr.io/distroless/nodejs:18
 USER root
 USER apprunner
 
-ADD ./ /var/server/
+WORKDIR /var/server
 
-CMD ["yarn", "start"]
+COPY assets ./assets
+COPY node_dist ./node_dist
+COPY frontend_production ./frontend_production
+COPY node_modules ./node_modules
+COPY package.json .
+
+CMD ["--es-module-specifier-resolution=node", "node_dist/backend/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /var/server
 COPY assets ./assets
 COPY node_dist ./node_dist
 COPY frontend_production ./frontend_production
+
+# Må kopiere package.json og node_modules for at backend skal fungere. Backend henter avhengigheter runtime fra node_modules, og package.json trengs for at 'import' statements skal fungere.
 COPY node_modules ./node_modules
 COPY package.json .
 


### PR DESCRIPTION
Favro: [NAV-15121](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15121)
### 💰 Hva forsøker du å løse i denne PR'en

* Oppdaterer `Dockerfile` til å bruke `gcr.io/distroless/nodejs:18` som node-image fremfor `ghcr.io/navikt/baseimages/node-express:16-alpine`.
* Bruker `COPY` på spesifikke mapper og filer fremfor `ADD .`Kopierer da mindre data over til imaget enn tidligere. Tidligere ble hele `/src`-folderen kopiert over sammen med en rekke andre unødvendige filer.
* Oppdatert workflows til å bruke node 18 i bygg.

EF har tidligere gjort tilsvarene: https://github.com/navikt/familie-ef-ettersending/commit/25be7197981bef6f462ffe93affc1e21ba5ee17a

Testet OK i preprod.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
