### PR TITLE
NAV-24505: Alltid vis KnyttTilNyBehandling om klage toggle er skrudd på

### DIFF
--- a/src/frontend/komponenter/ManuellJournalfør/KnyttJournalpostTilBehandling.tsx
+++ b/src/frontend/komponenter/ManuellJournalfør/KnyttJournalpostTilBehandling.tsx
@@ -6,6 +6,7 @@ import { Alert, Checkbox, Heading, Table } from '@navikt/ds-react';
 import { ASpacing8 } from '@navikt/ds-tokens/dist/tokens';
 
 import { KnyttTilNyBehandling } from './KnyttTilNyBehandling';
+import { useApp } from '../../context/AppContext';
 import { useManuellJournalfør } from '../../context/ManuellJournalførContext';
 import type { BehandlingÅrsak } from '../../typer/behandling';
 import {
@@ -14,6 +15,7 @@ import {
     behandlingstyper,
     behandlingÅrsak,
 } from '../../typer/behandling';
+import { ToggleNavn } from '../../typer/toggles';
 import { Datoformat, isoStringTilFormatertString } from '../../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../utils/fagsak';
 import type { VisningBehandling } from '../Fagsak/Saksoversikt/visningBehandling';
@@ -31,6 +33,8 @@ const StyledAlert = styled(Alert)`
 `;
 
 export const KnyttJournalpostTilBehandling: React.FC = () => {
+    const { toggles } = useApp();
+
     const {
         skjema,
         minimalFagsak,
@@ -49,6 +53,11 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
         !skjema.felter.knyttTilNyBehandling.verdi;
 
     const sorterteJournalføringsbehandlinger = hentSorterteJournalføringsbehandlinger();
+
+    const skalViseKnyttTilNyBehandling =
+        toggles[ToggleNavn.kanBehandleKlage] || // Skal alltid vises når klage er implementert
+        !åpenBehandling ||
+        åpenBehandling.status === BehandlingStatus.AVSLUTTET;
 
     return (
         <KnyttDiv>
@@ -125,9 +134,7 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
                     </Table>
                 </>
             )}
-            {(!åpenBehandling || åpenBehandling.status === BehandlingStatus.AVSLUTTET) && (
-                <KnyttTilNyBehandling />
-            )}
+            {skalViseKnyttTilNyBehandling && <KnyttTilNyBehandling />}
             {visGenerellSakInfoStripe && (
                 <StyledAlert variant="info">
                     <GenerellSakInfoStripeTittel>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24505](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24505)

Har pratet med Anna og vi kom fram til at denne knappen alltid skal vises når klage er implementert helt ferdig. Viser den dermed alltid når toggelen for klage er skrudd på.

Har kjørt opp løsningen lokalt og det ser ut til å fungere fint.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Trenger en større omskrivning/opprydning, ser ikke stort poeng med å skrive tester som mest sannsynlig må endres på senere uansett.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
<img width="548" alt="image" src="https://github.com/user-attachments/assets/8f5f67a7-e466-46b7-a869-37f02f3cbe9c" />