### PR TITLE
Fjern dependencies som ikke blir brukt

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "nav-frontend-tabell-style": "^2.1.1",
     "nav-frontend-typografi": "4.0.1",
     "nav-frontend-typografi-style": "^2.0.2",
-    "nav-hoykontrast": "^2.1.2",
     "prop-types": "^15.8.1",
     "query-string": "^7.1.0",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "query-string": "^7.1.0",
     "react": "^17.0.2",
     "react-collapse": "^5.0.1",
-    "react-day-picker": "^7.4.10",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.3.0",
     "react-router-hash-link": "^2.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,11 +8183,6 @@ nav-frontend-typografi@4.0.1:
   resolved "https://registry.yarnpkg.com/nav-frontend-typografi/-/nav-frontend-typografi-4.0.1.tgz#dee38984be84bc472e1ee3b726fa69b8f0b363b9"
   integrity sha512-zJrvysIWqZm0HSJqqgc1G5Lqr8bLO16B9Pg/FW7+mJQGGz/iqPhX5vvIFTXqAlXVo95qImoZ72uiWiHHRdGhPQ==
 
-nav-hoykontrast@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/nav-hoykontrast/-/nav-hoykontrast-2.1.2.tgz#4e6b686fa67af8b4381f7c33271612b89230a6c2"
-  integrity sha512-2mwwbiSImWdLh4m2Jhr1YKf0Ew/+C3bUCyVDbUCWXo8n3N2fZdweH2NSIdI6Zpk3fyp3T/E74vArOHkMSVcG9Q==
-
 needle@^2.5.2:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.9.1.tgz#22d1dffbe3490c2b83e301f7709b6736cd8f2684"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9227,13 +9227,6 @@ react-day-picker@8.3.4:
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.3.4.tgz#0942d66266c58cd815d393ec0d142372b0d42f4f"
   integrity sha512-UuCbfZ69DhQmd+UhEv8nCPp5PxMk7ioNTuOLMlU0X7q3wd7o8TKDdsjduQoeBYTPTMS3LFdbA1qqbrIpRHo/Vg==
 
-react-day-picker@^7.4.10:
-  version "7.4.10"
-  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.10.tgz#d3928fa65c04379ad28c76de22aa85374a8361e1"
-  integrity sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==
-  dependencies:
-    prop-types "^15.6.2"
-
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
`nav-hoykontrast` blir ikke brukt, så jeg fjerner den fra listen over dependencies. Det samme gjelder `react-day-picker` som ikke lenger trengs å importeres manuelt (ds-react har den som dependency men drar den inn på egenhånd).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Fjerner dependency

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
