### PR TITLE
Legg til varsel når søknad mottatt dato er mer enn 360 dager siden

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Button, Fieldset, Heading, Modal } from '@navikt/ds-react';
+import { Alert, Button, Fieldset, Heading, Modal } from '@navikt/ds-react';
 import { Dropdown } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -11,6 +11,14 @@ import OpprettBehandlingValg from './OpprettBehandlingValg';
 import useOpprettBehandling from './useOpprettBehandling';
 import { Behandlingstype } from '../../../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../../../typer/fagsak';
+import {
+    erFør,
+    iDag,
+    kalenderDatoMedFallback,
+    KalenderEnhet,
+    TIDENES_ENDE,
+    trekkFra,
+} from '../../../../../utils/kalender';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 
 interface IProps {
@@ -23,6 +31,10 @@ const Knapperad = styled.div`
 
 const StyledModal = styled(Modal)`
     width: 35rem;
+`;
+
+const StyledAlert = styled(Alert)`
+    margin-top: 1.5rem;
 `;
 
 const KnappVenstre = styled(Button)`
@@ -54,6 +66,16 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
         nullstillSkjemaStatus();
         settVisModal(false);
     };
+
+    const søknadMottattDato = kalenderDatoMedFallback(
+        opprettBehandlingSkjema.felter.søknadMottattDato.verdi,
+        TIDENES_ENDE
+    );
+
+    const søknadMottattDatoErMerEnn360DagerSiden = erFør(
+        søknadMottattDato,
+        trekkFra(iDag(), 360, KalenderEnhet.DAG)
+    );
 
     return (
         <>
@@ -112,6 +134,12 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
                             />
                         )}
                     </Fieldset>
+                    {søknadMottattDatoErMerEnn360DagerSiden && (
+                        <StyledAlert variant={'warning'}>
+                            Er mottatt dato riktig? <br />
+                            Det er mer enn 360 dager siden denne datoen.
+                        </StyledAlert>
+                    )}
                     <Knapperad>
                         <KnappVenstre
                             key={'bekreft'}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15632

Det er ønskelig å vise advarsel tekst dersom mottatt dato valgt på søknad er MER enn 360 dager siden sist.
Se video for demo.

https://github.com/navikt/familie-ba-sak-frontend/assets/110383605/3bdcce57-69de-4c31-9010-e9e4a07afe9c

