### PR TITLE
Fjern ubrukt request parameter

### DIFF
--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -381,7 +381,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
                         dataForManuellJournalføring.data.journalpost.journalpostId
                     }/journalfør/${oppgaveId}?journalfoerendeEnhet=${
                         innloggetSaksbehandler?.enhet ?? '9999'
-                    }&ferdigstill=true`,
+                    }`,
                     data: {
                         journalpostTittel: skjema.felter.journalpostTittel.verdi,
                         kategori: behandlingstema?.kategori ?? null,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22897

Oppdaget dette request parameteret som blir sendt ned mot backend.
Endepunktet tar ikke imot dette, så det er ikke vits å sende det. Tenker derfor det er greit å bare slette det.