### PR TITLE
Gjør så resetting av kontrollerte steg ikke er avhengig av hele behandlingen, men kun behandlingId

### DIFF
--- a/src/frontend/context/behandlingContext/BehandlingContext.ts
+++ b/src/frontend/context/behandlingContext/BehandlingContext.ts
@@ -90,7 +90,7 @@ const [BehandlingProvider, useBehandling] = createUseContext(({ behandling }: Pr
         );
 
         automatiskNavigeringTilSideForSteg();
-    }, [behandling]);
+    }, [behandling.id]);
 
     useEffect(() => {
         settForrigeÅpneSide(

--- a/src/frontend/context/behandlingContext/BehandlingContext.ts
+++ b/src/frontend/context/behandlingContext/BehandlingContext.ts
@@ -90,7 +90,7 @@ const [BehandlingProvider, useBehandling] = createUseContext(({ behandling }: Pr
         );
 
         automatiskNavigeringTilSideForSteg();
-    }, [behandling.id]);
+    }, [behandling.behandlingId]);
 
     useEffect(() => {
         settForrigeÅpneSide(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Nå oppdaterer vi behandlingen på besluttersteget når vi ser på behandlingsresultatsiden. Dette fører til at vi resetter hvilke steg som er kontrollert. 

Endrer så resettingen av kontrollerte steg ikke er avhengig av hele behandlingen, kun behandlingsid. 
  
### 👀 Screen shots
Før:

[Screen Recording 2024-06-18 at 15.05.38.webm](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/75e3c635-d3a7-4e03-b393-a0e53d991f70)


Etter:

[Screen Recording 2024-06-18 at 15.04.20.webm](https://github.com/navikt/familie-ba-sak-frontend/assets/17828446/17416766-bb9d-4ea2-97bc-1f14b69d7771)



