### PR TITLE
Legg til ingress på *.ansatt.dev.nav.no

### DIFF
--- a/build_n_deploy/naiserator/gcp-dev.yaml
+++ b/build_n_deploy/naiserator/gcp-dev.yaml
@@ -23,6 +23,7 @@ spec:
     path: /metrics
   ingresses:
     - https://barnetrygd.intern.dev.nav.no
+    - https://barnetrygd.ansatt.dev.nav.no
   azure:
     application:
       enabled: true


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Ref slacktråd: https://nav-it.slack.com/archives/C01DE3M9YBV/p1712576906736089

Legger til en igress på domenet `https://barnetrygd.ansatt.dev.nav.no` i dev slik at det blir enklere å nå tjenesten i preprod
