### PR TITLE
Fjerner eksplisitt lasting av font fra google

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
@@ -18,15 +18,6 @@ const Container = styled.div`
         box-shadow: 0 0 0 3px @fokusFarge;
         outline: none;
     }
-
-    span {
-        color: black;
-        font-family: 'Source Sans Pro', Arial, sans-serif;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        border-radius: 0.2rem;
-    }
 `;
 
 const Toast: React.FC<{ toastId: string; toast: IToast }> = ({ toastId, toast }) => {

--- a/src/frontend/public/index.html
+++ b/src/frontend/public/index.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="shortcut icon" href="/assets/favicon.svg" />
-    <style>
-        @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro');
-    </style>
 </head>
 <body style="margin: 0; height: 100%; overflow: hidden">
     <div id="app" style="height: 100%"></div>


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23151

### 💰 Hva forsøker du å løse i denne PR'en
Fjerner lastingen av `Source Sans Pro`, en gammel versjon av Aksel sin font `Source Sans 3`. Fjerner samtidig gammel styling som ikke blir brukt lenger (det finnes ingen `span` elementer nå i `Toast`). Vi laster inn `Source Sans 3` via [ds-css](https://github.com/navikt/aksel/blob/main/%40navikt/core/css/baseline/fonts.css), derfor trenger vi ikke laste inn egen font.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ittno bekymringer!

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ X] Nei
  
### 👀 Screen shots
Ingen visuelle endringer :)