### PR TITLE
Sjekk på ID fremfor visningsnavn

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -37,7 +37,7 @@ const EndreBehandlendeEnhet: React.FC = () => {
         if (
             steg &&
             hentStegNummer(steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK) &&
-            innloggetSaksbehandler?.displayName !== behandling?.totrinnskontroll?.saksbehandler
+            innloggetSaksbehandler?.navIdent !== behandling?.totrinnskontroll?.saksbehandlerId
         ) {
             return false;
         } else {

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -59,7 +59,7 @@ const Totrinnskontrollskjema: React.FunctionComponent<IProps> = ({
     const saksbehandler = totrinnskontroll?.saksbehandler ?? 'UKJENT SAKSBEHANDLER';
     const opprettetTidspunkt = totrinnskontroll?.opprettetTidspunkt ?? undefined;
 
-    const egetVedtak = totrinnskontroll?.saksbehandler === innloggetSaksbehandler?.displayName;
+    const egetVedtak = totrinnskontroll?.saksbehandlerId === innloggetSaksbehandler?.navIdent;
 
     return (
         <Fieldset

--- a/src/frontend/typer/totrinnskontroll.ts
+++ b/src/frontend/typer/totrinnskontroll.ts
@@ -12,6 +12,7 @@ export interface ITotrinnskontrollData {
 
 export interface ITotrinnskontroll {
     saksbehandler: string;
+    saksbehandlerId: string;
     beslutter?: string;
     godkjent: boolean;
     opprettetTidspunkt: string;

--- a/src/frontend/utils/test/behandling/behandling.mock.ts
+++ b/src/frontend/utils/test/behandling/behandling.mock.ts
@@ -79,6 +79,7 @@ export const mockBehandling = ({
         vedtak: undefined,
         totrinnskontroll: {
             saksbehandler: 'Saksbehandler',
+            saksbehandlerId: 'VL',
             beslutter: 'Beslutter',
             godkjent: true,
             opprettetTidspunkt,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24574

Når vi nå sjekker om saksbehandler er på sitt vedtak så sammenligner vi displayname (Etternavn, Fornavn), med det som ligger i vedtaksbrevet som signatur (Fornavn Mellomnavn Etternavn). Denne sjekken feiler etter at vi endret signatur på vedtaksbrevet.

Jeg synes uansett at denne sjekken bør sjekke på NAVIdent istedenfor, som er mer sikkert mtp at flere kan ha samme navn. Endrer det derfor til SB ident. Tilbakemeldinger tas imot med glede! :D

BackendPR for å sende opp saksbehandlerId: https://github.com/navikt/familie-ba-sak/pull/5153