### PR TITLE
Chore: fjern constate i brev modul

### DIFF
--- a/src/frontend/context/BrevModulContext.ts
+++ b/src/frontend/context/BrevModulContext.ts
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react';
 
-import createUseContext from 'constate';
-
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 import { hentDataFraRessurs } from '@navikt/familie-typer';
@@ -30,7 +28,7 @@ import {
     lagInitiellFritekst,
 } from '../utils/fritekstfelter';
 
-const [BrevModulProvider, useBrevModul] = createUseContext(() => {
+export const useBrevModul = () => {
     const { behandling } = useBehandling();
     const { minimalFagsak: minimalFagsakRessurs } = useFagsakContext();
 
@@ -441,6 +439,4 @@ const [BrevModulProvider, useBrevModul] = createUseContext(() => {
         visFritekstAvsnittTekstboks,
         settVisFritekstAvsnittTekstboks,
     };
-});
-
-export { BrevModulProvider, useBrevModul };
+};

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -31,8 +31,8 @@ import {
     opplysningsdokumenter,
     opplysningsdokumenterTilInstitusjon,
 } from './typer';
+import { useBrevModul } from './useBrevModul';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
-import { useBrevModul } from '../../../../context/BrevModulContext';
 import useDokument from '../../../../hooks/useDokument';
 import type { IBehandling } from '../../../../typer/behandling';
 import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -35,7 +35,6 @@ import { useBrevModul } from './useBrevModul';
 import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
 import useDokument from '../../../../hooks/useDokument';
 import type { IBehandling } from '../../../../typer/behandling';
-import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
 import type { IManueltBrevRequestPåBehandling } from '../../../../typer/dokument';
 import type { IPersonInfo } from '../../../../typer/person';
 import { målform } from '../../../../typer/søknad';
@@ -107,7 +106,6 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
         kanSendeSkjema,
         mottakersMålform,
         onSubmit,
-        settNavigerTilOpplysningsplikt,
         hentMuligeBrevMaler,
         makslengdeFritekstHvertKulepunkt,
         maksLengdeFritekstAvsnitt,
@@ -511,13 +509,6 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                     loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                     disabled={skjemaErLåst}
                     onClick={() => {
-                        const harRegistrertSøknad =
-                            hentStegNummer(behandling.steg) >
-                            hentStegNummer(BehandlingSteg.REGISTRERE_SØKNAD);
-                        settNavigerTilOpplysningsplikt(
-                            harRegistrertSøknad &&
-                                skjema.felter.brevmal.verdi === Brevmal.INNHENTE_OPPLYSNINGER
-                        );
                         onSubmit<IManueltBrevRequestPåBehandling>(
                             {
                                 method: 'POST',

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/useBrevModul.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/useBrevModul.ts
@@ -45,7 +45,6 @@ export const useBrevModul = () => {
     const personer = behandling?.personer ?? [];
     const brevmottakere = behandling?.brevmottakere ?? [];
     const institusjon = minimalFagsak?.institusjon;
-    const fagsakType = minimalFagsak?.fagsakType;
 
     const velgMottaker = (): string | undefined => {
         if (minimalFagsak?.fagsakType === FagsakType.INSTITUSJON && institusjon) {
@@ -286,9 +285,6 @@ export const useBrevModul = () => {
         skjemanavn: 'brevmodul',
     });
 
-    const [navigerTilOpplysningsplikt, settNavigerTilOpplysningsplikt] =
-        React.useState<boolean>(false);
-
     const nullstillBarnBrevetGjelder = () => {
         const barn = personer
             .filter(person => person.type === PersonType.BARN)
@@ -423,10 +419,7 @@ export const useBrevModul = () => {
         hentSkjemaData,
         kanSendeSkjema,
         mottakersMålform,
-        navigerTilOpplysningsplikt,
         onSubmit,
-        personer,
-        settNavigerTilOpplysningsplikt,
         leggTilFritekstKulepunkt,
         makslengdeFritekstHvertKulepunkt,
         maksLengdeFritekstAvsnitt,
@@ -435,7 +428,6 @@ export const useBrevModul = () => {
         erBrevmalMedObligatoriskFritekstKulepunkt,
         institusjon,
         brevmottakere,
-        fagsakType,
         visFritekstAvsnittTekstboks,
         settVisFritekstAvsnittTekstboks,
     };

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/useBrevModul.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/useBrevModul.ts
@@ -4,29 +4,29 @@ import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 import { hentDataFraRessurs } from '@navikt/familie-typer';
 
-import { useBehandling } from './behandlingContext/BehandlingContext';
-import { useFagsakContext } from './Fagsak/FagsakContext';
-import type { ISelectOptionMedBrevtekst } from '../komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
-import { Brevmal } from '../komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/typer';
-import type { IBehandling } from '../typer/behandling';
-import { BehandlingKategori } from '../typer/behandlingstema';
-import type { IManueltBrevRequestPåBehandling } from '../typer/dokument';
-import { FagsakType } from '../typer/fagsak';
-import type { IGrunnlagPerson } from '../typer/person';
-import { PersonType } from '../typer/person';
-import type { IBarnMedOpplysninger, Målform } from '../typer/søknad';
+import type { ISelectOptionMedBrevtekst } from './typer';
+import { Brevmal } from './typer';
+import { useBehandling } from '../../../../context/behandlingContext/BehandlingContext';
+import { useFagsakContext } from '../../../../context/Fagsak/FagsakContext';
+import type { IBehandling } from '../../../../typer/behandling';
+import { BehandlingKategori } from '../../../../typer/behandlingstema';
+import type { IManueltBrevRequestPåBehandling } from '../../../../typer/dokument';
+import { FagsakType } from '../../../../typer/fagsak';
+import type { IGrunnlagPerson } from '../../../../typer/person';
+import { PersonType } from '../../../../typer/person';
+import type { IBarnMedOpplysninger, Målform } from '../../../../typer/søknad';
 import {
     hentMuligeBrevmalerImplementering,
     mottakersMålformImplementering,
-} from '../utils/brevmal';
-import type { IsoDatoString } from '../utils/dato';
-import { dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '../utils/dato';
-import { useDeltBostedFelter } from '../utils/deltBostedSkjemaFelter';
-import type { IFritekstFelt } from '../utils/fritekstfelter';
+} from '../../../../utils/brevmal';
+import type { IsoDatoString } from '../../../../utils/dato';
+import { dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '../../../../utils/dato';
+import { useDeltBostedFelter } from '../../../../utils/deltBostedSkjemaFelter';
+import type { IFritekstFelt } from '../../../../utils/fritekstfelter';
 import {
     genererIdBasertPåAndreFritekstKulepunkter,
     lagInitiellFritekst,
-} from '../utils/fritekstfelter';
+} from '../../../../utils/fritekstfelter';
 
 export const useBrevModul = () => {
     const { behandling } = useBehandling();

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Hendelsesoversikt.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Hendelsesoversikt.tsx
@@ -11,7 +11,6 @@ import Totrinnskontroll from './Totrinnskontroll/Totrinnskontroll';
 import type { Hendelse } from './typer';
 import { Tabs } from './typer';
 import { useApp } from '../../../context/AppContext';
-import { BrevModulProvider } from '../../../context/BrevModulContext';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlerRolle, BehandlingStatus } from '../../../typer/behandling';
 import type { IPersonInfo } from '../../../typer/person';
@@ -53,24 +52,22 @@ const Hendelsesoversikt = ({ hendelser, åpenBehandling, bruker }: IHendelsesove
 
     return (
         <div>
-            <BrevModulProvider>
-                <Header
-                    aktivTab={aktivTab}
-                    settAktivTab={settAktivTab}
-                    skalViseTotrinnskontroll={skalViseTotrinnskontroll}
-                />
-                {aktivTab === Tabs.Totrinnskontroll && (
-                    <Totrinnskontroll åpenBehandling={åpenBehandling} />
-                )}
-                {aktivTab === Tabs.Historikk && hendelser.length > 0 && (
-                    <HistorikkTab>
-                        <HistorikkListe>{hendelser?.map(tilHendelseItem)}</HistorikkListe>
-                    </HistorikkTab>
-                )}
-                {aktivTab === Tabs.Meldinger && (
-                    <Brev onIModalClick={() => settAktivTab(Tabs.Historikk)} bruker={bruker} />
-                )}
-            </BrevModulProvider>
+            <Header
+                aktivTab={aktivTab}
+                settAktivTab={settAktivTab}
+                skalViseTotrinnskontroll={skalViseTotrinnskontroll}
+            />
+            {aktivTab === Tabs.Totrinnskontroll && (
+                <Totrinnskontroll åpenBehandling={åpenBehandling} />
+            )}
+            {aktivTab === Tabs.Historikk && hendelser.length > 0 && (
+                <HistorikkTab>
+                    <HistorikkListe>{hendelser?.map(tilHendelseItem)}</HistorikkListe>
+                </HistorikkTab>
+            )}
+            {aktivTab === Tabs.Meldinger && (
+                <Brev onIModalClick={() => settAktivTab(Tabs.Historikk)} bruker={bruker} />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23958

Som et forarbeid til å oppgradere react trenger vi å skrive oss bort fra constate. Fjerner bruken her for brev modul. I stedet for å skrive om til react context skriver jeg heller over til en vanlig hook fordi det kun ble brukt ett sted.

Fjerner også variabler for å navigere til opplysningsplikt fordi det aldri ble brukt. Fant ut hvor det ble implementert (se PR [her](https://github.com/navikt/familie-ba-sak-frontend/pull/342)), og all koden rundt er fjernet. Opplysningsplikt var en egen side på tidspunktet det ble implementert, men det er ikke lenger sånn det funker. Så koden kan trygt fjernes da den ikke hadde noen effekt

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det gir verdi

### 🤷‍♀ ️Hvor er det lurt å starte?
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  