### PR TITLE
Fix: unik key på hver rad i oppsummeringboks på behandlingsresultat

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -249,7 +249,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                         {utbetalingsperiode.utbetalingsperiodeDetaljer
                             .sort(sorterUtbetaling)
                             .map(detalj => (
-                                <UtbetalingsbeløpRad key={detalj.person.navn}>
+                                <UtbetalingsbeløpRad key={detalj.person.navn + detalj.ytelseType}>
                                     <BodyShort>{`${detalj.person.navn} (${hentAlderSomString(
                                         detalj.person.fødselsdato
                                     )}) | ${formaterIdent(detalj.person.personIdent)}`}</BodyShort>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Stig oppdaget en feil som var meldt inn i jira hvor det var en bug i hva som ble vist i Oppsummeringsboksen på behandlingsresultat-siden. Vi gjenskapte feilen lokalt, og fant ut at det skyldes at hver rad fikk key = navnet på personen det gjelder. Søker kan ha både småbarnstillegg og utvidet og det ble derfor noe krøll i den sammenheng. Problemet blir fikset ved at kombinasjonen av navn og ytelsetype er key for raden. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
