### PR TITLE
Hent siste versjon av image i docker-build-push

### DIFF
--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: nais/docker-build-push@v0
         id: docker-build-push
         with:
+          pull: true # optional, default false
           team: teamfamilie
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }} # Provided as Organization Secret
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }} # Provided as Organization Variable

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: nais/docker-build-push@v0
         id: docker-build-push
         with:
+          pull: true # optional, default false
           team: teamfamilie
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }} # Provided as Organization Secret
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }} # Provided as Organization Variable


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
For å få med sikkerhetspatcher i dockerimaget vi kjører på må vi huske å på å hente oppdateringer hver gang vi bygger. Så vi ikke bare laster ned image første gang vi bygger.


![image](https://github.com/user-attachments/assets/bee7fff3-8cb4-449c-82a5-a42ab0a1ee15)

![image](https://github.com/user-attachments/assets/18b8bf7d-e380-4077-84bd-da4395cd4007)
