### PR TITLE
Bruk radiogroup fra aksel i stedet for FamilieRadioGruppe

### DIFF
--- a/src/frontend/komponenter/Fagsak/Søknad/SøknadType.tsx
+++ b/src/frontend/komponenter/Fagsak/Søknad/SøknadType.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { Heading, Radio } from '@navikt/ds-react';
-import { FamilieRadioGruppe } from '@navikt/familie-form-elements/dist';
+import { Heading, Radio, RadioGroup } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useSøknad } from '../../../context/SøknadContext';
 import { behandlingUnderkategori, BehandlingUnderkategori } from '../../../typer/behandlingstema';
 
-const StyledFamilieRadioGruppe = styled(FamilieRadioGruppe)`
+const StyledRadioGroup = styled(RadioGroup)`
     margin: 2rem 0;
 `;
 
@@ -27,9 +26,9 @@ const SøknadType: React.FunctionComponent = () => {
     };
 
     return (
-        <StyledFamilieRadioGruppe
+        <StyledRadioGroup
             {...skjema.felter.underkategori.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-            erLesevisning={erLesevisning}
+            readOnly={erLesevisning}
             value={behandlingUnderkategori[skjema.felter.underkategori.verdi]}
             legend={<Heading size={'medium'} level={'2'} children={'Hva har bruker søkt om?'} />}
         >
@@ -49,7 +48,7 @@ const SøknadType: React.FunctionComponent = () => {
             >
                 {behandlingUnderkategori[BehandlingUnderkategori.UTVIDET]}
             </StyledRadio>
-        </StyledFamilieRadioGruppe>
+        </StyledRadioGroup>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Label, Radio, TextField } from '@navikt/ds-react';
-import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
-import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
+import { HStack, Label, Radio, RadioGroup, TextField, VStack } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { Country } from '@navikt/land-verktoy';
@@ -25,16 +23,6 @@ const StyledFamilieLandvelger = styled(FamilieLandvelger)`
     > * {
         margin: 0;
     }
-`;
-
-const FlexDatoInputWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: ${ASpacing3};
-`;
-
-const FlexRowDiv = styled.div`
-    display: flex;
 `;
 
 const StyledTextField = styled(TextField)`
@@ -73,8 +61,8 @@ const RefusjonEøsSkjema: React.FunctionComponent<IRefusjonEøsSkjemaProps> = ({
                 }
             />
 
-            <FamilieRadioGruppe
-                erLesevisning={erLesevisning}
+            <RadioGroup
+                readOnly={erLesevisning}
                 legend="Tekst i vedtaksbrev"
                 value={
                     erLesevisning
@@ -103,10 +91,10 @@ const RefusjonEøsSkjema: React.FunctionComponent<IRefusjonEøsSkjemaProps> = ({
                 >
                     {'Refusjon ikke avklart'}
                 </Radio>
-            </FamilieRadioGruppe>
-            <FlexDatoInputWrapper>
+            </RadioGroup>
+            <VStack gap={'2'}>
                 <Label size="small">Angi periode som skal refunderes til EØS-land</Label>
-                <FlexRowDiv style={{ gap: '2rem' }}>
+                <HStack gap={'4'}>
                     <Månedvelger
                         felt={skjema.felter.fom}
                         label={'F.o.m'}
@@ -124,8 +112,8 @@ const RefusjonEøsSkjema: React.FunctionComponent<IRefusjonEøsSkjemaProps> = ({
                         tilhørendeFomFelt={skjema.felter.fom}
                         kanKunVelgeFortid
                     />
-                </FlexRowDiv>
-            </FlexDatoInputWrapper>
+                </HStack>
+            </VStack>
             <StyledTextField
                 {...skjema.felter.refusjonsbeløp.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                 size="small"

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Fieldset, Radio, Textarea } from '@navikt/ds-react';
-import { FamilieKnapp, FamilieRadioGruppe } from '@navikt/familie-form-elements';
+import { Fieldset, Radio, RadioGroup, Textarea } from '@navikt/ds-react';
+import { FamilieKnapp } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { FeltState } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -46,7 +46,7 @@ const Knapperad = styled.div`
     margin: 1rem 0;
 `;
 
-const StyledFamilieRadioGruppe = styled(FamilieRadioGruppe)`
+const StyledRadioGroup = styled(RadioGroup)`
     && {
         margin: 1rem 0;
         legend {
@@ -170,8 +170,8 @@ const AnnenVurderingRadEndre: React.FC<IProps> = ({
                 $lesevisning={erLesevisning}
                 $vilkårResultat={redigerbartAnnenVurdering.verdi.resultat.verdi}
             >
-                <StyledFamilieRadioGruppe
-                    erLesevisning={erLesevisning}
+                <StyledRadioGroup
+                    readOnly={erLesevisning}
                     value={resultater[redigerbartAnnenVurdering.verdi.resultat.verdi]}
                     legend={
                         annenVurderingConfig.spørsmål
@@ -206,7 +206,7 @@ const AnnenVurderingRadEndre: React.FC<IProps> = ({
                     >
                         {'Nei'}
                     </Radio>
-                </StyledFamilieRadioGruppe>
+                </StyledRadioGroup>
 
                 <Textarea
                     readOnly={erLesevisning}

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
@@ -18,9 +18,6 @@ export const annenVurderingResultatFeilmeldingId = (annenVurdering: IAnnenVurder
 export const annenVurderingBegrunnelseFeilmeldingId = (annenVurdering: IAnnenVurdering) =>
     `annen-vurdering-begrunnelse_${annenVurdering.type}_${annenVurdering.id}`;
 
-export const annenVurderingPeriodeFeilmeldingId = (annenVurdering: IAnnenVurdering) =>
-    `annen-vurdering-periode_${annenVurdering.type}_${annenVurdering.id}`;
-
 interface IProps {
     person: IGrunnlagPerson;
     andreVurderinger: FeltState<IAnnenVurdering>[];

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
@@ -4,9 +4,9 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Button, Fieldset, Label, Radio, Select, Textarea } from '@navikt/ds-react';
+import { Button, Fieldset, Label, Radio, RadioGroup, Select, Textarea } from '@navikt/ds-react';
 import { ABorderDefault, ABorderWarning, ASurfaceAction } from '@navikt/ds-tokens/dist/tokens';
-import { FamilieKnapp, FamilieRadioGruppe } from '@navikt/familie-form-elements';
+import { FamilieKnapp } from '@navikt/familie-form-elements';
 import type { FeltState } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
@@ -69,7 +69,7 @@ const Knapperad = styled.div`
     margin: 1rem 0;
 `;
 
-const StyledFamilieRadioGruppe = styled(FamilieRadioGruppe)`
+const StyledRadioGroup = styled(RadioGroup)`
     && {
         margin: 1rem 0;
         legend {
@@ -262,8 +262,8 @@ const VilkårTabellRadEndre: React.FC<IProps> = ({
                         )}
                     </Select>
                 )}
-                <StyledFamilieRadioGruppe
-                    erLesevisning={lesevisning}
+                <StyledRadioGroup
+                    readOnly={lesevisning}
                     value={
                         redigerbartVilkår.verdi.resultatBegrunnelse
                             ? redigerbartVilkår.verdi.resultatBegrunnelse
@@ -314,7 +314,7 @@ const VilkårTabellRadEndre: React.FC<IProps> = ({
                                 Ikke aktuelt
                             </Radio>
                         )}
-                </StyledFamilieRadioGruppe>
+                </StyledRadioGroup>
                 {!gjelderInstitusjon && (
                     <UtdypendeVilkårsvurderingMultiselect
                         redigerbartVilkår={redigerbartVilkår}

--- a/src/frontend/komponenter/Felleskomponenter/MålformVelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/MålformVelger.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { Heading, Radio } from '@navikt/ds-react';
-import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
+import { Heading, Radio, RadioGroup } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 
 import { Målform, målform } from '../../typer/søknad';
 
-const StyledFamilieRadioGruppe = styled(FamilieRadioGruppe)`
+const StyledRadioGroup = styled(RadioGroup)`
     margin: 2rem 0;
 `;
 
@@ -34,9 +33,9 @@ const MålformVelger: React.FC<IProps> = ({
     };
 
     return (
-        <StyledFamilieRadioGruppe
+        <StyledRadioGroup
             {...målformFelt.hentNavBaseSkjemaProps(visFeilmeldinger)}
-            erLesevisning={erLesevisning}
+            readOnly={erLesevisning}
             value={målformFelt.verdi ? målform[målformFelt.verdi] : ''}
             legend={Legend}
         >
@@ -57,7 +56,7 @@ const MålformVelger: React.FC<IProps> = ({
             >
                 {målform[Målform.NN]}
             </StyledRadio>
-        </StyledFamilieRadioGruppe>
+        </StyledRadioGroup>
     );
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Fjern bruken av FamilieRadioKnapp slik at vi ikke trenger å forvalte denne knappen familie-frontend på sikt. Grunnen til dette er at vi kan bruke RadioGroup direkte fra Aksel.