### PR TITLE
Chore: rydd opp i bruk av ds-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@axe-core/react": "^4.8.1",
     "@navikt/aksel-icons": "5.11.4",
     "@navikt/ds-css": "5.11.4",
-    "@navikt/ds-icons": "2.2.0",
+    "@navikt/ds-icons": "1.3.27",
     "@navikt/ds-react": "5.11.4",
     "@navikt/ds-tokens": "5.11.4",
     "@navikt/familie-backend": "^10.0.10",

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnCheckbox.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/BarnSøktFor/BarnCheckbox.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Delete } from '@navikt/ds-icons';
+import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Checkbox } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
@@ -72,7 +72,7 @@ const BarnCheckbox: React.FC<IProps> = ({ barn, barnSøktForFelt }) => {
                                 ),
                             ]);
                         }}
-                        icon={<Delete />}
+                        icon={<TrashIcon />}
                     >
                         {'Fjern barn'}
                     </FjernBarnKnapp>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,10 +2061,10 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-css/5.11.4/4c44cc238b7aca5ab1cb0e62d204a3d98f50623b#4c44cc238b7aca5ab1cb0e62d204a3d98f50623b"
   integrity sha512-7iRniSsoQAijBA9Bj3OzBDS8dX/ANI8kEImJlaIuR8hssxd3h1NXeZAG2+sbOkqJYq+xG7PCRFDHwTXf/PLL3A==
 
-"@navikt/ds-icons@2.2.0":
-  version "2.2.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/ds-icons/2.2.0/3bcfc2145b897a7c36c6ca4ce20ba3b991d64a90#3bcfc2145b897a7c36c6ca4ce20ba3b991d64a90"
-  integrity sha512-86vmaBIwdk8THOOYqHusiSKZ8e7imaog7EdHsJz+9CCt7uKE+as+c/aVCyz1LUJjjXhdt7ify4mq4MzPuHK9MQ==
+"@navikt/ds-icons@1.3.27":
+  version "1.3.27"
+  resolved "https://npm.pkg.github.com/download/@navikt/ds-icons/1.3.27/7260508181259885d994ed5874ddb975ac03ff74#7260508181259885d994ed5874ddb975ac03ff74"
+  integrity sha512-VfFIZaDW7o4oXqxcyKrshSnGVH6WnhQonRk7U50N4n7FT5TCkm6X5BFzA9j3EQ4rNmxXaNVH7re1S3E6yecHGg==
 
 "@navikt/ds-react@5.11.4":
   version "5.11.4"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Erstatter et ikon som ble hentet fra ds-icons med tilsvarende i aksel-icons. Nedgraderer også versjonen av ds-icons fra 2 til 1, fordi landvelgeren og flagg-ikoner er de eneste som bruker ds-icons og de krever versjon 1.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Håper Aksel får ut ny landvelger snart, så kan vi fjerne gamle dependencies 🙏 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 🤷‍♀ ️Hvor er det lurt å starte?
U choose

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/b7d89979-8e00-4e59-bfe5-1f7ceace2493)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/6ad62c8a-9f5f-4c48-9696-680f38cfce4f)
