### PR TITLE
Fikser forhåndsvisning av vedtaksbrev lokalt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksbrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksbrev.tsx
@@ -161,6 +161,7 @@ export const Vedtaksbrev: React.FunctionComponent<Props> = ({ åpenBehandling, b
                     variant={'secondary'}
                     size={'medium'}
                     onClick={() => {
+                        settVisDokumentModal(true);
                         hentVedtaksbrev();
                     }}
                     loading={hentetDokument.status === RessursStatus.HENTER}

--- a/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksbrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/Vedtaksbrev.tsx
@@ -90,11 +90,6 @@ export const Vedtaksbrev: React.FunctionComponent<Props> = ({ åpenBehandling, b
         <>
             {visDokumentModal && (
                 <PdfVisningModal
-                    onRequestOpen={() => {
-                        if (hentetDokument.status !== RessursStatus.HENTER) {
-                            hentVedtaksbrev();
-                        }
-                    }}
                     onRequestClose={() => {
                         settVisDokumentModal(false);
                         nullstillDokument();
@@ -165,7 +160,9 @@ export const Vedtaksbrev: React.FunctionComponent<Props> = ({ åpenBehandling, b
                     id={'forhandsvis-vedtaksbrev'}
                     variant={'secondary'}
                     size={'medium'}
-                    onClick={() => settVisDokumentModal(!visDokumentModal)}
+                    onClick={() => {
+                        hentVedtaksbrev();
+                    }}
                     loading={hentetDokument.status === RessursStatus.HENTER}
                     icon={<FileTextIcon aria-hidden />}
                 >


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når vi kjører appen lokalt fører `<React.StrictMode>` til at alle komponenter rendres 2 ganger. I mange tilfeller fører dette til at backend-kall kjøres 2 ganger. I mange tilfeller går det bra at vi kjører kallende 2 ganger, men for forhåndsvisning av brev feiler det andre kallet og vi får ikke sett forhåndsvisningen. 

Endrer her til at vi henter forhåndsvisning ved klikk på knapp fremfor som en side-effect av at vi oppdaterer staten til komponenten. Da kjøres hent-forhåndsvisning 1 gang og forhåndsvisning vises som forventet.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
