### PR TITLE
bruk useBehandling for å finne brevmottakere i stedet for useBrevModul i Barna.tsx

### DIFF
--- a/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/Barna.tsx
@@ -8,7 +8,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import BarnMedOpplysninger from './BarnMedOpplysninger';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
-import { useBrevModul } from '../../../context/BrevModulContext';
 import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
 import { useSøknad } from '../../../context/SøknadContext';
 import RødError from '../../../ikoner/RødError';
@@ -41,8 +40,9 @@ const IngenBarnRegistrertInfo = styled(Alert)`
 `;
 
 const Barna: React.FunctionComponent = () => {
-    const { vurderErLesevisning, gjelderInstitusjon, gjelderEnsligMindreårig } = useBehandling();
-    const { brevmottakere } = useBrevModul();
+    const { vurderErLesevisning, gjelderInstitusjon, gjelderEnsligMindreårig, behandling } =
+        useBehandling();
+    const brevmottakere = behandling?.brevmottakere ?? [];
     const lesevisning = vurderErLesevisning();
     const { bruker } = useFagsakContext();
     const { skjema } = useSøknad();


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
bug der leggTilBarn-modulen ikke fungerte. Viste seg at vi hentet brevmottakere fra feil context. 
[Lenke til slack](https://nav-it.slack.com/archives/C01G9BA8JKZ/p1701417684130679)

Henter brevmottaker fra behandlingscontexten i stedet for brevmodulcontexten.