### PR TITLE
Oppdaterer CSP-header, bedre eventnavn for tracking av sidevisning

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@navikt/ds-icons": "1.3.27",
     "@navikt/ds-react": "7.14.1",
     "@navikt/ds-tokens": "7.14.1",
-    "@navikt/familie-backend": "^10.1.4",
+    "@navikt/familie-backend": "^10.1.5",
     "@navikt/familie-endringslogg": "14.0.0",
     "@navikt/familie-form-elements": "21.0.0",
     "@navikt/familie-header": "15.0.0",

--- a/src/frontend/hooks/useTrackTidsbrukPåSide.ts
+++ b/src/frontend/hooks/useTrackTidsbrukPåSide.ts
@@ -43,7 +43,7 @@ export const useTrackTidsbrukPåSide = (fagsak: IMinimalFagsak, behandling: IBeh
                 intervallISekunder: intervallISekunder,
             };
 
-            sendTilUmami('stegnavigasjon_v1', data);
+            sendTilUmami('sidevisning_i_behandling', data);
         };
     }, [sidevisning]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,10 +1739,10 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/7.14.1/e28573e7fca321d65e1f28795c7f2a5ec8807b8e#e28573e7fca321d65e1f28795c7f2a5ec8807b8e"
   integrity sha512-PXPPYuxWm0sLtuB54bobO43pY0I+dZMvk6bwpjuHxTT8+dPSMWaTTzVr1urXNCu/5uAPCked8nNQbucckY5IMA==
 
-"@navikt/familie-backend@^10.1.4":
-  version "10.1.4"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.1.4/a6dc8597e5a4ece1329022519f9fc5e8de0983ac#a6dc8597e5a4ece1329022519f9fc5e8de0983ac"
-  integrity sha512-qbjAs42sygvivC5j3ahRvbIYkZWKkmGAsBk4RkyQck8gmowfAhH+F3zQ8k3Esp53jZukokOHAvnla0k1NF1W3g==
+"@navikt/familie-backend@^10.1.5":
+  version "10.1.5"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.1.5/4ea251214c09a9a9c293eb04d78e0d277040d6e9#4ea251214c09a9a9c293eb04d78e0d277040d6e9"
+  integrity sha512-WmBUCIBmox2IZ+rM7xCwDtx5F0gZKOZO4VKnYRnvoiOAsSlN8d7vtAslM/mT9nZ61ZokWeH+5ekDMjLit3wzTg==
   dependencies:
     "@navikt/familie-logging" "^7.0.3"
     "@types/cookie-parser" "^1.4.8"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi trenger å oppdatere CSP-headeren slik at Umami-scriptet kan kjøre. Det er gjort i familie-backend, oppdaterer til den nyeste versjonen der. Endrer også eventnavnet på sidetracking til noe mer beskrivende i samme slengen.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen store bekymringer.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer