### PR TITLE
Bug: Feil nullstilling av datovelger

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { addDays, format, startOfDay, subDays } from 'date-fns';
+import { addDays, format, isValid, startOfDay, subDays } from 'date-fns';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
@@ -87,7 +87,9 @@ const Datovelger = ({
     });
 
     useEffect(() => {
-        setSelected(felt.verdi);
+        if (isValid(felt.verdi)) {
+            setSelected(felt.verdi);
+        }
     }, [felt.verdi]);
 
     const feilmeldingForDatoFørMinDato = () => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Jeg har innført en bug hvor datovelgeren blir nullstilt en gang for mye. Dette skjer når man starter å overskrive eksisterende valgt dato. Da nullstiller datovelgeren feltet, som igjen nullstiller datovelgeren, selv om brukeren har startet å skrive inn en ny verdi. Fikser dette ved at det kun er gyldige felt-verdier som kan overskrive dato-velger verdien

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Unødvendig

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Nei