### PR TITLE
Bug: stiplet linje på simuleringstabellen

### DIFF
--- a/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/SimuleringTabell.tsx
@@ -39,12 +39,12 @@ const ManuellPosteringRad = styled(Table.Row)`
 `;
 
 const HeaderCelle = styled(Table.HeaderCell)<{ $skalViseStipletLinje: boolean }>`
-    border-left: ${props => props.$skalViseStipletLinje && 'dotted'};
+    border-left: ${props => props.$skalViseStipletLinje && '1px dashed'};
 `;
 
 const DataCelle = styled(Table.DataCell)<{ $skalViseStipletLinje: boolean }>`
     width: ${ASpacing18};
-    border-left: ${props => props.$skalViseStipletLinje && 'dotted'};
+    border-left: ${props => props.$skalViseStipletLinje && '1px dashed'};
 `;
 
 const DataCellMedFarge = styled(DataCelle)<{


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikser opp så den stiplede linjen i simuleringstabellen ser ut som den skal. Ble nettopp gjort endringer på denne, men den har endt opp med å se annerledes ut enn det som var intensjonen. Retter det opp her.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/e7329a28-f003-4030-a0f4-be536b2e713b)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/cc4bb01d-0ba7-4c28-8022-81a789f575cc)
