### PR TITLE
Bug: Fiks styling av historikkliste

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/komponenter/HendelseItem.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/komponenter/HendelseItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, HStack, VStack } from '@navikt/ds-react';
+import { BodyShort, HGrid, VStack } from '@navikt/ds-react';
 import {
     ABorderDefault,
     ABorderSubtle,
@@ -26,6 +26,7 @@ const Hendelsesbeskrivelse = styled(BodyShort)`
 
 const StyledVStack = styled(VStack)`
     margin-bottom: ${ASpacing6};
+    margin-right: ${ASpacing4};
 `;
 
 const Sirkel = styled.div`
@@ -45,7 +46,7 @@ const Strek = styled.div`
 `;
 const HendelseItem = ({ hendelse }: IHendelseItemProps) => (
     <li>
-        <HStack gap="4">
+        <HGrid columns="0.5rem 1fr" gap="4">
             <VStack align="center">
                 <Sirkel />
                 <Strek />
@@ -63,7 +64,7 @@ const HendelseItem = ({ hendelse }: IHendelseItemProps) => (
                         : ''
                 }`}</BodyShort>
             </StyledVStack>
-        </HStack>
+        </HGrid>
     </li>
 );
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Oppdaget at stylingen på historikk-siden var brukket for lange historikkinnslag, etter at jeg gjorde en oppgradering her. Bytter fra å bruke `HStack` til `HGrid` og sier at kolonne 1 alltid kan ta en viss mengde plass.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Kun 1 commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Før
<img width="471" alt="image" src="https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/10ef748b-ef13-4cc5-916e-4a440aa31a45">


Etter
<img width="472" alt="image" src="https://github.com/navikt/familie-ba-sak-frontend/assets/25459913/a31b2671-b9c3-4ae9-80e0-30cf48b7a2c8">
