### PR TITLE
Sperre ved automatisk valutajustering og manuelle posteringer

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -101,7 +101,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
     const erMigreringFraInfotrygdMedAvvik =
         erMigreringFraInfotrygd && erAvvikISimuleringForBehandling;
 
-    const harManuellePosteringer = simResultat?.perioder.some(
+    const behandlingHarManuellePosteringer = simResultat?.perioder.some(
         periode => periode.manuellPostering && periode.manuellPostering > 0
     );
 
@@ -132,7 +132,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         erMigreringFraInfotrygdMedAvvik && !behandlingErMigreringMedAvvikInnenforBeløpsgrenser;
 
     const behandlingErMigreringMedManuellePosteringer =
-        erMigreringFraInfotrygd && harManuellePosteringer;
+        erMigreringFraInfotrygd && behandlingHarManuellePosteringer;
 
     const behandlingErEndreMigreringsdato =
         åpenBehandling.årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO;
@@ -268,6 +268,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         behandlingErMigreringMedManuellePosteringer,
         behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
         behandlingErEndreMigreringsdato,
+        behandlingHarManuellePosteringer,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -4,8 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 import type { Ressurs } from '@navikt/familie-typer';
+import { RessursStatus } from '@navikt/familie-typer';
 
 import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
@@ -15,6 +15,7 @@ import { useSimulering } from '../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingSteg } from '../../../typer/behandling';
+import { Vurderingsform } from '../../../typer/eøsPerioder';
 import type { ITilbakekreving } from '../../../typer/simulering';
 import { hentSøkersMålform } from '../../../utils/behandling';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
@@ -47,8 +48,13 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         behandlingErMigreringMedManuellePosteringer,
         behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
         behandlingErEndreMigreringsdato,
+        behandlingHarManuellePosteringer,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
+
+    const finnesPerioderMedAutomatiskBeregnetValutaIBehandling = åpenBehandling.valutakurser.some(
+        valutakurs => valutakurs.vurderingsform == Vurderingsform.AUTOMATISK
+    );
 
     const nesteOnClick = () => {
         if (vurderErLesevisning()) {
@@ -81,6 +87,9 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         return <div />;
     }
 
+    const behandlingHarManuellePosteringerOgAutomatiskBeregnetValuta =
+        behandlingHarManuellePosteringer && finnesPerioderMedAutomatiskBeregnetValutaIBehandling;
+
     return (
         <Skjemasteg
             senderInn={tilbakekrevingSkjema.submitRessurs.status === RessursStatus.HENTER}
@@ -89,6 +98,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             forrigeOnClick={forrigeOnClick}
             nesteOnClick={nesteOnClick}
             maxWidthStyle={'80rem'}
+            skalViseNesteKnapp={!behandlingHarManuellePosteringerOgAutomatiskBeregnetValuta}
             steg={BehandlingSteg.VURDER_TILBAKEKREVING}
         >
             {behandlingErMigreringFraInfotrygdMedKun0Utbetalinger && (
@@ -97,6 +107,13 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                     migreringsdato. Når behandlingsresultatet blir 0 kr i alle perioder, får vi ikke
                     simulert mot økonomi for å se eventuelle avvik. Det er derfor viktig at du selv
                     sjekker at det ikke har vært noen utbetalinger fra Infotrygd i disse periodene.
+                </StyledAlert>
+            )}
+            {behandlingHarManuellePosteringerOgAutomatiskBeregnetValuta && (
+                <StyledAlert variant={'warning'}>
+                    Behandlingen har perioder med manuelle posteringer og automatisk beregnet
+                    valuta. Gå tilbake til "behandlingsresultat" og legg inn valuta manuelt før du
+                    fortsetter behandlingen.
                 </StyledAlert>
             )}
             {simuleringsresultat?.status === RessursStatus.SUKSESS ? (

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -112,7 +112,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             {behandlingHarManuellePosteringerOgAutomatiskBeregnetValuta && (
                 <StyledAlert variant={'warning'}>
                     Behandlingen har perioder med manuelle posteringer og automatisk beregnet
-                    valuta. Gå tilbake til "behandlingsresultat" og legg inn valuta manuelt før du
+                    valuta. Gå tilbake til "Behandlingsresultat" og legg inn valuta manuelt før du
                     fortsetter behandlingen.
                 </StyledAlert>
             )}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20386

Legger til advarsel og fjerner neste knappen dersom en behandling har både automatiske vurderte valutaperioder og manuelle posteringer.

Se demo.

Første refresh viser en behandling uten manuelle posteringer eller automatiske vurderte valutaperioder.
Andre refresh viser en behandling med manuell postering på 55kr men ingen automatiske vurderte valutaperioder.
Tredje refresh viser en behandling med manuell postering på 55 kr og 1x automatisk vurdert valutaperiode.

https://github.com/navikt/familie-ba-sak-frontend/assets/110383605/d82ec9dd-8443-4a66-a76e-255ea264446f

