### PR TITLE
Grupper sentry-PRer fra dependabot som må oppgraderes sammen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-patch"]
+  groups:
+    sentry:
+      patterns:
+        - "@sentry/tracing"
+        - "@sentry/core"
+        - "@sentry/browser"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
@sentry/tracing, @sentry/core og @sentry/browser må alltid oppgraderes sammen, så prøver å få dependabot til å alltid gruppere disse sammen.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 🤷‍♀ ️Hvor er det lurt å starte?
Hvor du vil:)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  