### PR TITLE
Oppdater valutakurser og simulering automatisk for beslutter når de går inn på Behandlingsresultat-steget

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Behandlingsresultat.tsx
@@ -16,6 +16,7 @@ import MigreringInfoboks from './MigreringInfoboks';
 import { Oppsummeringsboks } from './Oppsummeringsboks';
 import TilkjentYtelseTidslinje from './TilkjentYtelseTidslinje';
 import UtbetaltAnnetLand from './UtbetaltAnnetLand/UtbetaltAnnetLand';
+import { useOppdaterValutakursOgSimuleringPåBeslutterSteg } from './Valutakurs/useOppdaterValutakursOgSimuleringPåBeslutterSteg';
 import Valutakurser from './Valutakurs/Valutakurser';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useEøs } from '../../../context/Eøs/EøsContext';
@@ -80,6 +81,8 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
         filterOgSorterAndelPersonerIGrunnlag,
         filterOgSorterGrunnlagPersonerMedAndeler,
     } = useTidslinje();
+
+    useOppdaterValutakursOgSimuleringPåBeslutterSteg();
 
     const { request } = useHttp();
 

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/useOppdaterValutakursOgSimuleringPåBeslutterSteg.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/useOppdaterValutakursOgSimuleringPåBeslutterSteg.ts
@@ -15,8 +15,8 @@ export const useOppdaterValutakursOgSimuleringPåBeslutterSteg = () => {
             behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK
         ) {
             request<void, IBehandling>({
-                method: 'POST',
-                url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/oppdater-valutakurser-og-simulering-automatisk`,
+                method: 'PUT',
+                url: `/familie-ba-sak/api/differanseberegning/valutakurs/${behandling.behandlingId}/oppdater-valutakurser-og-simulering-automatisk`,
             }).then(behandlingRessurs => {
                 settÅpenBehandling(behandlingRessurs);
             });

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/useOppdaterValutakursOgSimuleringPåBeslutterSteg.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/useOppdaterValutakursOgSimuleringPåBeslutterSteg.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
+import { BehandlingStatus, BehandlingSteg, type IBehandling } from '../../../../typer/behandling';
+
+export const useOppdaterValutakursOgSimuleringPåBeslutterSteg = () => {
+    const { request } = useHttp();
+    const { settÅpenBehandling, behandling } = useBehandling();
+
+    useEffect(() => {
+        if (
+            behandling.status === BehandlingStatus.FATTER_VEDTAK &&
+            behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK
+        ) {
+            request<void, IBehandling>({
+                method: 'POST',
+                url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/oppdater-valutakurser-og-simulering-automatisk`,
+            }).then(behandlingRessurs => {
+                settÅpenBehandling(behandlingRessurs);
+            });
+        }
+    }, [behandling.behandlingId]);
+};

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/useOppdaterValutakursOgSimuleringPåBeslutterSteg.ts
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/useOppdaterValutakursOgSimuleringPåBeslutterSteg.ts
@@ -2,17 +2,25 @@ import { useEffect } from 'react';
 
 import { useHttp } from '@navikt/familie-http';
 
+import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
-import { BehandlingStatus, BehandlingSteg, type IBehandling } from '../../../../typer/behandling';
+import {
+    BehandlerRolle,
+    BehandlingStatus,
+    BehandlingSteg,
+    type IBehandling,
+} from '../../../../typer/behandling';
 
 export const useOppdaterValutakursOgSimuleringPåBeslutterSteg = () => {
+    const { hentSaksbehandlerRolle } = useApp();
     const { request } = useHttp();
     const { settÅpenBehandling, behandling } = useBehandling();
 
     useEffect(() => {
         if (
             behandling.status === BehandlingStatus.FATTER_VEDTAK &&
-            behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK
+            behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK &&
+            hentSaksbehandlerRolle() === BehandlerRolle.BESLUTTER
         ) {
             request<void, IBehandling>({
                 method: 'PUT',


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Knyttet til denne oppgaven: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21578
Slik koden er nå oppdaterer vi valutakursene og simuleringen etter at beslutter har godkjent vedtaket. Dette er for at vi skal få med oss de siste valutakursene dersom beslutter har brukt lang tid. 

Ulempen med dette er at beslutter ikke får sett de siste endringene. 

Endrer derfor så vi heller oppdaterer valutakursene og simuleringen når beslutter går inn på behandlingsresultatesteget, slik at beslutter kan se de siste endringene. 