### PR TITLE
Bug: tillatt fom-dato frem i tid innenfor inneværende måned

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { endOfMonth } from 'date-fns';
 import styled from 'styled-components';
 
 import { HelpText, Label, Fieldset } from '@navikt/ds-react';
@@ -11,7 +12,7 @@ import { useBehandling } from '../../../../context/behandlingContext/BehandlingC
 import type { IVilkårResultat } from '../../../../typer/vilkår';
 import { Resultat } from '../../../../typer/vilkår';
 import type { IsoDatoString } from '../../../../utils/dato';
-import { nyIsoDatoPeriode } from '../../../../utils/dato';
+import { dagensDato, nyIsoDatoPeriode } from '../../../../utils/dato';
 import DatovelgerForGammelSkjemaløsning from '../../../Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
 
 interface IProps {
@@ -97,7 +98,7 @@ const VelgPeriode: React.FC<IProps> = ({
                     }}
                     visFeilmeldinger={false}
                     readOnly={erLesevisning}
-                    kanKunVelgeFortid
+                    maksDatoAvgrensning={endOfMonth(dagensDato)}
                 />
                 <DatovelgerForGammelSkjemaløsning
                     label={'T.o.m (valgfri)'}

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
@@ -6,7 +6,7 @@ import { isValid, parseISO } from 'date-fns';
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
 import { senesteRelevanteDato, tidligsteRelevanteDato } from './utils';
-import { dagensDato, dateTilFormatertString, Datoformat } from '../../../utils/dato';
+import { dateTilFormatertString, Datoformat } from '../../../utils/dato';
 import type { IsoDatoString } from '../../../utils/dato';
 
 interface IProps {
@@ -18,6 +18,7 @@ interface IProps {
     readOnly?: boolean;
     kanKunVelgeFortid?: boolean;
     minDatoAvgrensning?: Date;
+    maksDatoAvgrensning?: Date;
 }
 
 const DatovelgerForGammelSkjemaløsning = ({
@@ -26,9 +27,9 @@ const DatovelgerForGammelSkjemaløsning = ({
     label,
     visFeilmeldinger,
     minDatoAvgrensning,
+    maksDatoAvgrensning,
     feilmelding = undefined,
     readOnly = false,
-    kanKunVelgeFortid = false,
 }: IProps) => {
     const formatterDefaultSelected = () => {
         if (value === undefined) return undefined;
@@ -39,7 +40,7 @@ const DatovelgerForGammelSkjemaløsning = ({
     const { datepickerProps, inputProps, selectedDay } = useDatepicker({
         defaultSelected: formatterDefaultSelected(),
         fromDate: minDatoAvgrensning ? minDatoAvgrensning : tidligsteRelevanteDato,
-        toDate: kanKunVelgeFortid ? dagensDato : senesteRelevanteDato,
+        toDate: maksDatoAvgrensning ? maksDatoAvgrensning : senesteRelevanteDato,
         openOnFocus: false,
     });
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18053

Åpner opp for at datovelgeren godtar fom-dato frem i tid, så lenge det er i inneværende måned. Valideringsfunksjonen som kjøres har alltid tillatt dette, men datovelgeren har vært litt for streng.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testet manuelt, det holder

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Bare 1 commit:)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  