### PR TITLE
Klage: ikke ta ned journalføring hvis klage er nede + vis warning

### DIFF
--- a/src/frontend/api/useKlageApi.ts
+++ b/src/frontend/api/useKlageApi.ts
@@ -1,0 +1,28 @@
+import { useHttp } from '@navikt/familie-http';
+import { byggTomRessurs, type Ressurs } from '@navikt/familie-typer';
+
+import type { IKlagebehandling } from '../typer/klage';
+
+export const useKlageApi = () => {
+    const { request } = useHttp();
+
+    const hentKlagebehandlingerPåFagsak = (
+        fagsakId?: number
+    ): Promise<Ressurs<IKlagebehandling[]>> => {
+        if (!fagsakId) {
+            return Promise.resolve(byggTomRessurs());
+        }
+
+        return request<void, IKlagebehandling[]>({
+            method: 'GET',
+            url: `/familie-ba-sak/api/fagsaker/${fagsakId}/hent-klagebehandlinger`,
+            påvirkerSystemLaster: true,
+        }).then(klagebehandlingerRessurs => {
+            return klagebehandlingerRessurs;
+        });
+    };
+
+    return {
+        hentKlagebehandlingerPåFagsak,
+    };
+};

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -682,6 +682,7 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
         settMinimalFagsakTilNormalFagsakForPerson,
         settMinimalFagsakTilInstitusjonsfagsak,
         erDigitaltInnsendtDokument,
+        klageStatus: klagebehandlinger.status,
     };
 });
 

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -384,7 +384,6 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
     };
 
     const hentSorterteJournalføringsbehandlinger = (): Journalføringsbehandling[] => {
-        console.log(klagebehandlinger);
         const journalføringsbehandlingerKlage = (hentDataFraRessurs(klagebehandlinger) ?? []).map(
             klagebehandling => opprettJournalføringsbehandlingFraKlagebehandling(klagebehandling)
         );

--- a/src/frontend/context/ManuellJournalførContext.tsx
+++ b/src/frontend/context/ManuellJournalførContext.tsx
@@ -8,7 +8,12 @@ import { useNavigate, useParams } from 'react-router';
 import { useHttp } from '@navikt/familie-http';
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import { type IDokumentInfo, Journalstatus, type Ressurs } from '@navikt/familie-typer';
+import {
+    hentDataFraRessurs,
+    type IDokumentInfo,
+    Journalstatus,
+    type Ressurs,
+} from '@navikt/familie-typer';
 import {
     byggFeiletRessurs,
     byggHenterRessurs,
@@ -17,6 +22,7 @@ import {
 } from '@navikt/familie-typer';
 
 import { useApp } from './AppContext';
+import { useKlageApi } from '../api/useKlageApi';
 import useDokument from '../hooks/useDokument';
 import type { IOpprettBehandlingSkjemaBase } from '../sider/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling';
 import type { VisningBehandling } from '../sider/Fagsak/Saksoversikt/visningBehandling';
@@ -71,11 +77,11 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
     const { oppgaveId } = useParams<{ oppgaveId: string }>();
 
     const { hentForhåndsvisning, nullstillDokument, hentetDokument } = useDokument();
+    const { hentKlagebehandlingerPåFagsak } = useKlageApi();
 
     const [minimalFagsak, settMinimalFagsak] = useState<IMinimalFagsak | undefined>(undefined);
-    const [klagebehandlinger, settKlagebehandlinger] = useState<IKlagebehandling[] | undefined>(
-        undefined
-    );
+    const [klagebehandlinger, settKlagebehandlinger] =
+        useState<Ressurs<IKlagebehandling[]>>(byggTomRessurs());
     const [dataForManuellJournalføring, settDataForManuellJournalføring] =
         useState(byggTomRessurs<IDataForManuellJournalføring>());
     const [erDigitaltInnsendtDokument, settErDigialtInnsendtDokument] = useState<
@@ -225,7 +231,6 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
             if (dataForManuellJournalføring.data.minimalFagsak) {
                 settMinimalFagsak(dataForManuellJournalføring.data.minimalFagsak);
             }
-            settKlagebehandlinger(dataForManuellJournalføring.data.klagebehandlinger);
         }
     }, [dataForManuellJournalføring]);
 
@@ -238,6 +243,12 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
             );
         }
     }, [skjema.felter.bruker.verdi]);
+
+    useEffect(() => {
+        hentKlagebehandlingerPåFagsak(minimalFagsak?.id).then(klagebehandlinger =>
+            settKlagebehandlinger(klagebehandlinger)
+        );
+    }, [minimalFagsak]);
 
     const tilbakestillData = () => {
         nullstillSkjema();
@@ -373,8 +384,9 @@ const [ManuellJournalførProvider, useManuellJournalfør] = createUseContext(() 
     };
 
     const hentSorterteJournalføringsbehandlinger = (): Journalføringsbehandling[] => {
-        const journalføringsbehandlingerKlage = (klagebehandlinger ?? []).map(klagebehandling =>
-            opprettJournalføringsbehandlingFraKlagebehandling(klagebehandling)
+        console.log(klagebehandlinger);
+        const journalføringsbehandlingerKlage = (hentDataFraRessurs(klagebehandlinger) ?? []).map(
+            klagebehandling => opprettJournalføringsbehandlingFraKlagebehandling(klagebehandling)
         );
 
         const journalføringsbehandlingerBarnetrygd = (minimalFagsak?.behandlinger ?? []).map(

--- a/src/frontend/sider/ManuellJournalfør/KnyttJournalpostTilBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalfør/KnyttJournalpostTilBehandling.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, Checkbox, Heading, Table } from '@navikt/ds-react';
+import { Alert, BodyShort, Checkbox, Heading, Table, VStack } from '@navikt/ds-react';
 import { ASpacing8 } from '@navikt/ds-tokens/dist/tokens';
 
 import { KnyttTilNyBehandling } from './KnyttTilNyBehandling';
@@ -13,6 +13,7 @@ import { finnVisningstekstForJournalføringsbehandlingsårsak } from '../../type
 import { ToggleNavn } from '../../typer/toggles';
 import { Datoformat, isoStringTilFormatertString } from '../../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '../../utils/fagsak';
+import { ressursHarFeilet } from '../../utils/ressursUtils';
 import type { VisningBehandling } from '../Fagsak/Saksoversikt/visningBehandling';
 
 const KnyttDiv = styled.div`
@@ -36,6 +37,7 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
         hentSorterteJournalføringsbehandlinger,
         kanKnytteJournalpostTilBehandling,
         erLesevisning,
+        klageStatus,
     } = useManuellJournalfør();
 
     const åpenBehandling: VisningBehandling | undefined = minimalFagsak
@@ -57,90 +59,99 @@ export const KnyttJournalpostTilBehandling: React.FC = () => {
     return (
         <KnyttDiv>
             {sorterteJournalføringsbehandlinger.length > 0 && (
-                <>
-                    <Heading size={'small'} level={'2'}>
-                        Knytt til tidligere behandling(er)
-                    </Heading>
-                    <Table>
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.DataCell></Table.DataCell>
-                                <Table.HeaderCell>{'Dato'}</Table.HeaderCell>
-                                <Table.HeaderCell>{'Årsak'}</Table.HeaderCell>
-                                <Table.HeaderCell>{'Behandlingstype'}</Table.HeaderCell>
-                                <Table.HeaderCell>{'Status'}</Table.HeaderCell>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {sorterteJournalføringsbehandlinger.map(behandling => {
-                                return (
-                                    <Table.Row
-                                        key={behandling.id}
-                                        aria-selected={skjema.felter.tilknyttedeBehandlinger.verdi.some(
-                                            it => it.behandlingId === behandling.id
-                                        )}
-                                    >
-                                        <Table.DataCell>
-                                            <Checkbox
-                                                id={behandling.id}
-                                                value={behandling.id}
-                                                checked={skjema.felter.tilknyttedeBehandlinger.verdi.some(
-                                                    it => it.behandlingId === behandling.id
-                                                )}
-                                                onChange={() => {
-                                                    skjema.felter.tilknyttedeBehandlinger.validerOgSettFelt(
-                                                        [
-                                                            ...skjema.felter.tilknyttedeBehandlinger.verdi.filter(
-                                                                it =>
-                                                                    it.behandlingId !==
-                                                                    behandling.id
-                                                            ),
-                                                            ...(skjema.felter.tilknyttedeBehandlinger.verdi.some(
-                                                                it =>
-                                                                    it.behandlingId ===
-                                                                    behandling.id
-                                                            )
-                                                                ? []
-                                                                : [
-                                                                      {
-                                                                          behandlingstype:
-                                                                              behandling.type,
-                                                                          behandlingId:
-                                                                              behandling.id,
-                                                                      },
-                                                                  ]),
-                                                        ]
-                                                    );
-                                                }}
-                                                readOnly={!kanKnytteJournalpostTilBehandling()}
-                                                hideLabel={true}
-                                            >
-                                                {behandling.id}
-                                            </Checkbox>
-                                        </Table.DataCell>
-                                        <Table.DataCell>
-                                            {isoStringTilFormatertString({
-                                                isoString: behandling.opprettetTidspunkt,
-                                                tilFormat: Datoformat.DATO_FORKORTTET,
-                                            })}
-                                        </Table.DataCell>
-                                        <Table.DataCell>
-                                            {finnVisningstekstForJournalføringsbehandlingsårsak(
-                                                behandling.årsak
+                <VStack gap="6">
+                    {ressursHarFeilet(klageStatus) && (
+                        <Alert variant="warning">
+                            <BodyShort>
+                                Klagebehandlinger er ikke tilgjengelig for øyeblikket.
+                            </BodyShort>
+                        </Alert>
+                    )}
+                    <div>
+                        <Heading size={'small'} level={'2'}>
+                            Knytt til tidligere behandling(er)
+                        </Heading>
+                        <Table>
+                            <Table.Header>
+                                <Table.Row>
+                                    <Table.DataCell></Table.DataCell>
+                                    <Table.HeaderCell>{'Dato'}</Table.HeaderCell>
+                                    <Table.HeaderCell>{'Årsak'}</Table.HeaderCell>
+                                    <Table.HeaderCell>{'Behandlingstype'}</Table.HeaderCell>
+                                    <Table.HeaderCell>{'Status'}</Table.HeaderCell>
+                                </Table.Row>
+                            </Table.Header>
+                            <Table.Body>
+                                {sorterteJournalføringsbehandlinger.map(behandling => {
+                                    return (
+                                        <Table.Row
+                                            key={behandling.id}
+                                            aria-selected={skjema.felter.tilknyttedeBehandlinger.verdi.some(
+                                                it => it.behandlingId === behandling.id
                                             )}
-                                        </Table.DataCell>
-                                        <Table.DataCell>
-                                            {behandlingstyper[behandling.type].navn}
-                                        </Table.DataCell>
-                                        <Table.DataCell>
-                                            {behandlingsstatuser[behandling.status]}
-                                        </Table.DataCell>
-                                    </Table.Row>
-                                );
-                            })}
-                        </Table.Body>
-                    </Table>
-                </>
+                                        >
+                                            <Table.DataCell>
+                                                <Checkbox
+                                                    id={behandling.id}
+                                                    value={behandling.id}
+                                                    checked={skjema.felter.tilknyttedeBehandlinger.verdi.some(
+                                                        it => it.behandlingId === behandling.id
+                                                    )}
+                                                    onChange={() => {
+                                                        skjema.felter.tilknyttedeBehandlinger.validerOgSettFelt(
+                                                            [
+                                                                ...skjema.felter.tilknyttedeBehandlinger.verdi.filter(
+                                                                    it =>
+                                                                        it.behandlingId !==
+                                                                        behandling.id
+                                                                ),
+                                                                ...(skjema.felter.tilknyttedeBehandlinger.verdi.some(
+                                                                    it =>
+                                                                        it.behandlingId ===
+                                                                        behandling.id
+                                                                )
+                                                                    ? []
+                                                                    : [
+                                                                          {
+                                                                              behandlingstype:
+                                                                                  behandling.type,
+                                                                              behandlingId:
+                                                                                  behandling.id,
+                                                                          },
+                                                                      ]),
+                                                            ]
+                                                        );
+                                                    }}
+                                                    readOnly={!kanKnytteJournalpostTilBehandling()}
+                                                    hideLabel={true}
+                                                >
+                                                    {behandling.id}
+                                                </Checkbox>
+                                            </Table.DataCell>
+                                            <Table.DataCell>
+                                                {isoStringTilFormatertString({
+                                                    isoString: behandling.opprettetTidspunkt,
+                                                    tilFormat: Datoformat.DATO_FORKORTTET,
+                                                })}
+                                            </Table.DataCell>
+                                            <Table.DataCell>
+                                                {finnVisningstekstForJournalføringsbehandlingsårsak(
+                                                    behandling.årsak
+                                                )}
+                                            </Table.DataCell>
+                                            <Table.DataCell>
+                                                {behandlingstyper[behandling.type].navn}
+                                            </Table.DataCell>
+                                            <Table.DataCell>
+                                                {behandlingsstatuser[behandling.status]}
+                                            </Table.DataCell>
+                                        </Table.Row>
+                                    );
+                                })}
+                            </Table.Body>
+                        </Table>
+                    </div>
+                </VStack>
             )}
             {skalViseKnyttTilNyBehandling && <KnyttTilNyBehandling />}
             {visGenerellSakInfoStripe && (

--- a/src/frontend/typer/manuell-journalføring.ts
+++ b/src/frontend/typer/manuell-journalføring.ts
@@ -4,7 +4,6 @@ import type { BehandlingKategori, BehandlingUnderkategori } from './behandlingst
 import type { IMinimalFagsak } from './fagsak';
 import type { FagsakType } from './fagsak';
 import type { Journalføringsbehandlingstype } from './journalføringsbehandling';
-import { type IKlagebehandling } from './klage';
 import type { IOppgave } from './oppgave';
 import type { IPersonInfo } from './person';
 
@@ -13,7 +12,6 @@ export interface IDataForManuellJournalføring {
     oppgave: IOppgave;
     person?: IPersonInfo;
     minimalFagsak?: IMinimalFagsak;
-    klagebehandlinger: IKlagebehandling[];
 }
 
 export interface IRestJournalpostDokument {

--- a/src/frontend/utils/ressursUtils.ts
+++ b/src/frontend/utils/ressursUtils.ts
@@ -7,3 +7,11 @@ export const hentFrontendFeilmelding = <T>(ressurs: Ressurs<T>): string | undefi
     ressurs.status === RessursStatus.IKKE_TILGANG
         ? ressurs.frontendFeilmelding
         : undefined;
+
+export const ressursHarFeilet = (ressursStatus: RessursStatus): boolean => {
+    return [
+        RessursStatus.FEILET,
+        RessursStatus.FUNKSJONELL_FEIL,
+        RessursStatus.IKKE_TILGANG,
+    ].includes(ressursStatus);
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24775

Henter klagebehandlinger i eget kall i stedet for å hente med all annen journalføring-data. Fjernes også i backend i [egen PR](https://github.com/navikt/familie-ba-sak/pull/5194). Viser varselboks hvis vi ikke har suksess med å hente klagebehandlinger.

Varselboks på saksoversikten burde gjøres etter at [denne PRen](https://github.com/navikt/familie-ba-sak-frontend/pull/3623) er merget inn, så tenker det kan komme i en ny PR senere:)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det er noe vits å bruke tid på

### 🤷‍♀ ️Hvor er det lurt å starte?
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Med klagebehandling hentet inn
![image](https://github.com/user-attachments/assets/17df3948-7d46-41b8-99ab-b7f19373db58)

Hvis klage feiler:
![image](https://github.com/user-attachments/assets/86fcabf7-11e1-4174-b24f-89f337693e22)
