### PR TITLE
Oppgrader til MonthPicker for Feilutbetalt valuta og Refusjon EØS

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -29,7 +29,7 @@ import {
 import { lagPersonLabel } from '../../../utils/formatter';
 import type { YearMonth } from '../../../utils/kalender';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
-import Datovelger from '../../Felleskomponenter/Datovelger';
+import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import Knapperekke from '../../Felleskomponenter/Knapperekke';
 import MånedÅrVelger from '../../Felleskomponenter/MånedÅrInput/MånedÅrVelger';
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
@@ -13,7 +13,7 @@ import type { IBehandling, ISettPåVent } from '../../../../../typer/behandling'
 import { settPåVentÅrsaker } from '../../../../../typer/behandling';
 import { formatterDateTilIsoString } from '../../../../../utils/dato';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import Datovelger from '../../../../Felleskomponenter/Datovelger';
+import Datovelger from '../../../../Felleskomponenter/Datovelger/Datovelger';
 
 const Feltmargin = styled.div`
     margin-bottom: 2rem;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/useSettPåVentSkjema.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/useSettPåVentSkjema.ts
@@ -11,7 +11,7 @@ import { dagensDato, validerGyldigDato } from '../../../../../utils/dato';
 const STANDARD_ANTALL_DAGER_FRIST = 3 * 7;
 
 export const useSettPåVentSkjema = (settPåVent: ISettPåVent | undefined) => {
-    const standardfrist = addDays(dagensDato(), STANDARD_ANTALL_DAGER_FRIST);
+    const standardfrist = addDays(dagensDato, STANDARD_ANTALL_DAGER_FRIST);
     const settPåVentFrist = settPåVent?.frist ? new Date(settPåVent?.frist) : undefined;
 
     const årsaker = hentAlleÅrsaker();

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -12,7 +12,7 @@ import { Behandlingstype } from '../../../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../../../typer/fagsak';
 import { dagensDato } from '../../../../../utils/dato';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import Datovelger from '../../../../Felleskomponenter/Datovelger';
+import Datovelger from '../../../../Felleskomponenter/Datovelger/Datovelger';
 
 interface IProps {
     minimalFagsak: IMinimalFagsak;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -56,10 +56,7 @@ const OpprettBehandling: React.FC<IProps> = ({ minimalFagsak }) => {
 
     const søknadMottattDatoErMerEnn360DagerSiden =
         opprettBehandlingSkjema.felter.søknadMottattDato.verdi &&
-        isBefore(
-            opprettBehandlingSkjema.felter.søknadMottattDato.verdi,
-            subDays(dagensDato(), 360)
-        );
+        isBefore(opprettBehandlingSkjema.felter.søknadMottattDato.verdi, subDays(dagensDato, 360));
 
     return (
         <>

--- a/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
@@ -8,7 +8,7 @@ import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import type { IPersonInfo } from '../../../typer/person';
-import Datovelger from '../../Felleskomponenter/Datovelger';
+import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import type { IRegistrerBarnSkjema } from '../../Felleskomponenter/LeggTilBarn';
 
 interface IProps {

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -51,10 +51,6 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
         settFeilmelding: settFeilmelding,
     });
 
-    useEffect(() => {
-        tilbakestillOgLukkSkjema();
-    }, [feilutbetaltValuta]);
-
     const tilbakestillOgLukkSkjema = () => {
         settErRadEkspandert(false);
         tilbakestillSkjemafelterTilDefault();
@@ -70,6 +66,10 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
         }
     };
 
+    const lagrePeriodeOgLukkPanel = () => {
+        oppdaterEksisterendePeriode().then(() => settErRadEkspandert(false));
+    };
+
     return (
         <Table.ExpandableRow
             open={erLesevisning ? false : erRadEkspandert}
@@ -80,7 +80,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
                     <FlexRowDiv>
                         <Button
                             size="small"
-                            onClick={oppdaterEksisterendePeriode}
+                            onClick={lagrePeriodeOgLukkPanel}
                             variant={valideringErOk() ? 'primary' : 'secondary'}
                         >
                             Lagre periode

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -46,9 +46,9 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
         valideringErOk,
         tilbakestillSkjemafelterTilDefault,
     } = useFeilutbetaltValuta({
-        behandlingId: behandlingId,
+        behandlingId,
         feilutbetaltValuta,
-        settFeilmelding: settFeilmelding,
+        settFeilmelding,
     });
 
     const tilbakestillOgLukkSkjema = () => {

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -74,7 +74,9 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
                 <FlexColumnDiv>
                     <FeilutbetaltValutaSkjema
                         skjema={skjema}
-                        key={erRadEkspandert ? 'ekspandert' : 'lukket'}
+                        key={`${feilutbetaltValuta.id}-$${
+                            erRadEkspandert ? 'ekspandert' : 'lukket'
+                        }`}
                     />
                     <FlexRowDiv>
                         <Button

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -52,10 +52,10 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
     });
 
     useEffect(() => {
-        lukkSkjema();
+        tilbakestillOgLukkSkjema();
     }, [feilutbetaltValuta]);
 
-    const lukkSkjema = () => {
+    const tilbakestillOgLukkSkjema = () => {
         settErRadEkspandert(false);
         tilbakestillSkjemafelterTilDefault();
     };
@@ -64,7 +64,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
         if (erLesevisning) return;
 
         if (erRadEkspandert) {
-            lukkSkjema();
+            tilbakestillOgLukkSkjema();
         } else {
             settErRadEkspandert(true);
         }
@@ -85,7 +85,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
                         >
                             Lagre periode
                         </Button>
-                        <Button size="small" variant="tertiary" onClick={lukkSkjema}>
+                        <Button size="small" variant="tertiary" onClick={tilbakestillOgLukkSkjema}>
                             Avbryt
                         </Button>
                     </FlexRowDiv>

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -66,10 +66,6 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
         }
     };
 
-    const lagrePeriodeOgLukkPanel = () => {
-        oppdaterEksisterendePeriode().then(() => settErRadEkspandert(false));
-    };
-
     return (
         <Table.ExpandableRow
             open={erLesevisning ? false : erRadEkspandert}
@@ -80,7 +76,9 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
                     <FlexRowDiv>
                         <Button
                             size="small"
-                            onClick={lagrePeriodeOgLukkPanel}
+                            onClick={() =>
+                                oppdaterEksisterendePeriode(() => settErRadEkspandert(false))
+                            }
                             variant={valideringErOk() ? 'primary' : 'secondary'}
                         >
                             Lagre periode

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -39,7 +39,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { skjema, oppdaterEksisterendePeriode, nullstillSkjema, fjernPeriode, valideringErOk } =
+    const { skjema, oppdaterEksisterendePeriode, fjernPeriode, valideringErOk } =
         useFeilutbetaltValuta({
             behandlingId: behandlingId,
             feilutbetaltValuta,
@@ -47,11 +47,10 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
         });
 
     useEffect(() => {
-        nullstillOgLukkSkjema();
+        lukkSkjema();
     }, [feilutbetaltValuta]);
 
-    const nullstillOgLukkSkjema = () => {
-        nullstillSkjema();
+    const lukkSkjema = () => {
         settErRadEkspandert(false);
     };
 
@@ -59,7 +58,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
         if (erLesevisning) return;
 
         if (erRadEkspandert) {
-            nullstillOgLukkSkjema();
+            lukkSkjema();
         } else {
             settErRadEkspandert(true);
         }
@@ -80,7 +79,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
                         >
                             Lagre periode
                         </Button>
-                        <Button size="small" variant="tertiary" onClick={nullstillOgLukkSkjema}>
+                        <Button size="small" variant="tertiary" onClick={lukkSkjema}>
                             Avbryt
                         </Button>
                     </FlexRowDiv>

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -39,12 +39,17 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { skjema, oppdaterEksisterendePeriode, fjernPeriode, valideringErOk } =
-        useFeilutbetaltValuta({
-            behandlingId: behandlingId,
-            feilutbetaltValuta,
-            settFeilmelding: settFeilmelding,
-        });
+    const {
+        skjema,
+        oppdaterEksisterendePeriode,
+        fjernPeriode,
+        valideringErOk,
+        tilbakestillSkjemafelterTilDefault,
+    } = useFeilutbetaltValuta({
+        behandlingId: behandlingId,
+        feilutbetaltValuta,
+        settFeilmelding: settFeilmelding,
+    });
 
     useEffect(() => {
         lukkSkjema();
@@ -52,6 +57,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
 
     const lukkSkjema = () => {
         settErRadEkspandert(false);
+        tilbakestillSkjemafelterTilDefault();
     };
 
     const håndterLukkingOgÅpningAvPanel = () => {
@@ -70,7 +76,7 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
             onOpenChange={håndterLukkingOgÅpningAvPanel}
             content={
                 <FlexColumnDiv>
-                    <FeilutbetaltValutaSkjema skjema={skjema} />
+                    {erRadEkspandert && <FeilutbetaltValutaSkjema skjema={skjema} />}
                     <FlexRowDiv>
                         <Button
                             size="small"

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaPeriode.tsx
@@ -72,7 +72,10 @@ const FeilutbetaltValutaPeriode: React.FC<IFeilutbetaltValutaPeriode> = ({
             onOpenChange={håndterLukkingOgÅpningAvPanel}
             content={
                 <FlexColumnDiv>
-                    {erRadEkspandert && <FeilutbetaltValutaSkjema skjema={skjema} />}
+                    <FeilutbetaltValutaSkjema
+                        skjema={skjema}
+                        key={erRadEkspandert ? 'ekspandert' : 'lukket'}
+                    />
                     <FlexRowDiv>
                         <Button
                             size="small"

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
@@ -7,16 +7,12 @@ import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../context/AppContext';
 import type { IBehandling } from '../../../../typer/behandling';
-import type {
-    IFeilutbetaltValutaSkjemaFelter,
-    IRestFeilutbetaltValuta,
-} from '../../../../typer/eøs-feilutbetalt-valuta';
+import type { IFeilutbetaltValutaSkjemaFelter } from '../../../../typer/eøs-feilutbetalt-valuta';
 import { ToggleNavn } from '../../../../typer/toggles';
 import Månedvelger, { DagIMåneden } from '../../../Felleskomponenter/Datovelger/Månedvelger';
 
 interface IFeilutbetaltValutaSkjemaProps {
     skjema: ISkjema<IFeilutbetaltValutaSkjemaFelter, IBehandling>;
-    feilutbetaltValuta?: IRestFeilutbetaltValuta;
 }
 
 const FlexDatoInputWrapper = styled.div`
@@ -41,10 +37,8 @@ const StyledTextField = styled(TextField)`
 
 const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjemaProps> = ({
     skjema,
-    feilutbetaltValuta,
 }) => {
     const { toggles } = useApp();
-    console.log(feilutbetaltValuta);
     return (
         <>
             <FlexDatoInputWrapper>

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
@@ -3,16 +3,13 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Label, TextField } from '@navikt/ds-react';
-import type { ISODateString } from '@navikt/familie-datovelger';
-import { FamilieDatovelger } from '@navikt/familie-datovelger';
 import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../context/AppContext';
 import type { IBehandling } from '../../../../typer/behandling';
 import type { IFeilutbetaltValutaSkjemaFelter } from '../../../../typer/eøs-feilutbetalt-valuta';
 import { ToggleNavn } from '../../../../typer/toggles';
-import { serializeIso8601String, sisteDagIInneværendeMåned } from '../../../../utils/kalender';
-import { tilFørsteDagIMånedenHvisGyldigInput, tilSisteDagIMånedenHvisGyldigInput } from '../utils';
+import Månedvelger, { DagIMåneden } from '../../../Felleskomponenter/Datovelger/Månedvelger';
 
 interface IFeilutbetaltValutaSkjemaProps {
     skjema: ISkjema<IFeilutbetaltValutaSkjemaFelter, IBehandling>;
@@ -47,33 +44,20 @@ const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjem
             <FlexDatoInputWrapper>
                 <Label size="small">Angi periode med feilutbetalt valuta</Label>
                 <FlexRowDiv style={{ gap: '2rem' }}>
-                    <FamilieDatovelger
-                        {...skjema.felter.fom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        id="fom-dato"
-                        label="F.o.m"
-                        value={skjema.felter.fom.verdi}
-                        onChange={(dato?: ISODateString) => {
-                            skjema.felter.fom?.validerOgSettFelt(
-                                tilFørsteDagIMånedenHvisGyldigInput(dato)
-                            );
-                        }}
-                        limitations={{
-                            maxDate: serializeIso8601String(sisteDagIInneværendeMåned()),
-                        }}
+                    <Månedvelger
+                        felt={skjema.felter.fom}
+                        label={'F.o.m'}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        dagIMåneden={DagIMåneden.FØRSTE_DAG}
+                        kanKunVelgeFortid
                     />
-                    <FamilieDatovelger
-                        {...skjema.felter.tom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        id="fom-dato"
-                        label="T.o.m"
-                        value={skjema.felter.tom.verdi}
-                        onChange={(dato?: ISODateString) =>
-                            skjema.felter.tom?.validerOgSettFelt(
-                                tilSisteDagIMånedenHvisGyldigInput(dato)
-                            )
-                        }
-                        limitations={{
-                            maxDate: serializeIso8601String(sisteDagIInneværendeMåned()),
-                        }}
+                    <Månedvelger
+                        felt={skjema.felter.tom}
+                        label={'T.o.m'}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        dagIMåneden={DagIMåneden.SISTE_DAG}
+                        tilhørendeFomFelt={skjema.felter.fom}
+                        kanKunVelgeFortid
                     />
                 </FlexRowDiv>
             </FlexDatoInputWrapper>

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaSkjema.tsx
@@ -7,12 +7,16 @@ import type { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../context/AppContext';
 import type { IBehandling } from '../../../../typer/behandling';
-import type { IFeilutbetaltValutaSkjemaFelter } from '../../../../typer/eøs-feilutbetalt-valuta';
+import type {
+    IFeilutbetaltValutaSkjemaFelter,
+    IRestFeilutbetaltValuta,
+} from '../../../../typer/eøs-feilutbetalt-valuta';
 import { ToggleNavn } from '../../../../typer/toggles';
 import Månedvelger, { DagIMåneden } from '../../../Felleskomponenter/Datovelger/Månedvelger';
 
 interface IFeilutbetaltValutaSkjemaProps {
     skjema: ISkjema<IFeilutbetaltValutaSkjemaFelter, IBehandling>;
+    feilutbetaltValuta?: IRestFeilutbetaltValuta;
 }
 
 const FlexDatoInputWrapper = styled.div`
@@ -37,8 +41,10 @@ const StyledTextField = styled(TextField)`
 
 const FeilutbetaltValutaSkjema: React.FunctionComponent<IFeilutbetaltValutaSkjemaProps> = ({
     skjema,
+    feilutbetaltValuta,
 }) => {
     const { toggles } = useApp();
+    console.log(feilutbetaltValuta);
     return (
         <>
             <FlexDatoInputWrapper>

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
@@ -106,7 +106,7 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
         }
     };
 
-    const oppdaterEksisterendePeriode = async () => {
+    const oppdaterEksisterendePeriode = async (lukkPeriode: () => void) => {
         if (kanSendeSkjema() && feilutbetaltValuta) {
             onSubmit<IRestFeilutbetaltValuta>(
                 {
@@ -124,6 +124,7 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
                 (behandling: Ressurs<IBehandling>) => {
                     if (behandling.status === RessursStatus.SUKSESS) {
                         settÅpenBehandling(behandling);
+                        lukkPeriode();
                     } else {
                         settFeilmelding('Klarte ikke å lagre endringer');
                     }

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
@@ -63,11 +63,16 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
     });
 
     useEffect(() => {
+        tilbakestillSkjemafelterTilDefault();
+    }, [feilutbetaltValuta]);
+
+    const tilbakestillSkjemafelterTilDefault = () => {
         if (feilutbetaltValuta !== undefined) {
             skjema.felter.fom.validerOgSettFelt(new Date(feilutbetaltValuta.fom));
             skjema.felter.tom.validerOgSettFelt(new Date(feilutbetaltValuta.tom));
         }
-    }, [feilutbetaltValuta]);
+        skjema.felter.feilutbetaltBeløp.nullstill();
+    };
 
     const lagreNyPeriode = (lukkNyPeriode: () => void) => {
         if (kanSendeSkjema()) {
@@ -145,6 +150,7 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
         fjernPeriode,
         nullstillSkjema,
         valideringErOk,
+        tilbakestillSkjemafelterTilDefault,
     };
 };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import type { FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
@@ -62,10 +62,6 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
         skjemanavn: 'Feilutbetalt valuta',
     });
 
-    useEffect(() => {
-        tilbakestillSkjemafelterTilDefault();
-    }, []);
-
     const tilbakestillSkjemafelterTilDefault = () => {
         if (feilutbetaltValuta !== undefined) {
             skjema.felter.fom.validerOgSettFelt(new Date(feilutbetaltValuta.fom));
@@ -74,7 +70,8 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
         skjema.felter.feilutbetaltBeløp.nullstill();
     };
 
-    const [forrigeFeilutbetaltValuta, settForrigeFeilutbetaltValuta] = useState(feilutbetaltValuta);
+    const [forrigeFeilutbetaltValuta, settForrigeFeilutbetaltValuta] =
+        useState<IRestFeilutbetaltValuta>();
 
     if (forrigeFeilutbetaltValuta !== feilutbetaltValuta) {
         settForrigeFeilutbetaltValuta(feilutbetaltValuta);

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetaltValuta/useFeilutbetaltValuta.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
@@ -64,7 +64,7 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
 
     useEffect(() => {
         tilbakestillSkjemafelterTilDefault();
-    }, [feilutbetaltValuta]);
+    }, []);
 
     const tilbakestillSkjemafelterTilDefault = () => {
         if (feilutbetaltValuta !== undefined) {
@@ -73,6 +73,13 @@ const useFeilutbetaltValuta = ({ feilutbetaltValuta, settFeilmelding, behandling
         }
         skjema.felter.feilutbetaltBeløp.nullstill();
     };
+
+    const [forrigeFeilutbetaltValuta, settForrigeFeilutbetaltValuta] = useState(feilutbetaltValuta);
+
+    if (forrigeFeilutbetaltValuta !== feilutbetaltValuta) {
+        settForrigeFeilutbetaltValuta(feilutbetaltValuta);
+        tilbakestillSkjemafelterTilDefault();
+    }
 
     const lagreNyPeriode = (lukkNyPeriode: () => void) => {
         if (kanSendeSkjema()) {

--- a/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
@@ -9,7 +9,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useKorrigerVedtakSkjemaContext } from '../../../../context/KorrigerVedtak/KorrigerVedtakSkjemaContext';
 import type { IRestKorrigertVedtak } from '../../../../typer/vedtak';
-import Datovelger from '../../../Felleskomponenter/Datovelger';
+import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
 
 const AngreKnapp = styled(Button)`
     margin: 0.5rem 0;

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/NyRefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/NyRefusjonEøsPeriode.tsx
@@ -29,13 +29,12 @@ const NyRefusjonEøsPeriode: React.FC<INyRefusjonEøsPeriodeProps> = ({
 }) => {
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const { skjema, lagreNyPeriode, nullstillSkjema, valideringErOk } = useRefusjonEøs({
+    const { skjema, lagreNyPeriode, valideringErOk } = useRefusjonEøs({
         behandlingId,
         settFeilmelding: settFeilmelding,
     });
 
     const avbrytLeggTilNy = () => {
-        nullstillSkjema();
         lukkNyPeriode();
     };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -45,7 +45,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
     } = useRefusjonEøs({
         behandlingId,
         refusjonEøs,
-        settFeilmelding: settFeilmelding,
+        settFeilmelding,
     });
 
     const tilbakestillOgLukkSkjema = () => {

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -68,7 +68,10 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
             onOpenChange={håndterLukkingOgÅpningAvPanel}
             content={
                 <FlexColumnDiv>
-                    {erRadEkspandert && <RefusjonEøsSkjema skjema={skjema} />}
+                    <RefusjonEøsSkjema
+                        skjema={skjema}
+                        key={erRadEkspandert ? 'ekspandert' : 'lukket'}
+                    />
                     {!erLesevisning && (
                         <FlexRowDiv>
                             <Button

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -49,17 +49,17 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
     });
 
     useEffect(() => {
-        lukkSkjema();
+        tilbakestillOgLukkSkjema();
     }, [refusjonEøs]);
 
-    const lukkSkjema = () => {
+    const tilbakestillOgLukkSkjema = () => {
         settErRadEkspandert(false);
         tilbakestillSkjemafelterTilDefault();
     };
 
     const håndterLukkingOgÅpningAvPanel = () => {
         if (erRadEkspandert) {
-            lukkSkjema();
+            tilbakestillOgLukkSkjema();
         } else {
             validerAlleSynligeFelter();
             settErRadEkspandert(true);
@@ -82,7 +82,11 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
                             >
                                 Lagre periode
                             </Button>
-                            <Button size="small" variant="tertiary" onClick={lukkSkjema}>
+                            <Button
+                                size="small"
+                                variant="tertiary"
+                                onClick={tilbakestillOgLukkSkjema}
+                            >
                                 Avbryt
                             </Button>
                         </FlexRowDiv>

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -41,6 +41,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
         fjernPeriode,
         valideringErOk,
         validerAlleSynligeFelter,
+        tilbakestillSkjemafelterTilDefault,
     } = useRefusjonEøs({
         behandlingId,
         refusjonEøs,
@@ -53,6 +54,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
 
     const lukkSkjema = () => {
         settErRadEkspandert(false);
+        tilbakestillSkjemafelterTilDefault();
     };
 
     const håndterLukkingOgÅpningAvPanel = () => {
@@ -70,7 +72,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
             onOpenChange={håndterLukkingOgÅpningAvPanel}
             content={
                 <FlexColumnDiv>
-                    <RefusjonEøsSkjema skjema={skjema} />
+                    {erRadEkspandert && <RefusjonEøsSkjema skjema={skjema} />}
                     {!erLesevisning && (
                         <FlexRowDiv>
                             <Button

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -48,10 +48,6 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
         settFeilmelding: settFeilmelding,
     });
 
-    useEffect(() => {
-        tilbakestillOgLukkSkjema();
-    }, [refusjonEøs]);
-
     const tilbakestillOgLukkSkjema = () => {
         settErRadEkspandert(false);
         tilbakestillSkjemafelterTilDefault();
@@ -66,6 +62,10 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
         }
     };
 
+    const lagrePeriodeOgLukkPanel = () => {
+        oppdaterEksisterendePeriode().then(() => settErRadEkspandert(false));
+    };
+
     return (
         <Table.ExpandableRow
             open={erRadEkspandert}
@@ -77,7 +77,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
                         <FlexRowDiv>
                             <Button
                                 size="small"
-                                onClick={oppdaterEksisterendePeriode}
+                                onClick={lagrePeriodeOgLukkPanel}
                                 variant={valideringErOk() ? 'primary' : 'secondary'}
                             >
                                 Lagre periode

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -62,10 +62,6 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
         }
     };
 
-    const lagrePeriodeOgLukkPanel = () => {
-        oppdaterEksisterendePeriode().then(() => settErRadEkspandert(false));
-    };
-
     return (
         <Table.ExpandableRow
             open={erRadEkspandert}
@@ -77,7 +73,9 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
                         <FlexRowDiv>
                             <Button
                                 size="small"
-                                onClick={lagrePeriodeOgLukkPanel}
+                                onClick={() =>
+                                    oppdaterEksisterendePeriode(() => settErRadEkspandert(false))
+                                }
                                 variant={valideringErOk() ? 'primary' : 'secondary'}
                             >
                                 Lagre periode

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -70,7 +70,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
                 <FlexColumnDiv>
                     <RefusjonEøsSkjema
                         skjema={skjema}
-                        key={erRadEkspandert ? 'ekspandert' : 'lukket'}
+                        key={`${refusjonEøs.id}-$${erRadEkspandert ? 'ekspandert' : 'lukket'}`}
                     />
                     {!erLesevisning && (
                         <FlexRowDiv>

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -38,7 +38,6 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
     const {
         skjema,
         oppdaterEksisterendePeriode,
-        nullstillSkjema,
         fjernPeriode,
         valideringErOk,
         validerAlleSynligeFelter,
@@ -49,17 +48,16 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
     });
 
     useEffect(() => {
-        nullstillOgLukkSkjema();
+        lukkSkjema();
     }, [refusjonEøs]);
 
-    const nullstillOgLukkSkjema = () => {
-        nullstillSkjema();
+    const lukkSkjema = () => {
         settErRadEkspandert(false);
     };
 
     const håndterLukkingOgÅpningAvPanel = () => {
         if (erRadEkspandert) {
-            nullstillOgLukkSkjema();
+            lukkSkjema();
         } else {
             validerAlleSynligeFelter();
             settErRadEkspandert(true);
@@ -82,7 +80,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
                             >
                                 Lagre periode
                             </Button>
-                            <Button size="small" variant="tertiary" onClick={nullstillOgLukkSkjema}>
+                            <Button size="small" variant="tertiary" onClick={lukkSkjema}>
                                 Avbryt
                             </Button>
                         </FlexRowDiv>

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
@@ -4,8 +4,6 @@ import styled from 'styled-components';
 
 import { Label, Radio, TextField } from '@navikt/ds-react';
 import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
-import type { ISODateString } from '@navikt/familie-datovelger';
-import { FamilieDatovelger } from '@navikt/familie-datovelger';
 import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
 import type { ISkjema } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
@@ -15,9 +13,8 @@ import { useBehandling } from '../../../../context/behandlingContext/BehandlingC
 import type { IBehandling } from '../../../../typer/behandling';
 import type { IRefusjonEøsSkjemaFelter } from '../../../../typer/refusjon-eøs';
 import { randomUUID } from '../../../../utils/commons';
-import { serializeIso8601String, sisteDagIInneværendeMåned } from '../../../../utils/kalender';
+import Månedvelger, { DagIMåneden } from '../../../Felleskomponenter/Datovelger/Månedvelger';
 import { FamilieLandvelger } from '../../Behandlingsresultat/EøsPeriode/FamilieLandvelger';
-import { tilFørsteDagIMånedenHvisGyldigInput, tilSisteDagIMånedenHvisGyldigInput } from '../utils';
 
 interface IRefusjonEøsSkjemaProps {
     skjema: ISkjema<IRefusjonEøsSkjemaFelter, IBehandling>;
@@ -110,35 +107,22 @@ const RefusjonEøsSkjema: React.FunctionComponent<IRefusjonEøsSkjemaProps> = ({
             <FlexDatoInputWrapper>
                 <Label size="small">Angi periode som skal refunderes til EØS-land</Label>
                 <FlexRowDiv style={{ gap: '2rem' }}>
-                    <FamilieDatovelger
-                        {...skjema.felter.fom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        id={`fom-dato-${inputUuid}`}
-                        label="F.o.m"
-                        value={skjema.felter.fom.verdi}
-                        onChange={(dato?: ISODateString) => {
-                            skjema.felter.fom.validerOgSettFelt(
-                                tilFørsteDagIMånedenHvisGyldigInput(dato)
-                            );
-                        }}
-                        limitations={{
-                            maxDate: serializeIso8601String(sisteDagIInneværendeMåned()),
-                        }}
-                        erLesesvisning={erLesevisning}
+                    <Månedvelger
+                        felt={skjema.felter.fom}
+                        label={'F.o.m'}
+                        readOnly={erLesevisning}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        dagIMåneden={DagIMåneden.FØRSTE_DAG}
+                        kanKunVelgeFortid
                     />
-                    <FamilieDatovelger
-                        {...skjema.felter.tom?.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        id={`fom-dato-${inputUuid}`}
-                        label="T.o.m"
-                        value={skjema.felter.tom.verdi}
-                        onChange={(dato?: ISODateString) =>
-                            skjema.felter.tom.validerOgSettFelt(
-                                tilSisteDagIMånedenHvisGyldigInput(dato)
-                            )
-                        }
-                        limitations={{
-                            maxDate: serializeIso8601String(sisteDagIInneværendeMåned()),
-                        }}
-                        erLesesvisning={erLesevisning}
+                    <Månedvelger
+                        felt={skjema.felter.tom}
+                        label={'T.o.m'}
+                        visFeilmeldinger={skjema.visFeilmeldinger}
+                        readOnly={erLesevisning}
+                        dagIMåneden={DagIMåneden.SISTE_DAG}
+                        tilhørendeFomFelt={skjema.felter.fom}
+                        kanKunVelgeFortid
                     />
                 </FlexRowDiv>
             </FlexDatoInputWrapper>

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import type { FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
@@ -69,10 +69,6 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
             skjemanavn: 'Refusjon EØS',
         });
 
-    useEffect(() => {
-        tilbakestillSkjemafelterTilDefault();
-    }, []);
-
     const tilbakestillSkjemafelterTilDefault = () => {
         if (refusjonEøs !== undefined) {
             skjema.felter.fom.validerOgSettFelt(new Date(refusjonEøs.fom));
@@ -83,7 +79,7 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
         skjema.felter.refusjonAvklart.nullstill();
     };
 
-    const [forrigeRefusjonEøs, settForrigeRefusjonEøs] = useState(refusjonEøs);
+    const [forrigeRefusjonEøs, settForrigeRefusjonEøs] = useState<IRestRefusjonEøs>();
 
     if (forrigeRefusjonEøs !== refusjonEøs) {
         settForrigeRefusjonEøs(refusjonEøs);

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
@@ -116,7 +116,7 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
         }
     };
 
-    const oppdaterEksisterendePeriode = async () => {
+    const oppdaterEksisterendePeriode = async (lukkPeriode: () => void) => {
         if (kanSendeSkjema() && refusjonEøs) {
             onSubmit<IRestRefusjonEøs>(
                 {
@@ -135,6 +135,7 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
                 (behandling: Ressurs<IBehandling>) => {
                     if (behandling.status === RessursStatus.SUKSESS) {
                         settÅpenBehandling(behandling);
+                        lukkPeriode();
                     } else {
                         settFeilmelding('Klarte ikke å lagre endringer');
                     }

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
@@ -48,39 +48,40 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
             felt.verdi !== undefined ? ok(felt) : feil(felt, 'Du må oppgi om refusjon er avklart'),
     });
 
-    const {
-        skjema,
-        kanSendeSkjema,
-        onSubmit,
-        nullstillSkjema,
-        valideringErOk,
-        validerAlleSynligeFelter,
-    } = useSkjema<IRefusjonEøsSkjemaFelter, IBehandling>({
-        felter: {
-            fom: fomFelt,
-            tom: useFelt<Date | undefined>({
-                verdi: undefined,
-                avhengigheter: {
-                    fom: fomFelt,
-                },
-                valideringsfunksjon: validerGyldigDato,
-            }),
-            refusjonsbeløp: useFelt<string>({
-                verdi: refusjonEøs?.refusjonsbeløp.toString() ?? '',
-                valideringsfunksjon: validerFeilutbetaltBeløp,
-            }),
-            land,
-            refusjonAvklart,
-        },
-        skjemanavn: 'Refusjon EØS',
-    });
+    const { skjema, kanSendeSkjema, onSubmit, valideringErOk, validerAlleSynligeFelter } =
+        useSkjema<IRefusjonEøsSkjemaFelter, IBehandling>({
+            felter: {
+                fom: fomFelt,
+                tom: useFelt<Date | undefined>({
+                    verdi: undefined,
+                    avhengigheter: {
+                        fom: fomFelt,
+                    },
+                    valideringsfunksjon: validerGyldigDato,
+                }),
+                refusjonsbeløp: useFelt<string>({
+                    verdi: refusjonEøs?.refusjonsbeløp.toString() ?? '',
+                    valideringsfunksjon: validerFeilutbetaltBeløp,
+                }),
+                land,
+                refusjonAvklart,
+            },
+            skjemanavn: 'Refusjon EØS',
+        });
 
     useEffect(() => {
+        tilbakestillSkjemafelterTilDefault();
+    }, [refusjonEøs]);
+
+    const tilbakestillSkjemafelterTilDefault = () => {
         if (refusjonEøs !== undefined) {
             skjema.felter.fom.validerOgSettFelt(new Date(refusjonEøs.fom));
             skjema.felter.tom.validerOgSettFelt(new Date(refusjonEøs.tom));
         }
-    }, [refusjonEøs]);
+        skjema.felter.refusjonsbeløp.nullstill();
+        skjema.felter.land.nullstill();
+        skjema.felter.refusjonAvklart.nullstill();
+    };
 
     const lagreNyPeriode = (lukkNyPeriode: () => void) => {
         if (kanSendeSkjema()) {
@@ -158,9 +159,9 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
         lagreNyPeriode,
         oppdaterEksisterendePeriode,
         fjernPeriode,
-        nullstillSkjema,
         valideringErOk,
         validerAlleSynligeFelter,
+        tilbakestillSkjemafelterTilDefault,
     };
 };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/useRefusjonEøs.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
@@ -71,7 +71,7 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
 
     useEffect(() => {
         tilbakestillSkjemafelterTilDefault();
-    }, [refusjonEøs]);
+    }, []);
 
     const tilbakestillSkjemafelterTilDefault = () => {
         if (refusjonEøs !== undefined) {
@@ -82,6 +82,13 @@ const useRefusjonEøs = ({ refusjonEøs, settFeilmelding, behandlingId }: IProps
         skjema.felter.land.nullstill();
         skjema.felter.refusjonAvklart.nullstill();
     };
+
+    const [forrigeRefusjonEøs, settForrigeRefusjonEøs] = useState(refusjonEøs);
+
+    if (forrigeRefusjonEøs !== refusjonEøs) {
+        settForrigeRefusjonEøs(refusjonEøs);
+        tilbakestillSkjemafelterTilDefault();
+    }
 
     const lagreNyPeriode = (lukkNyPeriode: () => void) => {
         if (kanSendeSkjema()) {

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
@@ -19,7 +19,7 @@ import { useBehandling } from '../../../../../context/behandlingContext/Behandli
 import { formatterDate } from '../../../../../utils/dato';
 import { Datoformat } from '../../../../../utils/formatter';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import Datovelger from '../../../../Felleskomponenter/Datovelger';
+import Datovelger from '../../../../Felleskomponenter/Datovelger/Datovelger';
 
 const StyledAlert = styled(Alert)`
     margin-top: 2rem;

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -37,14 +37,14 @@ const Datovelger = ({
 
     const hentToDate = () => {
         if (maksDatoAvgrensning) return maksDatoAvgrensning;
-        if (kanKunVelgeFortid) return dagensDato();
-        return senesteRelevanteDato();
+        if (kanKunVelgeFortid) return dagensDato;
+        return senesteRelevanteDato;
     };
 
     const hentFromDate = () => {
         if (minDatoAvgrensning) return minDatoAvgrensning;
-        if (kanKunVelgeFremtid) return dagensDato();
-        return tidligsteRelevanteDato();
+        if (kanKunVelgeFremtid) return dagensDato;
+        return tidligsteRelevanteDato;
     };
 
     const nullstillOgSettFeilmelding = (feilmelding: Feilmelding) => {

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -69,7 +69,7 @@ const Datovelger = ({
             } else if (val.isAfter) {
                 nullstillOgSettFeilmelding(Feilmelding.ETTER_MAKS_DATO);
             } else if (!val.isValidDate) {
-                nullstillOgSettFeilmelding(Feilmelding.UGYDLIG_DATO);
+                nullstillOgSettFeilmelding(Feilmelding.UGYLDIG_DATO);
             } else {
                 setError(undefined);
             }
@@ -96,7 +96,7 @@ const Datovelger = ({
     };
 
     const feilmeldinger: Record<Feilmelding, string> = {
-        UGYDLIG_DATO: 'Du må velge en gyldig dato',
+        UGYLDIG_DATO: 'Du må velge en gyldig dato',
         FØR_MIN_DATO: feilmeldingForDatoFørMinDato(),
         ETTER_MAKS_DATO: feilmeldingForDatoEtterMaksDato(),
     };

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { addDays, format, startOfDay, subDays } from 'date-fns';
+import { addDays, format, subDays } from 'date-fns';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
+import { Feilmelding, senesteRelevanteDato, tidligsteRelevanteDato } from './utils';
 import { dagensDato } from '../../../utils/dato';
 import { Datoformat } from '../../../utils/formatter';
 
@@ -20,16 +21,6 @@ interface IProps {
     datoMåFyllesUt?: boolean;
     readOnly?: boolean;
 }
-
-enum Feilmelding {
-    UGYDLIG_DATO = 'UGYDLIG_DATO',
-    FØR_MIN_DATO = 'FØR_MIN_DATO',
-    ETTER_MAKS_DATO = 'ETTER_MAKS_DATO',
-}
-
-const tidligsteRelevanteDato = () => startOfDay(new Date(1900, 0));
-
-const senesteRelevanteDato = () => startOfDay(new Date(2500, 0));
 
 const Datovelger = ({
     felt,

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -6,8 +6,8 @@ import { addDays, format, startOfDay, subDays } from 'date-fns';
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
-import { dagensDato } from '../../utils/dato';
-import { Datoformat } from '../../utils/formatter';
+import { dagensDato } from '../../../utils/dato';
+import { Datoformat } from '../../../utils/formatter';
 
 interface IProps {
     felt: Felt<Date | undefined>;

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { endOfMonth, isAfter, isSameDay, startOfDay, startOfMonth } from 'date-fns';
 
@@ -46,6 +46,9 @@ const Månedvelger = ({
     tilhørendeFomFelt,
 }: IProps) => {
     const [error, setError] = useState<Feilmelding | undefined>();
+    const [forrigeTilhørendeFomVerdi, settforrigeTilhørendeFomVerdi] = useState(
+        tilhørendeFomFelt?.verdi
+    );
 
     const hentFromDate = () => {
         if (tilhørendeFomFelt?.verdi !== undefined) return tilhørendeFomFelt.verdi;
@@ -94,7 +97,7 @@ const Månedvelger = ({
         },
     });
 
-    useEffect(() => {
+    const validerDatoErGyldigIKombinasjonMedTilhøredeFom = () => {
         if (
             tilhørendeFomFelt?.verdi &&
             selectedMonth &&
@@ -105,7 +108,12 @@ const Månedvelger = ({
             setError(undefined);
             felt.validerOgSettFelt(selectedMonth);
         }
-    }, [tilhørendeFomFelt?.verdi]);
+    };
+
+    if (forrigeTilhørendeFomVerdi !== tilhørendeFomFelt?.verdi) {
+        settforrigeTilhørendeFomVerdi(tilhørendeFomFelt?.verdi);
+        validerDatoErGyldigIKombinasjonMedTilhøredeFom();
+    }
 
     const feilmeldingForDatoFørMinDato = () => {
         const tidligsteFraDato = hentFromDate();

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
-import { endOfMonth, isAfter, isSameDay, isValid, startOfDay, startOfMonth } from 'date-fns';
+import { endOfMonth, isAfter, isSameDay, startOfDay, startOfMonth } from 'date-fns';
 
 import { MonthPicker, useMonthpicker } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
@@ -65,7 +65,7 @@ const Månedvelger = ({
         }
     };
 
-    const { monthpickerProps, inputProps, selectedMonth, setSelected } = useMonthpicker({
+    const { monthpickerProps, inputProps, selectedMonth } = useMonthpicker({
         defaultSelected: felt.verdi,
         onMonthChange: (dato?: Date) => {
             if (dato === undefined) felt.nullstill();
@@ -91,12 +91,6 @@ const Månedvelger = ({
             }
         },
     });
-
-    useEffect(() => {
-        if (selectedMonth === undefined && isValid(felt.verdi)) {
-            setSelected(felt.verdi);
-        }
-    }, [felt.verdi]);
 
     useEffect(() => {
         if (

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+import { endOfMonth, isAfter, isSameDay, isValid, startOfDay, startOfMonth } from 'date-fns';
+
+import { MonthPicker, useMonthpicker } from '@navikt/ds-react';
+import type { Felt } from '@navikt/familie-skjema';
+
+import { dagensDato, formatterDate } from '../../../utils/dato';
+import { Datoformat } from '../../../utils/formatter';
+
+interface IProps {
+    felt: Felt<Date | undefined>;
+    label: string;
+    readOnly?: boolean;
+    visFeilmeldinger: boolean;
+    kanKunVelgeFortid?: boolean;
+    kanKunVelgeFremtid?: boolean;
+    dagIMåneden: DagIMåneden;
+    tilhørendeFomFelt?: Felt<Date | undefined>;
+}
+
+enum Feilmelding {
+    UGYDLIG_DATO = 'UGYDLIG_DATO',
+    FØR_MIN_DATO = 'FØR_MIN_DATO',
+    ETTER_MAKS_DATO = 'ETTER_MAKS_DATO',
+}
+
+export enum DagIMåneden {
+    FØRSTE_DAG = 'FØRSTE_DAG',
+    SISTE_DAG = 'SISTE_DAG',
+}
+
+const tidligsteRelevanteDato = () => startOfDay(new Date(1900, 0));
+
+const senesteRelevanteDato = () => startOfDay(new Date(2500, 0));
+
+const Månedvelger = ({
+    felt,
+    label,
+    visFeilmeldinger,
+    dagIMåneden,
+    readOnly = false,
+    kanKunVelgeFremtid = false,
+    kanKunVelgeFortid = false,
+    tilhørendeFomFelt,
+}: IProps) => {
+    const [error, setError] = useState<Feilmelding | undefined>();
+
+    const hentFromDate = () => {
+        if (tilhørendeFomFelt?.verdi !== undefined) return tilhørendeFomFelt.verdi;
+        if (kanKunVelgeFremtid) return dagensDato();
+        return tidligsteRelevanteDato();
+    };
+
+    const hentToDate = () => {
+        if (kanKunVelgeFortid) return dagensDato();
+        return senesteRelevanteDato();
+    };
+
+    const nullstillOgSettFeilmelding = (feilmelding: Feilmelding) => {
+        if (error !== feilmelding) {
+            setError(feilmelding);
+            felt.nullstill();
+        }
+    };
+
+    const { monthpickerProps, inputProps, selectedMonth, setSelected } = useMonthpicker({
+        defaultSelected: felt.verdi,
+        onMonthChange: (dato?: Date) => {
+            if (dato === undefined) felt.nullstill();
+            else {
+                if (dagIMåneden === DagIMåneden.FØRSTE_DAG) {
+                    felt.validerOgSettFelt(startOfMonth(dato));
+                } else if (dagIMåneden === DagIMåneden.SISTE_DAG) {
+                    felt.validerOgSettFelt(endOfMonth(dato));
+                } else felt.validerOgSettFelt(dato);
+            }
+        },
+        fromDate: hentFromDate(),
+        toDate: hentToDate(),
+        onValidate: val => {
+            if (val.isBefore) {
+                nullstillOgSettFeilmelding(Feilmelding.FØR_MIN_DATO);
+            } else if (val.isAfter) {
+                nullstillOgSettFeilmelding(Feilmelding.ETTER_MAKS_DATO);
+            } else if (!val.isValidMonth) {
+                nullstillOgSettFeilmelding(Feilmelding.UGYDLIG_DATO);
+            } else {
+                setError(undefined);
+            }
+        },
+    });
+
+    useEffect(() => {
+        if (selectedMonth === undefined && isValid(felt.verdi)) {
+            setSelected(felt.verdi);
+        }
+    }, [felt.verdi]);
+
+    useEffect(() => {
+        if (
+            tilhørendeFomFelt?.verdi &&
+            selectedMonth &&
+            isAfter(tilhørendeFomFelt.verdi, selectedMonth)
+        ) {
+            nullstillOgSettFeilmelding(Feilmelding.FØR_MIN_DATO);
+        } else {
+            setError(undefined);
+            felt.validerOgSettFelt(selectedMonth);
+        }
+    }, [tilhørendeFomFelt?.verdi]);
+
+    const feilmeldingForDatoFørMinDato = () => {
+        const tidligsteFraDato = hentFromDate();
+
+        if (isSameDay(tidligsteFraDato, dagensDato())) {
+            return 'Du kan ikke sette en måned som er tilbake i tid';
+        }
+        if (tilhørendeFomFelt?.verdi && isSameDay(tidligsteFraDato, tilhørendeFomFelt?.verdi)) {
+            return `Du må velge en måned som er ${formatterDate({
+                dato: tilhørendeFomFelt.verdi,
+                datoformat: Datoformat.MÅNED_ÅR_NAVN,
+            })} eller senere`;
+        }
+
+        return `Du må velge en måned som er senere enn ${formatterDate({
+            dato: tidligsteFraDato,
+            datoformat: Datoformat.MÅNED_ÅR_NAVN,
+        })}`;
+    };
+
+    const feilmeldingForDatoFørMaksDato = () => {
+        if (kanKunVelgeFortid) {
+            return 'Du kan ikke sette en måned som er frem i tid';
+        }
+        const senesteDato = hentToDate();
+        return `Du må velge en måned som er tidligere enn ${formatterDate({
+            dato: senesteDato,
+            datoformat: Datoformat.MÅNED_ÅR_NAVN,
+        })}`;
+    };
+
+    const feilmeldinger: Record<Feilmelding, string> = {
+        UGYDLIG_DATO: 'Du må velge en gyldig måned',
+        FØR_MIN_DATO: feilmeldingForDatoFørMinDato(),
+        ETTER_MAKS_DATO: feilmeldingForDatoFørMaksDato(),
+    };
+
+    return (
+        <div>
+            <MonthPicker {...monthpickerProps} dropdownCaption>
+                <MonthPicker.Input
+                    {...inputProps}
+                    label={label}
+                    readOnly={readOnly}
+                    error={
+                        error && visFeilmeldinger
+                            ? feilmeldinger[error]
+                            : felt.hentNavBaseSkjemaProps(visFeilmeldinger).error
+                    }
+                />
+            </MonthPicker>
+        </div>
+    );
+};
+
+export default Månedvelger;

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { useState } from 'react';
 
-import { endOfMonth, isAfter, isSameDay, startOfDay, startOfMonth } from 'date-fns';
+import { endOfMonth, isAfter, isSameDay, startOfMonth } from 'date-fns';
 
 import { MonthPicker, useMonthpicker } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
+import { Feilmelding, senesteRelevanteDato, tidligsteRelevanteDato } from './utils';
 import { dagensDato, formatterDate } from '../../../utils/dato';
 import { Datoformat } from '../../../utils/formatter';
 
@@ -20,20 +21,10 @@ interface IProps {
     tilhørendeFomFelt?: Felt<Date | undefined>;
 }
 
-enum Feilmelding {
-    UGYDLIG_DATO = 'UGYDLIG_DATO',
-    FØR_MIN_DATO = 'FØR_MIN_DATO',
-    ETTER_MAKS_DATO = 'ETTER_MAKS_DATO',
-}
-
 export enum DagIMåneden {
     FØRSTE_DAG = 'FØRSTE_DAG',
     SISTE_DAG = 'SISTE_DAG',
 }
-
-const tidligsteRelevanteDato = () => startOfDay(new Date(1900, 0));
-
-const senesteRelevanteDato = () => startOfDay(new Date(2500, 0));
 
 const Månedvelger = ({
     felt,

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -65,16 +65,18 @@ const Månedvelger = ({
         }
     };
 
+    const formatterTilRiktigDagIMåneden = (dato: Date): Date => {
+        if (dagIMåneden === DagIMåneden.FØRSTE_DAG) return startOfMonth(dato);
+        else if (dagIMåneden === DagIMåneden.SISTE_DAG) return endOfMonth(dato);
+        else return dato;
+    };
+
     const { monthpickerProps, inputProps, selectedMonth } = useMonthpicker({
         defaultSelected: felt.verdi,
         onMonthChange: (dato?: Date) => {
             if (dato === undefined) felt.nullstill();
             else {
-                if (dagIMåneden === DagIMåneden.FØRSTE_DAG) {
-                    felt.validerOgSettFelt(startOfMonth(dato));
-                } else if (dagIMåneden === DagIMåneden.SISTE_DAG) {
-                    felt.validerOgSettFelt(endOfMonth(dato));
-                } else felt.validerOgSettFelt(dato);
+                felt.validerOgSettFelt(formatterTilRiktigDagIMåneden(dato));
             }
         },
         fromDate: hentFromDate(),
@@ -96,7 +98,7 @@ const Månedvelger = ({
         if (
             tilhørendeFomFelt?.verdi &&
             selectedMonth &&
-            isAfter(tilhørendeFomFelt.verdi, selectedMonth)
+            isAfter(tilhørendeFomFelt.verdi, formatterTilRiktigDagIMåneden(selectedMonth))
         ) {
             nullstillOgSettFeilmelding(Feilmelding.FØR_MIN_DATO);
         } else {

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -83,7 +83,7 @@ const Månedvelger = ({
             } else if (val.isAfter) {
                 nullstillOgSettFeilmelding(Feilmelding.ETTER_MAKS_DATO);
             } else if (!val.isValidMonth) {
-                nullstillOgSettFeilmelding(Feilmelding.UGYDLIG_DATO);
+                nullstillOgSettFeilmelding(Feilmelding.UGYLDIG_DATO);
             } else {
                 setError(undefined);
             }
@@ -136,7 +136,7 @@ const Månedvelger = ({
     };
 
     const feilmeldinger: Record<Feilmelding, string> = {
-        UGYDLIG_DATO: 'Du må velge en gyldig måned',
+        UGYLDIG_DATO: 'Du må velge en gyldig måned',
         FØR_MIN_DATO: feilmeldingForDatoFørMinDato(),
         ETTER_MAKS_DATO: feilmeldingForDatoEtterMaksDato(),
     };

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -124,7 +124,7 @@ const Månedvelger = ({
         })}`;
     };
 
-    const feilmeldingForDatoFørMaksDato = () => {
+    const feilmeldingForDatoEtterMaksDato = () => {
         if (kanKunVelgeFortid) {
             return 'Du kan ikke sette en måned som er frem i tid';
         }
@@ -138,7 +138,7 @@ const Månedvelger = ({
     const feilmeldinger: Record<Feilmelding, string> = {
         UGYDLIG_DATO: 'Du må velge en gyldig måned',
         FØR_MIN_DATO: feilmeldingForDatoFørMinDato(),
-        ETTER_MAKS_DATO: feilmeldingForDatoFørMaksDato(),
+        ETTER_MAKS_DATO: feilmeldingForDatoEtterMaksDato(),
     };
 
     return (

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -43,13 +43,13 @@ const Månedvelger = ({
 
     const hentFromDate = () => {
         if (tilhørendeFomFelt?.verdi !== undefined) return tilhørendeFomFelt.verdi;
-        if (kanKunVelgeFremtid) return dagensDato();
-        return tidligsteRelevanteDato();
+        if (kanKunVelgeFremtid) return dagensDato;
+        return tidligsteRelevanteDato;
     };
 
     const hentToDate = () => {
-        if (kanKunVelgeFortid) return dagensDato();
-        return senesteRelevanteDato();
+        if (kanKunVelgeFortid) return dagensDato;
+        return senesteRelevanteDato;
     };
 
     const nullstillOgSettFeilmelding = (feilmelding: Feilmelding) => {
@@ -108,7 +108,7 @@ const Månedvelger = ({
     const feilmeldingForDatoFørMinDato = () => {
         const tidligsteFraDato = hentFromDate();
 
-        if (isSameDay(tidligsteFraDato, dagensDato())) {
+        if (isSameDay(tidligsteFraDato, dagensDato)) {
             return 'Du kan ikke sette en måned som er tilbake i tid';
         }
         if (tilhørendeFomFelt?.verdi && isSameDay(tidligsteFraDato, tilhørendeFomFelt?.verdi)) {

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/utils.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/utils.ts
@@ -1,8 +1,8 @@
 import { startOfDay } from 'date-fns';
 
-export const tidligsteRelevanteDato = () => startOfDay(new Date(1900, 0));
+export const tidligsteRelevanteDato = startOfDay(new Date(1900, 0));
 
-export const senesteRelevanteDato = () => startOfDay(new Date(2500, 0));
+export const senesteRelevanteDato = startOfDay(new Date(2500, 0));
 
 export enum Feilmelding {
     UGYDLIG_DATO = 'UGYDLIG_DATO',

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/utils.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/utils.ts
@@ -1,0 +1,11 @@
+import { startOfDay } from 'date-fns';
+
+export const tidligsteRelevanteDato = () => startOfDay(new Date(1900, 0));
+
+export const senesteRelevanteDato = () => startOfDay(new Date(2500, 0));
+
+export enum Feilmelding {
+    UGYDLIG_DATO = 'UGYDLIG_DATO',
+    FØR_MIN_DATO = 'FØR_MIN_DATO',
+    ETTER_MAKS_DATO = 'ETTER_MAKS_DATO',
+}

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/utils.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/utils.ts
@@ -5,7 +5,7 @@ export const tidligsteRelevanteDato = startOfDay(new Date(1900, 0));
 export const senesteRelevanteDato = startOfDay(new Date(2500, 0));
 
 export enum Feilmelding {
-    UGYDLIG_DATO = 'UGYDLIG_DATO',
+    UGYLDIG_DATO = 'UGYLDIG_DATO',
     FØR_MIN_DATO = 'FØR_MIN_DATO',
     ETTER_MAKS_DATO = 'ETTER_MAKS_DATO',
 }

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -37,7 +37,7 @@ import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import { FamilieMultiLandvelger } from '../../../Fagsak/Behandlingsresultat/EøsPeriode/FamilieLandvelger';
 import DeltBostedSkjema from '../../../Fagsak/Dokumentutsending/DeltBosted/DeltBostedSkjema';
 import { useSamhandlerRequest } from '../../../Fagsak/InstitusjonOgVerge/useSamhandler';
-import Datovelger from '../../Datovelger';
+import Datovelger from '../../Datovelger/Datovelger';
 import Knapperekke from '../../Knapperekke';
 import PdfVisningModal from '../../PdfVisningModal/PdfVisningModal';
 

--- a/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDatoModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/RegistrerDødsfallDato/RegistrerDødsfallDatoModal.tsx
@@ -6,7 +6,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useRegistrerDødsfallDatoSkjemaContext } from '../../../context/RegistrerDødsfallDato/RegistrerDødsfallDatoSkjemaContext';
 import type { IGrunnlagPerson } from '../../../typer/person';
-import Datovelger from '../Datovelger';
+import Datovelger from '../Datovelger/Datovelger';
 
 interface IProps {
     lukkModal: () => void;

--- a/src/frontend/typer/eøs-feilutbetalt-valuta.ts
+++ b/src/frontend/typer/eøs-feilutbetalt-valuta.ts
@@ -1,21 +1,21 @@
-import type { FamilieIsoDate } from '../utils/kalender';
+import type { IsoDatoString } from '../utils/dato';
 
 export interface IRestFeilutbetaltValuta {
     id: number;
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: IsoDatoString;
+    tom: IsoDatoString;
     feilutbetaltBeløp: number;
     erPerMåned?: boolean;
 }
 
 export interface IRestNyFeilutbetaltValutaPeriode {
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: IsoDatoString;
+    tom: IsoDatoString;
     feilutbetaltBeløp: number;
 }
 
 export interface IFeilutbetaltValutaSkjemaFelter {
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: Date | undefined;
+    tom: Date | undefined;
     feilutbetaltBeløp: string;
 }

--- a/src/frontend/typer/refusjon-eøs.ts
+++ b/src/frontend/typer/refusjon-eøs.ts
@@ -1,24 +1,24 @@
-import type { FamilieIsoDate } from '../utils/kalender';
+import type { IsoDatoString } from '../utils/dato';
 export interface IRestRefusjonEøs {
     id: number;
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: IsoDatoString;
+    tom: IsoDatoString;
     refusjonsbeløp: number;
     land: string;
     refusjonAvklart: boolean;
 }
 
 export interface IRestNyRefusjonEøs {
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: IsoDatoString;
+    tom: IsoDatoString;
     refusjonsbeløp: number;
     land: string;
     refusjonAvklart: boolean;
 }
 
 export interface IRefusjonEøsSkjemaFelter {
-    fom: FamilieIsoDate;
-    tom: FamilieIsoDate;
+    fom: Date | undefined;
+    tom: Date | undefined;
     refusjonsbeløp: string;
     land: string;
     refusjonAvklart: boolean | undefined;

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -7,7 +7,7 @@ import { Datoformat } from './formatter';
 
 export type IsoDatoString = string; // Format YYYY-MM-DD (ISO)
 
-export const dagensDato = () => startOfToday();
+export const dagensDato = startOfToday();
 
 interface FormatterProps {
     dato?: Date;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16053

Bytter ut gamle datovelger-komponenter for "feilutbetalt valute" og "refusjon EØS". I stedet for å gå til ny Datepicker, velger jeg å gå til Monthpicker. Dette er fordi den forrige datovelgeren kun hadde 1 gyldig dato hver måned å velge, så du velger egentlig måned og ikke dag. Har gjort dette i samarbeid med Lars og Anna.

Har laget ny Månedsvelger-komponent som ligner veldig på Datovelger-komponenten, men litt tilpasset. Har trukket fellesting ut i egen fil.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei, se kommentarer isåfall

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bytter ut komponenter, så ser ikke helt poenget

### 🤷‍♀ ️Hvor er det lurt å starte?
Kan være fint å gå commit for commit, men det er mange endringer som har blitt justert i etterkant, så sjekk gjerne det endelige "resultatet" før dere kommenterer på ting 😅

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Feilutbetalt valuta
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/03ed6852-8f35-42d7-ab5d-3555145e130f)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/b6a2db10-98af-4ebc-a979-a3d1f0a078cd)


Refusjon EØS
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/105fd58d-03a7-41cb-a83b-47fc35bf3adc)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/55f56d4b-6265-4e87-b3c3-c11048ea3385)
