### PR TITLE
Advarsel om ulovlig avregning

### DIFF
--- a/src/frontend/context/SimuleringContext.tsx
+++ b/src/frontend/context/SimuleringContext.tsx
@@ -91,6 +91,14 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         0
     );
 
+    const erAvregning =
+        simResultat &&
+        simResultat.perioder.some(periode => {
+            const erFeilutbetalingIPeriode = periode.feilutbetaling && periode.feilutbetaling > 0;
+            const erEtterbetalingIPeriode = periode.etterbetaling && periode.etterbetaling > 0;
+            return erFeilutbetalingIPeriode && erEtterbetalingIPeriode;
+        });
+
     const erFeilutbetaling = simResultat && simResultat.feilutbetaling > 0;
     const erEtterutbetaling = totalEtterbetalingFørMars2023 > 0;
 
@@ -259,6 +267,7 @@ const [SimuleringProvider, useSimulering] = constate(({ åpenBehandling }: IProp
         onSubmit,
         hentFeilTilOppsummering,
         erFeilutbetaling,
+        erAvregning,
         hentSkjemadata,
         maksLengdeTekst,
         harÅpenTilbakekrevingRessurs,

--- a/src/frontend/komponenter/Fagsak/Simulering/AvregningAlert.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/AvregningAlert.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import styled from 'styled-components';
+
+import { Alert, BodyLong, List } from '@navikt/ds-react';
+
+const StyledAlert = styled(Alert)`
+    margin-top: 2rem;
+    width: fit-content;
+`;
+
+const AvregningAlert = () => {
+    return (
+        <StyledAlert variant="warning">
+            <BodyLong spacing>
+                Denne saken inneholder både en etterbetaling og en feilutbetaling. Vi kan ikke
+                automatisk avregne feilutbetalinger mot etterbetalinger.
+            </BodyLong>
+            <BodyLong>Du må derfor:</BodyLong>
+            <List>
+                <List.Item>
+                    Først gjøre vedtak om etterbetalingen, og deretter gjøre nytt vedtak om
+                    feilutbetalingen og opprette t-sak («splitte saken»).
+                </List.Item>
+            </List>
+        </StyledAlert>
+    );
+};
+
+export default AvregningAlert;

--- a/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
+++ b/src/frontend/komponenter/Fagsak/Simulering/Simulering.tsx
@@ -7,15 +7,18 @@ import { Alert } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import AvregningAlert from './AvregningAlert';
 import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
+import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { useSimulering } from '../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingSteg } from '../../../typer/behandling';
 import type { ITilbakekreving } from '../../../typer/simulering';
+import { ToggleNavn } from '../../../typer/toggles';
 import { hentSøkersMålform } from '../../../utils/behandling';
 import Skjemasteg from '../../Felleskomponenter/Skjemasteg/Skjemasteg';
 
@@ -33,6 +36,7 @@ const StyledBeløpsgrenseAlert = styled(Alert)`
 `;
 
 const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling }) => {
+    const { toggles } = useApp();
     const { fagsakId } = useSakOgBehandlingParams();
     const navigate = useNavigate();
     const {
@@ -42,6 +46,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         tilbakekrevingSkjema,
         harÅpenTilbakekrevingRessurs,
         erFeilutbetaling,
+        erAvregning,
         behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
         behandlingErMigreringMedManuellePosteringer,
@@ -49,6 +54,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         behandlingErEndreMigreringsdato,
     } = useSimulering();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
+
+    const erAvregningOgToggleErPå = erAvregning && toggles[ToggleNavn.validerIkkeAvregning];
 
     const nesteOnClick = () => {
         if (vurderErLesevisning()) {
@@ -90,6 +97,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             nesteOnClick={nesteOnClick}
             maxWidthStyle={'80rem'}
             steg={BehandlingSteg.VURDER_TILBAKEKREVING}
+            skalDisableNesteKnapp={erAvregningOgToggleErPå}
         >
             {behandlingErMigreringFraInfotrygdMedKun0Utbetalinger && (
                 <StyledAlert variant={'warning'}>
@@ -149,7 +157,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                     to-trinnskontroll.
                                 </StyledBeløpsgrenseAlert>
                             )}
-                        {erFeilutbetaling && (
+                        {erAvregningOgToggleErPå && <AvregningAlert />}
+                        {erFeilutbetaling && !erAvregningOgToggleErPå && (
                             <TilbakekrevingSkjema
                                 søkerMålform={hentSøkersMålform(åpenBehandling)}
                                 harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}

--- a/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemasteg/Skjemasteg.tsx
@@ -30,6 +30,7 @@ interface IProps extends PropsWithChildren {
     senderInn: boolean;
     tittel: string | React.ReactNode;
     maxWidthStyle?: string;
+    skalDisableNesteKnapp?: boolean;
     skalViseNesteKnapp?: boolean;
     skalViseForrigeKnapp?: boolean;
     feilmelding?: string;
@@ -72,6 +73,7 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
     tittel,
     maxWidthStyle = '40rem',
     skalViseNesteKnapp = true,
+    skalDisableNesteKnapp = false,
     skalViseForrigeKnapp = true,
     feilmelding = '',
 }) => {
@@ -136,7 +138,7 @@ const Skjemasteg: React.FunctionComponent<IProps> = ({
                         (!vurderErLesevisning() || kanGåVidereILesevisning) && (
                             <Button
                                 loading={senderInn}
-                                disabled={senderInn}
+                                disabled={senderInn || skalDisableNesteKnapp}
                                 onClick={() => {
                                     if (!senderInn) {
                                         nesteOnClick();

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -16,6 +16,7 @@ export enum ToggleNavn {
     selvstendigRettInfobrev = 'familie-ba-sak.selvstendig-rett-infobrev',
     kanOppretteRevurderingMedAarsakIverksetteKaVedtak = 'familie-ba-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak',
     brukFunksjonalitetForUlovfestetMotregning = 'familie-ba-sak.ulovfestet-motregning',
+    validerIkkeAvregning = 'familie-ba-sak.valider-ikke-avregning',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-24534

Dersom det eksisterer en etterbetaling og en feilutbetaling eller en tilbakekreving på fagsaken (avregning) skjer følgende:
- Det vises en advarsel til saksbehandler om at dette ikke er mulig
- Tilbakekrevingskjemaet skjules
- 'Neste'-knappen disables

### 👀 Screen shots
![ec95aba0586f2da5283b5c41178da1a7](https://github.com/user-attachments/assets/db36038e-0efe-4a48-a82a-3794619d1329)
