### PR TITLE
Redirect til ansatt-subdomene i preprod om man går til intern-subdomene

### DIFF
--- a/build_n_deploy/naiserator/gcp-dev.yaml
+++ b/build_n_deploy/naiserator/gcp-dev.yaml
@@ -29,7 +29,7 @@ spec:
       enabled: true
       tenant: trygdeetaten.no
       replyURLs:
-        - https://barnetrygd.intern.dev.nav.no/auth/openid/callback
+        - https://barnetrygd.ansatt.dev.nav.no/auth/openid/callback
       claims:
         groups:
           - id: "93a26831-9866-4410-927b-74ff51a9107c"  # VEILEDER_ROLLE

--- a/src/backend/konfigurerApp.ts
+++ b/src/backend/konfigurerApp.ts
@@ -23,7 +23,7 @@ export const konfigurerAzure = () => {
             break;
         case 'preprod':
             process.env.AAD_LOGOUT_REDIRECT_URL = `https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/logout?post_logout_redirect_uri=https:\\\\${host}.intern.dev.nav.no`;
-            process.env.AAD_REDIRECT_URL = `https://${host}.intern.dev.nav.no/auth/openid/callback`;
+            process.env.AAD_REDIRECT_URL = `https://${host}.ansatt.dev.nav.no/auth/openid/callback`;
             process.env.GRAPH_API = 'https://graph.microsoft.com/v1.0/me';
             settAzureAdPropsFraEnv();
             break;

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import type { Response, Request, Router } from 'express';
+import type { Response, Request, Router, NextFunction } from 'express';
 
 import type { Client } from '@navikt/familie-backend';
 import { ensureAuthenticated, logRequest, envVar } from '@navikt/familie-backend';
@@ -8,6 +8,16 @@ import { LOG_LEVEL } from '@navikt/familie-logging';
 
 import { buildPath } from './config';
 import { prometheusTellere } from './metrikker';
+
+const redirectHvisInternUrlIPreprod = () => {
+    return async (req: Request, res: Response, next: NextFunction) => {
+        if (process.env.ENV === 'preprod' && req.headers.host === 'barnetrygd.intern.dev.nav.no') {
+            res.redirect(`https://barnetrygd.ansatt.dev.nav.no${req.url}`);
+        } else {
+            next();
+        }
+    };
+};
 
 export default (authClient: Client, router: Router) => {
     router.get('/version', (_: Request, res: Response) => {
@@ -28,11 +38,16 @@ export default (authClient: Client, router: Router) => {
     });
 
     // APP
-    router.get('*', ensureAuthenticated(authClient, false), (_: Request, res: Response) => {
-        prometheusTellere.appLoad.inc();
+    router.get(
+        '*',
+        redirectHvisInternUrlIPreprod(),
+        ensureAuthenticated(authClient, false),
+        (_: Request, res: Response) => {
+            prometheusTellere.appLoad.inc();
 
-        res.sendFile('index.html', { root: path.join(process.cwd(), buildPath) });
-    });
+            res.sendFile('index.html', { root: path.join(process.cwd(), buildPath) });
+        }
+    );
 
     return router;
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: NAV-20732
Bygger videre på #3108 og koker av Charlie: https://github.com/navikt/familie-tilbake-frontend/pull/1781

Dersom man i preprod aksesserer løsningen fra `*.intern.dev.nav.no` redirecter vi til `*.ansatt.dev.nav.no`. Dette gjør ansatt-subdomenet til hovedadresse i preprod og gjør det mulig for fagressursene å aksessere løsningen uten Chrome SKSS samt at de kan dele løsningen med saksbehandlere/NFP for testing 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Ønsker å pushe og teste det i preprod før merge 😇 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
