### PR TITLE
Chore: fjern constate for simulering context

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
@@ -9,19 +9,19 @@ import RegistrerSøknad from './Sider/RegistrerSøknad/RegistrerSøknad';
 import { sider } from './Sider/sider';
 import type { SideId } from './Sider/sider';
 import Simulering from './Sider/Simulering/Simulering';
+import { SimuleringProvider } from './Sider/Simulering/SimuleringContext';
 import OppsummeringVedtak from './Sider/Vedtak/OppsummeringVedtak';
+import Vilkårsvurdering from './Sider/Vilkårsvurdering/Vilkårsvurdering';
 import { useBehandling } from '../../../context/behandlingContext/BehandlingContext';
 import { VedtakStegProvider } from '../../../context/behandlingContext/useVedtakSteg';
-import { SimuleringProvider } from '../../../context/SimuleringContext';
 import { SøknadProvider } from '../../../context/SøknadContext';
 import { TidslinjeProvider } from '../../../context/TidslinjeContext';
+import { SammensattKontrollsakProvider } from './Sider/Vedtak/SammensattKontrollsak/useSammensattKontrollsak';
 import { VilkårsvurderingProvider } from '../../../context/Vilkårsvurdering/VilkårsvurderingContext';
 import { useTrackTidsbrukPåSide } from '../../../hooks/useTrackTidsbrukPåSide';
+import type { IMinimalFagsak } from '../../../typer/fagsak';
 import type { IPersonInfo } from '../../../typer/person';
 import { hentSideHref } from '../../../utils/miljø';
-import { SammensattKontrollsakProvider } from './Sider/Vedtak/SammensattKontrollsak/useSammensattKontrollsak';
-import Vilkårsvurdering from './Sider/Vilkårsvurdering/Vilkårsvurdering';
-import type { IMinimalFagsak } from '../../../typer/fagsak';
 
 interface Props {
     bruker: IPersonInfo;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -8,12 +8,12 @@ import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import AvregningAlert from './AvregningAlert';
+import { useSimuleringContext } from './SimuleringContext';
 import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
-import { useSimuleringContext } from '../../../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingSteg } from '../../../../../typer/behandling';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -13,7 +13,7 @@ import SimuleringTabell from './SimuleringTabell';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
-import { useSimulering } from '../../../../../context/SimuleringContext';
+import { useSimuleringContext } from '../../../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingSteg } from '../../../../../typer/behandling';
@@ -52,7 +52,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         behandlingErMigreringMedManuellePosteringer,
         behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
         behandlingErEndreMigreringsdato,
-    } = useSimulering();
+    } = useSimuleringContext();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandling();
 
     const erAvregningOgToggleErPå =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
@@ -34,7 +34,7 @@ interface ITilbakekrevingsskjema {
     begrunnelse: string;
 }
 
-interface ISimuleringContext {
+interface SimuleringContextValue {
     simuleringsresultat: Ressurs<ISimuleringDTO>;
     tilbakekrevingSkjema: ISkjema<ITilbakekrevingsskjema, IBehandling>;
     onSubmit: <SkjemaData>(
@@ -56,7 +56,7 @@ interface ISimuleringContext {
     behandlingErEndreMigreringsdato: boolean;
 }
 
-const SimuleringContext = createContext<ISimuleringContext | undefined>(undefined);
+const SimuleringContext = createContext<SimuleringContextValue | undefined>(undefined);
 
 export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
     const { request } = useHttp();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
@@ -8,13 +8,21 @@ import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import useSakOgBehandlingParams from '../hooks/useSakOgBehandlingParams';
-import type { IBehandling } from '../typer/behandling';
-import { Behandlingstype, BehandlingÅrsak } from '../typer/behandling';
-import { PersonType } from '../typer/person';
-import type { ISimuleringDTO, ISimuleringPeriode, ITilbakekreving } from '../typer/simulering';
-import { Tilbakekrevingsvalg } from '../typer/simulering';
-import { isoStringTilDate, isoStringTilDateMedFallback, tidenesMorgen } from '../utils/dato';
+import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
+import type { IBehandling } from '../../../../../typer/behandling';
+import { Behandlingstype, BehandlingÅrsak } from '../../../../../typer/behandling';
+import { PersonType } from '../../../../../typer/person';
+import type {
+    ISimuleringDTO,
+    ISimuleringPeriode,
+    ITilbakekreving,
+} from '../../../../../typer/simulering';
+import { Tilbakekrevingsvalg } from '../../../../../typer/simulering';
+import {
+    isoStringTilDate,
+    isoStringTilDateMedFallback,
+    tidenesMorgen,
+} from '../../../../../utils/dato';
 
 interface IProps extends React.PropsWithChildren {
     åpenBehandling: IBehandling;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
@@ -28,7 +28,7 @@ interface IProps extends React.PropsWithChildren {
     åpenBehandling: IBehandling;
 }
 
-interface ITilbakekrevingsskjema {
+interface Tilbakekrevingsskjema {
     tilbakekrevingsvalg: Tilbakekrevingsvalg | undefined;
     fritekstVarsel: string;
     begrunnelse: string;
@@ -36,7 +36,7 @@ interface ITilbakekrevingsskjema {
 
 interface SimuleringContextValue {
     simuleringsresultat: Ressurs<ISimuleringDTO>;
-    tilbakekrevingSkjema: ISkjema<ITilbakekrevingsskjema, IBehandling>;
+    tilbakekrevingSkjema: ISkjema<Tilbakekrevingsskjema, IBehandling>;
     onSubmit: <SkjemaData>(
         requestConfig: FamilieRequestConfig<SkjemaData>,
         onSuccess: (ressurs: Ressurs<IBehandling>) => void,
@@ -240,7 +240,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
         skjema: tilbakekrevingSkjema,
         hentFeilTilOppsummering,
         onSubmit,
-    } = useSkjema<ITilbakekrevingsskjema, IBehandling>({
+    } = useSkjema<Tilbakekrevingsskjema, IBehandling>({
         felter: { tilbakekrevingsvalg, fritekstVarsel, begrunnelse },
         skjemanavn: 'Opprett tilbakekreving',
     });

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
@@ -24,7 +24,7 @@ import type { Ressurs } from '@navikt/familie-typer';
 import { hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
-import { useSimulering } from '../../../../../context/SimuleringContext';
+import { useSimuleringContext } from '../../../../../context/SimuleringContext';
 import useDokument from '../../../../../hooks/useDokument';
 import type { BrevmottakereAlertBehandlingProps } from '../../../../../komponenter/Brevmottaker/BrevmottakereAlert';
 import { BrevmottakereAlert } from '../../../../../komponenter/Brevmottaker/BrevmottakereAlert';
@@ -98,7 +98,8 @@ const TilbakekrevingSkjema: React.FC<{
     åpenBehandling: IBehandling;
 }> = ({ søkerMålform, harÅpenTilbakekrevingRessurs, åpenBehandling }) => {
     const { vurderErLesevisning } = useBehandling();
-    const { tilbakekrevingSkjema, hentFeilTilOppsummering, maksLengdeTekst } = useSimulering();
+    const { tilbakekrevingSkjema, hentFeilTilOppsummering, maksLengdeTekst } =
+        useSimuleringContext();
     const { hentForhåndsvisning, visDokumentModal, hentetDokument, settVisDokumentModal } =
         useDokument();
     const { bruker: brukerRessurs } = useFagsakContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
@@ -23,8 +23,8 @@ import {
 import type { Ressurs } from '@navikt/familie-typer';
 import { hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 
+import { useSimuleringContext } from './SimuleringContext';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
-import { useSimuleringContext } from '../../../../../context/SimuleringContext';
 import useDokument from '../../../../../hooks/useDokument';
 import type { BrevmottakereAlertBehandlingProps } from '../../../../../komponenter/Brevmottaker/BrevmottakereAlert';
 import { BrevmottakereAlert } from '../../../../../komponenter/Brevmottaker/BrevmottakereAlert';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/OppsummeringVedtak.tsx
@@ -13,13 +13,13 @@ import { Vedtaksbrev } from './Vedtaksbrev';
 import Vedtaksmeny from './Vedtaksmeny';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import { useVedtakSteg } from '../../../../../context/behandlingContext/useVedtakSteg';
-import { useSimuleringContext } from '../../../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingStatus, BehandlingSteg, Behandlingstype } from '../../../../../typer/behandling';
 import type { IPersonInfo } from '../../../../../typer/person';
 import { erBehandlingMedVedtaksbrevutsending } from '../../../../../utils/behandling';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
+import { useSimuleringContext } from '../Simulering/SimuleringContext';
 import Skjemasteg from '../Skjemasteg';
 
 interface IVedtakProps {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/OppsummeringVedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/OppsummeringVedtak.tsx
@@ -13,7 +13,7 @@ import { Vedtaksbrev } from './Vedtaksbrev';
 import Vedtaksmeny from './Vedtaksmeny';
 import { useBehandling } from '../../../../../context/behandlingContext/BehandlingContext';
 import { useVedtakSteg } from '../../../../../context/behandlingContext/useVedtakSteg';
-import { useSimulering } from '../../../../../context/SimuleringContext';
+import { useSimuleringContext } from '../../../../../context/SimuleringContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingStatus, BehandlingSteg, Behandlingstype } from '../../../../../typer/behandling';
@@ -51,7 +51,7 @@ const OppsummeringVedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehand
         erUlagretNyRefusjonEøsPeriode,
     } = useVedtakSteg();
 
-    const { behandlingErMigreringMedAvvikUtenforBeløpsgrenser } = useSimulering();
+    const { behandlingErMigreringMedAvvikUtenforBeløpsgrenser } = useSimuleringContext();
 
     const erLesevisning = vurderErLesevisning();
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24695

Bytter fra constate til react context api for simulering context.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Koster for mye for hva det er verdt akkurat for øyeblikket. Det jeg faktisk har endret på har jeg kjørt opp lokalt og sjekket at funker.

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
