### PR TITLE
NAV-24505: Viser klagebehandlinger i journalfør skjermbilde

### DIFF
--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -660,7 +660,6 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         settMinimalFagsakTilNormalFagsakForPerson,
         settMinimalFagsakTilInstitusjonsfagsak,
         erDigitaltInnsendtDokument,
-        klagebehandlinger,
     };
 });
 

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -25,7 +25,12 @@ import type { IBehandlingstema } from '../typer/behandlingstema';
 import { behandlingstemaer } from '../typer/behandlingstema';
 import type { IMinimalFagsak } from '../typer/fagsak';
 import { FagsakType } from '../typer/fagsak';
-import type { Klagebehandlingstype } from '../typer/klage';
+import {
+    type Journalføringsbehandling,
+    opprettJournalføringsbehandlingFraBarnetrygdbehandling,
+    opprettJournalføringsbehandlingFraKlagebehandling,
+} from '../typer/journalføringsbehandling';
+import type { IKlagebehandling, Klagebehandlingstype } from '../typer/klage';
 import type {
     IDataForManuellJournalføring,
     IRestJournalføring,
@@ -41,6 +46,7 @@ import type { IPersonInfo } from '../typer/person';
 import { Adressebeskyttelsegradering } from '../typer/person';
 import type { ISamhandlerInfo } from '../typer/samhandler';
 import type { Tilbakekrevingsbehandlingstype } from '../typer/tilbakekrevingsbehandling';
+import { ToggleNavn } from '../typer/toggles';
 import { isoStringTilDate } from '../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '../utils/fagsak';
 
@@ -51,13 +57,14 @@ export interface ManuellJournalføringSkjemaFelter extends IOpprettBehandlingSkj
     avsenderNavn: string;
     avsenderIdent: string;
     knyttTilNyBehandling: boolean;
-    tilknyttedeBehandlingIder: number[];
+    tilknyttedeBehandlingIder: string[];
     fagsakType: FagsakType;
     samhandler: ISamhandlerInfo | undefined;
 }
 
 const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() => {
-    const { innloggetSaksbehandler } = useApp();
+    const { innloggetSaksbehandler, toggles } = useApp();
+
     const navigate = useNavigate();
     const { request } = useHttp();
     const { oppgaveId } = useParams<{ oppgaveId: string }>();
@@ -66,6 +73,9 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
 
     const [minimalFagsak, settMinimalFagsak] = useState<IMinimalFagsak | undefined>(undefined);
     const [erKlage, settErKlage] = useState<boolean>(false);
+    const [klagebehandlinger, settKlagebehandlinger] = useState<IKlagebehandling[] | undefined>(
+        undefined
+    );
     const [dataForManuellJournalføring, settDataForManuellJournalføring] =
         useState(byggTomRessurs<IDataForManuellJournalføring>());
     const [erDigitaltInnsendtDokument, settErDigialtInnsendtDokument] = useState<
@@ -172,7 +182,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
             knyttTilNyBehandling,
             behandlingstype,
             behandlingsårsak,
-            tilknyttedeBehandlingIder: useFelt<number[]>({
+            tilknyttedeBehandlingIder: useFelt<string[]>({
                 verdi: [],
             }),
             fagsakType: useFelt<FagsakType>({
@@ -212,7 +222,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
             if (dataForManuellJournalføring.data.minimalFagsak) {
                 settMinimalFagsak(dataForManuellJournalføring.data.minimalFagsak);
             }
-
+            settKlagebehandlinger(dataForManuellJournalføring.data.klagebehandlinger);
             settErKlage(erOppgaveJournalførKlage(dataForManuellJournalføring.data.oppgave));
         }
     }, [dataForManuellJournalføring]);
@@ -360,15 +370,27 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         return aktivBehandling;
     };
 
-    const hentSorterteBehandlinger = () => {
-        return minimalFagsak?.behandlinger.length
-            ? minimalFagsak.behandlinger.sort((a, b) =>
-                  differenceInMilliseconds(
-                      isoStringTilDate(b.opprettetTidspunkt),
-                      isoStringTilDate(a.opprettetTidspunkt)
-                  )
-              )
-            : [];
+    const hentSorterteJournalføringsbehandlinger = (): Journalføringsbehandling[] => {
+        const journalføringsbehandlingerKlage = (klagebehandlinger ?? []).map(klagebehandling =>
+            opprettJournalføringsbehandlingFraKlagebehandling(klagebehandling)
+        );
+
+        const journalføringsbehandlingerBarnetrygd = (minimalFagsak?.behandlinger ?? []).map(
+            barnetrygdbehandling =>
+                opprettJournalføringsbehandlingFraBarnetrygdbehandling(barnetrygdbehandling)
+        );
+
+        const journalføringsbehandlinger = [
+            ...(toggles[ToggleNavn.kanBehandleKlage] ? journalføringsbehandlingerKlage : []),
+            ...journalføringsbehandlingerBarnetrygd,
+        ];
+
+        return journalføringsbehandlinger.sort((behandling1, behandling2) =>
+            differenceInMilliseconds(
+                isoStringTilDate(behandling2.opprettetTidspunkt),
+                isoStringTilDate(behandling1.opprettetTidspunkt)
+            )
+        );
     };
 
     const journalfør = () => {
@@ -621,7 +643,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         minimalFagsak,
         hentAktivBehandlingForJournalføring,
         hentFeilTilOppsummering,
-        hentSorterteBehandlinger,
+        hentSorterteJournalføringsbehandlinger,
         journalfør,
         knyttTilNyBehandling,
         nullstillSkjema,
@@ -638,6 +660,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         settMinimalFagsakTilNormalFagsakForPerson,
         settMinimalFagsakTilInstitusjonsfagsak,
         erDigitaltInnsendtDokument,
+        klagebehandlinger,
     };
 });
 

--- a/src/frontend/komponenter/ManuellJournalfør/KnyttJournalpostTilBehandling.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/KnyttJournalpostTilBehandling.tsx
@@ -34,10 +34,11 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
     const {
         skjema,
         minimalFagsak,
-        hentSorterteBehandlinger,
+        hentSorterteJournalføringsbehandlinger,
         kanKnytteJournalpostTilBehandling,
         erLesevisning,
     } = useManuellJournalfør();
+
     const åpenBehandling: VisningBehandling | undefined = minimalFagsak
         ? hentAktivBehandlingPåMinimalFagsak(minimalFagsak)
         : undefined;
@@ -46,14 +47,16 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
         !erLesevisning() &&
         skjema.felter.tilknyttedeBehandlingIder.verdi.length === 0 &&
         !skjema.felter.knyttTilNyBehandling.verdi;
+
+    const sorterteJournalføringsbehandlinger = hentSorterteJournalføringsbehandlinger();
+
     return (
         <KnyttDiv>
-            {!!minimalFagsak?.behandlinger.length && (
+            {sorterteJournalføringsbehandlinger.length > 0 && (
                 <>
                     <Heading size={'small'} level={'2'}>
                         Knytt til tidligere behandling(er)
                     </Heading>
-
                     <Table>
                         <Table.Header>
                             <Table.Row>
@@ -65,68 +68,57 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
                             </Table.Row>
                         </Table.Header>
                         <Table.Body>
-                            {hentSorterteBehandlinger().map((behandling: VisningBehandling) => {
-                                const behandlingId: number | undefined =
-                                    typeof behandling.behandlingId == 'number'
-                                        ? behandling.behandlingId
-                                        : undefined;
-
+                            {sorterteJournalføringsbehandlinger.map(behandling => {
                                 return (
-                                    behandlingId !== undefined && (
-                                        <Table.Row
-                                            key={behandlingId}
-                                            aria-selected={skjema.felter.tilknyttedeBehandlingIder.verdi.includes(
-                                                behandlingId
-                                            )}
-                                        >
-                                            <Table.DataCell>
-                                                <Checkbox
-                                                    id={behandlingId.toString()}
-                                                    value={behandlingId.toString()}
-                                                    checked={skjema.felter.tilknyttedeBehandlingIder.verdi.includes(
-                                                        behandlingId
-                                                    )}
-                                                    onChange={() => {
-                                                        skjema.felter.tilknyttedeBehandlingIder.validerOgSettFelt(
-                                                            [
-                                                                ...skjema.felter.tilknyttedeBehandlingIder.verdi.filter(
-                                                                    it => it !== behandlingId
-                                                                ),
-                                                                ...(skjema.felter.tilknyttedeBehandlingIder.verdi.includes(
-                                                                    behandlingId
-                                                                )
-                                                                    ? []
-                                                                    : [behandlingId]),
-                                                            ]
-                                                        );
-                                                    }}
-                                                    readOnly={!kanKnytteJournalpostTilBehandling()}
-                                                    hideLabel
-                                                >
-                                                    {behandlingId.toString()}
-                                                </Checkbox>
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {isoStringTilFormatertString({
-                                                    isoString: behandling.opprettetTidspunkt,
-                                                    tilFormat: Datoformat.DATO_FORKORTTET,
-                                                })}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {
-                                                    behandlingÅrsak[
-                                                        behandling.årsak as BehandlingÅrsak
-                                                    ]
-                                                }
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {behandlingstyper[behandling.type].navn}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {behandlingsstatuser[behandling.status]}
-                                            </Table.DataCell>
-                                        </Table.Row>
-                                    )
+                                    <Table.Row
+                                        key={behandling.id}
+                                        aria-selected={skjema.felter.tilknyttedeBehandlingIder.verdi.includes(
+                                            behandling.id
+                                        )}
+                                    >
+                                        <Table.DataCell>
+                                            <Checkbox
+                                                id={behandling.id}
+                                                value={behandling.id}
+                                                checked={skjema.felter.tilknyttedeBehandlingIder.verdi.includes(
+                                                    behandling.id
+                                                )}
+                                                onChange={() => {
+                                                    skjema.felter.tilknyttedeBehandlingIder.validerOgSettFelt(
+                                                        [
+                                                            ...skjema.felter.tilknyttedeBehandlingIder.verdi.filter(
+                                                                it => it !== behandling.id
+                                                            ),
+                                                            ...(skjema.felter.tilknyttedeBehandlingIder.verdi.includes(
+                                                                behandling.id
+                                                            )
+                                                                ? []
+                                                                : [behandling.id]),
+                                                        ]
+                                                    );
+                                                }}
+                                                readOnly={!kanKnytteJournalpostTilBehandling()}
+                                                hideLabel={true}
+                                            >
+                                                {behandling.id}
+                                            </Checkbox>
+                                        </Table.DataCell>
+                                        <Table.DataCell>
+                                            {isoStringTilFormatertString({
+                                                isoString: behandling.opprettetTidspunkt,
+                                                tilFormat: Datoformat.DATO_FORKORTTET,
+                                            })}
+                                        </Table.DataCell>
+                                        <Table.DataCell>
+                                            {behandlingÅrsak[behandling.årsak as BehandlingÅrsak]}
+                                        </Table.DataCell>
+                                        <Table.DataCell>
+                                            {behandlingstyper[behandling.type].navn}
+                                        </Table.DataCell>
+                                        <Table.DataCell>
+                                            {behandlingsstatuser[behandling.status]}
+                                        </Table.DataCell>
+                                    </Table.Row>
                                 );
                             })}
                         </Table.Body>
@@ -139,7 +131,7 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
             {visGenerellSakInfoStripe && (
                 <StyledAlert variant="info">
                     <GenerellSakInfoStripeTittel>
-                        {hentSorterteBehandlinger().length > 0
+                        {sorterteJournalføringsbehandlinger.length > 0
                             ? `Du velger å journalføre uten å knytte til behandling(er).`
                             : `Du velger å journalføre uten å knytte til ny behandling.`}
                     </GenerellSakInfoStripeTittel>

--- a/src/frontend/typer/journalføringsbehandling.test.ts
+++ b/src/frontend/typer/journalføringsbehandling.test.ts
@@ -52,7 +52,7 @@ describe('Journalføringsbehandling', () => {
             expect(journalføringsbehandling.opprettetTidspunkt).toBe(
                 barnetrygdbehandling.opprettetTidspunkt
             );
-            expect(journalføringsbehandling.type).toBe(Behandlingstype.FØRSTEGANGSBEHANDLING);
+            expect(journalføringsbehandling.type).toBe(barnetrygdbehandling.type);
             expect(journalføringsbehandling.status).toBe(barnetrygdbehandling.status);
         });
 
@@ -78,7 +78,7 @@ describe('Journalføringsbehandling', () => {
             expect(journalføringsbehandling.opprettetTidspunkt).toBe(
                 barnetrygdbehandling.opprettetTidspunkt
             );
-            expect(journalføringsbehandling.type).toBe(Behandlingstype.FØRSTEGANGSBEHANDLING);
+            expect(journalføringsbehandling.type).toBe(barnetrygdbehandling.type);
             expect(journalføringsbehandling.status).toBe(barnetrygdbehandling.status);
         });
     });

--- a/src/frontend/typer/journalføringsbehandling.test.ts
+++ b/src/frontend/typer/journalføringsbehandling.test.ts
@@ -1,0 +1,85 @@
+import { BehandlingStatus, Behandlingstype } from './behandling';
+import { BehandlingKategori, BehandlingUnderkategori } from './behandlingstema';
+import {
+    opprettJournalføringsbehandlingFraBarnetrygdbehandling,
+    opprettJournalføringsbehandlingFraKlagebehandling,
+} from './journalføringsbehandling';
+import { KlageStatus } from './klage';
+import { KlageTestdata } from '../testdata/klageTestdata';
+
+describe('Journalføringsbehandling', () => {
+    describe('OpprettJournalføringsbehandlingFraKlagebehandling', () => {
+        test('skal opprette journalføringsbehandling fra klagebehandling', () => {
+            // Arrange
+            const klagebehandling = KlageTestdata.lagKlagebehandling({
+                id: '1',
+                opprettet: '2025-03-06',
+                status: KlageStatus.UTREDES,
+            });
+
+            // Act
+            const journalføringsbehandling =
+                opprettJournalføringsbehandlingFraKlagebehandling(klagebehandling);
+
+            // Expect
+            expect(journalføringsbehandling.id).toBe(klagebehandling.id);
+            expect(journalføringsbehandling.opprettetTidspunkt).toBe(klagebehandling.opprettet);
+            expect(journalføringsbehandling.type).toBe(Behandlingstype.KLAGE);
+            expect(journalføringsbehandling.status).toBe(klagebehandling.status);
+        });
+    });
+
+    describe('OpprettJournalføringsbehandlingFraBarnetrygdbehandling', () => {
+        test('skal opprette journalføringsbehandling fra barnetrygdbehandling hvor behandlingsiden er et number', () => {
+            // Arrange
+            const barnetrygdbehandling = {
+                aktiv: true,
+                behandlingId: 123,
+                opprettetTidspunkt: '2015-03-06',
+                aktivertTidspunkt: '2015-03-06',
+                status: BehandlingStatus.UTREDES,
+                type: Behandlingstype.FØRSTEGANGSBEHANDLING,
+                kategori: BehandlingKategori.NASJONAL,
+                underkategori: BehandlingUnderkategori.ORDINÆR,
+            };
+
+            // Act
+            const journalføringsbehandling =
+                opprettJournalføringsbehandlingFraBarnetrygdbehandling(barnetrygdbehandling);
+
+            // Expect
+            expect(journalføringsbehandling.id).toBe(barnetrygdbehandling.behandlingId + '');
+            expect(journalføringsbehandling.opprettetTidspunkt).toBe(
+                barnetrygdbehandling.opprettetTidspunkt
+            );
+            expect(journalføringsbehandling.type).toBe(Behandlingstype.FØRSTEGANGSBEHANDLING);
+            expect(journalføringsbehandling.status).toBe(barnetrygdbehandling.status);
+        });
+
+        test('skal opprette journalføringsbehandling fra barnetrygdbehandling hvor behandlingsiden er en string', () => {
+            // Arrange
+            const barnetrygdbehandling = {
+                aktiv: true,
+                behandlingId: '123',
+                opprettetTidspunkt: '2015-03-06',
+                aktivertTidspunkt: '2015-03-06',
+                status: BehandlingStatus.UTREDES,
+                type: Behandlingstype.FØRSTEGANGSBEHANDLING,
+                kategori: BehandlingKategori.NASJONAL,
+                underkategori: BehandlingUnderkategori.ORDINÆR,
+            };
+
+            // Act
+            const journalføringsbehandling =
+                opprettJournalføringsbehandlingFraBarnetrygdbehandling(barnetrygdbehandling);
+
+            // Expect
+            expect(journalføringsbehandling.id).toBe(barnetrygdbehandling.behandlingId);
+            expect(journalføringsbehandling.opprettetTidspunkt).toBe(
+                barnetrygdbehandling.opprettetTidspunkt
+            );
+            expect(journalføringsbehandling.type).toBe(Behandlingstype.FØRSTEGANGSBEHANDLING);
+            expect(journalføringsbehandling.status).toBe(barnetrygdbehandling.status);
+        });
+    });
+});

--- a/src/frontend/typer/journalføringsbehandling.ts
+++ b/src/frontend/typer/journalføringsbehandling.ts
@@ -28,7 +28,7 @@ export function opprettJournalføringsbehandlingFraBarnetrygdbehandling(
     barnetrygdbehandling: VisningBehandling
 ): Journalføringsbehandling {
     return {
-        id: barnetrygdbehandling.behandlingId + '',
+        id: barnetrygdbehandling.behandlingId.toString(),
         opprettetTidspunkt: barnetrygdbehandling.opprettetTidspunkt,
         årsak: barnetrygdbehandling.årsak,
         type: barnetrygdbehandling.type,

--- a/src/frontend/typer/journalføringsbehandling.ts
+++ b/src/frontend/typer/journalføringsbehandling.ts
@@ -1,0 +1,37 @@
+import type { BehandlingStatus } from './behandling';
+import { Behandlingstype, type BehandlingÅrsak } from './behandling';
+import type { KlageStatus } from './klage';
+import { type IKlagebehandling } from './klage';
+import type { VisningBehandling } from '../komponenter/Fagsak/Saksoversikt/visningBehandling';
+import type { IsoDatoString } from '../utils/dato';
+
+export type Journalføringsbehandling = {
+    id: string;
+    opprettetTidspunkt: IsoDatoString;
+    årsak?: BehandlingÅrsak;
+    type: Behandlingstype;
+    status: BehandlingStatus | KlageStatus;
+};
+
+export function opprettJournalføringsbehandlingFraKlagebehandling(
+    klagebehandling: IKlagebehandling
+): Journalføringsbehandling {
+    return {
+        id: klagebehandling.id,
+        opprettetTidspunkt: klagebehandling.opprettet,
+        type: Behandlingstype.KLAGE,
+        status: klagebehandling.status,
+    };
+}
+
+export function opprettJournalføringsbehandlingFraBarnetrygdbehandling(
+    barnetrygdbehandling: VisningBehandling
+): Journalføringsbehandling {
+    return {
+        id: barnetrygdbehandling.behandlingId + '',
+        opprettetTidspunkt: barnetrygdbehandling.opprettetTidspunkt,
+        årsak: barnetrygdbehandling.årsak,
+        type: barnetrygdbehandling.type,
+        status: barnetrygdbehandling.status,
+    };
+}

--- a/src/frontend/typer/manuell-journalføring.ts
+++ b/src/frontend/typer/manuell-journalføring.ts
@@ -30,7 +30,7 @@ export interface IRestJournalføring {
     journalpostTittel?: string;
     dokumenter?: IRestJournalpostDokument[];
     knyttTilFagsak: boolean;
-    tilknyttedeBehandlingIder: number[];
+    tilknyttedeBehandlingIder: string[];
     opprettOgKnyttTilNyBehandling: boolean;
     navIdent: string;
     kategori: BehandlingKategori | null;

--- a/src/frontend/typer/oppgave.ts
+++ b/src/frontend/typer/oppgave.ts
@@ -194,7 +194,7 @@ export enum PrioritetFilter {
 
 export interface IRestLukkOppgaveOgKnyttJournalpost {
     journalpostId: string;
-    tilknyttedeBehandlingIder: number[];
+    tilknyttedeBehandlingIder: string[];
     opprettOgKnyttTilNyBehandling: boolean;
     bruker?: INavnOgIdent;
     datoMottatt?: string;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Ønsker å vise klagebehandlinger i tabelloversikten ved journalføring.

Har kjørt det opp lokalt og ser ut til å fungere fint.

Toggelen som tillater å utlede klagebehandlinger er kun skrudd på i dev.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [X] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før:
![image](https://github.com/user-attachments/assets/9b20f9cb-5c24-43b7-842b-df0c834253c6)

Etter:
![image](https://github.com/user-attachments/assets/97a59d7d-e83c-441e-b250-1bd282b59d69)