### PR TITLE
Skjul månedligvaluta justeringer

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/utils.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/utils.tsx
@@ -13,6 +13,7 @@ import {
     behandlingsresultater,
     BehandlingStatus,
     behandlingstyper,
+    BehandlingÅrsak,
     behandlingÅrsak,
     erBehandlingHenlagt,
 } from '../../../typer/behandling';
@@ -48,7 +49,7 @@ export type Saksoversiktsbehandling =
           saksoversiktbehandlingstype: Saksoversiktbehandlingstype.KLAGE;
       });
 
-export const skalRadVises = (
+export const skalHenlagtBehandlingVises = (
     behandling: Saksoversiktsbehandling,
     visHenlagteBehandlinger: boolean
 ): boolean => {
@@ -58,6 +59,15 @@ export const skalRadVises = (
         return !erBehandlingHenlagt(behandling.resultat);
     }
     return Behandlingsresultatstype.HENLAGT !== behandling.resultat;
+};
+
+export const skalMånedligValutajusteringVises = (
+    behandling: Saksoversiktsbehandling,
+    visMånedligValutajusteringer: boolean
+): boolean => {
+    if (visMånedligValutajusteringer) return true;
+
+    return behandling.årsak !== BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING;
 };
 
 export const hentOpprettetTidspunkt = (saksoversiktsbehandling: Saksoversiktsbehandling) => {

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -75,6 +75,7 @@ export enum BehandlingÅrsak {
     ENDRE_MIGRERINGSDATO = 'ENDRE_MIGRERINGSDATO',
     HELMANUELL_MIGRERING = 'HELMANUELL_MIGRERING',
     OMREGNING_SMÅBARNSTILLEGG = 'OMREGNING_SMÅBARNSTILLEGG',
+    MÅNEDLIG_VALUTAJUSTERING = 'MÅNEDLIG_VALUTAJUSTERING',
 }
 
 export const behandlingÅrsak: Record<
@@ -105,6 +106,7 @@ export const behandlingÅrsak: Record<
     REVURDERING_OPPLYSNINGER_OM_FORELDELSE: 'Nye opplysninger',
     REVURDERING_FEILUTBETALT_BELØP_HELT_ELLER_DELVIS_BORTFALT:
         'Feilutbetalt beløp helt eller delvis bortfalt',
+    MÅNEDLIG_VALUTAJUSTERING: 'Månedlig valutajustering',
 
     /** Klage: **/
     ANNET: 'Annet',


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18499

Vi ønsker å skjule månedlige valutajusteringer by default i saksoversikten.
Vi ønsker også å bare få switchen for å vise dem dersom det finnes en behandling på fagsak som har årsak månedlig valutajustering.

Se video som viser:

1. Behandling med bare 1 sak
2. Behandling med 2 saker, 1 vanlig og 1 henlagt behandling
3. Behandling med 2 saker, 1 vanlig og 1 månedlig valutajustering
4. Behandling med 3 saker, 1 vanlig, 1 månedlig valutajustering, 1 henlagt behandling.


https://github.com/navikt/familie-ba-sak-frontend/assets/110383605/dd06d28a-166d-4065-8d06-17acaec1133f



