### PR TITLE
Øker makslengden til fritekst-kulepunktene i vedtaksbegrunnelser fra 220 til 350 tegn

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -292,6 +292,7 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
             lagInitiellFritekst(
                 '',
                 genererIdBasertPåAndreFritekster(fritekster),
+                makslengdeFritekst,
                 valideringsmelding
             ),
         ]);

--- a/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
+++ b/src/frontend/komponenter/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
@@ -44,7 +44,11 @@ const KanSøkeFritekst = ({
     const leggTilFritekst = () => {
         friteksterFelt.validerOgSettFelt([
             ...friteksterFelt.verdi,
-            lagInitiellFritekst('', genererIdBasertPåAndreFritekster(friteksterFelt)),
+            lagInitiellFritekst(
+                '',
+                genererIdBasertPåAndreFritekster(friteksterFelt),
+                makslengdeFritekst
+            ),
         ]);
     };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/Context/VedtaksperiodeMedBegrunnelserContext.ts
@@ -50,7 +50,7 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
         const { settVedtaksperioderMedBegrunnelserRessurs } = useVedtaksperioder();
 
         const maksAntallKulepunkter = 3;
-        const makslengdeFritekst = 220;
+        const makslengdeFritekst = 350;
 
         const periode = useFelt<IIsoDatoPeriode>({
             verdi: {
@@ -101,7 +101,7 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
 
             skjema.felter.fritekster.validerOgSettFelt(
                 vedtaksperiodeMedBegrunnelser.fritekster.map((fritekst, id) =>
-                    lagInitiellFritekst(fritekst, id)
+                    lagInitiellFritekst(fritekst, id, makslengdeFritekst)
                 )
             );
         };
@@ -203,7 +203,11 @@ const [VedtaksperiodeMedBegrunnelserPanelProvider, useVedtaksperiodeMedBegrunnel
         const leggTilFritekst = () => {
             skjema.felter.fritekster.validerOgSettFelt([
                 ...skjema.felter.fritekster.verdi,
-                lagInitiellFritekst('', genererIdBasertPåAndreFritekster(skjema.felter.fritekster)),
+                lagInitiellFritekst(
+                    '',
+                    genererIdBasertPåAndreFritekster(skjema.felter.fritekster),
+                    makslengdeFritekst
+                ),
             ]);
         };
 

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -30,7 +30,6 @@ import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
 import type { IManueltBrevRequestPåBehandling } from '../../../../typer/dokument';
 import type { IPersonInfo } from '../../../../typer/person';
 import { målform } from '../../../../typer/søknad';
-import type { IFritekstFelt } from '../../../../utils/fritekstfelter';
 import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import { FamilieMultiLandvelger } from '../../../Fagsak/Behandlingsresultat/EøsPeriode/FamilieLandvelger';
 import DeltBostedSkjema from '../../../Fagsak/Dokumentutsending/DeltBosted/DeltBostedSkjema';

--- a/src/frontend/utils/fritekstfelter.ts
+++ b/src/frontend/utils/fritekstfelter.ts
@@ -17,6 +17,7 @@ export const genererIdBasertPåAndreFritekster = (fritekster?: Felt<FeltState<IF
 export const lagInitiellFritekst = (
     initiellVerdi: string,
     id: number,
+    makslengde: number,
     valideringsmelding?: string
 ): FeltState<IFritekstFelt> => ({
     feilmelding: initiellVerdi === '' ? 'Fritekstfeltet er tomt.' : '',
@@ -25,8 +26,8 @@ export const lagInitiellFritekst = (
         id: id,
     },
     valider: (felt: FeltState<IFritekstFelt>) => {
-        if (felt.verdi.tekst.length > 220) {
-            return feil(felt, 'Du har nådd maks antall tegn: 220.');
+        if (felt.verdi.tekst.length > makslengde) {
+            return feil(felt, `Du har nådd maks antall tegn: ${makslengde}.`);
         } else if (felt.verdi.tekst.trim().length === 0) {
             return feil(
                 felt,


### PR DESCRIPTION
Favro: [NAV-20104](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20104)

### 💰 Hva forsøker du å løse i denne PR'en
* Øker makslengde til fritekst i vedtaksbegrunnelser fra 220 -> 350
* Utvidet metoden `lagInitiellFritekst` til å ta inn makslengde, slik at fritekstfelter i forskjellige deler av appen kan ha ulik makslengde.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/70642183/78419c49-15d6-44e8-9da9-36a9afb3ee4e)
