### PR TITLE
Chore: oppdater http-proxy-middleware til v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "deep-equal": "^2.2.0",
     "dotenv": "^16.4.0",
     "express": "^4.19.2",
-    "http-proxy-middleware": "2.0.6",
+    "http-proxy-middleware": "3.0.0",
     "lodash.throttle": "^4.1.1",
     "react": "^18.2.0",
     "react-collapse": "^5.0.1",

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -67,11 +67,6 @@ export const sessionConfig: ISessionKonfigurasjon = {
     sessionMaxAgeSekunder: 12 * 60 * 60,
 };
 
-export const saksbehandlerConfig: IApi = {
-    clientId: appConfig.clientId,
-    scopes: [`${appConfig.clientId}/.default`],
-};
-
 if (!process.env.BA_SAK_SCOPE) {
     throw new Error('Scope mot familie-ba-sak er ikke konfigurert');
 }
@@ -88,7 +83,6 @@ export const oboConfig: IApi = {
 export const buildPath = env.buildPath;
 export const proxyUrl = env.proxyUrl;
 export const endringsloggProxyUrl = env.endringsloggProxyUrl;
-export const namespace = env.namespace;
 
 export const redirectRecords: Record<string, string> = {
     '/redirect/familie-tilbake': env.familieTilbakeUrl,

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -8,7 +8,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_development',
             namespace: 'local',
-            proxyUrl: 'http://localhost:8089',
+            proxyUrl: 'http://localhost:8089/api',
             familieTilbakeUrl: 'http://localhost:8000',
             familieKlageUrl: 'http://localhost:8000',
             endringsloggProxyUrl: 'https://familie-endringslogg.intern.dev.nav.no',
@@ -17,7 +17,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_development',
             namespace: 'local',
-            proxyUrl: 'https://familie-ba-sak.intern.dev.nav.no',
+            proxyUrl: 'https://familie-ba-sak.intern.dev.nav.no/api',
             familieTilbakeUrl: 'https://familie-tilbake.intern.dev.nav.no',
             familieKlageUrl: 'https://familie-klage.intern.dev.nav.no',
             endringsloggProxyUrl: 'https://familie-endringslogg.intern.dev.nav.no',
@@ -26,7 +26,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_production',
             namespace: 'e2e',
-            proxyUrl: 'http://familie-ba-sak:8089',
+            proxyUrl: 'http://familie-ba-sak:8089/api',
             familieTilbakeUrl: 'http://familie-tilbake-frontend:8000',
             familieKlageUrl: '',
             endringsloggProxyUrl: 'https://familie-endringslogg.intern.dev.nav.no',
@@ -35,7 +35,7 @@ const Environment = () => {
         return {
             buildPath: 'frontend_production',
             namespace: 'preprod',
-            proxyUrl: 'http://familie-ba-sak',
+            proxyUrl: 'http://familie-ba-sak/api',
             familieTilbakeUrl: 'https://familie-tilbake-frontend.intern.dev.nav.no',
             familieKlageUrl: 'https://familie-klage.intern.dev.nav.no',
             endringsloggProxyUrl: 'http://familie-endringslogg',
@@ -45,7 +45,7 @@ const Environment = () => {
     return {
         buildPath: 'frontend_production',
         namespace: 'production',
-        proxyUrl: 'http://familie-ba-sak',
+        proxyUrl: 'http://familie-ba-sak/api',
         familieTilbakeUrl: 'https://familietilbakekreving.intern.nav.no',
         familieKlageUrl: 'https://familie-klage.intern.nav.no',
         endringsloggProxyUrl: 'http://familie-endringslogg',

--- a/src/backend/proxy.ts
+++ b/src/backend/proxy.ts
@@ -20,17 +20,12 @@ const restream = (proxyReq: ClientRequest, req: Request, _res: Response) => {
 
 // eslint-disable-next-line
 export const doProxy: any = () => {
-    return createProxyMiddleware('/familie-ba-sak/api', {
+    return createProxyMiddleware({
         changeOrigin: true,
-        logLevel: 'info',
-        onProxyReq: restream,
-        pathRewrite: (path: string, _req: Request) => {
-            const newPath = path.replace('/familie-ba-sak/api', '');
-            return `/api${newPath}`;
-        },
+        on: { proxyReq: restream },
         secure: true,
         target: `${proxyUrl}`,
-        logProvider: () => stdoutLogger,
+        logger: stdoutLogger,
     });
 };
 

--- a/src/backend/proxy.ts
+++ b/src/backend/proxy.ts
@@ -31,17 +31,12 @@ export const doProxy: any = () => {
 
 // eslint-disable-next-line
 export const doEndringslogProxy: any = () => {
-    return createProxyMiddleware('/endringslogg', {
+    return createProxyMiddleware({
         changeOrigin: true,
-        logLevel: 'info',
-        onProxyReq: restream,
-        pathRewrite: (path: string, _req: Request) => {
-            const newPath = path.replace('/endringslogg', '');
-            return `${newPath}`;
-        },
+        on: { proxyReq: restream },
         secure: true,
         target: `${endringsloggProxyUrl}`,
-        logProvider: () => stdoutLogger,
+        logger: stdoutLogger,
     });
 };
 

--- a/src/backend/proxy.ts
+++ b/src/backend/proxy.ts
@@ -30,7 +30,7 @@ export const doProxy: any = () => {
 };
 
 // eslint-disable-next-line
-export const doEndringslogProxy: any = () => {
+export const doEndringsloggProxy: any = () => {
     return createProxyMiddleware({
         changeOrigin: true,
         on: { proxyReq: restream },

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -17,7 +17,7 @@ import { logInfo } from '@navikt/familie-logging';
 
 import { sessionConfig } from './config';
 import { prometheusTellere } from './metrikker';
-import { attachToken, doEndringslogProxy, doProxy, doRedirectProxy } from './proxy';
+import { attachToken, doEndringsloggProxy, doProxy, doRedirectProxy } from './proxy';
 import setupRouter from './router';
 import webpackDevConfig from '../webpack/webpack.dev';
 
@@ -60,7 +60,7 @@ backend(sessionConfig, prometheusTellere).then(({ app, azureAuthClient, router }
         '/endringslogg',
         ensureAuthenticated(azureAuthClient, true),
         attachToken(azureAuthClient),
-        doEndringslogProxy()
+        doEndringsloggProxy()
     );
 
     app.use('/redirect', doRedirectProxy());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,10 +2623,10 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.0.0.tgz#563c1c6c132cd204e71512f9c0b394ff90d3fae7"
   integrity sha512-NZwaaynfs1oIoLAV1vg18e7QMVDvw+6SQrdJc8w3BwUaoroVSf6EBj/Sk4PBWGxsq0dzhA2drbsuMC1/6C6KgQ==
 
-"@types/http-proxy@^1.17.8":
-  version "1.17.11"
-  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.11.tgz#0ca21949a5588d55ac2b659b69035c84bd5da293"
-  integrity sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==
+"@types/http-proxy@^1.17.10":
+  version "1.17.14"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.14.tgz#57f8ccaa1c1c3780644f8a94f9c6b5000b5e2eec"
+  integrity sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==
   dependencies:
     "@types/node" "*"
 
@@ -6465,16 +6465,17 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
-  integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
+http-proxy-middleware@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz#550790357d6f92a9b82ab2d63e07343a791cf26b"
+  integrity sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==
   dependencies:
-    "@types/http-proxy" "^1.17.8"
+    "@types/http-proxy" "^1.17.10"
+    debug "^4.3.4"
     http-proxy "^1.18.1"
     is-glob "^4.0.1"
     is-plain-obj "^3.0.0"
-    micromatch "^4.0.2"
+    micromatch "^4.0.5"
 
 http-proxy@^1.18.1:
   version "1.18.1"
@@ -8048,7 +8049,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@4.0.5, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@4.0.5, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Oppdaterer http-proxy-middleware på samme måte som jeg har gjort i ks-sak-frontend: https://github.com/navikt/familie-ks-sak-frontend/pull/619.

Fulgt denne migreringsguiden: https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md. De største endringene er at vi kan droppe bruk av pathRewrite til fordel for å endre target-url til å ha /api bak seg (gjelder kun ba-sak-backend). Endringslogg-targetURL trenger vi ikke å endre fordi pathRewrite fjernet pathen, så det som nå ligger i target blir fortsatt riktig.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Har testet lokalt mot preprod, skal også kjøre ut og teste i preprod før jeg merger.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Testet manuelt

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Commit for commit er sikkert fint

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  