### PR TITLE
NAV-24727: Korrigerer logikken for å vise behandlingstema-dropdown komponenten ved oppretting av klagebehandling i journalføringsbilde

### DIFF
--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -30,7 +30,8 @@ import {
     opprettJournalføringsbehandlingFraBarnetrygdbehandling,
     opprettJournalføringsbehandlingFraKlagebehandling,
 } from '../typer/journalføringsbehandling';
-import type { IKlagebehandling, Klagebehandlingstype } from '../typer/klage';
+import type { IKlagebehandling } from '../typer/klage';
+import { Klagebehandlingstype } from '../typer/klage';
 import type {
     IDataForManuellJournalføring,
     IRestJournalføring,
@@ -40,7 +41,6 @@ import { JournalpostKanal } from '../typer/manuell-journalføring';
 import {
     type IRestLukkOppgaveOgKnyttJournalpost,
     finnBehandlingstemaFraOppgave,
-    erOppgaveJournalførKlage,
 } from '../typer/oppgave';
 import { OppgavetypeFilter } from '../typer/oppgave';
 import type { IPersonInfo } from '../typer/person';
@@ -73,7 +73,6 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
     const { hentForhåndsvisning, nullstillDokument, hentetDokument } = useDokument();
 
     const [minimalFagsak, settMinimalFagsak] = useState<IMinimalFagsak | undefined>(undefined);
-    const [erKlage, settErKlage] = useState<boolean>(false);
     const [klagebehandlinger, settKlagebehandlinger] = useState<IKlagebehandling[] | undefined>(
         undefined
     );
@@ -146,11 +145,14 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
                     minimalFagsak?.fagsakType === FagsakType.INSTITUSJON
                         ? behandlingstemaer.NASJONAL_INSTITUSJON
                         : undefined,
-                avhengigheter: { knyttTilNyBehandling: knyttTilNyBehandling.verdi },
+                avhengigheter: {
+                    knyttTilNyBehandling: knyttTilNyBehandling.verdi,
+                    behandlingstype: behandlingstype.verdi,
+                },
                 skalFeltetVises: (avhengigheter: Avhengigheter) =>
                     avhengigheter.knyttTilNyBehandling &&
                     minimalFagsak?.fagsakType !== FagsakType.INSTITUSJON &&
-                    !erKlage,
+                    avhengigheter.behandlingstype !== Klagebehandlingstype.KLAGE,
                 valideringsfunksjon: (felt: FeltState<IBehandlingstema | undefined>) =>
                     felt.verdi ? ok(felt) : feil(felt, 'Behandlingstema må settes.'),
             }),
@@ -224,7 +226,6 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
                 settMinimalFagsak(dataForManuellJournalføring.data.minimalFagsak);
             }
             settKlagebehandlinger(dataForManuellJournalføring.data.klagebehandlinger);
-            settErKlage(erOppgaveJournalførKlage(dataForManuellJournalføring.data.oppgave));
         }
     }, [dataForManuellJournalføring]);
 

--- a/src/frontend/typer/oppgave.ts
+++ b/src/frontend/typer/oppgave.ts
@@ -203,17 +203,7 @@ export interface IRestLukkOppgaveOgKnyttJournalpost {
     underkategori: BehandlingUnderkategori | null;
 }
 
-export function erOppgaveJournalførKlage(oppgave: IOppgave): boolean {
-    return (
-        oppgave.oppgavetype === OppgavetypeFilter.JFR &&
-        oppgave.behandlingstype === BehandlingstypeFilter.ae0058
-    );
-}
-
 export function finnBehandlingstemaFraOppgave(oppgave: IOppgave): IBehandlingstema | undefined {
-    if (erOppgaveJournalførKlage(oppgave)) {
-        return undefined;
-    }
     const { behandlingstema: gjelder, behandlingstype } = oppgave;
     return gjelder in kodeTilBehandlingUnderkategoriMap &&
         behandlingstype in kodeTilBehandlingKategoriMap


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24727

Endrer logikk for visning av behandlingstema-dropdown komponenten. Den skal vises så lenge man ikke har valgt behandlingstype KLAGE. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Finnes ingen tester fra før og her burde nok man gjøre en større refaktorering for at det skal være vits. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Vises for førstegangsbehandling:
<img width="561" alt="image" src="https://github.com/user-attachments/assets/14e59367-1fdc-47dc-b354-cc78b6460970" />

Vises ikke for klage:
<img width="561" alt="image" src="https://github.com/user-attachments/assets/a93deca7-b07e-4d56-bed9-d6d68f9a8ae4" />
