### PR TITLE
Legg til knapp for å gjenomføre valutajustering

### DIFF
--- a/src/frontend/komponenter/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
@@ -17,7 +17,7 @@ const StyledButton = styled(Button)`
     margin-top: 1rem;
 `;
 
-export const GjenomførValutajusteringKnapp: React.FunctionComponent<Props> = ({ fagsakId }) => {
+export const GjennomførValutajusteringKnapp: React.FunctionComponent<Props> = ({ fagsakId }) => {
     const { request } = useHttp();
     const { settMinimalFagsak } = useFagsakContext();
     const [visFeilmelidng, settVisFeilmelding] = useState(false);

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/GjenomførValutajusteringKnapp.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/GjenomførValutajusteringKnapp.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { Button, ErrorMessage } from '@navikt/ds-react';
+import { useHttp } from '@navikt/familie-http';
+import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
+
+import { useFagsakContext } from '../../../context/fagsak/FagsakContext';
+import type { IMinimalFagsak } from '../../../typer/fagsak';
+
+interface Props {
+    fagsakId: number;
+}
+
+const StyledButton = styled(Button)`
+    margin-top: 1rem;
+`;
+
+export const GjenomførValutajusteringKnapp: React.FunctionComponent<Props> = ({ fagsakId }) => {
+    const { request } = useHttp();
+    const { settMinimalFagsak } = useFagsakContext();
+    const [visFeilmelidng, settVisFeilmelding] = useState(false);
+
+    const gjenomførValutajustering = () => {
+        settVisFeilmelding(false);
+
+        request<void, IMinimalFagsak>({
+            url: `/familie-ba-sak/api/forvalter/valutajustering/${fagsakId}/juster-valuta`,
+            method: 'POST',
+            påvirkerSystemLaster: true,
+        }).then(response => {
+            if (response.status === RessursStatus.SUKSESS) {
+                settMinimalFagsak(response);
+            } else {
+                settVisFeilmelding(true);
+            }
+        });
+    };
+
+    return (
+        <>
+            <StyledButton onClick={gjenomførValutajustering}>
+                Gjennomfør valutajustering
+            </StyledButton>
+            {visFeilmelidng && (
+                <ErrorMessage>Noe gikk galt med gjennomføringen av valutajustering</ErrorMessage>
+            )}
+        </>
+    );
+};

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -9,7 +9,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import Behandlinger from './Behandlinger';
 import FagsakLenkepanel, { SaksoversiktPanelBredde } from './FagsakLenkepanel';
-import { GjenomførValutajusteringKnapp } from './GjenomførValutajusteringKnapp';
+import { GjennomførValutajusteringKnapp } from './GjennomførValutajusteringKnapp';
 import Utbetalinger from './Utbetalinger';
 import type { VisningBehandling } from './visningBehandling';
 import { useApp } from '../../../context/AppContext';
@@ -184,7 +184,7 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
 
                     {toggles[ToggleNavn.kanStarteValutajustering] &&
                         minimalFagsak.løpendeKategori === BehandlingKategori.EØS && (
-                            <GjenomførValutajusteringKnapp fagsakId={minimalFagsak.id} />
+                            <GjennomførValutajusteringKnapp fagsakId={minimalFagsak.id} />
                         )}
 
                     <FagsakLenkepanel minimalFagsak={minimalFagsak} />

--- a/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/komponenter/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -9,8 +9,10 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import Behandlinger from './Behandlinger';
 import FagsakLenkepanel, { SaksoversiktPanelBredde } from './FagsakLenkepanel';
+import { GjenomførValutajusteringKnapp } from './GjenomførValutajusteringKnapp';
 import Utbetalinger from './Utbetalinger';
 import type { VisningBehandling } from './visningBehandling';
+import { useApp } from '../../../context/AppContext';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingStatus, erBehandlingHenlagt } from '../../../typer/behandling';
 import {
@@ -20,6 +22,7 @@ import {
 } from '../../../typer/behandlingstema';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakStatus } from '../../../typer/fagsak';
+import { ToggleNavn } from '../../../typer/toggles';
 import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import { Datoformat, isoStringTilDate, periodeOverlapperMedValgtDato } from '../../../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../../utils/fagsak';
@@ -48,6 +51,7 @@ const StyledAlert = styled(Alert)`
 
 const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
     const { hentInfotrygdsaker, infotrygdsakerRessurs } = useInfotrygdRequest();
+    const { toggles } = useApp();
 
     const iverksatteBehandlinger = minimalFagsak.behandlinger.filter(
         (behandling: VisningBehandling) =>
@@ -177,6 +181,11 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
             <Tabs.Panel value={basakTab.key}>
                 <SaksoversiktWrapper>
                     <Heading size={'large'} level={'1'} children={'Saksoversikt'} />
+
+                    {toggles[ToggleNavn.kanStarteValutajustering] &&
+                        minimalFagsak.løpendeKategori === BehandlingKategori.EØS && (
+                            <GjenomførValutajusteringKnapp fagsakId={minimalFagsak.id} />
+                        )}
 
                     <FagsakLenkepanel minimalFagsak={minimalFagsak} />
                     {minimalFagsak.status === FagsakStatus.LØPENDE && (

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -7,6 +7,7 @@ export enum ToggleNavn {
     kanBehandleTekniskEndring = 'familie-ba-sak.behandling.teknisk-endring',
     kanManueltKorrigereMedVedtaksbrev = 'familie-ba-sak.behandling.korreksjon-vedtaksbrev',
     tekniskVedlikeholdHenleggelse = 'familie-ba-sak.teknisk-vedlikehold-henleggelse.tilgangsstyring',
+    kanStarteValutajustering = 'familie-ba-sak.kan-starte-valutajustering',
 
     // Release
     kanBehandleKlage = 'familie-ba-sak.klage',


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Hører til denne oppgaven: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18511

Ønsker at fag skal kunne teste automatisk valutajustering i prod selv, så endrer slik at vi kan trykke på en knapp i frontend og åpner for at alle med tilgang til toggle kan se knappen og kjøre valutajustering.

Toggle finnes her: https://teamfamilie-unleash-web.nav.cloud.nais.io/projects/default/features/familie-ba-sak.kan-starte-valutajustering

Backend for oppgaven: https://github.com/navikt/familie-ba-sak/pull/4439

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
<img width="1209" alt="image" src="https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/747d501c-2aad-4d34-bfe2-2bbc8090e62c">

