### PR TITLE
fjern filtrering på erPåvirketAvEndring i hentVedtaksperiodeTittel

### DIFF
--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -82,9 +82,9 @@ export const hentVedtaksperiodeTittel = (
     const { type, utbetalingsperiodeDetaljer } = vedtaksperiodeMedBegrunnelser;
 
     const ytelseTyperUtenEndring =
-        utbetalingsperiodeDetaljer
-            .filter(utbetalingsperiodeDetalj => !utbetalingsperiodeDetalj.erPåvirketAvEndring)
-            .map(utbetalingsperiodeDetalj => utbetalingsperiodeDetalj.ytelseType) ?? [];
+        utbetalingsperiodeDetaljer.map(
+            utbetalingsperiodeDetalj => utbetalingsperiodeDetalj.ytelseType
+        ) ?? [];
 
     if (
         (type === Vedtaksperiodetype.UTBETALING ||


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15553)
[Sak i prod](https://barnetrygd.intern.nav.no/fagsak/1272941/3772820/vedtak)

Når vi har endret utbetaling samtidig som f.eks. utvidet vil vedtaksperiodeTittelen bli Ordinær. Dette er fordi vedtaksperiodetypen ENDRET_UTBETALING er deprecated i ba-sak og vi filtrerer vekk ytelsetyper med erPåvirketAvEndring == true, som igjen blir bestemt av hvorvidt vi har andeler med endring. (Se UtbetalingsperiodeDetalj - klassen i Utbetalingsperiode.kt i ba-sak). 
Fjerner filtreringen på erPåvirketEndring slik at vi får riktig tittel på vedtaksperioder med endret utbetaling og noe annet enn ordinær. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Har antatt at det er unødvendig å filtrere på hvorvidt en utbetalingsperiodedetalj erPåvirketAvEndring eller ikke så  gjerne gi input hvis det høres feil ut!! 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testet med lokal kjøring
