### PR TITLE
Fix: Fjerner unødvendig validering på simuleringssiden

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -268,7 +268,6 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         behandlingErMigreringMedManuellePosteringer,
         behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
         behandlingErEndreMigreringsdato,
-        behandlingHarManuellePosteringer,
     };
 });
 

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -15,7 +15,6 @@ import { useSimulering } from '../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingSteg } from '../../../typer/behandling';
-import { Vurderingsform } from '../../../typer/eøsPerioder';
 import type { ITilbakekreving } from '../../../typer/simulering';
 import { hentSøkersMålform } from '../../../utils/behandling';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
@@ -48,13 +47,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         behandlingErMigreringMedManuellePosteringer,
         behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
         behandlingErEndreMigreringsdato,
-        behandlingHarManuellePosteringer,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
-
-    const finnesPerioderMedAutomatiskBeregnetValutaIBehandling = åpenBehandling.valutakurser.some(
-        valutakurs => valutakurs.vurderingsform == Vurderingsform.AUTOMATISK
-    );
 
     const nesteOnClick = () => {
         if (vurderErLesevisning()) {
@@ -87,9 +81,6 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         return <div />;
     }
 
-    const behandlingHarManuellePosteringerOgAutomatiskBeregnetValuta =
-        behandlingHarManuellePosteringer && finnesPerioderMedAutomatiskBeregnetValutaIBehandling;
-
     return (
         <Skjemasteg
             senderInn={tilbakekrevingSkjema.submitRessurs.status === RessursStatus.HENTER}
@@ -98,7 +89,6 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             forrigeOnClick={forrigeOnClick}
             nesteOnClick={nesteOnClick}
             maxWidthStyle={'80rem'}
-            skalViseNesteKnapp={!behandlingHarManuellePosteringerOgAutomatiskBeregnetValuta}
             steg={BehandlingSteg.VURDER_TILBAKEKREVING}
         >
             {behandlingErMigreringFraInfotrygdMedKun0Utbetalinger && (
@@ -107,13 +97,6 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                     migreringsdato. Når behandlingsresultatet blir 0 kr i alle perioder, får vi ikke
                     simulert mot økonomi for å se eventuelle avvik. Det er derfor viktig at du selv
                     sjekker at det ikke har vært noen utbetalinger fra Infotrygd i disse periodene.
-                </StyledAlert>
-            )}
-            {behandlingHarManuellePosteringerOgAutomatiskBeregnetValuta && (
-                <StyledAlert variant={'warning'}>
-                    Behandlingen har perioder med manuelle posteringer og automatisk beregnet
-                    valuta. Gå tilbake til "Behandlingsresultat" og legg inn valuta manuelt før du
-                    fortsetter behandlingen.
                 </StyledAlert>
             )}
             {simuleringsresultat?.status === RessursStatus.SUKSESS ? (


### PR DESCRIPTION
Favro: [NAV-21220](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21220)

### 💰 Hva forsøker du å løse i denne PR'en
På simuleringssiden har vi hatt en validering som krever at alle valutakurser er manuelt satt dersom det finnes manuelle posteringer i simulering. Dette er ikke lenger nødvendig da backend kun setter automatiske valutakurser for perioder etter siste manuelle postering. For alle perioder som kommer før siste manuelle postering må saksbehandler sette manuelle valutakurser. Dette "tvinges" saksbehandler til på behandlingsresultat-siden og det er derfor ikke lenger nødvendig å sjekke dette på nytt på simuleringssiden.

Fjerner derfor valideringskoden på simuleringssiden, som hindrer saksbehandler fra å gå videre dersom det finnes både manuelle posteringer og automatiske valutakurser.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
