### PR TITLE
Send med `vurderLesevisning` til LeggTilUregistrertBarn

### DIFF
--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnSøktForSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnSøktForSkjema.tsx
@@ -72,6 +72,7 @@ const BarnSøktForSkjema = (props: IProps) => {
             <LeggTilBarn
                 barnaMedOpplysninger={barnSøktForFelt}
                 manuelleBrevmottakere={manuelleBrevmottakerePåFagsak}
+                vurderErLesevisning={() => false}
             />
         </CheckboxGroup>
     );

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnSøktForSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnSøktForSkjema.tsx
@@ -6,6 +6,7 @@ import { CheckboxGroup } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import BarnCheckbox from './BarnCheckbox';
+import { useApp } from '../../../../context/AppContext';
 import { useFagsakContext } from '../../../../context/fagsak/FagsakContext';
 import type { IBarnMedOpplysninger } from '../../../../typer/søknad';
 import { isoStringTilDate } from '../../../../utils/dato';
@@ -20,6 +21,7 @@ interface IProps {
 const BarnSøktForSkjema = (props: IProps) => {
     const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
     const { barnSøktForFelt, visFeilmeldinger, settVisFeilmeldinger } = props;
+    const { harInnloggetSaksbehandlerSkrivetilgang } = useApp();
 
     const sorterteBarn = barnSøktForFelt.verdi.sort(
         (a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
@@ -72,7 +74,7 @@ const BarnSøktForSkjema = (props: IProps) => {
             <LeggTilBarn
                 barnaMedOpplysninger={barnSøktForFelt}
                 manuelleBrevmottakere={manuelleBrevmottakerePåFagsak}
-                vurderErLesevisning={() => false}
+                vurderErLesevisning={() => !harInnloggetSaksbehandlerSkrivetilgang()}
             />
         </CheckboxGroup>
     );

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DeltBosted/DeltBostedSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DeltBosted/DeltBostedSkjema.tsx
@@ -21,6 +21,7 @@ interface IProps {
     visFeilmeldinger: boolean;
     settVisFeilmeldinger: (visFeilmeldinger: boolean) => void;
     manuelleBrevmottakere: SkjemaBrevmottaker[] | IRestBrevmottaker[];
+    vurderErLesevisning: () => boolean;
 }
 
 const DeltBostedSkjema = (props: IProps) => {
@@ -30,6 +31,7 @@ const DeltBostedSkjema = (props: IProps) => {
         visFeilmeldinger,
         settVisFeilmeldinger,
         manuelleBrevmottakere,
+        vurderErLesevisning,
     } = props;
 
     const sorterteBarn = barnMedDeltBostedFelt.verdi.sort(
@@ -119,6 +121,7 @@ const DeltBostedSkjema = (props: IProps) => {
                     });
                 }}
                 manuelleBrevmottakere={manuelleBrevmottakere}
+                vurderErLesevisning={vurderErLesevisning}
             />
         </CheckboxGroup>
     );

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -198,6 +198,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
                             visFeilmeldinger={skjema.visFeilmeldinger}
                             settVisFeilmeldinger={settVisfeilmeldinger}
                             manuelleBrevmottakere={manuelleBrevmottakerePåFagsak}
+                            vurderErLesevisning={() => false}
                         />
                     )}
 

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -70,6 +70,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
         brukerHarUkjentAdresse,
         hentDistribusjonskanal,
     } = useDokumentutsending();
+    const { harInnloggetSaksbehandlerSkrivetilgang } = useApp();
 
     const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
 
@@ -198,7 +199,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
                             visFeilmeldinger={skjema.visFeilmeldinger}
                             settVisFeilmeldinger={settVisfeilmeldinger}
                             manuelleBrevmottakere={manuelleBrevmottakerePåFagsak}
-                            vurderErLesevisning={() => false}
+                            vurderErLesevisning={() => !harInnloggetSaksbehandlerSkrivetilgang()}
                         />
                     )}
 

--- a/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
@@ -142,6 +142,7 @@ const Barna: React.FunctionComponent = () => {
                     <LeggTilBarn
                         barnaMedOpplysninger={skjema.felter.barnaMedOpplysninger}
                         manuelleBrevmottakere={brevmottakere}
+                        vurderErLesevisning={vurderErLesevisning}
                     />
                 )}
             </StyledCheckboxGroup>

--- a/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/LeggTilUregistrertBarn.tsx
@@ -6,13 +6,13 @@ import styled from 'styled-components';
 import { BodyShort, Checkbox, CheckboxGroup, Heading, TextField } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 
-import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import type { IPersonInfo } from '../../../typer/person';
 import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import type { IRegistrerBarnSkjema } from '../../Felleskomponenter/LeggTilBarn';
 
 interface IProps {
     registrerBarnSkjema: ISkjema<IRegistrerBarnSkjema, IPersonInfo>;
+    vurderErLesevisning: () => boolean;
 }
 
 const Container = styled.div`
@@ -26,9 +26,7 @@ const UregistrertBarnInputs = styled.div`
     gap: 1rem;
 `;
 
-const LeggTilUregistrertBarn: React.FC<IProps> = ({ registrerBarnSkjema }) => {
-    const { vurderErLesevisning } = useBehandling();
-
+const LeggTilUregistrertBarn: React.FC<IProps> = ({ registrerBarnSkjema, vurderErLesevisning }) => {
     return (
         <Container>
             {vurderErLesevisning() ? (

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -374,6 +374,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                         visFeilmeldinger={skjema.visFeilmeldinger}
                         settVisFeilmeldinger={settVisfeilmeldinger}
                         manuelleBrevmottakere={brevmottakere}
+                        vurderErLesevisning={vurderErLesevisning}
                     />
                 )}
                 {skjema.felter.brevmal.verdi === Brevmal.VARSEL_OM_REVURDERING_SAMBOER && (

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn.tsx
@@ -52,12 +52,14 @@ interface IProps {
     barnaMedOpplysninger: Felt<IBarnMedOpplysninger[]>;
     onSuccess?: (barn: IPersonInfo) => void;
     manuelleBrevmottakere: SkjemaBrevmottaker[] | IRestBrevmottaker[];
+    vurderErLesevisning: () => boolean;
 }
 
 const LeggTilBarn: React.FC<IProps> = ({
     barnaMedOpplysninger,
     onSuccess,
     manuelleBrevmottakere,
+    vurderErLesevisning,
 }) => {
     const { request } = useHttp();
     const [visModal, settVisModal] = useState<boolean>(false);
@@ -330,7 +332,10 @@ const LeggTilBarn: React.FC<IProps> = ({
                                 </Link>
                             </DrekLenkeContainer>
                             {registrerBarnSkjema.felter.erFolkeregistrert.erSynlig && (
-                                <LeggTilUregistrertBarn registrerBarnSkjema={registrerBarnSkjema} />
+                                <LeggTilUregistrertBarn
+                                    registrerBarnSkjema={registrerBarnSkjema}
+                                    vurderErLesevisning={vurderErLesevisning}
+                                />
                             )}
                         </Fieldset>
                     </Modal.Body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,16 +3117,6 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/experimental-utils@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/parser@^6.13.1":
   version "6.13.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.13.1.tgz#29d6d4e5fab4669e58bc15f6904b67da65567487"
@@ -3160,19 +3150,6 @@
   version "6.13.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.13.1.tgz#b56f26130e7eb8fa1e429c75fb969cae6ad7bb5c"
   integrity sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@6.13.1":
   version "6.13.1"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
I #2866 endret vi slik at vi ikke alltid har tilgang på behandlingscontexten når vi er på en fagsak. Det gjør at vi ikke har tilgang til behandlingsspesifike funksjoner når vi ikke er inne på en behandling. 

"Legg til barn" for manuelle brev gjenbrukes av både dokumenutsending på fagsak og på behandling. Siden det er forskjellige regler for om en saksbehandler har skrivetilgang for fagsak og behandling må vi sende med om det er lesevisning