### PR TITLE
Chore: grupper minor og patch-oppdateringer fra dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,12 @@ updates:
     - dependency-name: "*"
       update-types: ["version-update:semver-patch"]
   groups:
+    minor-and-patch:
+      patterns:
+        - '*'
+      update-types:
+        - 'minor'
+        - 'patch'
     typescript-eslint:
       patterns:
         - "@typescript-eslint/eslint-plugin"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
For å få færre dependabot PRer prøver jeg her å gruppere alle minor og patch oppdateringer inn i 1 PR. Fortsetter med de nåværende grupperingene for major-oppdateringer.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Litt usikker på hvordan det funker med grupperinger når ting passer inn i flere grupper her, men har troen på at dette kan funke. Om noe så grupperer det alle andre minor og patch oppdateringer enn de dependenciene som allerede blir gruppert i dag
