### PR TITLE
Viser fritekst-funksjonalitet for begrunnelser med `støtterFritekst = true` 

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakBegrunnelserTabell/VedtaksperioderMedBegrunnelser/VedtaksperiodeMedBegrunnelserPanel.tsx
@@ -35,10 +35,17 @@ const VedtaksperiodeMedBegrunnelserPanel: React.FC<IProps> = ({
                 Standardbegrunnelse.ETTER_ENDRET_UTBETALING_ETTERBETALING
         ).length > 0;
 
+    const vedtaksperiodeInneholderBegrunnelseSomStøtterFritekst = () => {
+        return vedtaksperiodeMedBegrunnelser.begrunnelser.some(
+            vedtaksbegrunnelse => vedtaksbegrunnelse.støtterFritekst
+        );
+    };
+
     const visFritekster = () =>
         (vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.UTBETALING &&
             vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.ENDRET_UTBETALING) ||
         vedtaksperiodeInneholderEtterbetaling3ÅrBegrunnelse() ||
+        vedtaksperiodeInneholderBegrunnelseSomStøtterFritekst() ||
         vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
             begrunnelse =>
                 !ugyldigeReduksjonsteksterForÅTriggeFritekst.includes(

--- a/src/frontend/typer/vedtaksperiode.ts
+++ b/src/frontend/typer/vedtaksperiode.ts
@@ -18,6 +18,7 @@ export interface IVedtaksperiodeMedBegrunnelser {
 export interface IRestVedtaksbegrunnelse {
     standardbegrunnelse: VedtakBegrunnelse;
     vedtakBegrunnelseType: VedtakBegrunnelseType;
+    støtterFritekst: boolean;
 }
 
 export interface IRestPutVedtaksperiodeMedFritekster {

--- a/src/frontend/utils/test/vedtak/vedtaksperiode.mock.ts
+++ b/src/frontend/utils/test/vedtak/vedtaksperiode.mock.ts
@@ -16,6 +16,7 @@ const mockBegrunnelse = (): IRestVedtaksbegrunnelse => {
     return {
         standardbegrunnelse: 'Test',
         vedtakBegrunnelseType: VedtakBegrunnelseType.INNVILGET,
+        støtterFritekst: false,
     };
 };
 


### PR DESCRIPTION
Favro: [NAV-20229](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20229)

### 💰 Hva forsøker du å løse i denne PR'en
Viser fritekst-funksjonalitet for begrunnelser med `støtterFritekst = true`. Tilsvarende som for ks-sak.


### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
