### PR TITLE
Ikke ta ned saksoversikt hvis tilbake er nede + vis warning hvis nede

### DIFF
--- a/src/frontend/api/useTilbakekrevingApi.ts
+++ b/src/frontend/api/useTilbakekrevingApi.ts
@@ -1,0 +1,26 @@
+import { useHttp } from '@navikt/familie-http';
+import { byggTomRessurs, type Ressurs } from '@navikt/familie-typer';
+
+import type { ITilbakekrevingsbehandling } from '../typer/tilbakekrevingsbehandling';
+
+export const useTilbakekrevingApi = () => {
+    const { request } = useHttp();
+
+    const hentTilbakekrevingsbehandlinger = (
+        fagsakId: number | undefined
+    ): Promise<Ressurs<ITilbakekrevingsbehandling[]>> => {
+        if (!fagsakId) {
+            return Promise.resolve(byggTomRessurs());
+        }
+
+        return request<void, ITilbakekrevingsbehandling[]>({
+            method: 'GET',
+            url: `/familie-ba-sak/api/tilbakekreving/${fagsakId}/hent-tilbakekrevingsbehandlinger`,
+            påvirkerSystemLaster: true,
+        });
+    };
+
+    return {
+        hentTilbakekrevingsbehandlinger,
+    };
+};

--- a/src/frontend/api/useTilbakekrevingApi.ts
+++ b/src/frontend/api/useTilbakekrevingApi.ts
@@ -15,7 +15,7 @@ export const useTilbakekrevingApi = () => {
 
         return request<void, ITilbakekrevingsbehandling[]>({
             method: 'GET',
-            url: `/familie-ba-sak/api/tilbakekreving/${fagsakId}/hent-tilbakekrevingsbehandlinger`,
+            url: `/familie-ba-sak/api/tilbakekreving/fagsak/${fagsakId}`,
             påvirkerSystemLaster: true,
         });
     };

--- a/src/frontend/sider/Fagsak/FagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContext.tsx
@@ -42,6 +42,7 @@ interface IFagsakContext {
     klageStatus: RessursStatus;
     oppdaterKlagebehandlingerPåFagsak: () => void;
     tilbakekrevingsbehandlinger: ITilbakekrevingsbehandling[];
+    tilbakekrevingStatus: RessursStatus;
     manuelleBrevmottakerePåFagsak: SkjemaBrevmottaker[];
     settManuelleBrevmottakerePåFagsak: (brevmottakere: SkjemaBrevmottaker[]) => void;
 }
@@ -174,6 +175,7 @@ export const FagsakProvider = (props: PropsWithChildren) => {
                 klageStatus: klagebehandlinger.status,
                 oppdaterKlagebehandlingerPåFagsak,
                 tilbakekrevingsbehandlinger: hentDataFraRessurs(tilbakekrevingsbehandlinger) ?? [],
+                tilbakekrevingStatus: tilbakekrevingsbehandlinger.status,
                 manuelleBrevmottakerePåFagsak,
                 settManuelleBrevmottakerePåFagsak,
             }}

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -55,7 +55,8 @@ interface IBehandlingshistorikkProps {
 }
 
 const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) => {
-    const { klagebehandlinger, klageStatus, tilbakekrevingsbehandlinger } = useFagsakContext();
+    const { klagebehandlinger, klageStatus, tilbakekrevingsbehandlinger, tilbakekrevingStatus } =
+        useFagsakContext();
 
     const behandlinger = hentBehandlingerTilSaksoversikten(
         minimalFagsak,
@@ -81,6 +82,11 @@ const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) =
             {ressursHarFeilet(klageStatus) && (
                 <Alert variant="warning">
                     <BodyShort>Klagebehandlinger er ikke tilgjengelig for øyeblikket.</BodyShort>
+                </Alert>
+            )}
+            {ressursHarFeilet(tilbakekrevingStatus) && (
+                <Alert variant="warning">
+                    <BodyShort>Tilbakekreving er ikke tilgjengelig for øyeblikket.</BodyShort>
                 </Alert>
             )}
             <div>

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -55,9 +55,13 @@ interface IBehandlingshistorikkProps {
 }
 
 const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) => {
-    const { klagebehandlinger, klageStatus } = useFagsakContext();
+    const { klagebehandlinger, klageStatus, tilbakekrevingsbehandlinger } = useFagsakContext();
 
-    const behandlinger = hentBehandlingerTilSaksoversikten(minimalFagsak, klagebehandlinger);
+    const behandlinger = hentBehandlingerTilSaksoversikten(
+        minimalFagsak,
+        klagebehandlinger,
+        tilbakekrevingsbehandlinger
+    );
 
     const finnesHenlagteBehandlingerSomKanFiltreresBort = behandlinger.some(
         (behandling: Saksoversiktsbehandling) =>

--- a/src/frontend/sider/Fagsak/Saksoversikt/utils.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/utils.tsx
@@ -101,7 +101,8 @@ export const hentBehandlingId = (saksoversiktsbehandling: Saksoversiktsbehandlin
 
 export const hentBehandlingerTilSaksoversikten = (
     minimalFagsak: IMinimalFagsak,
-    klagebehandlinger: IKlagebehandling[]
+    klagebehandlinger: IKlagebehandling[],
+    tilbakekrevingsbehandlinger: ITilbakekrevingsbehandling[]
 ): Saksoversiktsbehandling[] => {
     const barnetrygdBehandlinger: Saksoversiktsbehandling[] = minimalFagsak.behandlinger.map(
         behandling => ({
@@ -109,8 +110,8 @@ export const hentBehandlingerTilSaksoversikten = (
             saksoversiktbehandlingstype: Saksoversiktbehandlingstype.BARNETRYGD,
         })
     );
-    const tilbakekrevingsbehandlinger: Saksoversiktsbehandling[] =
-        minimalFagsak.tilbakekrevingsbehandlinger.map(behandling => ({
+    const saksoversiktTilbakekrevingsbehandlinger: Saksoversiktsbehandling[] =
+        tilbakekrevingsbehandlinger.map(behandling => ({
             ...behandling,
             saksoversiktbehandlingstype: Saksoversiktbehandlingstype.TILBAKEBETALING,
         }));
@@ -122,7 +123,7 @@ export const hentBehandlingerTilSaksoversikten = (
     );
     return [
         ...barnetrygdBehandlinger,
-        ...tilbakekrevingsbehandlinger,
+        ...saksoversiktTilbakekrevingsbehandlinger,
         ...saksoversiktKlagebehandlinger,
     ];
 };

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -2,7 +2,6 @@ import type { BehandlingÅrsak } from './behandling';
 import type { BehandlingKategori, BehandlingUnderkategori } from './behandlingstema';
 import type { INøkkelPar } from './common';
 import type { IInstitusjon } from './institusjon';
-import type { ITilbakekrevingsbehandling } from './tilbakekrevingsbehandling';
 import type { Utbetalingsperiode } from './vedtaksperiode';
 import type { VisningBehandling } from '../sider/Fagsak/Saksoversikt/visningBehandling';
 
@@ -36,7 +35,6 @@ export interface IBaseFagsak {
 export interface IMinimalFagsak extends IBaseFagsak {
     migreringsdato?: string;
     behandlinger: VisningBehandling[];
-    tilbakekrevingsbehandlinger: ITilbakekrevingsbehandling[];
     gjeldendeUtbetalingsperioder: Utbetalingsperiode[];
 }
 

--- a/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
+++ b/src/frontend/utils/test/minimalFagsak/minimalFagsak.mock.ts
@@ -44,7 +44,6 @@ export const mockMinimalFagsak = ({
     status,
     underBehandling,
     gjeldendeUtbetalingsperioder,
-    tilbakekrevingsbehandlinger: [],
     løpendeKategori,
     løpendeUnderkategori,
     fagsakType,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24805

Hent tilbakekrevingsbehandlinger i eget endepunkt sånn at løsningen vår ikke går ned om tilbakekreving er nede. Viser warning på saksoversikt hvis tilbakekreving er nede. Dette er løst likt som for klage.

Tilhørende backend PR som må merges først: https://github.com/navikt/familie-ba-sak/pull/5201

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Syns ikke det gir mening her

### 🤷‍♀ ️Hvor er det lurt å starte?
Samme

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://github.com/user-attachments/assets/4ef304df-d31e-4de0-b15d-f97bc2a72e66)

