### PR TITLE
Avregning: Link til Modia og Sett på vent-modal

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/AvregningAlert.tsx
@@ -1,15 +1,32 @@
 import * as React from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, BodyLong, List } from '@navikt/ds-react';
+import { Alert, BodyLong, Button, Link, List } from '@navikt/ds-react';
+
+import { SettBehandlingPåVentModalMotregning } from './SettBehandlingPåVentModalMotregning';
+import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
+import { erProd } from '../../../../../utils/miljø';
 
 const StyledAlert = styled(Alert)`
     margin-top: 2rem;
     width: fit-content;
 `;
 
+const StyledLink = styled(Link)`
+    margin-top: 1rem;
+`;
+
 const AvregningAlert = () => {
+    const [visModal, settVisModal] = useState(false);
+    const { behandling, vurderErLesevisning } = useBehandling();
+    const erLesevisning = vurderErLesevisning();
+
+    const modiaPersonoversiktUrl = erProd()
+        ? 'https://modiapersonoversikt.intern.nav.no'
+        : 'https://modiapersonoversikt.intern.dev.nav.no';
+
     return (
         <StyledAlert variant="warning">
             <BodyLong spacing>
@@ -28,6 +45,23 @@ const AvregningAlert = () => {
                     tilbake, må du splitte saken.
                 </List.Item>
             </List>
+            {!erLesevisning && (
+                <StyledLink
+                    href={modiaPersonoversiktUrl}
+                    target={'_blank'}
+                    style={{ textDecoration: 'none' }}
+                >
+                    <Button variant={'secondary-neutral'} onClick={() => settVisModal(true)}>
+                        Be om samtykke fra bruker
+                    </Button>
+                </StyledLink>
+            )}
+            {visModal && (
+                <SettBehandlingPåVentModalMotregning
+                    lukkModal={() => settVisModal(false)}
+                    behandling={behandling}
+                />
+            )}
         </StyledAlert>
     );
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SettBehandlingPåVentModalMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SettBehandlingPåVentModalMotregning.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+
+import { addDays } from 'date-fns';
+import styled from 'styled-components';
+
+import {
+    BodyShort,
+    Button,
+    DatePicker,
+    Fieldset,
+    Modal,
+    Select,
+    useDatepicker,
+} from '@navikt/ds-react';
+import { useHttp } from '@navikt/familie-http';
+import {
+    byggHenterRessurs,
+    byggTomRessurs,
+    type Ressurs,
+    RessursStatus,
+} from '@navikt/familie-typer';
+
+import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
+import {
+    type IBehandling,
+    type ISettPåVent,
+    SettPåVentÅrsak,
+    settPåVentÅrsaker,
+} from '../../../../../typer/behandling';
+import { dagensDato, dateTilIsoDatoString } from '../../../../../utils/dato';
+import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
+
+const Feltmargin = styled.div`
+    margin-bottom: 2rem;
+`;
+const StyledBodyShort = styled(BodyShort)`
+    margin-bottom: 2rem;
+`;
+
+interface IProps {
+    lukkModal: () => void;
+    behandling: IBehandling;
+}
+
+const dagerFristForAvventerSamtykkeUlovfestetMotregning = 5;
+
+export const SettBehandlingPåVentModalMotregning: React.FC<IProps> = ({
+    lukkModal,
+    behandling,
+}) => {
+    const { settÅpenBehandling } = useBehandling();
+
+    const { request } = useHttp();
+
+    const årsak = SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING;
+    const frist = addDays(dagensDato, dagerFristForAvventerSamtykkeUlovfestetMotregning);
+
+    const erBehandlingAlleredePåVent = !!behandling.aktivSettPåVent;
+
+    const [submitRessurs, settSubmitRessurs] = useState<Ressurs<IBehandling>>(byggTomRessurs());
+
+    const settBehandlingPåVent = () => {
+        settSubmitRessurs(byggHenterRessurs());
+        request<ISettPåVent, IBehandling>({
+            method: erBehandlingAlleredePåVent ? 'PUT' : 'POST',
+            data: {
+                frist: dateTilIsoDatoString(frist),
+                årsak: årsak,
+            },
+            url: `/familie-ba-sak/api/sett-på-vent/${behandling.behandlingId}`,
+        }).then(ressurs => {
+            settSubmitRessurs(ressurs);
+            if (ressurs.status === RessursStatus.SUKSESS) {
+                settÅpenBehandling(ressurs);
+                lukkModal();
+            }
+        });
+    };
+
+    const { datepickerProps, inputProps } = useDatepicker({ defaultSelected: frist });
+
+    return (
+        <Modal
+            open
+            onClose={lukkModal}
+            width={'37rem'}
+            header={{
+                heading: erBehandlingAlleredePåVent
+                    ? 'Endre ventende behandling'
+                    : 'Sett behandling på vent',
+                size: 'small',
+            }}
+            portal
+        >
+            <Modal.Body>
+                <Fieldset
+                    error={hentFrontendFeilmelding(submitRessurs)}
+                    errorPropagation={false}
+                    legend="Sett behandling på vent"
+                    hideLegend
+                >
+                    {erBehandlingAlleredePåVent && (
+                        <StyledBodyShort>Behandlingen er satt på vent.</StyledBodyShort>
+                    )}
+
+                    <StyledBodyShort>
+                        Behandlingen settes på vent i 5 dager mens vi venter på svar fra bruker.
+                    </StyledBodyShort>
+
+                    <Feltmargin>
+                        <DatePicker dropdownCaption {...datepickerProps}>
+                            <DatePicker.Input {...inputProps} label={'Frist'} readOnly={true} />
+                        </DatePicker>
+                    </Feltmargin>
+                    <Select label={'Årsak'} readOnly={true}>
+                        <option value={årsak.valueOf()} key={årsak.valueOf()}>
+                            {settPåVentÅrsaker[årsak]}
+                        </option>
+                    </Select>
+                </Fieldset>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    variant={'primary'}
+                    key={erBehandlingAlleredePåVent ? 'Oppdater' : 'Bekreft'}
+                    size={'medium'}
+                    onClick={settBehandlingPåVent}
+                    children={erBehandlingAlleredePåVent ? 'Oppdater' : 'Bekreft'}
+                    loading={submitRessurs.status === RessursStatus.HENTER}
+                    disabled={submitRessurs.status === RessursStatus.HENTER}
+                />
+                <Button
+                    variant={'tertiary'}
+                    key={'Avbryt'}
+                    size="medium"
+                    onClick={lukkModal}
+                    children={'Avbryt'}
+                />
+            </Modal.Footer>
+        </Modal>
+    );
+};

--- a/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
@@ -6,7 +6,7 @@ import { BodyShort, Button, Fieldset, Modal, Select } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { hentAlleÅrsaker } from './settPåVentUtils';
+import { hentVelgbareÅrsaker } from './settPåVentUtils';
 import { useSettPåVentSkjema } from './useSettPåVentSkjema';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import Datovelger from '../../../../../komponenter/Datovelger/Datovelger';
@@ -29,7 +29,7 @@ interface IProps {
 }
 
 export const SettBehandlingPåVentModal: React.FC<IProps> = ({ lukkModal, behandling }) => {
-    const årsaker = hentAlleÅrsaker();
+    const årsaker = hentVelgbareÅrsaker();
     const { skjema, kanSendeSkjema, onSubmit } = useSettPåVentSkjema(behandling.aktivSettPåVent);
     const { settÅpenBehandling } = useBehandling();
 

--- a/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/settPåVentUtils.ts
+++ b/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggBehandlingPåVent/settPåVentUtils.ts
@@ -2,3 +2,10 @@ import { SettPåVentÅrsak } from '../../../../../typer/behandling';
 
 export const hentAlleÅrsaker = () =>
     Object.keys(SettPåVentÅrsak).filter(key => isNaN(Number(key))) as SettPåVentÅrsak[];
+
+export const hentVelgbareÅrsaker = () =>
+    Object.keys(SettPåVentÅrsak)
+        .filter(key => isNaN(Number(key)))
+        .filter(
+            årsak => årsak !== SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING
+        ) as SettPåVentÅrsak[];

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -437,8 +437,11 @@ export interface ISettPåVent {
 
 export enum SettPåVentÅrsak {
     AVVENTER_DOKUMENTASJON = 'AVVENTER_DOKUMENTASJON',
+    AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING = 'AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING',
 }
 
 export const settPåVentÅrsaker: Record<SettPåVentÅrsak, string> = {
     AVVENTER_DOKUMENTASJON: 'Avventer dokumentasjon',
+    AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING:
+        'Avventer samtykke om ulovfestet motregning etter unntaksregel',
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-24732

Dersom det er avregning i en behandling skal saksbehandler kunne be bruker om samtykke til å motregne i Modia, og deretter sette behandling på vent i 5 dager.
Legger til knapp som åpner Modia i ny fane og deretter åpner en modal for å sette behandlingen på vent med låst årsak `Avventer samtykke om ulovfestet motregning etter unntaksregel` og frist 5 dager.
Obs: Det er riktig at Modia-lenken er den "generelle" Modia-url'en, men man blir redirected inn på den spesifikke brukeren dersom Modia-kontekst er satt for innlogget saksbehandler. Oppdatering av Modia-kontekst skjer i en annen PR.

### 👀 Screen shots
**Før**:
![4b54536ef646b8392aed0bb079f84049](https://github.com/user-attachments/assets/2d21609c-3d0a-4783-916c-b51afc935b05)

**Etter**:
![7e8b7ff9d3328b1e8cdd735f5bebe0e2](https://github.com/user-attachments/assets/c03f2819-649a-4a78-8537-cdf6021be50b)
![644970953c3b99dd8468218e3471b6be](https://github.com/user-attachments/assets/30518537-87bf-4304-a5e5-577338ab771a)
