### PR TITLE
Oppgrader til nytt React-API for å rendre rotnoden

### DIFF
--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -9,6 +9,7 @@ import { Integrations } from '@sentry/tracing';
 import { setDefaultOptions } from 'date-fns';
 import { nb } from 'date-fns/locale';
 import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import App from './komponenter/App';
 
@@ -33,9 +34,10 @@ if (process.env.NODE_ENV !== 'production') {
     axe(React, ReactDOM, 1000);
 }
 
-ReactDOM.render(
+const container = document.getElementById('app');
+const root = createRoot(container!);
+root.render(
     <React.StrictMode>
         <App />
-    </React.StrictMode>,
-    document.getElementById('app')
+    </React.StrictMode>
 );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Som følge av oppgraderingen i #2928 må vi endre hvordan vi rendrer rotnoden. Frem til vi gjør det oppfører React seg som om vi ikke hadde oppgradert til 18

Se dokumentasjonen her:
https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
