### PR TITLE
Legg til lazy loading av content i ExpandableRow i ValutakursTabellRad

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/ValutakursTabellRad.tsx
@@ -25,6 +25,9 @@ const ValutakursTabellRad: React.FC<IProps> = ({
     åpenBehandling,
     visFeilmeldinger,
 }) => {
+    const [skalRendreContentIEkspanderbartPanel, settSkalRendreContentIEkspanderbartPanel] =
+        React.useState(false);
+
     const barn: OptionType[] = valutakurs.barnIdenter.map(barn => ({
         value: barn,
         label: lagPersonLabel(barn, åpenBehandling.personer),
@@ -46,6 +49,10 @@ const ValutakursTabellRad: React.FC<IProps> = ({
         valutakurs,
         barnIValutakurs: barn,
     });
+
+    if (erValutakursEkspandert && !skalRendreContentIEkspanderbartPanel) {
+        settSkalRendreContentIEkspanderbartPanel(true);
+    }
 
     React.useEffect(() => {
         if (visFeilmeldinger && erValutakursEkspandert) {
@@ -69,19 +76,21 @@ const ValutakursTabellRad: React.FC<IProps> = ({
             onOpenChange={() => toggleForm(true)}
             id={valutakursFeilmeldingId(valutakurs)}
             content={
-                <ValutakursTabellRadEndre
-                    skjema={skjema}
-                    tilgjengeligeBarn={barn}
-                    status={valutakurs.status}
-                    valideringErOk={valideringErOk}
-                    sendInnSkjema={sendInnSkjema}
-                    toggleForm={toggleForm}
-                    slettValutakurs={slettValutakurs}
-                    sletterValutakurs={sletterValutakurs}
-                    erManuellInputAvKurs={erManuellInputAvKurs}
-                    key={`${valutakurs.id}-${erValutakursEkspandert ? 'ekspandert' : 'lukket'}`}
-                    vurderingsform={valutakurs.vurderingsform}
-                />
+                skalRendreContentIEkspanderbartPanel ? (
+                    <ValutakursTabellRadEndre
+                        skjema={skjema}
+                        tilgjengeligeBarn={barn}
+                        status={valutakurs.status}
+                        valideringErOk={valideringErOk}
+                        sendInnSkjema={sendInnSkjema}
+                        toggleForm={toggleForm}
+                        slettValutakurs={slettValutakurs}
+                        sletterValutakurs={sletterValutakurs}
+                        erManuellInputAvKurs={erManuellInputAvKurs}
+                        key={`${valutakurs.id}-${erValutakursEkspandert ? 'ekspandert' : 'lukket'}`}
+                        vurderingsform={valutakurs.vurderingsform}
+                    />
+                ) : null
             }
         >
             <StatusBarnCelleOgPeriodeCelle


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Etter dersom vi får en del rader i valutakursene begynner ting å gå veldig tregt. Fikser det med å endre renderingen av innholdet til å være lazy, slik at vi ikke rendrer det før vi trenger det. Dette gjør at det går en del fortere


Uten lazy loading:
![Screen Recording 2024-04-21 at 22 33 54](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/055d0f04-6f88-45f9-bafe-3fb3f09d033a)

Med lazy loading:
![Screen Recording 2024-04-21 at 22 37 14](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/802163d1-000b-4f85-b123-0d61e2fe4257)