### PR TITLE
Slett unødvendig toggle

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/Valutakurs/Valutakurser.tsx
@@ -83,8 +83,6 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
         erGjenopprettAutomatiskeValutakurserModalÅpen,
         settErGjenopprettAutomatiskeValutakurserModalÅpen,
     ] = useState(false);
-    const kanOppretteAutomatiskeValutakurserPåManuelleSaker =
-        toggles[ToggleNavn.kanOppretteAutomatiskeValutakurserPåManuelleSaker];
     const kanOverstyreAutomatiskeValutakurser =
         åpenBehandling.type == Behandlingstype.TEKNISK_ENDRING &&
         toggles[ToggleNavn.kanBehandleTekniskEndring];
@@ -120,8 +118,7 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
         });
     };
 
-    const finnesValutaperioderSomKanSkjules =
-        valutakurser.length > 1 && kanOppretteAutomatiskeValutakurserPåManuelleSaker;
+    const finnesValutaperioderSomKanSkjules = valutakurser.length > 1;
     const [visAlleValutaperioder, setVisAlleValutaperioder] = useState(false);
     const erValutakursSomErVurdertAutomatisk = valutakurser.some(
         restValutakurs => restValutakurs.vurderingsform == Vurderingsform.AUTOMATISK
@@ -204,7 +201,6 @@ const Valutakurser: React.FC<IProps> = ({ valutakurser, åpenBehandling, visFeil
                             (valutakurs, index) =>
                                 index === 0 ||
                                 valutakurs.status !== EøsPeriodeStatus.OK ||
-                                !kanOppretteAutomatiskeValutakurserPåManuelleSaker ||
                                 visAlleValutaperioder
                         )
                         .map(valutakurs => (

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -13,7 +13,6 @@ export enum ToggleNavn {
     // Release
     kanBehandleKlage = 'familie-ba-sak.klage',
     selvstendigRettInfobrev = 'familie-ba-sak.selvstendig-rett-infobrev',
-    kanOppretteAutomatiskeValutakurserPåManuelleSaker = 'familie-ba-sak.kan-opprette-automatiske-valutakurser-paa-manuelle-saker',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Denne toggle'en blir per nå kun brukt til å styre hvorvidt valutakursperioder kan kollapses på behandlingsresultatsiden

Ble fjernet fra backend i [denne PR'en](https://github.com/navikt/familie-ba-sak/pull/4698/files)

[Toggle](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ba-sak.kan-opprette-automatiske-valutakurser-paa-manuelle-saker) kan slettes fra Unleash når denne merges

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei