### PR TITLE
Kun rendre kompetanseskjema og utenlandsk periode tabell dersom raden er åpen

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Kompetanse/KompetanseTabellRad.tsx
@@ -84,18 +84,20 @@ const KompetanseTabellRad: React.FC<IProps> = ({
             onOpenChange={() => toggleForm(true)}
             id={kompetanseFeilmeldingId(kompetanse)}
             content={
-                <KompetanseTabellRadEndre
-                    skjema={skjema}
-                    tilgjengeligeBarn={barn}
-                    valideringErOk={valideringErOk}
-                    sendInnSkjema={sendInnSkjema}
-                    toggleForm={toggleForm}
-                    slettKompetanse={slettKompetanse}
-                    status={kompetanse.status}
-                    erAnnenForelderOmfattetAvNorskLovgivning={
-                        kompetanse.erAnnenForelderOmfattetAvNorskLovgivning
-                    }
-                />
+                erKompetanseEkspandert && (
+                    <KompetanseTabellRadEndre
+                        skjema={skjema}
+                        tilgjengeligeBarn={barn}
+                        valideringErOk={valideringErOk}
+                        sendInnSkjema={sendInnSkjema}
+                        toggleForm={toggleForm}
+                        slettKompetanse={slettKompetanse}
+                        status={kompetanse.status}
+                        erAnnenForelderOmfattetAvNorskLovgivning={
+                            kompetanse.erAnnenForelderOmfattetAvNorskLovgivning
+                        }
+                    />
+                )
             }
         >
             <StatusBarnCelleOgPeriodeCelle

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
@@ -85,15 +85,17 @@ const UtenlandskPeriodeBeløpRad: React.FC<IProps> = ({
             onOpenChange={() => toggleForm(true)}
             id={utenlandskPeriodeBeløpFeilmeldingId(utenlandskPeriodeBeløp)}
             content={
-                <UtenlandskPeriodeBeløpTabellRadEndre
-                    skjema={skjema}
-                    tilgjengeligeBarn={barn}
-                    valideringErOk={valideringErOk}
-                    sendInnSkjema={sendInnSkjema}
-                    toggleForm={toggleForm}
-                    slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
-                    status={utenlandskPeriodeBeløp.status}
-                />
+                erUtenlandskPeriodeBeløpEkspandert && (
+                    <UtenlandskPeriodeBeløpTabellRadEndre
+                        skjema={skjema}
+                        tilgjengeligeBarn={barn}
+                        valideringErOk={valideringErOk}
+                        sendInnSkjema={sendInnSkjema}
+                        toggleForm={toggleForm}
+                        slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
+                        status={utenlandskPeriodeBeløp.status}
+                    />
+                )
             }
         >
             <StatusBarnCelleOgPeriodeCelle


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: NAV-20797
Når kompetanseskjema og utenlandsk beløp er utfylt og man deretter trykker på fjern, blir verdien borte i skjemaet, men henger igjen i nedtrekksmenyen.

Løser problemet ved å kun rendre den ekspanderbare raden når den er åpen, slik at verdiene ikke henger igjen hvis man tømmer skjemaet og åpner raden på nytt

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Det er ikke mulig å lukke raden uten å lagre, så det er ikke fare for at man mister data ved et uhell

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
