### PR TITLE
Skru på cache for webpack og babel

### DIFF
--- a/src/webpack/webpack.dev.js
+++ b/src/webpack/webpack.dev.js
@@ -30,8 +30,13 @@ export default merge.mergeWithRules({
                 options: {
                     presets: ['react-app'],
                     plugins: ['react-refresh/babel'],
+                    cacheCompression: false,
+                    cacheDirectory: true,
                 },
             },
         ],
+    },
+    cache: {
+        type: 'filesystem',
     },
 });


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Legger til cache for webpack og babel. Reduserte byggetiden med ~2 minutter

Uten cache:
![Skjermbilde 2023-11-21 kl  12 33 42](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/45780978-ed8c-4bb2-ad49-9098864d625e)

Med cache:
![Skjermbilde 2023-11-21 kl  12 35 59](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/5d403874-7399-4d86-b648-8cb67c49fcce)
