### PR TITLE
Bumper tidslinjebiblioteket til 10.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@navikt/familie-ikoner": "9.0.0",
     "@navikt/familie-logging": "7.0.0",
     "@navikt/familie-skjema": "8.2.7",
-    "@navikt/familie-tidslinje": "10.0.0",
+    "@navikt/familie-tidslinje": "10.0.4",
     "@navikt/familie-typer": "8.0.2",
     "@navikt/familie-visittkort": "15.1.0",
     "@navikt/flagg-ikoner": "3.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,13 +1816,13 @@
     deep-equal "^2.2.3"
     hashids "^2.3.0"
 
-"@navikt/familie-tidslinje@10.0.0":
-  version "10.0.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-tidslinje/10.0.0/c9419e864955b4376cf8da65c11351f801eabac3#c9419e864955b4376cf8da65c11351f801eabac3"
-  integrity sha512-GWPGBX+DkBL9P46FHliJsu/TxN8saTFlEPYtzo4IadtjBeGX2n756EYTIjN2Ywtkqhgqvbba1HKnUasfZp41BQ==
+"@navikt/familie-tidslinje@10.0.4":
+  version "10.0.4"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-tidslinje/10.0.4/498a4bb2a08ee28ccd3852854965b386138c56e7#498a4bb2a08ee28ccd3852854965b386138c56e7"
+  integrity sha512-lcXkxrC2N02ZXjm1kZO5WwDe2ZCNm0RL0zow8V6eX1AX75u1E0tRmFSC+ijXCX6ZgIIlCxcdvV8mXIvTcy84Fg==
   dependencies:
     classnames "^2.5.1"
-    nanoid "^5.0.4"
+    nanoid "^5.0.7"
 
 "@navikt/familie-typer@8.0.2", "@navikt/familie-typer@^8.0.1", "@navikt/familie-typer@^8.0.2":
   version "8.0.2"
@@ -7726,10 +7726,10 @@ nanoid@^3.3.6, nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
-nanoid@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.4.tgz#d2b608d8169d7da669279127615535705aa52edf"
-  integrity sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==
+nanoid@^5.0.7:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.9.tgz#977dcbaac055430ce7b1e19cf0130cea91a20e50"
+  integrity sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bumper tidslinjebiblioteket. Den tidligere versjonen hadde en dependency på `nanoid` som var usikker. Etter denne oppdateringen kan vi fikse versjonen av `nanoid` i dette prosjektet.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen bekymringer. Merk at dette ikke er siste versjon av tidslinjebiblioteket. Den siste versjonen krever React v19, som vi ikke har gått over til ennå. Dette er den nyeste versjonen på React v18.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant