### PR TITLE
NAV-22989: Bedre melding til saksbehandler ved manglende tilgang til dokument i dokumentoversikt

### DIFF
--- a/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
@@ -28,7 +28,7 @@ export const JournalpostDokument: React.FC<IProps> = ({
     hentForhåndsvisning,
     tilgangsstyrtJournalpost,
 }) => {
-    const { journalpost, harTilgang } = tilgangsstyrtJournalpost;
+    const { journalpost, journalpostTilgang } = tilgangsstyrtJournalpost;
 
     const hentPdfDokument = (dokumentId: string | undefined) => {
         if (dokumentId !== undefined) {
@@ -46,7 +46,7 @@ export const JournalpostDokument: React.FC<IProps> = ({
     return (
         <ListeElement>
             <HStack gap="1">
-                {harTilgang ? (
+                {journalpostTilgang?.harTilgang ? (
                     <>
                         <EllipsisBodyShort size="small" title={dokumentTittel}>
                             <Link href="#" onClick={() => hentPdfDokument(dokument.dokumentInfoId)}>
@@ -66,7 +66,9 @@ export const JournalpostDokument: React.FC<IProps> = ({
                 ) : (
                     <>
                         <BodyShort size="small">{dokumentTittel}</BodyShort>
-                        <PadlockLockedIcon title="Dokumentet krever ekstra tilganger" />
+                        <PadlockLockedIcon
+                            title={`Dokumentet krever ekstra tilganger. ${journalpostTilgang?.begrunnelse}`}
+                        />
                     </>
                 )}
             </HStack>

--- a/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
@@ -46,7 +46,7 @@ export const JournalpostDokument: React.FC<IProps> = ({
     return (
         <ListeElement>
             <HStack gap="1">
-                {journalpostTilgang?.harTilgang ? (
+                {journalpostTilgang.harTilgang ? (
                     <>
                         <EllipsisBodyShort size="small" title={dokumentTittel}>
                             <Link href="#" onClick={() => hentPdfDokument(dokument.dokumentInfoId)}>
@@ -67,7 +67,7 @@ export const JournalpostDokument: React.FC<IProps> = ({
                     <>
                         <BodyShort size="small">{dokumentTittel}</BodyShort>
                         <PadlockLockedIcon
-                            title={`Dokumentet krever ekstra tilganger. ${journalpostTilgang?.begrunnelse}`}
+                            title={`Dokumentet krever ekstra tilganger. ${journalpostTilgang.begrunnelse}`}
                         />
                     </>
                 )}

--- a/src/frontend/sider/Fagsak/journalposter/JournalpostListe.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/JournalpostListe.tsx
@@ -192,15 +192,14 @@ const JournalpostListe = ({ bruker }: IProps) => {
     }
 
     if (journalposterRessurs.status === RessursStatus.SUKSESS) {
-        const journalposterMedOverstyrtDato = journalposterRessurs.data?.map(
-            tilgangsstyrtJournalpost => {
-                const { harTilgang, journalpost } = tilgangsstyrtJournalpost;
+        const journalposterMedOverstyrtDato: ITilgangsstyrtJournalpost[] =
+            journalposterRessurs.data?.map(tilgangsstyrtJournalpost => {
+                const { journalpost, journalpostTilgang } = tilgangsstyrtJournalpost;
                 return {
-                    harTilgang,
+                    journalpostTilgang,
                     journalpost: settRiktigDatoMottatForJournalpost(journalpost),
                 };
-            }
-        );
+            });
         const sorterteJournalPoster = hentSorterteJournalposter(
             journalposterMedOverstyrtDato,
             sortering

--- a/src/frontend/typer/journalpost.ts
+++ b/src/frontend/typer/journalpost.ts
@@ -2,5 +2,10 @@ import type { IJournalpost } from '@navikt/familie-typer';
 
 export interface ITilgangsstyrtJournalpost {
     journalpost: IJournalpost;
+    journalpostTilgang: IJournalpostTilgang;
+}
+
+export interface IJournalpostTilgang {
     harTilgang: boolean;
+    begrunnelse: string;
 }


### PR DESCRIPTION
Favro: [NAV-22989](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22989)

### 💰 Hva forsøker du å løse i denne PR'en
Tar i bruk ny kontrakt for `TilgangsstyrtJournalpost` som inneholder `begrunnelse` for hvorfor saksbehandler ikke har tilgang til dokument.

  
### 👀 Screen shots
Når saksbehandler ikke har tilgang til et dokument vises et "lås"-ikon. Ikonet har nå en bedre tittel, som inneholder begrunnelse for hvorfor saksbehandler ikke har tilgang.
![image](https://github.com/user-attachments/assets/99cbbf63-e6c1-46fa-baf8-5b8233ca168f)
