### PR TITLE
Ny måte å finne ut av hvilken sporingskode som skal brukes per miljø

### DIFF
--- a/src/frontend/hooks/useStartUmami.ts
+++ b/src/frontend/hooks/useStartUmami.ts
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 
+import { erProd } from '../utils/miljø';
+
 export const useStartUmami = () => {
     useEffect(() => {
-        const websiteId =
-            process.env.NODE_ENV === 'production'
-                ? 'e0e5e641-6d90-46ef-823c-e11ef40472cc'
-                : 'a95c215b-4c37-450f-8ec6-b1355d53a36b';
+        const websiteId = erProd()
+            ? 'e0e5e641-6d90-46ef-823c-e11ef40472cc'
+            : 'a95c215b-4c37-450f-8ec6-b1355d53a36b';
 
         const script = document.createElement('script');
         script.src = 'https://cdn.nav.no/team-researchops/sporing/sporing.js';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
`NODE_ENV` er production i både dev og prod, derfor trenger vi å bruke en annen måte for å finne ut hvilken sporingsnøkkel i Umami vi skal bruke. `erProd()` to the rescue, som vi også bruker mange andre steder til lignende formål.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen bekymringer

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer