### PR TITLE
Fiks lesevisning når vi skal kunne overstyre automatiske valutakurser

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/StatusOgBarnValutakurs.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/StatusOgBarnValutakurs.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { CogRotationIcon, PencilWritingIcon } from '@navikt/aksel-icons';
 import { BodyShort, HStack } from '@navikt/ds-react';
 
+import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import { mapEøsPeriodeStatusTilStatus } from '../../../../context/Eøs/EøsContext';
 import StatusIkon from '../../../../ikoner/StatusIkon';
 import { type IBehandling, VurderingsstrategiForValutakurser } from '../../../../typer/behandling';
@@ -34,8 +35,14 @@ const PeriodeStatus: React.FC<StatusProps> = ({
     valutakurs,
     vurderingsstrategiForValutakurser,
 }) => {
+    const { vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
+
     if (valutakurs.vurderingsform === Vurderingsform.AUTOMATISK) {
-        if (vurderingsstrategiForValutakurser === VurderingsstrategiForValutakurser.MANUELL) {
+        if (
+            !erLesevisning &&
+            vurderingsstrategiForValutakurser === VurderingsstrategiForValutakurser.MANUELL
+        ) {
             return (
                 <BlåPencilIcon
                     title="Automatisk vurdert valutakurs åpen for redigering"

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
@@ -62,11 +62,13 @@ interface IProps {
 const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeilmeldinger }) => {
     const { erValutakurserGyldige } = useEøs();
     const { toggles } = useApp();
-    const { settÅpenBehandling } = useBehandling();
+    const { settÅpenBehandling, vurderErLesevisning } = useBehandling();
     const { request } = useHttp();
     const månedligValutajusteringToggleErSlåttPå = toggles[ToggleNavn.månedligValutajustering];
     const kanOverstyreAutomatiskeValutakurser =
         toggles[ToggleNavn.kanOverstyreAutomatiskeValutakurser];
+
+    const erLesevisning = vurderErLesevisning();
 
     const hentNesteVurderingsstrategi = (
         vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser | null
@@ -127,7 +129,8 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
                             Vis alle valutaperioder
                         </Switch>
                     )}
-                    {kanOverstyreAutomatiskeValutakurser &&
+                    {!erLesevisning &&
+                        kanOverstyreAutomatiskeValutakurser &&
                         (åpenBehandling.vurderingsstrategiForValutakurser ===
                             VurderingsstrategiForValutakurser.MANUELL ||
                             erValutakursSomErVurdertAutomatisk) && (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20661

Når vi er i lesevisning skal vi ikke vise redigeringsikonet for automatiske valutakurser selv om man kan overstyre dem i behanldingen. 

Knappen for å overstyre automatiske valutakurser skal heller ikke vises
  
### 👀 Screen shots
Ved lesevisning og vi har skrudd på muligheten for å redigere automatiske behandlinger
Før:
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/d63b75cd-9bec-4285-810e-598ff13c37bb)

Etter
![image](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/06a808c2-1728-4819-8ee4-075f5f77f589)
