### PR TITLE
Fix: holder endret utbetaling andel sin skjematilstand oppdatert ved endringer

### DIFF
--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -27,7 +27,7 @@ interface IProps {
 const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseContext(
     ({ endretUtbetalingAndel }: IProps) => {
         const årsakFelt = useFelt<IEndretUtbetalingAndelÅrsak | undefined>({
-            verdi: endretUtbetalingAndel.årsak,
+            verdi: undefined,
             valideringsfunksjon: felt =>
                 felt.verdi && Object.values(IEndretUtbetalingAndelÅrsak).includes(felt.verdi)
                     ? ok(felt)
@@ -35,14 +35,14 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
         });
 
         const utbetalingFelt = useFelt<Utbetaling | undefined>({
-            verdi: prosentTilUtbetaling(endretUtbetalingAndel.prosent),
+            verdi: undefined,
             valideringsfunksjon: felt =>
                 felt.verdi ? ok(felt) : feil(felt, 'Du må velge utbetaling'),
             avhengigheter: årsakFelt,
             nullstillVedAvhengighetEndring: true,
         });
 
-        const { skjema, kanSendeSkjema, onSubmit, nullstillSkjema } = useSkjema<
+        const { skjema, kanSendeSkjema, onSubmit } = useSkjema<
             {
                 person: string | undefined;
                 fom: IsoDatoString | undefined;
@@ -57,19 +57,19 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
         >({
             felter: {
                 person: useFelt<string | undefined>({
-                    verdi: endretUtbetalingAndel.personIdent,
+                    verdi: undefined,
                     valideringsfunksjon: felt =>
                         felt.verdi ? ok(felt) : feil(felt, 'Du må velge en person'),
                 }),
                 fom: useFelt<IsoDatoString | undefined>({
-                    verdi: endretUtbetalingAndel.fom,
+                    verdi: undefined,
                     valideringsfunksjon: felt =>
                         erIsoStringGyldig(felt.verdi)
                             ? ok(felt)
                             : feil(felt, 'Du må velge f.o.m-dato'),
                 }),
                 tom: useFelt<IsoDatoString | undefined>({
-                    verdi: endretUtbetalingAndel.tom,
+                    verdi: undefined,
                 }),
                 utbetaling: utbetalingFelt,
                 årsak: årsakFelt,
@@ -88,7 +88,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
                     valideringsfunksjon: validerGyldigDato,
                 }),
                 begrunnelse: useFelt<string | undefined>({
-                    verdi: endretUtbetalingAndel.begrunnelse,
+                    verdi: undefined,
                     valideringsfunksjon: felt =>
                         felt.verdi ? ok(felt) : feil(felt, 'Du må oppgi en begrunnelse.'),
                 }),
@@ -109,6 +109,29 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             );
         };
 
+        const settFelterTilDefault = () => {
+            skjema.felter.person.validerOgSettFelt(endretUtbetalingAndel.personIdent);
+            skjema.felter.fom.validerOgSettFelt(endretUtbetalingAndel.fom);
+            skjema.felter.tom.validerOgSettFelt(endretUtbetalingAndel.tom);
+            skjema.felter.utbetaling.validerOgSettFelt(
+                prosentTilUtbetaling(endretUtbetalingAndel.prosent)
+            );
+            skjema.felter.årsak.validerOgSettFelt(endretUtbetalingAndel.årsak);
+
+            skjema.felter.begrunnelse.validerOgSettFelt(endretUtbetalingAndel.begrunnelse);
+
+            skjema.felter.søknadstidspunkt.validerOgSettFelt(
+                endretUtbetalingAndel.søknadstidspunkt
+                    ? new Date(endretUtbetalingAndel.søknadstidspunkt)
+                    : undefined
+            );
+            skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(
+                endretUtbetalingAndel.avtaletidspunktDeltBosted
+                    ? new Date(endretUtbetalingAndel.avtaletidspunktDeltBosted)
+                    : undefined
+            );
+        };
+
         const [forrigeEndretUtbetalingAndel, settForrigeEndretUtbetalingAndel] =
             useState<IRestEndretUtbetalingAndel>();
 
@@ -116,11 +139,6 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             settForrigeEndretUtbetalingAndel(endretUtbetalingAndel);
             settDatofelterTilDefaultverdier();
         }
-
-        const tilbakestillFelterTilDefault = () => {
-            nullstillSkjema();
-            settDatofelterTilDefaultverdier();
-        };
 
         const hentSkjemaData = () => {
             const {
@@ -154,7 +172,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             kanSendeSkjema,
             onSubmit,
             hentSkjemaData,
-            tilbakestillFelterTilDefault,
+            settFelterTilDefault,
         };
     }
 );

--- a/src/frontend/context/EndretUtbetalingAndelContext.ts
+++ b/src/frontend/context/EndretUtbetalingAndelContext.ts
@@ -96,19 +96,6 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
             skjemanavn: 'Endre utbetalingsperiode',
         });
 
-        const settDatofelterTilDefaultverdier = () => {
-            skjema.felter.søknadstidspunkt.validerOgSettFelt(
-                endretUtbetalingAndel.søknadstidspunkt
-                    ? new Date(endretUtbetalingAndel.søknadstidspunkt)
-                    : undefined
-            );
-            skjema.felter.avtaletidspunktDeltBosted.validerOgSettFelt(
-                endretUtbetalingAndel.avtaletidspunktDeltBosted
-                    ? new Date(endretUtbetalingAndel.avtaletidspunktDeltBosted)
-                    : undefined
-            );
-        };
-
         const settFelterTilDefault = () => {
             skjema.felter.person.validerOgSettFelt(endretUtbetalingAndel.personIdent);
             skjema.felter.fom.validerOgSettFelt(endretUtbetalingAndel.fom);
@@ -137,7 +124,7 @@ const [EndretUtbetalingAndelProvider, useEndretUtbetalingAndel] = createUseConte
 
         if (endretUtbetalingAndel !== forrigeEndretUtbetalingAndel) {
             settForrigeEndretUtbetalingAndel(endretUtbetalingAndel);
-            settDatofelterTilDefaultverdier();
+            settFelterTilDefault();
         }
 
         const hentSkjemaData = () => {

--- a/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingsresultat/EndretUtbetalingAndelSkjema.tsx
@@ -76,7 +76,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
         kanSendeSkjema,
         onSubmit,
         hentSkjemaData,
-        tilbakestillFelterTilDefault,
+        settFelterTilDefault,
     } = useEndretUtbetalingAndel();
 
     const oppdaterEndretUtbetaling = (avbrytEndringAvUtbetalingsperiode: () => void) => {
@@ -305,7 +305,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 variant="tertiary"
                                 size="small"
                                 onClick={() => {
-                                    tilbakestillFelterTilDefault();
+                                    settFelterTilDefault();
                                     lukkSkjema();
                                 }}
                             >


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22991
Fikser også denne bugen: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23190

Kopi av denne PRen: https://github.com/navikt/familie-ks-sak-frontend/pull/917

Skjemaet er satt opp til å initielt være verdiene til endret utbetaling andel som kommer fra backend. Problemet er når denne verdien endrer seg, så blir ikke dette propagert til skjemaet på riktig måte. Løser dette på samme måte som er løst for dato-felter tidligere, ved å sette feltene til å initielt være undefined, også heller oppdatere feltene hver gang endret utbetaling andelen endrer seg. Se punktet under for noen tanker 👇

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
To ting:
1.
Jeg syns vi skal vurdere å skrive om hele måten Endret utbetaling er satt opp på. Det er ganske krøllete når contexten er satt opp på den måten den er. Den tar inn en endretUtbetalingAndel som parameter og måten hele skjemaet er satt opp på baserer seg på denne andelen. Men, når det skjer endringer i andeler (ved lagring feks) så blir ikke det propagert til skjemaet på riktig måte. Tror det er mye forbedringspotensiale på hele strukturen her

Når vi setter feltene til undefined initielt og heller oppdaterer ved endringer på endret utbetaling andel, så vil extention-funksjonen .nullstill() på feltet sette feltet til undefined og ikke til den "initielle/default"-verdien til endret utbetaling andel. Dette ble brukt tre steder på fom og tom-feltene i dag, men jeg mener at det fungerer like godt å sette feltet til undefined som initiell verdi i alle de tilfellene.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det er vits her

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
