### PR TITLE
Bug: Legg tilbake infobrev tilknyttet EØS praksisendring som skal trigge BarnSøktForSkjema

### DIFF
--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -62,9 +62,11 @@ const DokumentutsendingSkjema: React.FC = () => {
 
     const årsakVerdi = skjema.felter.årsak.verdi;
 
-    //TODO: Fjern dette når toggle selvstendigRettInfobrev skrus på.
     const barnSøktForÅrsaker = [
         DokumentÅrsak.TIL_FORELDER_MED_SELVSTENDIG_RETT_VI_HAR_FÅTT_F016_KAN_SØKE_OM_BARNETRYGD,
+        DokumentÅrsak.TIL_FORELDER_OMFATTET_NORSK_LOVGIVNING_HAR_FÅTT_EN_SØKNAD_FRA_ANNEN_FORELDER,
+        DokumentÅrsak.TIL_FORELDER_OMFATTET_NORSK_LOVGIVNING_HAR_GJORT_VEDTAK_TIL_ANNEN_FORELDER,
+        DokumentÅrsak.TIL_FORELDER_OMFATTET_NORSK_LOVGIVNING_VARSEL_OM_ÅRLIG_KONTROLL,
     ];
 
     const { toggles } = useApp();
@@ -93,7 +95,8 @@ const DokumentutsendingSkjema: React.FC = () => {
                         //TODO: Fjern dette når toggle selvstendigRettInfobrev skrus på.
                         .filter(
                             årsak =>
-                                !barnSøktForÅrsaker.includes(årsak) ||
+                                årsak !==
+                                    DokumentÅrsak.TIL_FORELDER_MED_SELVSTENDIG_RETT_VI_HAR_FÅTT_F016_KAN_SØKE_OM_BARNETRYGD ||
                                 toggles[ToggleNavn.selvstendigRettInfobrev]
                         )
                         .map(årsak => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bug i prod hvor BarnSøktForSkjema ikke dukket opp for infobrevene tilknyttet EØS praksisendring. Dette er fordi skjemaet rendres hvis dokumentårsaken som er valgt ligger i `barnSøktForÅrsaker`. I #2801 ble disse brevene fjernet derfra for å skjule noe annet, fordi man ikke så at denne listen også ble brukt til å si om skjemaet skulle rendres eller ikke.

Fikser så skjemaet rendres hvis de tre årsakene er valgt. OG at den årsaken som ikke skal være mulig å velge hvis ikke selstendig rett toggle er på IKKE kan velges i prod uten at toggle er på.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bruker ikke tid på det nå, haster å få ut

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Bruker ikke tid på det nå