### PR TITLE
Gå bort fra per måned til totalt for refusjon eøs

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøs.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøs.tsx
@@ -75,7 +75,7 @@ const RefusjonEøs: React.FC<IRefusjonEøs> = ({
                 `${isoDatoPeriodeTilFormatertString({
                     fom: refusjonEøs.fom,
                     tom: refusjonEøs.tom,
-                })} kr/mnd ${refusjonEøs.refusjonsbeløp}`
+                })} kroner ${refusjonEøs.refusjonsbeløp}`
         )
         .join('\n')}`;
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -102,7 +102,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
                     tom: refusjonEøs.tom,
                 })}
             </Table.DataCell>
-            <Table.DataCell align="right">{refusjonEøs.refusjonsbeløp} kr/mnd</Table.DataCell>
+            <Table.DataCell align="right">{refusjonEøs.refusjonsbeløp} kr</Table.DataCell>
             <Table.DataCell align="center">
                 {!erLesevisning && (
                     <Tooltip content="Fjern periode">

--- a/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
@@ -117,7 +117,7 @@ const RefusjonEøsSkjema: React.FunctionComponent<IRefusjonEøsSkjemaProps> = ({
             <StyledTextField
                 {...skjema.felter.refusjonsbeløp.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                 size="small"
-                label="Refusjonsbeløp (kr/mnd)"
+                label="Refusjonsbeløp (kr)"
                 value={skjema.felter.refusjonsbeløp.verdi}
                 type="text"
                 inputMode="numeric"

--- a/src/frontend/komponenter/Fagsak/Vedtak/utils.test.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/utils.test.ts
@@ -27,7 +27,7 @@ describe('Vedtakutils', () => {
                 REFUSJONSPERIODE_TRE_MÅNEDER,
                 REFUSJONSPERIODE_EN_MÅNED,
             ])
-        ).toBe(950);
+        ).toBe(375);
         expect(
             summerBeløpForPerioder([
                 {
@@ -51,7 +51,7 @@ describe('Vedtakutils', () => {
                     beløp: 108,
                 },
             ])
-        ).toBe(2181);
+        ).toBe(403);
     });
     test('antallMånederIPeriode skal finne antall hele måneder en periode varer', () => {
         expect(antallMånederIPeriode(REFUSJONSPERIODE_FIRE_MÅNEDER)).toBe(4);

--- a/src/frontend/komponenter/Fagsak/Vedtak/utils.ts
+++ b/src/frontend/komponenter/Fagsak/Vedtak/utils.ts
@@ -8,10 +8,7 @@ interface PeriodeMedBeløp {
     beløp: number;
 }
 export const summerBeløpForPerioder = (periodeListe: PeriodeMedBeløp[]): number => {
-    return periodeListe.reduce(
-        (sum, periode) => sum + periode.beløp * antallMånederIPeriode(periode),
-        0
-    );
+    return periodeListe.reduce((sum, periode) => sum + periode.beløp, 0);
 };
 
 export const antallMånederIPeriode = (periode: PeriodeMedBeløp): number => {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21480

Vi ønsker at summen man legger inn ved refusjon eøs skal gjenspeile totalt for hele perioden, og ikke "per måned" basis.
Fjerner derfor per måned fra tekst.

Backend pr: https://github.com/navikt/familie-ba-sak/pull/4626