### PR TITLE
NAV-24505: Gjemmer behandlingstema ved tilknytning til ny behandling i journalføring hvis det er en klage

### DIFF
--- a/src/frontend/typer/behandlingstema.ts
+++ b/src/frontend/typer/behandlingstema.ts
@@ -1,5 +1,3 @@
-import type { IOppgave } from './oppgave';
-
 export enum BehandlingKategori {
     NASJONAL = 'NASJONAL',
     EØS = 'EØS',
@@ -22,6 +20,7 @@ export interface IRestEndreBehandlingUnderkategori {
     behandlingKategori: BehandlingKategori;
     behandlingUnderkategori: BehandlingUnderkategori;
 }
+
 export const behandlingKategori: Record<BehandlingKategori, string> = {
     NASJONAL: 'Nasjonal',
     EØS: 'EØS',
@@ -81,23 +80,12 @@ export const tilBehandlingstema = (
     );
 };
 
-const kodeTilBehandlingUnderkategoriMap: Record<string, BehandlingUnderkategori> = {
+export const kodeTilBehandlingUnderkategoriMap: Record<string, BehandlingUnderkategori> = {
     ab0180: BehandlingUnderkategori.ORDINÆR,
     ab0096: BehandlingUnderkategori.UTVIDET,
 };
 
-const kodeTilBehandlingKategoriMap: Record<string, BehandlingKategori> = {
+export const kodeTilBehandlingKategoriMap: Record<string, BehandlingKategori> = {
     ae0118: BehandlingKategori.NASJONAL,
     ae0120: BehandlingKategori.EØS,
-};
-
-export const utredBehandlingstemaFraOppgave = (oppgave: IOppgave): IBehandlingstema | undefined => {
-    const { behandlingstema: gjelder, behandlingstype } = oppgave;
-    return gjelder in kodeTilBehandlingUnderkategoriMap &&
-        behandlingstype in kodeTilBehandlingKategoriMap
-        ? tilBehandlingstema(
-              kodeTilBehandlingKategoriMap[behandlingstype],
-              kodeTilBehandlingUnderkategoriMap[gjelder]
-          )
-        : undefined;
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Skal ikke vise knappen for behandlingstema hvis det er en klage.

Har kjørt opp løsningen lokalt og ser ut til å fungere fint.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Trenger en større omstrukturering før det er vits å skrive tester. Tar det derfor i en senere PR ved en bedre anledning.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Før:
![image](https://github.com/user-attachments/assets/62d20532-14e5-48f3-b13c-19c1a141d7f3)

Etter:
![image](https://github.com/user-attachments/assets/6668ec29-12cd-4c1c-bfb1-5ac551d79da0)
