### PR TITLE
Gjør liste med manuelle brevmottakere non-null når vi sender manuelt brev fra fagsak

### DIFF
--- a/src/frontend/context/DokumentutsendingContext.ts
+++ b/src/frontend/context/DokumentutsendingContext.ts
@@ -200,6 +200,7 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
                     mottakerMålform: målform,
                     mottakerNavn: bruker.data.navn,
                     brevmal: Informasjonsbrev.INFORMASJONSBREV_DELT_BOSTED,
+                    manuelleBrevmottakere: manuelleBrevmottakerePåFagsak,
                 };
             } else {
                 throw Error('Bruker ikke hentet inn og vi kan ikke sende inn skjema');

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/Informasjonsbrev/enkeltInformasjonsbrevUtils.ts
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/Informasjonsbrev/enkeltInformasjonsbrevUtils.ts
@@ -11,7 +11,7 @@ interface IHentEnkeltInformasjonsbrevRequestInput {
     bruker: Ressurs<IPersonInfo>;
     målform: Målform;
     brevmal: Informasjonsbrev;
-    manuelleBrevmottakerePåFagsak?: SkjemaBrevmottaker[];
+    manuelleBrevmottakerePåFagsak: SkjemaBrevmottaker[];
 }
 
 export const hentEnkeltInformasjonsbrevRequest = ({

--- a/src/frontend/typer/dokument.ts
+++ b/src/frontend/typer/dokument.ts
@@ -30,7 +30,7 @@ export interface IManueltBrevRequestPåFagsak extends IManueltBrevRequest {
     barnasFødselsdager?: never;
     behandlingKategori?: never;
     brevmal: Brevmal | Informasjonsbrev;
-    manuelleBrevmottakere?: SkjemaBrevmottaker[];
+    manuelleBrevmottakere: SkjemaBrevmottaker[];
     mottakerMålform: Målform;
     mottakerNavn: string;
     mottakerlandSed?: never;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-10363)

Ser vi ikke sendte med tilstandsverdien til  manuelle brevmottakerene som var satt i en av brevene fra fagsak. 

Endrer så manuelle brevmottakere er obligatorisk slik at vi sørger for at den alltid blir sendt med. 