### PR TITLE
Vi fjerner endringsmottaker toggle + legger ut allerede utbetalt til prod

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -12,15 +12,15 @@ import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useEndretUtbetalingAndel } from '../../../context/EndretUtbetalingAndelContext';
 import type { IBehandling } from '../../../typer/behandling';
-import { ToggleNavn } from '../../../typer/toggles';
-import type { IRestEndretUtbetalingAndel } from '../../../typer/utbetalingAndel';
+import type {
+    IRestEndretUtbetalingAndel,
+    IEndretUtbetalingAndelÅrsak,
+} from '../../../typer/utbetalingAndel';
 import {
     IEndretUtbetalingAndelFullSats,
-    IEndretUtbetalingAndelÅrsak,
     optionTilsats,
     satser,
     satsTilOption,
@@ -83,7 +83,6 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
 }) => {
     const { request } = useHttp();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
-    const { toggles } = useApp();
     const erLesevisning = vurderErLesevisning();
 
     const {
@@ -152,16 +151,6 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 )
             ).getFullYear() - new Date().getFullYear()
         );
-    };
-
-    const endringsårsakSkalVises = (årsak: IEndretUtbetalingAndelÅrsak): boolean => {
-        if (årsak === IEndretUtbetalingAndelÅrsak.ENDRE_MOTTAKER) {
-            return toggles[ToggleNavn.endreMottakerEndringsårsaker];
-        } else if (årsak === IEndretUtbetalingAndelÅrsak.ALLEREDE_UTBETALT) {
-            return toggles[ToggleNavn.eøsPraksisendringSeptember2023];
-        } else {
-            return true;
-        }
     };
 
     useEffect(() => {
@@ -259,7 +248,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                         }
                     >
                         <option value={undefined}>Velg årsak</option>
-                        {årsaker.filter(endringsårsakSkalVises).map(årsak => (
+                        {årsaker.map(årsak => (
                             <option value={årsak.valueOf()} key={årsak.valueOf()}>
                                 {årsakTekst[årsak]}
                             </option>

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -11,7 +11,6 @@ export enum ToggleNavn {
     kanAutomatiskSetteVilkår = 'familie-ba-sak.kan-automatisk-sette-vilkaar',
 
     // Release
-    endreMottakerEndringsårsaker = 'familie-ba-sak.behandling.endringsperiode.endre-mottaker-aarsaker.utgivelse',
     kanBehandleKlage = 'familie-ba-sak.klage',
     støtterEnsligMindreårig = 'familie-ba-sak.behandling.enslig-mindreaarig',
     manuellPostering = 'familie-ba-sak.manuell-postering',


### PR DESCRIPTION
ToggleNavn.endreMottakerEndringsårsaker har vært på i prod en stund.
Vi fjerner togglen.

I tillegg er det ønskelig at allerede utbetalt ikke skal ligge bak en toggle, så vi slenger ut den også.