### PR TITLE
Vis modal før vi gjenoppretter de automatiske valutakursene

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
@@ -153,7 +153,11 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
                             erValutakursSomErVurdertAutomatisk) && (
                             <Button
                                 size="xsmall"
-                                variant="danger"
+                                variant={
+                                    erManuellVurderingsstrategiForValutakurser
+                                        ? 'danger'
+                                        : 'primary'
+                                }
                                 onClick={() =>
                                     erManuellVurderingsstrategiForValutakurser
                                         ? visGjenopprettAutomatiskeValutakurserModal()


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi har en flyt for å kunne overstyre de automatiske valutakursene. Etter at vi har trykket på knappen for overstyring får vi muligheten til å gjenopprette de automatiske valutakursene. Da sletter vi alt det manuelle som er lagt inn i valutakursene for denne behandlingen. 

Vi ønsker at det skal dukke opp en modal som bekrefter at vi skal slette alle manuelle endringer som saksbehandleren har lagt inn. Legger til det i denne PRen

### 👀 Screen shots
[Screen Recording 2024-04-30 at 17.10.52.webm](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/00964555-d22a-4fcb-b045-246534041eb2)
