### PR TITLE
Ikke redirect om vi ikke har behandling på fagsak

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -41,7 +41,11 @@ const useOpprettBehandling = (
     lukkModal: () => void,
     onOpprettTilbakekrevingSuccess: () => void
 ) => {
-    const { bruker: brukerRessurs, minimalFagsak: minimalFagsakRessurs } = useFagsakContext();
+    const {
+        bruker: brukerRessurs,
+        minimalFagsak: minimalFagsakRessurs,
+        hentMinimalFagsak,
+    } = useFagsakContext();
     const { innloggetSaksbehandler } = useApp();
     const navigate = useNavigate();
     const { oppdaterKlagebehandlingerPåFagsak } = useFagsakContext();
@@ -244,6 +248,8 @@ const useOpprettBehandling = (
             },
             response => {
                 if (response.status === RessursStatus.SUKSESS) {
+                    hentMinimalFagsak(fagsakId, true);
+
                     lukkModal();
                     nullstillSkjema();
 


### PR DESCRIPTION
Dersom vi er på fagsak x og behandling y altså `barnetrygd/fagsak/x/y` ønsker vi å redirecte til fagsaken dersom behandling ikke tilhører fagsaken. 

Når vi oppretter en behandling oppdaterer vi ikke fagsaken og dermed ikke hvilke behandlinger som er på fagsaken. Når vi da prøver å redirecte til behanldingen blir vi redirecta tilbake til fagsaken fordi systemet tror at behandlingen ikke tilhører fagsaken.

Endrer så vi oppdaterer fagsaken når vi lager en ny behandling