### PR TITLE
Fiks lesevisning om dokument er digitalt sendt inn

### DIFF
--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -64,6 +64,9 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
     const [dataForManuellJournalføring, settDataForManuellJournalføring] = useState(
         byggTomRessurs<IDataForManuellJournalføring>()
     );
+    const [erDigitaltInnsendtDokument, settErDigialtInnsendtDokument] = useState<
+        boolean | undefined
+    >(undefined);
     const [institusjonsfagsaker, settInstitusjonsfagsaker] = useState<Ressurs<IMinimalFagsak[]>>(
         byggTomRessurs<IMinimalFagsak[]>()
     );
@@ -288,6 +291,10 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
                 settDataForManuellJournalføring(hentetDataForManuellJournalføring);
 
                 if (hentetDataForManuellJournalføring.status === RessursStatus.SUKSESS) {
+                    settErDigialtInnsendtDokument(
+                        hentetDataForManuellJournalføring.data.journalpost.kanal ===
+                            JournalpostKanal.NAV_NO
+                    );
                     const førsteDokument =
                         hentetDataForManuellJournalføring.data.journalpost.dokumenter?.find(
                             () => true
@@ -297,12 +304,15 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
                         hentetDataForManuellJournalføring.data.journalpost.journalpostId,
                         førsteDokument?.dokumentInfoId
                     );
+                } else {
+                    settErDigialtInnsendtDokument(undefined);
                 }
             })
             .catch((_error: AxiosError) => {
                 settDataForManuellJournalføring(
                     byggFeiletRessurs('Ukjent feil ved henting av oppgave')
                 );
+                settErDigialtInnsendtDokument(undefined);
             });
     };
 
@@ -614,6 +624,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         institusjonsfagsaker,
         settMinimalFagsakTilNormalFagsakForPerson,
         settMinimalFagsakTilInstitusjonsfagsak,
+        erDigitaltInnsendtDokument,
     };
 });
 

--- a/src/frontend/komponenter/ManuellJournalfør/AvsenderPanel.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/AvsenderPanel.tsx
@@ -25,8 +25,13 @@ const StyledExpansionContent = styled(ExpansionCard.Content)`
 `;
 
 export const AvsenderPanel: React.FC = () => {
-    const { skjema, erLesevisning, settAvsenderLikBruker, tilbakestillAvsender } =
-        useManuellJournalfør();
+    const {
+        skjema,
+        erLesevisning,
+        settAvsenderLikBruker,
+        tilbakestillAvsender,
+        erDigitaltInnsendtDokument,
+    } = useManuellJournalfør();
     const [åpen, settÅpen] = useState(false);
     const [brukerErAvsender, settBrukerErAvsender] = useState(false);
 
@@ -43,6 +48,8 @@ export const AvsenderPanel: React.FC = () => {
         skjema.felter.avsenderNavn.valideringsstatus,
         skjema.felter.avsenderIdent.valideringsstatus,
     ]);
+
+    const lesevisning = erLesevisning() || erDigitaltInnsendtDokument;
 
     return (
         <StyledExpansionCard
@@ -63,7 +70,7 @@ export const AvsenderPanel: React.FC = () => {
                 </ExpansionCard.Title>
             </ExpansionCard.Header>
             <StyledExpansionContent>
-                {erLesevisning() ? (
+                {lesevisning ? (
                     brukerErAvsender ? (
                         <BodyShort
                             className={classNames('skjemaelement', 'lese-felt')}
@@ -85,7 +92,7 @@ export const AvsenderPanel: React.FC = () => {
                 <br />
                 <FamilieInput
                     {...skjema.felter.avsenderNavn.hentNavInputProps(skjema.visFeilmeldinger)}
-                    erLesevisning={erLesevisning()}
+                    erLesevisning={lesevisning}
                     label={'Navn'}
                     size={'medium'}
                     placeholder={'Navn'}
@@ -95,7 +102,7 @@ export const AvsenderPanel: React.FC = () => {
                 <br />
                 <FamilieInput
                     {...skjema.felter.avsenderIdent.hentNavInputProps(skjema.visFeilmeldinger)}
-                    erLesevisning={erLesevisning()}
+                    erLesevisning={lesevisning}
                     label={'Ident'}
                     size={'medium'}
                     placeholder={'Fnr/dnr/orgnr'}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15633

Hvis dokument er sendt inn digitalt skal det ikke være mulig å endre avsender.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Vi har to ulike kanaler NAV_NO og SCAN_IM. Min antagelse i denne oppgaven er at alle journalposter med kanal=NAV_NO er digitalt sendt inn. Venter på avklaring for å dobbeltsjekke at dette stemmer.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ser ikke poenget her

### 🤷‍♀ ️Hvor er det lurt å starte?
🤷 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/1f96af9a-dc9a-44b0-ba2d-77611f9a1d69)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/ad3d4432-f0d2-4eb0-8907-6a2a5387e5ec)
