### PR TITLE
Datovelgere på vilkårsvurderingen

### DIFF
--- a/src/frontend/context/Vilkårsvurdering/validering.ts
+++ b/src/frontend/context/Vilkårsvurdering/validering.ts
@@ -10,7 +10,7 @@ import type {
     UtdypendeVilkårsvurdering,
 } from '../../typer/vilkår';
 import { VilkårType } from '../../typer/vilkår';
-import type { IPeriode } from '../../utils/kalender';
+import type { IPeriode } from '../../utils/dato';
 
 export const validerVilkår = (
     nyttVilkårResultat: FeltState<IVilkårResultat>,

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -24,12 +24,12 @@ import type {
     IVedtaksperiodeMedBegrunnelser,
 } from '../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
+import type { IPeriode } from '../../../../../utils/dato';
 import type { IFritekstFelt } from '../../../../../utils/fritekstfelter';
 import {
     genererIdBasertPåAndreFritekster,
     lagInitiellFritekst,
 } from '../../../../../utils/fritekstfelter';
-import type { IPeriode } from '../../../../../utils/kalender';
 import { useVilkårBegrunnelser } from '../Hooks/useVedtaksbegrunnelser';
 
 interface IProps {

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Hooks/useVedtaksbegrunnelser.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Hooks/useVedtaksbegrunnelser.ts
@@ -16,7 +16,7 @@ import type {
 } from '../../../../../typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '../../../../../typer/vedtaksperiode';
 import type { VedtaksbegrunnelseTekster } from '../../../../../typer/vilkår';
-import type { IPeriode } from '../../../../../utils/kalender';
+import type { IPeriode } from '../../../../../utils/dato';
 import { useVedtaksbegrunnelseTekster } from '../Context/VedtaksbegrunnelseTeksterContext';
 
 export const useVilkårBegrunnelser = ({

--- a/src/frontend/komponenter/Fagsak/Vedtak/utils.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/utils.test.ts
@@ -1,9 +1,4 @@
-import {
-    antallMånederIPeriode,
-    summerBeløpForPerioder,
-    tilFørsteDagIMånedenHvisGyldigInput,
-    tilSisteDagIMånedenHvisGyldigInput,
-} from './utils';
+import { antallMånederIPeriode, summerBeløpForPerioder } from './utils';
 
 const REFUSJONSPERIODE_FIRE_MÅNEDER = {
     fom: '2022-06-01',
@@ -24,21 +19,6 @@ const REFUSJONSPERIODE_EN_MÅNED = {
 };
 
 describe('Vedtakutils', () => {
-    test('tilFørsteDagIMånedenHvisGyldigInput skal gjøre om gyldig input til første dag i måneden', () => {
-        expect(tilFørsteDagIMånedenHvisGyldigInput('2023-01-20')).toBe('2023-01-01');
-        expect(tilFørsteDagIMånedenHvisGyldigInput('2023-05-02')).toBe('2023-05-01');
-    });
-    test('tilFørsteDagIMånedenHvisGyldigInput skal ikke endre ugyldig input', () => {
-        expect(tilFørsteDagIMånedenHvisGyldigInput('NaN')).toBe('NaN');
-        expect(tilFørsteDagIMånedenHvisGyldigInput(undefined)).toBe('');
-    });
-    test('tilSisteDagIMånedenHvisGyldigInput skal gjøre om gyldig input til første dag i måneden', () => {
-        expect(tilSisteDagIMånedenHvisGyldigInput('2023-01-20')).toBe('2023-01-31');
-        expect(tilSisteDagIMånedenHvisGyldigInput('2023-02-27')).toBe('2023-02-28');
-        expect(tilSisteDagIMånedenHvisGyldigInput('2024-02-14')).toBe('2024-02-29');
-        expect(tilSisteDagIMånedenHvisGyldigInput('2023-04-02')).toBe('2023-04-30');
-    });
-
     test('summerRefusjonsbeløpForPerioder skal finne totalt refusjonsbeløp for alle perioder', () => {
         expect(summerBeløpForPerioder([])).toBe(0);
         expect(

--- a/src/frontend/komponenter/Fagsak/Vedtak/utils.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/utils.ts
@@ -1,28 +1,6 @@
 import { addDays, differenceInCalendarMonths } from 'date-fns';
 
 import type { FamilieIsoDate } from '../../../utils/kalender';
-import {
-    erIsoStringGyldig,
-    FamilieIsoTilFørsteDagIMåneden,
-    FamilieIsoTilSisteDagIMåneden,
-} from '../../../utils/kalender';
-
-const gjørOmDatoHvisGyldigInput = (
-    dato: string | undefined,
-    omgjøringsfunksjon: (dato: FamilieIsoDate) => FamilieIsoDate
-): string => {
-    if (dato === undefined) return '';
-    if (erIsoStringGyldig(dato)) return omgjøringsfunksjon(dato);
-    else return dato;
-};
-
-export const tilFørsteDagIMånedenHvisGyldigInput = (dato: string | undefined): string => {
-    return gjørOmDatoHvisGyldigInput(dato, FamilieIsoTilFørsteDagIMåneden);
-};
-
-export const tilSisteDagIMånedenHvisGyldigInput = (dato: string | undefined): string => {
-    return gjørOmDatoHvisGyldigInput(dato, FamilieIsoTilSisteDagIMåneden);
-};
 
 interface PeriodeMedBeløp {
     fom: FamilieIsoDate;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -18,7 +18,7 @@ import type {
 } from '../../../../typer/vedtak';
 import { VedtakBegrunnelseType } from '../../../../typer/vedtak';
 import type { Regelverk, VilkårType } from '../../../../typer/vilkår';
-import type { IPeriode } from '../../../../utils/kalender';
+import type { IPeriode } from '../../../../utils/dato';
 import { hentBakgrunnsfarge, hentBorderfarge } from '../../../../utils/vedtakUtils';
 import { useVedtaksbegrunnelseTekster } from '../../Vedtak/VedtakBegrunnelserTabell/Context/VedtaksbegrunnelseTeksterContext';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -14,6 +14,7 @@ import type { IVilkårResultat } from '../../../../typer/vilkår';
 import { Resultat } from '../../../../typer/vilkår';
 import { DatoformatNorsk } from '../../../../utils/formatter';
 import { nyPeriode } from '../../../../utils/kalender';
+import DatovelgerForGammelSkjemaløsning from '../../../Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
 
 interface IProps {
     redigerbartVilkår: FeltState<IVilkårResultat>;
@@ -77,23 +78,15 @@ const VelgPeriode: React.FC<IProps> = ({
 
             <FlexDiv>
                 {(!erLesevisning || redigerbartVilkår.verdi.periode.verdi.fom) && (
-                    <FamilieDatovelger
-                        allowInvalidDateSelection={false}
-                        limitations={{
-                            maxDate: new Date().toISOString(),
-                        }}
-                        erLesesvisning={erLesevisning}
-                        id={`${vilkårPeriodeFeilmeldingId(
-                            redigerbartVilkår.verdi
-                        )}__fastsett-periode-fom`}
+                    <DatovelgerForGammelSkjemaløsning
                         label={
                             redigerbartVilkår.verdi.resultat.verdi === Resultat.IKKE_OPPFYLT &&
                             redigerbartVilkår.verdi.erEksplisittAvslagPåSøknad
                                 ? 'F.o.m (valgfri)'
                                 : 'F.o.m'
                         }
-                        placeholder={DatoformatNorsk.DATO}
-                        onChange={(dato?: ISODateString) => {
+                        value={redigerbartVilkår.verdi.periode.verdi.fom}
+                        onDateChange={(dato?: ISODateString) => {
                             validerOgSettRedigerbartVilkår({
                                 ...redigerbartVilkår,
                                 verdi: {
@@ -108,7 +101,9 @@ const VelgPeriode: React.FC<IProps> = ({
                                 },
                             });
                         }}
-                        value={redigerbartVilkår.verdi.periode.verdi.fom}
+                        visFeilmeldinger={false}
+                        readOnly={erLesevisning}
+                        kanKunVelgeFortid
                     />
                 )}
                 {(!erLesevisning || redigerbartVilkår.verdi.periode.verdi.tom) && (

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -75,58 +75,54 @@ const VelgPeriode: React.FC<IProps> = ({
             )}
 
             <FlexDiv>
-                {(!erLesevisning || redigerbartVilkår.verdi.periode.verdi.fom) && (
-                    <DatovelgerForGammelSkjemaløsning
-                        label={
-                            redigerbartVilkår.verdi.resultat.verdi === Resultat.IKKE_OPPFYLT &&
-                            redigerbartVilkår.verdi.erEksplisittAvslagPåSøknad
-                                ? 'F.o.m (valgfri)'
-                                : 'F.o.m'
-                        }
-                        value={redigerbartVilkår.verdi.periode.verdi.fom}
-                        onDateChange={(dato?: ISODateString) => {
-                            validerOgSettRedigerbartVilkår({
-                                ...redigerbartVilkår,
-                                verdi: {
-                                    ...redigerbartVilkår.verdi,
-                                    periode: {
-                                        ...redigerbartVilkår.verdi.periode,
-                                        verdi: nyPeriode(
-                                            dato,
-                                            redigerbartVilkår.verdi.periode.verdi.tom
-                                        ),
-                                    },
+                <DatovelgerForGammelSkjemaløsning
+                    label={
+                        redigerbartVilkår.verdi.resultat.verdi === Resultat.IKKE_OPPFYLT &&
+                        redigerbartVilkår.verdi.erEksplisittAvslagPåSøknad
+                            ? 'F.o.m (valgfri)'
+                            : 'F.o.m'
+                    }
+                    value={redigerbartVilkår.verdi.periode.verdi.fom}
+                    onDateChange={(dato?: ISODateString) => {
+                        validerOgSettRedigerbartVilkår({
+                            ...redigerbartVilkår,
+                            verdi: {
+                                ...redigerbartVilkår.verdi,
+                                periode: {
+                                    ...redigerbartVilkår.verdi.periode,
+                                    verdi: nyPeriode(
+                                        dato,
+                                        redigerbartVilkår.verdi.periode.verdi.tom
+                                    ),
                                 },
-                            });
-                        }}
-                        visFeilmeldinger={false}
-                        readOnly={erLesevisning}
-                        kanKunVelgeFortid
-                    />
-                )}
-                {(!erLesevisning || redigerbartVilkår.verdi.periode.verdi.tom) && (
-                    <DatovelgerForGammelSkjemaløsning
-                        label={'T.o.m (valgfri)'}
-                        value={redigerbartVilkår.verdi.periode.verdi.tom}
-                        onDateChange={(dato?: ISODateString) => {
-                            validerOgSettRedigerbartVilkår({
-                                ...redigerbartVilkår,
-                                verdi: {
-                                    ...redigerbartVilkår.verdi,
-                                    periode: {
-                                        ...redigerbartVilkår.verdi.periode,
-                                        verdi: nyPeriode(
-                                            redigerbartVilkår.verdi.periode.verdi.fom,
-                                            dato
-                                        ),
-                                    },
+                            },
+                        });
+                    }}
+                    visFeilmeldinger={false}
+                    readOnly={erLesevisning}
+                    kanKunVelgeFortid
+                />
+                <DatovelgerForGammelSkjemaløsning
+                    label={'T.o.m (valgfri)'}
+                    value={redigerbartVilkår.verdi.periode.verdi.tom}
+                    onDateChange={(dato?: ISODateString) => {
+                        validerOgSettRedigerbartVilkår({
+                            ...redigerbartVilkår,
+                            verdi: {
+                                ...redigerbartVilkår.verdi,
+                                periode: {
+                                    ...redigerbartVilkår.verdi.periode,
+                                    verdi: nyPeriode(
+                                        redigerbartVilkår.verdi.periode.verdi.fom,
+                                        dato
+                                    ),
                                 },
-                            });
-                        }}
-                        visFeilmeldinger={false}
-                        readOnly={erLesevisning}
-                    />
-                )}
+                            },
+                        });
+                    }}
+                    visFeilmeldinger={false}
+                    readOnly={erLesevisning}
+                />
             </FlexDiv>
         </MarginFieldset>
     );

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { HelpText, Label, Fieldset } from '@navikt/ds-react';
-import { FamilieDatovelger } from '@navikt/familie-datovelger';
 import type { ISODateString } from '@navikt/familie-datovelger';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { FeltState } from '@navikt/familie-skjema';
@@ -12,7 +11,6 @@ import { vilkårPeriodeFeilmeldingId } from './VilkårTabell';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import type { IVilkårResultat } from '../../../../typer/vilkår';
 import { Resultat } from '../../../../typer/vilkår';
-import { DatoformatNorsk } from '../../../../utils/formatter';
 import { nyPeriode } from '../../../../utils/kalender';
 import DatovelgerForGammelSkjemaløsning from '../../../Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
 
@@ -107,14 +105,10 @@ const VelgPeriode: React.FC<IProps> = ({
                     />
                 )}
                 {(!erLesevisning || redigerbartVilkår.verdi.periode.verdi.tom) && (
-                    <FamilieDatovelger
-                        erLesesvisning={erLesevisning}
-                        id={`${vilkårPeriodeFeilmeldingId(
-                            redigerbartVilkår.verdi
-                        )}__fastsett-periode-tom`}
+                    <DatovelgerForGammelSkjemaløsning
                         label={'T.o.m (valgfri)'}
-                        placeholder={DatoformatNorsk.DATO}
-                        onChange={(dato?: ISODateString) => {
+                        value={redigerbartVilkår.verdi.periode.verdi.tom}
+                        onDateChange={(dato?: ISODateString) => {
                             validerOgSettRedigerbartVilkår({
                                 ...redigerbartVilkår,
                                 verdi: {
@@ -129,7 +123,8 @@ const VelgPeriode: React.FC<IProps> = ({
                                 },
                             });
                         }}
-                        value={redigerbartVilkår.verdi.periode.verdi.tom}
+                        visFeilmeldinger={false}
+                        readOnly={erLesevisning}
                     />
                 )}
             </FlexDiv>

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -117,6 +117,7 @@ const VilkårTabellRad: React.FC<IProps> = ({
             id={vilkårFeilmeldingId(vilkårResultat.verdi)}
             content={
                 <VilkårTabellRadEndre
+                    key={`${vilkårResultat.verdi.id}-${ekspandertVilkår ? 'ekspandert' : 'lukket'}`}
                     person={person}
                     vilkårFraConfig={vilkårFraConfig}
                     vilkårResultat={vilkårResultat}

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
@@ -6,7 +6,7 @@ import { isValid, parseISO } from 'date-fns';
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
 import { senesteRelevanteDato, tidligsteRelevanteDato } from './utils';
-import { formatterDate } from '../../../utils/dato';
+import { dagensDato, formatterDate } from '../../../utils/dato';
 import type { IsoDatoString } from '../../../utils/dato';
 import { Datoformat } from '../../../utils/formatter';
 
@@ -15,7 +15,9 @@ interface IProps {
     onDateChange: (dato: IsoDatoString) => void;
     label: string;
     visFeilmeldinger: boolean;
-    feilmelding: string | undefined;
+    feilmelding?: string;
+    readOnly?: boolean;
+    kanKunVelgeFortid?: boolean;
 }
 
 const DatovelgerForGammelSkjemaløsning = ({
@@ -23,7 +25,9 @@ const DatovelgerForGammelSkjemaløsning = ({
     onDateChange,
     label,
     visFeilmeldinger,
-    feilmelding,
+    feilmelding = undefined,
+    readOnly = false,
+    kanKunVelgeFortid = false,
 }: IProps) => {
     const formatterDefaultSelected = () => {
         if (value === undefined) return undefined;
@@ -34,7 +38,7 @@ const DatovelgerForGammelSkjemaløsning = ({
     const { datepickerProps, inputProps, selectedDay } = useDatepicker({
         defaultSelected: formatterDefaultSelected(),
         fromDate: tidligsteRelevanteDato,
-        toDate: senesteRelevanteDato,
+        toDate: kanKunVelgeFortid ? dagensDato : senesteRelevanteDato,
     });
 
     useEffect(() => {
@@ -53,6 +57,7 @@ const DatovelgerForGammelSkjemaløsning = ({
                 {...inputProps}
                 label={label}
                 placeholder={'DD.MM.ÅÅÅÅ'}
+                readOnly={readOnly}
                 error={visFeilmeldinger && feilmelding}
             />
         </DatePicker>

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
@@ -18,7 +18,7 @@ interface IProps {
     feilmelding: string | undefined;
 }
 
-const FilterSkjemaDatovelger = ({
+const DatovelgerForGammelSkjemaløsning = ({
     value,
     onDateChange,
     label,
@@ -59,4 +59,4 @@ const FilterSkjemaDatovelger = ({
     );
 };
 
-export default FilterSkjemaDatovelger;
+export default DatovelgerForGammelSkjemaløsning;

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/FilterSkjemaDatovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/FilterSkjemaDatovelger.tsx
@@ -5,13 +5,10 @@ import { isValid, parseISO } from 'date-fns';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
-import type { IsoDatoString } from '../../utils/dato';
-import { formatterDate } from '../../utils/dato';
-import { Datoformat } from '../../utils/formatter';
-import {
-    senesteRelevanteDato,
-    tidligsteRelevanteDato,
-} from '../Felleskomponenter/Datovelger/utils';
+import { senesteRelevanteDato, tidligsteRelevanteDato } from './utils';
+import { formatterDate } from '../../../utils/dato';
+import type { IsoDatoString } from '../../../utils/dato';
+import { Datoformat } from '../../../utils/formatter';
 
 interface IProps {
     value: string | undefined;

--- a/src/frontend/komponenter/Oppgavebenk/FilterSkjema.tsx
+++ b/src/frontend/komponenter/Oppgavebenk/FilterSkjema.tsx
@@ -7,11 +7,11 @@ import type { ISODateString } from '@navikt/familie-datovelger';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import FilterSkjemaDatovelger from './FilterSkjemaDatovelger';
 import type { IOppgaveFelt } from './oppgavefelter';
 import { useApp } from '../../context/AppContext';
 import { useOppgaver } from '../../context/OppgaverContext';
 import type { IPar } from '../../typer/common';
+import DatovelgerForGammelSkjemaløsning from '../Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
 
 const StyledButton = styled(Button)`
     margin-top: 0.5rem;
@@ -53,7 +53,7 @@ const FilterSkjema: React.FunctionComponent = () => {
                         switch (oppgaveFelt.filter?.type) {
                             case 'dato':
                                 return (
-                                    <FilterSkjemaDatovelger
+                                    <DatovelgerForGammelSkjemaløsning
                                         key={oppgaveFelt.nøkkel}
                                         label={oppgaveFelt.label}
                                         onDateChange={(dato: ISODateString) => {

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -1,7 +1,7 @@
 import type { OptionType } from '@navikt/familie-form-elements';
 
-import type { IsoDatoString } from '../utils/dato';
-import type { IPeriode, IYearMonthPeriode, YearMonth } from '../utils/kalender';
+import type { IPeriode, IsoDatoString } from '../utils/dato';
+import type { IYearMonthPeriode, YearMonth } from '../utils/kalender';
 
 export const LandkodeNorge = 'NO';
 

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -8,7 +8,7 @@ import type {
     VedtakBegrunnelse,
     VedtakBegrunnelseType,
 } from './vedtak';
-import type { FamilieIsoDate, IPeriode } from '../utils/kalender';
+import type { IPeriode, IsoDatoString } from '../utils/dato';
 
 export enum Resultat {
     IKKE_OPPFYLT = 'IKKE_OPPFYLT',
@@ -109,8 +109,8 @@ export interface IRestVilkårResultat {
     erAutomatiskVurdert: boolean;
     erVurdert: boolean;
     id: number;
-    periodeFom?: FamilieIsoDate;
-    periodeTom?: FamilieIsoDate;
+    periodeFom?: IsoDatoString;
+    periodeTom?: IsoDatoString;
     resultat: Resultat;
     resultatBegrunnelse: ResultatBegrunnelse | null;
     erEksplisittAvslagPåSøknad?: boolean;

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -7,6 +7,12 @@ import { Datoformat } from './formatter';
 
 export type IsoDatoString = string; // Format YYYY-MM-DD (ISO)
 
+export interface IPeriode {
+    // Format YYYY-MM-DD (ISO)
+    fom?: IsoDatoString;
+    tom?: IsoDatoString;
+}
+
 export const dagensDato = startOfToday();
 
 interface FormatterProps {

--- a/src/frontend/utils/kalender/kalenderMåned.ts
+++ b/src/frontend/utils/kalender/kalenderMåned.ts
@@ -9,11 +9,6 @@ export const kalenderMåned = (dato: FamilieIsoDate): MånedÅr => {
     };
 };
 
-export const sisteDatoIMnd = (måned: number, år: number): Date => {
-    // Måneden i Date objektet er 0-indeksert
-    return new Date(år, måned + 1, 0);
-};
-
 export const sisteDagIMåned = (dagMånedÅr: DagMånedÅr): DagMånedÅr => ({
     ...dagMånedÅr,
     dag: antallDagerIMåned({ år: dagMånedÅr.år, måned: dagMånedÅr.måned }),

--- a/src/frontend/utils/kalender/periode.ts
+++ b/src/frontend/utils/kalender/periode.ts
@@ -1,4 +1,6 @@
-import type { FamilieIsoDate, IPeriode, IYearMonthPeriode, YearMonth } from '.';
+import type { IPeriode } from '../dato';
+
+import type { FamilieIsoDate, IYearMonthPeriode, YearMonth } from '.';
 import {
     erEtter,
     erFør,

--- a/src/frontend/utils/kalender/periode.ts
+++ b/src/frontend/utils/kalender/periode.ts
@@ -64,10 +64,6 @@ export const periodeDiff = (første: IPeriode, andre: IPeriode) => {
     );
 };
 
-export const lagPeriodeId = (periode: IPeriode) => {
-    return periodeToString(periode);
-};
-
 export const yearMonthPeriodeToString = (periode: IYearMonthPeriode) => {
     return `${yearMonthTilVisning(
         periode.fom ? yearMonthTilKalenderMåned(periode.fom) : undefined

--- a/src/frontend/utils/kalender/typer.ts
+++ b/src/frontend/utils/kalender/typer.ts
@@ -17,12 +17,6 @@ export enum KalenderEnhet {
     ÅR,
 }
 
-export interface IPeriode {
-    // Format YYYY-MM-DD (ISO)
-    fom?: FamilieIsoDate;
-    tom?: FamilieIsoDate;
-}
-
 export interface IYearMonthPeriode {
     // Format YYYY-MM
     fom?: YearMonth;

--- a/src/frontend/utils/test/validators.test.ts
+++ b/src/frontend/utils/test/validators.test.ts
@@ -22,7 +22,7 @@ import {
     UtdypendeVilkårsvurderingGenerell,
     UtdypendeVilkårsvurderingNasjonal,
 } from '../../typer/vilkår';
-import type { IPeriode } from '../kalender';
+import type { IPeriode } from '../dato';
 import { nyPeriode } from '../kalender';
 import type { UtdypendeVilkårsvurderingAvhengigheter } from '../utdypendeVilkårsvurderinger';
 import {

--- a/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
+++ b/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
@@ -10,7 +10,7 @@ import type {
     UtdypendeVilkårsvurdering,
 } from '../../../typer/vilkår';
 import { Regelverk, Resultat, VilkårType } from '../../../typer/vilkår';
-import type { IPeriode } from '../../kalender';
+import type { IPeriode } from '../../dato';
 import { erIkkeGenereltVilkår } from '../../vilkår';
 
 interface IMockVilkårResultat {

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -1,7 +1,7 @@
 import { feil, ok, Valideringsstatus } from '@navikt/familie-skjema';
 import type { Avhengigheter, FeltState, ValiderFelt } from '@navikt/familie-skjema';
 
-import type { IPeriode } from './kalender';
+import type { IPeriode } from './dato';
 import {
     erEtter,
     erFør,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16053

Bytter ut datovelgere på vilkårsvurderingen. Vilkårsvurderingen bruker ikke skjema-hooken, og jeg får derfor ikke brukt den vanlige datovelgeren som er laget. Ønsker egentlig å skrive om til skjema-hooken, men det er en mye større oppgave. Tar derfor i stedet i bruk datovelgeren jeg laget til oppgavebenken hvor vi heller ikke bruker skjema-hooken. Siden vi egentlig ønsker å ta i bruk skjema-hooken disse stedene kaller jeg datovelgeren for "gammel" slik at man skjønner at denne egentlig ikke er ønskelig å bruke.

Gjør i tillegg en endring som gjør at datovelgeren vises selv om det er lesevisning og feltet ikke har noen verdi:
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/d2b04c27-3b07-4e9c-95b0-965d43fb1151)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/742fd9d4-ff7a-477b-a78f-45ad45c46ee5)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ikke noe mer enn det jeg har skrevet over her 👆

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Bytter bare ut komponent

### 🤷‍♀ ️Hvor er det lurt å starte?
Commit for commit er fint

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/57748e70-a8f3-430f-a654-b74cbcb43433)

![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/d994ed99-2860-4fe1-8345-8735da39527f)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/57bbf0cd-771f-45da-b75a-b96ec9224462)

![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/1f5fc33d-4b37-487c-ba9e-923ba4d42e79)
