### PR TITLE
Bug datovelger: statehåndtering

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettEllerOppdaterVenting.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettEllerOppdaterVenting.tsx
@@ -1,47 +1,18 @@
 import React, { useState } from 'react';
 
 import { Dropdown } from '@navikt/ds-react';
-import type { Ressurs } from '@navikt/familie-typer';
 
 import { SettBehandlingPåVentModal } from './SettBehandlingPåVentModal';
-import { useSettPåVentSkjema } from './useSettPåVentSkjema';
-import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
-import type { IBehandling, ISettPåVent } from '../../../../../typer/behandling';
-import { formatterDateTilIsoString } from '../../../../../utils/dato';
+import type { IBehandling } from '../../../../../typer/behandling';
 
 interface IProps {
     behandling: IBehandling;
 }
 
 const SettEllerOppdaterVenting: React.FC<IProps> = ({ behandling }) => {
-    const { settÅpenBehandling } = useBehandling();
     const [visModal, settVisModal] = useState<boolean>(!!behandling.aktivSettPåVent);
-    const { skjema, kanSendeSkjema, onSubmit } = useSettPåVentSkjema(
-        behandling.aktivSettPåVent,
-        visModal
-    );
-    const { årsak, frist } = skjema.felter;
 
     const erBehandlingAlleredePåVent = !!behandling.aktivSettPåVent;
-
-    const settBehandlingPåVent = () => {
-        if (kanSendeSkjema() && årsak.verdi && frist.verdi) {
-            onSubmit<ISettPåVent>(
-                {
-                    method: erBehandlingAlleredePåVent ? 'PUT' : 'POST',
-                    data: {
-                        frist: formatterDateTilIsoString(frist.verdi),
-                        årsak: årsak.verdi,
-                    },
-                    url: `/familie-ba-sak/api/sett-på-vent/${behandling.behandlingId}`,
-                },
-                (ressurs: Ressurs<IBehandling>) => {
-                    settÅpenBehandling(ressurs);
-                    settVisModal(false);
-                }
-            );
-        }
-    };
 
     return (
         <>
@@ -53,10 +24,8 @@ const SettEllerOppdaterVenting: React.FC<IProps> = ({ behandling }) => {
 
             {visModal && (
                 <SettBehandlingPåVentModal
-                    onAvbryt={() => settVisModal(false)}
-                    settBehandlingPåVent={settBehandlingPåVent}
-                    skjema={skjema}
-                    erBehandlingAlleredePåVent={erBehandlingAlleredePåVent}
+                    lukkModal={() => settVisModal(false)}
+                    behandling={behandling}
                 />
             )}
         </>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/useSettPåVentSkjema.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/useSettPåVentSkjema.ts
@@ -25,7 +25,7 @@ export const useSettPåVentSkjema = (settPåVent: ISettPåVent | undefined, moda
     >({
         felter: {
             frist: useFelt<Date | undefined>({
-                verdi: settPåVentFrist ?? standardfrist,
+                verdi: undefined,
                 valideringsfunksjon: validerGyldigDato,
             }),
             årsak: useFelt<SettPåVentÅrsak | undefined>({
@@ -52,7 +52,7 @@ export const useSettPåVentSkjema = (settPåVent: ISettPåVent | undefined, moda
         } else {
             fyllInnStandardverdier();
         }
-    }, [modalVises]);
+    }, []);
 
     return settPåVentSkjema;
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/useSettPåVentSkjema.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/useSettPåVentSkjema.ts
@@ -10,7 +10,7 @@ import { dagensDato, validerGyldigDato } from '../../../../../utils/dato';
 
 const STANDARD_ANTALL_DAGER_FRIST = 3 * 7;
 
-export const useSettPåVentSkjema = (settPåVent: ISettPåVent | undefined, modalVises: boolean) => {
+export const useSettPåVentSkjema = (settPåVent: ISettPåVent | undefined) => {
     const standardfrist = addDays(dagensDato(), STANDARD_ANTALL_DAGER_FRIST);
     const settPåVentFrist = settPåVent?.frist ? new Date(settPåVent?.frist) : undefined;
 
@@ -46,7 +46,7 @@ export const useSettPåVentSkjema = (settPåVent: ISettPåVent | undefined, moda
     };
 
     useEffect(() => {
-        if (modalVises && settPåVent) {
+        if (settPåVent) {
             settPåVentSkjema.skjema.felter.frist.validerOgSettFelt(settPåVentFrist);
             settPåVentSkjema.skjema.felter.årsak.validerOgSettFelt(settPåVent.årsak);
         } else {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter at jeg tok i bruk ny datovelger på SettPåVent er noe av statehåndteringen brukket. Oppdaget det selv i test et annet sted i en ny branch at nullstilling ikke funker når defaultverdien til datofeltet er satt til noe annet enn undefined. Resultatet blir at skjemaet tror det er den standardverdien som gjelder, selv om datovelgeren er tom, noe som gjør at skjemaet validerer ok og man kan sende inn skjemaet (med feil verdi).

Når datovelgeren tømmes så nullstiller vi datofeltet ved å sette `felt.nullstill()`, som i dette tilfelle nullstilte feltet til `standardverdi` (og ikke `undefined` som man forventet). Hadde kunne løst dette enklere ved å bruke `felt.validerOgSettFelt(undefined)` i stedet for nullstilling, men det å sette feltet til undefined er ikke gyldig og det skjer dermed ingenting. Dette er eneste løsningen jeg har funnet: datofelt må alltid settes til `verdi: undefined`, også må man heller ha en `useEffect` som oppdaterer verdien til en annen standardverdi.

Refaktorerer også litt rundt hvilken komponent det er som bruker useSettPåVentSkjema-hooken, for å sikre at feltene blir tømt for hver gang man åpner og lukker modalen.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Hvorfor funker ikke `felt.validerOgSettFelt(undefined)` :(

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke verdi her

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuell endring annet enn at man nå ikke kommer seg videre hvis datofeltet er tomt.