### PR TITLE
Unngå å vise vurderingsdato som kan være feil

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -14,11 +14,7 @@ import VilkårResultatIkon from '../../../../ikoner/VilkårResultatIkon';
 import type { IGrunnlagPerson } from '../../../../typer/person';
 import type { IVilkårConfig, IVilkårResultat } from '../../../../typer/vilkår';
 import { Resultat, resultatVisningsnavn } from '../../../../typer/vilkår';
-import {
-    Datoformat,
-    isoDatoPeriodeTilFormatertString,
-    isoStringTilFormatertString,
-} from '../../../../utils/dato';
+import { isoDatoPeriodeTilFormatertString } from '../../../../utils/dato';
 import { alleRegelverk } from '../../../../utils/vilkår';
 
 interface IProps {
@@ -184,10 +180,7 @@ const VilkårTabellRad: React.FC<IProps> = ({
                         {vilkårResultat.verdi.erVurdert
                             ? vilkårResultat.verdi.behandlingId === behandling.behandlingId
                                 ? 'Vurdert i denne behandlingen'
-                                : `Vurdert ${isoStringTilFormatertString({
-                                      isoString: vilkårResultat.verdi.endretTidspunkt,
-                                      tilFormat: Datoformat.DATO_FORKORTTET,
-                                  })}`
+                                : 'Vurdert i tidligere behandling'
                             : ''}
                     </div>
                 </FlexDiv>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
NAV-15526 _Viser feil dato vilkår er sist endret_

<img width="298" alt="image" src="https://github.com/navikt/familie-ba-sak-frontend/assets/2379098/f36bedbb-b6ca-4d6e-a047-9114ec983a54">

I dag viser vi `endretTidspunkt` for å vise når et vilkårresultat ble vurdert sist. Denne verdien overskrives når vi i en revurdering kopierer over vilkårene fra forrige behandling, dermed kan dette feltet ofte inneholde feil.

Etter diskusjon med fagressursene kom det frem at det egentlige behovet er å synliggjøre hvorvidt vurderingen er gjort i denne eller tidligere behandling. Forenkler verdien vi viser til å kun skille på `denne behandlingen` og `tidligere behandling`.

![image](https://github.com/navikt/familie-ba-sak-frontend/assets/2379098/a2f27823-e439-4bf4-b354-bef003424c3e)
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/2379098/13e4dd11-7ce2-45bd-a063-1bee989866c2)

⚠️ Venter med å merge til jeg har fått endelig avklaring fra Miriam angående ordlyden. _edit:_ ✅

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_