### PR TITLE
Delt utbetaling ved 3 år endret utbetaling

### DIFF
--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -5,9 +5,9 @@ import createUseContext from 'constate';
 import type { Avhengigheter } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 
+import type { Utbetaling } from '../komponenter/Fagsak/Behandlingsresultat/Utbetaling';
 import {
     prosentTilUtbetaling,
-    Utbetaling,
     utbetalingTilProsent,
 } from '../komponenter/Fagsak/Behandlingsresultat/Utbetaling';
 import type { IBehandling } from '../typer/behandling';
@@ -49,7 +49,6 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 årsak: IEndretUtbetalingAndelÅrsak | undefined;
                 søknadstidspunkt: Date | undefined;
                 avtaletidspunktDeltBosted: Date | undefined;
-                fullSats: boolean | undefined;
                 begrunnelse: string | undefined;
             },
             IBehandling
@@ -85,20 +84,6 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     skalFeltetVises: (avhengigheter: Avhengigheter) =>
                         avhengigheter?.årsak.verdi === IEndretUtbetalingAndelÅrsak.DELT_BOSTED,
                     valideringsfunksjon: validerGyldigDato,
-                }),
-                fullSats: useFelt<boolean | undefined>({
-                    verdi:
-                        endretUtbetalingAndel.prosent !== null &&
-                        endretUtbetalingAndel.prosent !== undefined
-                            ? endretUtbetalingAndel.prosent === 100
-                            : undefined,
-                    avhengigheter: {
-                        årsak: årsakFelt,
-                        periodeSkalUtbetalesTilSøker: utbetalingFelt,
-                    },
-                    skalFeltetVises: (avhengigheter: Avhengigheter) =>
-                        avhengigheter?.årsak.verdi === IEndretUtbetalingAndelÅrsak.DELT_BOSTED &&
-                        utbetalingFelt.verdi === Utbetaling.FULL_UTBETALING,
                 }),
                 begrunnelse: useFelt<string | undefined>({
                     verdi: endretUtbetalingAndel.begrunnelse,

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -2,9 +2,14 @@ import { useState } from 'react';
 
 import createUseContext from 'constate';
 
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Avhengigheter } from '@navikt/familie-skjema';
+import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 
+import {
+    prosentTilUtbetaling,
+    Utbetaling,
+    utbetalingTilProsent,
+} from '../komponenter/Fagsak/Behandlingsresultat/Utbetaling';
 import type { IBehandling } from '../typer/behandling';
 import type { IRestEndretUtbetalingAndel } from '../typer/utbetalingAndel';
 import { IEndretUtbetalingAndelÅrsak } from '../typer/utbetalingAndel';
@@ -29,12 +34,10 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     : feil(felt, 'Du må velge en årsak'),
         });
 
-        const periodeSkalUtbetalesTilSøkerFelt = useFelt<boolean | undefined>({
-            verdi:
-                endretUtbetalingAndel.prosent === undefined ||
-                endretUtbetalingAndel.prosent === null
-                    ? undefined
-                    : endretUtbetalingAndel.prosent > 0,
+        const utbetalingFelt = useFelt<Utbetaling | undefined>({
+            verdi: prosentTilUtbetaling(endretUtbetalingAndel.prosent),
+            valideringsfunksjon: felt =>
+                felt.verdi ? ok(felt) : feil(felt, 'Du må velge utbetaling'),
         });
 
         const { skjema, kanSendeSkjema, onSubmit, nullstillSkjema } = useSkjema<
@@ -42,7 +45,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 person: string | undefined;
                 fom: IsoDatoString | undefined;
                 tom: IsoDatoString | undefined;
-                periodeSkalUtbetalesTilSøker: boolean | undefined;
+                utbetaling: Utbetaling | undefined;
                 årsak: IEndretUtbetalingAndelÅrsak | undefined;
                 søknadstidspunkt: Date | undefined;
                 avtaletidspunktDeltBosted: Date | undefined;
@@ -67,7 +70,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                 tom: useFelt<IsoDatoString | undefined>({
                     verdi: endretUtbetalingAndel.tom,
                 }),
-                periodeSkalUtbetalesTilSøker: periodeSkalUtbetalesTilSøkerFelt,
+                utbetaling: utbetalingFelt,
                 årsak: årsakFelt,
                 søknadstidspunkt: useFelt<Date | undefined>({
                     verdi: undefined,
@@ -91,20 +94,11 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                             : undefined,
                     avhengigheter: {
                         årsak: årsakFelt,
-                        periodeSkalUtbetalesTilSøker: periodeSkalUtbetalesTilSøkerFelt,
+                        periodeSkalUtbetalesTilSøker: utbetalingFelt,
                     },
                     skalFeltetVises: (avhengigheter: Avhengigheter) =>
                         avhengigheter?.årsak.verdi === IEndretUtbetalingAndelÅrsak.DELT_BOSTED &&
-                        periodeSkalUtbetalesTilSøkerFelt.verdi === true,
-                    valideringsfunksjon: (felt, avhengigheter) => {
-                        const feilmelding = 'Du må velge om brukeren skal ha full sats eller ikke.';
-                        if (avhengigheter?.årsak.verdi === IEndretUtbetalingAndelÅrsak.DELT_BOSTED)
-                            return felt.verdi ? ok(felt) : feil(felt, feilmelding);
-                        else
-                            return typeof felt.verdi === 'boolean'
-                                ? ok(felt)
-                                : feil(felt, feilmelding);
-                    },
+                        utbetalingFelt.verdi === Utbetaling.FULL_UTBETALING,
                 }),
                 begrunnelse: useFelt<string | undefined>({
                     verdi: endretUtbetalingAndel.begrunnelse,
@@ -141,13 +135,6 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             settDatofelterTilDefaultverdier();
         };
 
-        const hentProsentForEndretUtbetaling = () => {
-            return (
-                (skjema.felter.periodeSkalUtbetalesTilSøker.verdi ? 100 : 0) /
-                (skjema.felter.fullSats.verdi ? 1 : 2)
-            );
-        };
-
         const hentSkjemaData = () => {
             const {
                 person,
@@ -161,7 +148,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             return {
                 id: endretUtbetalingAndel.id,
                 personIdent: person && person.verdi,
-                prosent: hentProsentForEndretUtbetaling(),
+                prosent: utbetalingTilProsent(skjema.felter.utbetaling.verdi),
                 fom: fom && fom.verdi,
                 tom: tom && tom.verdi,
                 årsak: årsak && årsak.verdi,

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -15,15 +15,7 @@ import { useBehandling } from '../../../context/behandlingContext/BehandlingCont
 import { useEndretUtbetalingAndel } from '../../../context/EndretUtbetalingAndelContext';
 import type { IBehandling } from '../../../typer/behandling';
 import type { IRestEndretUtbetalingAndel } from '../../../typer/utbetalingAndel';
-import {
-    IEndretUtbetalingAndelFullSats,
-    IEndretUtbetalingAndelÅrsak,
-    optionTilsats,
-    satser,
-    satsTilOption,
-    årsaker,
-    årsakTekst,
-} from '../../../typer/utbetalingAndel';
+import { IEndretUtbetalingAndelÅrsak, årsaker, årsakTekst } from '../../../typer/utbetalingAndel';
 import type { IsoMånedString } from '../../../utils/dato';
 import { lagPersonLabel } from '../../../utils/formatter';
 import { hentFrontendFeilmelding } from '../../../utils/ressursUtils';
@@ -48,10 +40,6 @@ const StyledFieldset = styled(Fieldset)`
 const StyledSelectPersonvelger = styled(Select)`
     min-width: 20rem;
     z-index: 1000;
-`;
-
-const StyledSelectSatsvelger = styled(Select)`
-    max-width: 10rem;
 `;
 
 const Feltmargin = styled.div`
@@ -281,41 +269,6 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                             visFeilmeldinger={skjema.visFeilmeldinger}
                             readOnly={erLesevisning}
                         />
-                    </Feltmargin>
-                )}
-                {skjema.felter.fullSats.erSynlig && (
-                    <Feltmargin>
-                        <StyledSelectSatsvelger
-                            {...skjema.felter.fullSats.hentNavBaseSkjemaProps(
-                                skjema.visFeilmeldinger
-                            )}
-                            label={<Label>Sats</Label>}
-                            value={
-                                skjema.felter.fullSats.verdi !== undefined &&
-                                skjema.felter.fullSats.verdi !== null
-                                    ? skjema.felter.fullSats.verdi
-                                        ? IEndretUtbetalingAndelFullSats.FULL_SATS.valueOf()
-                                        : undefined
-                                    : undefined
-                            }
-                            readOnly={erLesevisning}
-                            onChange={(event: React.ChangeEvent<HTMLSelectElement>): void => {
-                                skjema.felter.fullSats.validerOgSettFelt(
-                                    optionTilsats(event.target.value)
-                                );
-                            }}
-                        >
-                            <option value={undefined}>Velg sats</option>
-                            {satser.map(sats => (
-                                <option value={sats.valueOf()} key={sats.valueOf()}>
-                                    {
-                                        satsTilOption(
-                                            sats === IEndretUtbetalingAndelFullSats.FULL_SATS
-                                        ).label
-                                    }
-                                </option>
-                            ))}
-                        </StyledSelectSatsvelger>
                     </Feltmargin>
                 )}
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -4,30 +4,20 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import {
-    BodyShort,
-    Button,
-    Label,
-    Radio,
-    RadioGroup,
-    Fieldset,
-    Select,
-    Textarea,
-} from '@navikt/ds-react';
+import { Button, Fieldset, Label, Radio, RadioGroup, Select, Textarea } from '@navikt/ds-react';
 import { ABorderAction } from '@navikt/ds-tokens/dist/tokens';
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { Utbetaling, utbetalingTilLabel } from './Utbetaling';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useEndretUtbetalingAndel } from '../../../context/EndretUtbetalingAndelContext';
 import type { IBehandling } from '../../../typer/behandling';
-import type {
-    IRestEndretUtbetalingAndel,
-    IEndretUtbetalingAndelÅrsak,
-} from '../../../typer/utbetalingAndel';
+import type { IRestEndretUtbetalingAndel } from '../../../typer/utbetalingAndel';
 import {
     IEndretUtbetalingAndelFullSats,
+    IEndretUtbetalingAndelÅrsak,
     optionTilsats,
     satser,
     satsTilOption,
@@ -249,37 +239,28 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                 </Feltmargin>
 
                 <Feltmargin>
-                    {erLesevisning ? (
-                        <>
-                            <Label>Utbetaling</Label>
-                            <BodyShort>
-                                {skjema.felter.periodeSkalUtbetalesTilSøker.verdi ? 'Ja' : 'Nei'}
-                            </BodyShort>
-                        </>
-                    ) : (
-                        <RadioGroup
-                            legend={<Label>Utbetaling</Label>}
-                            value={skjema.felter.periodeSkalUtbetalesTilSøker.verdi}
-                            onChange={(val: boolean | undefined) =>
-                                skjema.felter.periodeSkalUtbetalesTilSøker.validerOgSettFelt(val)
+                    <RadioGroup
+                        legend={<Label>Utbetaling</Label>}
+                        value={skjema.felter.utbetaling.verdi}
+                        onChange={skjema.felter.utbetaling.validerOgSettFelt}
+                        readOnly={erLesevisning}
+                    >
+                        {Object.values(Utbetaling).map(utbetaling => {
+                            if (
+                                utbetaling === Utbetaling.DELT_UTBETALING &&
+                                skjema.felter.årsak.verdi !==
+                                    IEndretUtbetalingAndelÅrsak.ETTERBETALING_3ÅR
+                            ) {
+                                return;
                             }
-                        >
-                            <Radio
-                                name={'utbetaling'}
-                                value={true}
-                                id={'ja-perioden-utbetales-til-søker'}
-                            >
-                                {'Perioden skal utbetales'}
-                            </Radio>
-                            <Radio
-                                name={'utbetaling'}
-                                value={false}
-                                id={'nei-perioden-skal-ikke-utbetales-til-søker'}
-                            >
-                                {'Perioden skal ikke utbetales'}
-                            </Radio>
-                        </RadioGroup>
-                    )}
+
+                            return (
+                                <Radio name={'utbetaling'} value={utbetaling} id={utbetaling}>
+                                    {utbetalingTilLabel(utbetaling)}
+                                </Radio>
+                            );
+                        })}
+                    </RadioGroup>
                 </Feltmargin>
 
                 <Feltmargin>

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Utbetaling.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Utbetaling.ts
@@ -1,0 +1,50 @@
+export enum Utbetaling {
+    FULL_UTBETALING = 'FULL_UTBETALING',
+    DELT_UTBETALING = 'DELT_UTBETALING',
+    INGEN_UTBETALING = 'INGEN_UTBETALING',
+}
+
+export function prosentTilUtbetaling(prosent?: number) {
+    switch (prosent) {
+        case 100:
+            return Utbetaling.FULL_UTBETALING;
+        case 50:
+            return Utbetaling.DELT_UTBETALING;
+        case 0:
+            return Utbetaling.INGEN_UTBETALING;
+        case undefined:
+            return undefined;
+        case null:
+            return undefined;
+        default:
+            throw new Error(`Klarer ikke å konvertere fra ${prosent} til Utbetaling-enum`);
+    }
+}
+
+export function utbetalingTilProsent(utbetaling?: Utbetaling) {
+    switch (utbetaling) {
+        case Utbetaling.FULL_UTBETALING:
+            return 100;
+        case Utbetaling.DELT_UTBETALING:
+            return 50;
+        case Utbetaling.INGEN_UTBETALING:
+            return 0;
+        case undefined:
+            return undefined;
+        default:
+            throw new Error(`Klarer ikke å konvertere fra ${utbetaling} til prosent`);
+    }
+}
+
+export function utbetalingTilLabel(utbetaling?: Utbetaling) {
+    switch (utbetaling) {
+        case Utbetaling.FULL_UTBETALING:
+            return 'Perioden skal utbetales fullt';
+        case Utbetaling.DELT_UTBETALING:
+            return 'Perioden skal utbetales delt';
+        case Utbetaling.INGEN_UTBETALING:
+            return 'Perioden skal ikke utbetales';
+        case undefined:
+            return 'Ikke valgt';
+    }
+}

--- a/src/frontend/typer/utbetalingAndel.ts
+++ b/src/frontend/typer/utbetalingAndel.ts
@@ -1,5 +1,3 @@
-import type { OptionType } from '@navikt/familie-form-elements';
-
 import type { IsoDatoString, IsoMånedString } from '../utils/dato';
 
 export interface IRestEndretUtbetalingAndel {
@@ -32,25 +30,3 @@ export const årsakTekst: { [key in IEndretUtbetalingAndelÅrsak]: string } = {
 export const årsaker: IEndretUtbetalingAndelÅrsak[] = Object.keys(IEndretUtbetalingAndelÅrsak).map(
     k => k as IEndretUtbetalingAndelÅrsak
 );
-
-export enum IEndretUtbetalingAndelFullSats {
-    FULL_SATS = 'FULL_SATS',
-}
-
-export interface SatsOption extends OptionType {
-    fullSats: boolean;
-}
-
-export const satsTilOption = (fullSats: boolean): SatsOption => ({
-    value: fullSats ? '100' : '50',
-    label: fullSats ? 'Full' : 'Delt',
-    fullSats: fullSats,
-});
-
-export const optionTilsats = (satsLabel: string): boolean => {
-    return satsLabel === IEndretUtbetalingAndelFullSats.FULL_SATS.valueOf();
-};
-
-export const satser: IEndretUtbetalingAndelFullSats[] = Object.keys(
-    IEndretUtbetalingAndelFullSats
-).map(k => k as IEndretUtbetalingAndelFullSats);


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17493

Dersom vi har en behandling som endrer fra delt til full utbetaling, men deler av endringen ikke kan innvilges på grunn av etterbetaling 3 år, ønsker vi å fremdeles utbetale det som tidligere har vært utbetalt. Se bilde under. 
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/2a3dc881-1744-4110-bf04-e2f55f6e97cc)

Det er ikke mulig slik løsningen er i dag, siden endret utbetaling med årsak `etterbetaling 3 år` kun kun tillater å endre til full eller ingen utbetaling.
Før:
<img width="486" alt="image" src="https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/672dd420-a94d-4cdb-948b-20e3aa187fa8">

Endrer så vi også kan velge at utbetalingen skal være delt dersom årsaken er `etterbetaling 3 år`
Etter:
<img width="486" alt="image" src="https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/cff8e055-e6c9-4a1f-ac16-67f6d626e2d0">
