### PR TITLE
Ekskluderer XU i brevmottaker landvelger

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -104,8 +104,8 @@ const BrevmottakerSkjema = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
                     utenMargin
                     eksluderLand={
                         skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
-                            ? ['NO']
-                            : undefined
+                            ? ['NO', 'XU']
+                            : ['XU']
                     }
                     feil={
                         skjema.visFeilmeldinger &&


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23347

Ønsker ikke muligheten til å velge Ukjent som land ved opprettelse av brevmottaker