### PR TITLE
Bug: datovelger på endret utbetaling skjema

### DIFF
--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -34,7 +34,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     : endretUtbetalingAndel.prosent > 0,
         });
 
-        const { skjema, kanSendeSkjema, onSubmit } = useSkjema<
+        const { skjema, kanSendeSkjema, onSubmit, nullstillSkjema } = useSkjema<
             {
                 person: string | undefined;
                 fom: FamilieIsoDate | undefined;
@@ -134,13 +134,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
         }
 
         const tilbakestillFelterTilDefault = () => {
-            skjema.felter.person.nullstill();
-            skjema.felter.fom.nullstill();
-            skjema.felter.tom.nullstill();
-            skjema.felter.årsak.nullstill();
-            skjema.felter.begrunnelse.nullstill();
-            skjema.felter.fullSats.nullstill();
-            skjema.felter.periodeSkalUtbetalesTilSøker.nullstill();
+            nullstillSkjema();
             settDatofelterTilDefaultverdier();
         };
 

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -133,6 +133,17 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             settDatofelterTilDefaultverdier();
         }
 
+        const tilbakestillFelterTilDefault = () => {
+            skjema.felter.person.nullstill();
+            skjema.felter.fom.nullstill();
+            skjema.felter.tom.nullstill();
+            skjema.felter.årsak.nullstill();
+            skjema.felter.begrunnelse.nullstill();
+            skjema.felter.fullSats.nullstill();
+            skjema.felter.periodeSkalUtbetalesTilSøker.nullstill();
+            settDatofelterTilDefaultverdier();
+        };
+
         const hentProsentForEndretUtbetaling = () => {
             return (
                 (skjema.felter.periodeSkalUtbetalesTilSøker.verdi ? 100 : 0) /
@@ -172,6 +183,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             kanSendeSkjema,
             onSubmit,
             hentSkjemaData,
+            tilbakestillFelterTilDefault,
         };
     }
 );

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useState } from 'react';
 
 import createUseContext from 'constate';
 
@@ -19,7 +19,7 @@ interface IProps {
 const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseContext(
     ({ endretUtbetalingAndel }: IProps) => {
         const årsakFelt = useFelt<IEndretUtbetalingAndelÅrsak | undefined>({
-            verdi: endretUtbetalingAndel.årsak ? endretUtbetalingAndel.årsak : undefined,
+            verdi: endretUtbetalingAndel.årsak,
             valideringsfunksjon: felt =>
                 felt.verdi && Object.values(IEndretUtbetalingAndelÅrsak).includes(felt.verdi)
                     ? ok(felt)
@@ -75,6 +75,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     avhengigheter: {
                         årsak: årsakFelt,
                     },
+                    nullstillVedAvhengighetEndring: false,
                     skalFeltetVises: (avhengigheter: Avhengigheter) =>
                         avhengigheter?.årsak.verdi === IEndretUtbetalingAndelÅrsak.DELT_BOSTED,
                     valideringsfunksjon: validerGyldigDato,
@@ -111,7 +112,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             skjemanavn: 'Endre utbetalingsperiode',
         });
 
-        useEffect(() => {
+        const settDatofelterTilDefaultverdier = () => {
             skjema.felter.søknadstidspunkt.validerOgSettFelt(
                 endretUtbetalingAndel.søknadstidspunkt
                     ? new Date(endretUtbetalingAndel.søknadstidspunkt)
@@ -122,7 +123,15 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     ? new Date(endretUtbetalingAndel.avtaletidspunktDeltBosted)
                     : undefined
             );
-        }, [endretUtbetalingAndel]);
+        };
+
+        const [forrigeEndretUtbetalingAndel, settForrigeEndretUtbetalingAndel] =
+            useState<IRestEndretUtbetalingAndel>();
+
+        if (endretUtbetalingAndel !== forrigeEndretUtbetalingAndel) {
+            settForrigeEndretUtbetalingAndel(endretUtbetalingAndel);
+            settDatofelterTilDefaultverdier();
+        }
 
         const hentProsentForEndretUtbetaling = () => {
             return (

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
@@ -94,7 +94,7 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
                         lukkSkjema={() => {
                             settÅpenUtbetalingsAndel(false);
                         }}
-                        key={åpenUtbetalingsAndel ? 'åpent' : 'lukket'}
+                        key={åpenUtbetalingsAndel ? 'åpen' : 'lukket'}
                     />
                 }
             >

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
@@ -89,14 +89,13 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
                 open={åpenUtbetalingsAndel}
                 onOpenChange={() => toggleForm()}
                 content={
-                    åpenUtbetalingsAndel && (
-                        <EndretUtbetalingAndelSkjema
-                            åpenBehandling={åpenBehandling}
-                            lukkSkjema={() => {
-                                settÅpenUtbetalingsAndel(false);
-                            }}
-                        />
-                    )
+                    <EndretUtbetalingAndelSkjema
+                        åpenBehandling={åpenBehandling}
+                        lukkSkjema={() => {
+                            settÅpenUtbetalingsAndel(false);
+                        }}
+                        key={åpenUtbetalingsAndel ? 'åpent' : 'lukket'}
+                    />
                 }
             >
                 <Table.DataCell>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelRad.tsx
@@ -89,12 +89,14 @@ const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRa
                 open={åpenUtbetalingsAndel}
                 onOpenChange={() => toggleForm()}
                 content={
-                    <EndretUtbetalingAndelSkjema
-                        åpenBehandling={åpenBehandling}
-                        avbrytEndringAvUtbetalingsperiode={() => {
-                            settÅpenUtbetalingsAndel(false);
-                        }}
-                    />
+                    åpenUtbetalingsAndel && (
+                        <EndretUtbetalingAndelSkjema
+                            åpenBehandling={åpenBehandling}
+                            lukkSkjema={() => {
+                                settÅpenUtbetalingsAndel(false);
+                            }}
+                        />
+                    )
                 }
             >
                 <Table.DataCell>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -70,19 +70,25 @@ const StyledFamilieTextarea = styled(FamilieTextarea)`
 
 interface IEndretUtbetalingAndelSkjemaProps {
     åpenBehandling: IBehandling;
-    avbrytEndringAvUtbetalingsperiode: () => void;
+    lukkSkjema: () => void;
 }
 
 const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAndelSkjemaProps> = ({
     åpenBehandling,
-    avbrytEndringAvUtbetalingsperiode,
+    lukkSkjema,
 }) => {
     const { request } = useHttp();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
     const erLesevisning = vurderErLesevisning();
 
-    const { endretUtbetalingAndel, skjema, kanSendeSkjema, onSubmit, hentSkjemaData } =
-        useEndretUtbetalingAndel();
+    const {
+        endretUtbetalingAndel,
+        skjema,
+        kanSendeSkjema,
+        onSubmit,
+        hentSkjemaData,
+        tilbakestillFelterTilDefault,
+    } = useEndretUtbetalingAndel();
 
     const oppdaterEndretUtbetaling = (avbrytEndringAvUtbetalingsperiode: () => void) => {
         if (kanSendeSkjema()) {
@@ -350,16 +356,17 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                             <StyledFerdigKnapp
                                 size="small"
                                 variant="secondary"
-                                onClick={() =>
-                                    oppdaterEndretUtbetaling(avbrytEndringAvUtbetalingsperiode)
-                                }
+                                onClick={() => oppdaterEndretUtbetaling(lukkSkjema)}
                             >
                                 Bekreft
                             </StyledFerdigKnapp>
                             <Button
                                 variant="tertiary"
                                 size="small"
-                                onClick={avbrytEndringAvUtbetalingsperiode}
+                                onClick={() => {
+                                    tilbakestillFelterTilDefault();
+                                    lukkSkjema();
+                                }}
                             >
                                 Avbryt
                             </Button>

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-import { addDays, format, isValid, startOfDay, subDays } from 'date-fns';
+import { addDays, format, startOfDay, subDays } from 'date-fns';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
@@ -62,8 +62,7 @@ const Datovelger = ({
             felt.nullstill();
         }
     };
-
-    const { datepickerProps, inputProps, setSelected } = useDatepicker({
+    const { datepickerProps, inputProps } = useDatepicker({
         defaultSelected: felt.verdi,
         onDateChange: (dato?: Date) => {
             felt.validerOgSettFelt(dato);
@@ -85,12 +84,6 @@ const Datovelger = ({
             }
         },
     });
-
-    useEffect(() => {
-        if (isValid(felt.verdi)) {
-            setSelected(felt.verdi);
-        }
-    }, [felt.verdi]);
 
     const feilmeldingForDatoFørMinDato = () => {
         if (kanKunVelgeFremtid) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Går bort fra at Datovelger bruker useEffect som oppdaterer datovelgeren sin verdi hvis feltet sin verdi endrer seg. Etter oppdateringer i endret utbetaling sin context funker dette nå som det skal. Grunnen til at man trengte useeffecten i utgagnspunktet var at feltet var undefined i et millisekund før det fikk en verdi, og da rakk datovelgeren å rendre med undefined. Men har gått bort fra useEffect i contexten, som gjør at datovelger rendres med riktig verdi fra start.

I tillegg fikser jeg en bug som gjør at skjemaet for endret utbetaling andel nå blir satt tilbake til default-verdier hvis man klikker på "Avbryt". Dette skjedde ikke før, noe som var veldig rart.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det gir mening her

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit er nok fint

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Nei, bare logikken på hvilke datoer som vises