### PR TITLE
Klage: rename visningsnavn i behandlingsoversikt til "oversendt til KA"

### DIFF
--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -404,7 +404,7 @@ export const behandlingsresultater: Record<
     HENLAGT: 'Henlagt',
 
     /** For klagebehandlinger: **/
-    IKKE_MEDHOLD: 'Ikke medhold',
+    IKKE_MEDHOLD: 'Oversendt til KA',
     IKKE_MEDHOLD_FORMKRAV_AVVIST: 'Ikke medhold formkrav avvist',
     IKKE_SATT: 'Ikke satt',
     MEDHOLD: 'Medhold',


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når vi har oversendt klage til KA vil resultatet i løsningen vår stå som "Ikke medhold" frem til vi får svar fra KA. Dette ønsker vi å endre til "oversendt til KA" for å gi mer kontekst til saksbehandler. Akkurat samme som er gjort av EF.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Gir ikke mening

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
