### PR TITLE
Bytter til bruk av POST endepunkter for søk av personer slik at vi går bort fra GET med headers

### DIFF
--- a/src/backend/cypress-server.ts
+++ b/src/backend/cypress-server.ts
@@ -35,7 +35,7 @@ app.get('/familie-ba-sak/api/fagsaker/*splat/hent-klagebehandlinger', (_, res) =
 app.get('/familie-ba-sak/api/fagsaker/*splat', (_, res) => {
     res.status(200).send(fagsakMock);
 });
-app.get('/familie-ba-sak/api/person', (_, res) => {
+app.post('/familie-ba-sak/api/person', (_, res) => {
     res.status(200).send(personMock);
 });
 app.get('/user/profile', (_, res) => {

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -167,11 +167,11 @@ const [AppContentProvider, useApp] = createUseContext(() => {
     };
 
     const hentPerson = async (brukerIdent: string): Promise<Ressurs<IPersonInfo>> => {
-        return request<{ brukerIdent: string }, IPersonInfo>({
-            method: 'GET',
+        return request<{ ident: string }, IPersonInfo>({
+            method: 'POST',
             url: '/familie-ba-sak/api/person/enkel',
-            headers: {
-                personIdent: brukerIdent,
+            data: {
+                ident: brukerIdent,
             },
         }).then((ressurs: Ressurs<IPersonInfo>) => {
             if ('data' in ressurs && ressurs.data.harTilgang === false) {

--- a/src/frontend/context/Fagsak/FagsakContext.tsx
+++ b/src/frontend/context/Fagsak/FagsakContext.tsx
@@ -78,13 +78,12 @@ const [FagsakProvider, useFagsakContext] = createUseContext(() => {
 
     const hentBruker = (personIdent: string): void => {
         settBruker(byggHenterRessurs());
-        request<void, IPersonInfo>({
-            method: 'GET',
+        request<{ ident: string }, IPersonInfo>({
+            method: 'POST',
             url: '/familie-ba-sak/api/person',
-            headers: {
-                personIdent,
+            data: {
+                ident: personIdent,
             },
-            påvirkerSystemLaster: true,
         }).then((hentetPerson: Ressurs<IPersonInfo>) => {
             const brukerEtterTilgangssjekk = sjekkTilgangTilPerson(hentetPerson);
             if (skalObfuskereData) {

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -264,12 +264,12 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         }
     };
 
-    const endreBrukerOgSettNormalFagsak = async (personId: string) => {
-        const hentetPerson = await request<void, IPersonInfo>({
-            method: 'GET',
+    const endreBrukerOgSettNormalFagsak = async (personIdent: string) => {
+        const hentetPerson = await request<{ ident: string }, IPersonInfo>({
+            method: 'POST',
             url: '/familie-ba-sak/api/person',
-            headers: {
-                personIdent: personId,
+            data: {
+                ident: personIdent,
             },
         });
 

--- a/src/frontend/komponenter/Felleskomponenter/LeggTilBarn/LeggTilBarn.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/LeggTilBarn/LeggTilBarn.tsx
@@ -174,11 +174,11 @@ const LeggTilBarn: React.FC<IProps> = ({
                 }).then((ressurs: Ressurs<IRestTilgang>) => {
                     if (ressurs.status === RessursStatus.SUKSESS) {
                         if (ressurs.data.saksbehandlerHarTilgang) {
-                            request<void, IPersonInfo>({
-                                method: 'GET',
+                            request<{ ident: string }, IPersonInfo>({
+                                method: 'POST',
                                 url: '/familie-ba-sak/api/person/enkel',
-                                headers: {
-                                    personIdent: registrerBarnSkjema.felter.ident.verdi,
+                                data: {
+                                    ident: registrerBarnSkjema.felter.ident.verdi,
                                 },
                             }).then((hentetPerson: Ressurs<IPersonInfo>) => {
                                 settSubmitRessurs(hentetPerson);


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24650

Bytter til POST fra GET ved henting av personer.
Da unngår vi å måtte legge personident i header, men heller i body mtp sensitiv info i headers.

Backend PR: https://github.com/navikt/familie-ba-sak/pull/5174