### PR TITLE
Lagre sortering av oppgavebenken

### DIFF
--- a/src/frontend/context/OppgaverContext.tsx
+++ b/src/frontend/context/OppgaverContext.tsx
@@ -42,6 +42,8 @@ import { erIsoStringGyldig } from '../utils/dato';
 import { hentFnrFraOppgaveIdenter } from '../utils/oppgave';
 import { hentFrontendFeilmelding } from '../utils/ressursUtils';
 
+const OPPGAVEBENK_SORTERINGSNØKKEL = 'OPPGAVEBENK_SORTERINGSNØKKEL';
+
 export const oppgaveSideLimit = 15;
 
 export const maksAntallOppgaver = 150;
@@ -68,6 +70,8 @@ const [OppgaverProvider, useOppgaver] = createUseContext(() => {
             : [];
     }, [oppgaver]);
 
+    const lagretSortering = localStorage.getItem(OPPGAVEBENK_SORTERINGSNØKKEL);
+
     const tableInstance: TableInstance<IOppgaveRad> &
         UseSortByInstanceProps<IOppgaveRad> &
         UsePaginationInstanceProps<IOppgaveRad> = useTable<IOppgaveRad>(
@@ -77,11 +81,21 @@ const [OppgaverProvider, useOppgaver] = createUseContext(() => {
             initialState: {
                 pageSize: oppgaveSideLimit,
                 pageIndex: 0,
+                sortBy: lagretSortering
+                    ? JSON.parse(lagretSortering)
+                    : [{ id: 'opprettetTidspunkt', desc: false }],
             },
         },
         useSortBy,
         usePagination
     );
+
+    useEffect(() => {
+        localStorage.setItem(
+            OPPGAVEBENK_SORTERINGSNØKKEL,
+            JSON.stringify(tableInstance.state.sortBy)
+        );
+    }, [tableInstance.state.sortBy]);
 
     useEffect(() => {
         settOppgaveFelter(initialOppgaveFelter(innloggetSaksbehandler));


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17106)

Det er et ønske fra saksbehandlerene at vi lagrer sorteringen og filtreringen de gjør i oppgavebenken mellom sessjoner. Filtreringen lagres allerede.

Gjør det samme som i ks-sak: https://github.com/navikt/familie-ks-sak-frontend/pull/373. Legger til lagring av sortering i oppgavebenken i localstorage. 

