### PR TITLE
Fiks: Får ikke legge til manuell adresse i informasjonsbrev fra fagsak

### DIFF
--- a/src/frontend/context/DokumentutsendingContext.ts
+++ b/src/frontend/context/DokumentutsendingContext.ts
@@ -330,12 +330,12 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
             skjema.submitRessurs.status === RessursStatus.HENTER ||
             hentetDokument.status === RessursStatus.HENTER;
 
-        const brukerHarManuellAdresse = manuelleBrevmottakerePåFagsak.some(
+        const brukerHarUtenlandskAdresse = manuelleBrevmottakerePåFagsak.some(
             mottaker => mottaker.type === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
         );
 
         const brukerHarUkjentAdresse = () =>
-            !brukerHarManuellAdresse &&
+            !brukerHarUtenlandskAdresse &&
             (distribusjonskanal.status !== RessursStatus.SUKSESS ||
                 distribusjonskanal.data === Distribusjonskanal.UKJENT ||
                 distribusjonskanal.data === Distribusjonskanal.INGEN_DISTRIBUSJON);
@@ -389,7 +389,7 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
             skjema,
             nullstillSkjema,
             distribusjonskanal,
-            brukerHarManuellAdresse,
+            brukerHarUtenlandskAdresse,
             brukerHarUkjentAdresse,
             hentDistribusjonskanal,
         };

--- a/src/frontend/context/DokumentutsendingContext.ts
+++ b/src/frontend/context/DokumentutsendingContext.ts
@@ -7,10 +7,10 @@ import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useApp } from './AppContext';
 import { useFagsakContext } from './fagsak/FagsakContext';
 import useDokument from '../hooks/useDokument';
 import { hentEnkeltInformasjonsbrevRequest } from '../komponenter/Fagsak/Dokumentutsending/Informasjonsbrev/enkeltInformasjonsbrevUtils';
+import { Mottaker } from '../komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { ISelectOptionMedBrevtekst } from '../komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
 import {
     Informasjonsbrev,
@@ -20,7 +20,6 @@ import type { IManueltBrevRequestPåFagsak } from '../typer/dokument';
 import { Distribusjonskanal } from '../typer/dokument';
 import type { IBarnMedOpplysninger } from '../typer/søknad';
 import { Målform } from '../typer/søknad';
-import { ToggleNavn } from '../typer/toggles';
 import { useBarnSøktForFelter } from '../utils/barnSøktForFelter';
 import type { IsoDatoString } from '../utils/dato';
 import { Datoformat, isoStringTilFormatertString } from '../utils/dato';
@@ -65,7 +64,6 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
         const [visInnsendtBrevModal, settVisInnsendtBrevModal] = useState(false);
         const { hentForhåndsvisning, hentetDokument, distribusjonskanal, hentDistribusjonskanal } =
             useDokument();
-        const { toggles } = useApp();
 
         const [sistBrukteDataVedForhåndsvisning, settSistBrukteDataVedForhåndsvisning] = useState<
             IManueltBrevRequestPåFagsak | undefined
@@ -332,8 +330,12 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
             skjema.submitRessurs.status === RessursStatus.HENTER ||
             hentetDokument.status === RessursStatus.HENTER;
 
+        const brukerHarManuellAdresse = manuelleBrevmottakerePåFagsak.some(
+            mottaker => mottaker.type === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
+        );
+
         const brukerHarUkjentAdresse = () =>
-            toggles[ToggleNavn.verifiserDokdistKanal] &&
+            !brukerHarManuellAdresse &&
             (distribusjonskanal.status !== RessursStatus.SUKSESS ||
                 distribusjonskanal.data === Distribusjonskanal.UKJENT ||
                 distribusjonskanal.data === Distribusjonskanal.INGEN_DISTRIBUSJON);
@@ -387,6 +389,7 @@ export const [DokumentutsendingProvider, useDokumentutsending] = createUseContex
             skjema,
             nullstillSkjema,
             distribusjonskanal,
+            brukerHarManuellAdresse,
             brukerHarUkjentAdresse,
             hentDistribusjonskanal,
         };

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -76,7 +76,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
         distribusjonskanal,
         brukerHarUkjentAdresse,
         hentDistribusjonskanal,
-        brukerHarManuellAdresse,
+        brukerHarUtenlandskAdresse,
     } = useDokumentutsending();
     const { harInnloggetSaksbehandlerSkrivetilgang } = useApp();
 
@@ -147,7 +147,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
     return (
         <Container>
             <Heading size={'large'} level={'1'} children={'Send informasjonsbrev'} />
-            {!brukerHarManuellAdresse && distribusjonskanalInfo()}
+            {!brukerHarUtenlandskAdresse && distribusjonskanalInfo()}
 
             {manuelleBrevmottakerePåFagsak.length > 0 && (
                 <StyledBrevmottakereAlert

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -19,7 +19,10 @@ import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
 import { Distribusjonskanal } from '../../../typer/dokument';
 import type { IPersonInfo } from '../../../typer/person';
 import { ToggleNavn } from '../../../typer/toggles';
-import { BrevmottakereAlert } from '../../Felleskomponenter/BrevmottakereAlert';
+import {
+    BrevmottakereAlert,
+    type BrevmottakereAlertFagsakProps,
+} from '../../Felleskomponenter/BrevmottakereAlert';
 import MålformVelger from '../../Felleskomponenter/MålformVelger';
 
 interface Props {
@@ -54,6 +57,10 @@ const SendBrevKnapp = styled(Button)`
     margin-right: 1rem;
 `;
 
+const StyledBrevmottakereAlert = styled(BrevmottakereAlert)<BrevmottakereAlertFagsakProps>`
+    margin: 1rem 0;
+`;
+
 const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
     const {
         hentForhåndsvisningPåFagsak,
@@ -69,6 +76,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
         distribusjonskanal,
         brukerHarUkjentAdresse,
         hentDistribusjonskanal,
+        brukerHarManuellAdresse,
     } = useDokumentutsending();
     const { harInnloggetSaksbehandlerSkrivetilgang } = useApp();
 
@@ -86,9 +94,6 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
     const { toggles } = useApp();
 
     useEffect(() => {
-        if (!toggles[ToggleNavn.verifiserDokdistKanal]) {
-            return;
-        }
         hentDistribusjonskanal(bruker.personIdent);
     }, []);
 
@@ -142,10 +147,10 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
     return (
         <Container>
             <Heading size={'large'} level={'1'} children={'Send informasjonsbrev'} />
-            {toggles[ToggleNavn.verifiserDokdistKanal] && distribusjonskanalInfo()}
+            {!brukerHarManuellAdresse && distribusjonskanalInfo()}
 
             {manuelleBrevmottakerePåFagsak.length > 0 && (
-                <BrevmottakereAlert
+                <StyledBrevmottakereAlert
                     erPåBehandling={false}
                     brevmottakere={manuelleBrevmottakerePåFagsak}
                     bruker={bruker}

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -19,10 +19,7 @@ import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
 import { Distribusjonskanal } from '../../../typer/dokument';
 import type { IPersonInfo } from '../../../typer/person';
 import { ToggleNavn } from '../../../typer/toggles';
-import {
-    BrevmottakereAlert,
-    type BrevmottakereAlertFagsakProps,
-} from '../../Felleskomponenter/BrevmottakereAlert';
+import { BrevmottakereAlert } from '../../Felleskomponenter/BrevmottakereAlert';
 import MålformVelger from '../../Felleskomponenter/MålformVelger';
 
 interface Props {
@@ -57,7 +54,7 @@ const SendBrevKnapp = styled(Button)`
     margin-right: 1rem;
 `;
 
-const StyledBrevmottakereAlert = styled(BrevmottakereAlert)<BrevmottakereAlertFagsakProps>`
+const StyledBrevmottakereAlert = styled(BrevmottakereAlert)`
     margin: 1rem 0;
 `;
 

--- a/src/frontend/komponenter/Felleskomponenter/BrevmottakereAlert.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/BrevmottakereAlert.tsx
@@ -31,7 +31,7 @@ export interface BrevmottakereAlertBehandlingProps extends Props {
     åpenBehandling: IBehandling;
 }
 
-interface BrevmottakereAlertFagsakProps extends Props {
+export interface BrevmottakereAlertFagsakProps extends Props {
     erPåBehandling: false;
     brevmottakere: SkjemaBrevmottaker[];
 }

--- a/src/frontend/komponenter/Felleskomponenter/BrevmottakereAlert.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/BrevmottakereAlert.tsx
@@ -31,7 +31,7 @@ export interface BrevmottakereAlertBehandlingProps extends Props {
     åpenBehandling: IBehandling;
 }
 
-export interface BrevmottakereAlertFagsakProps extends Props {
+interface BrevmottakereAlertFagsakProps extends Props {
     erPåBehandling: false;
     brevmottakere: SkjemaBrevmottaker[];
 }

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -12,7 +12,6 @@ export enum ToggleNavn {
     kanBehandleKlage = 'familie-ba-sak.klage',
     selvstendigRettInfobrev = 'familie-ba-sak.selvstendig-rett-infobrev',
     manuellMottakerInfobrev = 'familie-ba-sak.manuell-mottaker-infobrev',
-    verifiserDokdistKanal = 'familie-ba-sak.dokdistkanal-integrasjon',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17868

Åpner for å sende brev til bruker med ukjent adresse fra fagsak idet det er lagt til en adresse manuelt

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Grunnen til at menyvalget for å legge til adresse ikke var til stede er fordi toggelen ikke er aktivert i prod. Er det noe mer som gjenstår enn å bare skru den på?
  
### 👀 Screen shots
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/47184872/0775c85a-e6ff-4b40-ab67-dcaa778a6e0a)
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/47184872/7c92e2d9-6354-4229-9ec7-368850a5d7ac)
