### PR TITLE
Vi legger til søknad mottatt dato i behandlingskortet

### DIFF
--- a/src/frontend/komponenter/Fagsak/Behandlingskort/Behandlingskort.tsx
+++ b/src/frontend/komponenter/Fagsak/Behandlingskort/Behandlingskort.tsx
@@ -117,6 +117,15 @@ const Behandlingskort: React.FC<IBehandlingskortProps> = ({ åpenBehandling }) =
                     tekstFarge={hentResultatfargeTekst(åpenBehandling.resultat)}
                 />
                 <div>
+                    {åpenBehandling.søknadMottattDato && (
+                        <Informasjonsbolk
+                            label="Søknad mottatt"
+                            tekst={isoStringTilFormatertString({
+                                isoString: åpenBehandling.søknadMottattDato,
+                                tilFormat: Datoformat.DATO,
+                            })}
+                        />
+                    )}
                     <Informasjonsbolk
                         label="Opprettet"
                         tekst={isoStringTilFormatertString({


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24106

Vi legger til datoen søknad er mottatt i behandlingskortet.
Den vises bare hvis søknadsdato eksisterer (og derfor vil bare vises for behandlingsårsak søknad)

<img width="401" alt="dato" src="https://github.com/user-attachments/assets/5885cc49-a585-4e11-9efa-4376a24d617c" />
