### PR TITLE
Fjerner behandlingsårsak 'Klage' fra mulige behandlingsårsaker ved op…

### DIFF
--- a/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -80,7 +80,8 @@ const hentTilgjengeligeBehandlingsårsaker = (
                   årsak !== BehandlingÅrsak.HELMANUELL_MIGRERING &&
                   årsak !== BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING &&
                   (årsak !== BehandlingÅrsak.IVERKSETTE_KA_VEDTAK ||
-                      kanOppretteRevurderingMedÅrsakIverksetteKAVedtak)
+                      kanOppretteRevurderingMedÅrsakIverksetteKAVedtak) &&
+                  årsak !== BehandlingÅrsak.KLAGE
           );
 
 interface IProps {


### PR DESCRIPTION
Favro: [NAV-24779](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24779)

### 💰 Hva forsøker du å løse i denne PR'en
Det skal ikke lenger være mulig å opprette revurderinger med årsak "Klage".

Filtrerer her ut "Klage" fra de mulige behandlingsårsakene.

### 👀 Screen shots
Før:
![image](https://github.com/user-attachments/assets/b7fb11bb-86cf-4fc2-b900-46b3a5c2022e)

Etter:
![image](https://github.com/user-attachments/assets/2ab379f9-967b-46d0-abdb-a0e760dfb56c)
