### PR TITLE
Bug: Sørg for at datovelgere ikke åpnes automatisk ved fokus

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -69,6 +69,7 @@ const Datovelger = ({
         fromDate: hentFromDate(),
         toDate: hentToDate(),
         disableWeekends: disableWeekends,
+        openOnFocus: false,
         onValidate: val => {
             if (val.isEmpty && !datoMåFyllesUt) {
                 felt.nullstill();

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
@@ -40,6 +40,7 @@ const DatovelgerForGammelSkjemaløsning = ({
         defaultSelected: formatterDefaultSelected(),
         fromDate: minDatoAvgrensning ? minDatoAvgrensning : tidligsteRelevanteDato,
         toDate: kanKunVelgeFortid ? dagensDato : senesteRelevanteDato,
+        openOnFocus: false,
     });
 
     useEffect(() => {

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Månedvelger.tsx
@@ -82,6 +82,7 @@ const Månedvelger = ({
         onMonthChange: oppdaterFeltMedValgtDato,
         fromDate: hentFromDate(),
         toDate: hentToDate(),
+        openOnFocus: false,
         onValidate: val => {
             if (val.isBefore) {
                 nullstillOgSettFeilmelding(Feilmelding.FØR_MIN_DATO);


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17061

For å spare saksbehandler for klikk ønsker vi ikke at kalenderen åpnes automatisk ved fokus. Ønsker kun at den skal åpnes når man klikker på kalender-ikonet. Det gjør at saksbehandler lettere kan tabbe seg gjennom skjema.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Undøvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
Kun en commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/22aa5794-1660-4f07-97c3-606ec6915394)

etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/7347d682-ca41-4257-8518-809c295289c3)
