### PR TITLE
Legg til logikk for forenklet tilbakekreving på simuleringsteg

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/MigreringAlerts.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/MigreringAlerts.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+
+import styled from 'styled-components';
+
+import { Alert } from '@navikt/ds-react';
+
+const StyledBeløpsgrenseAlert = styled(Alert)`
+    margin-top: 2rem;
+    width: fit-content;
+`;
+
+interface IProps {
+    behandlingErEndreMigreringsdato: boolean;
+    behandlingErMigreringMedAvvikInnenforBeløpsgrenser: boolean;
+    behandlingErMigreringMedAvvikUtenforBeløpsgrenser: boolean;
+    behandlingErMigreringMedManuellePosteringer: boolean | undefined;
+    behandlingErMigreringFraInfotrygdMedKun0Utbetalinger: boolean;
+}
+
+export const MigreringAlerts = ({
+    behandlingErEndreMigreringsdato,
+    behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
+    behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
+    behandlingErMigreringMedManuellePosteringer,
+    behandlingErMigreringFraInfotrygdMedKun0Utbetalinger,
+}: IProps) => {
+    return (
+        <>
+            {behandlingErMigreringFraInfotrygdMedKun0Utbetalinger && (
+                <StyledBeløpsgrenseAlert variant="warning">
+                    Migrering av denne saken gir ingen utbetaling for periodene etter
+                    migreringsdato. Når behandlingsresultatet blir 0 kr i alle perioder, får vi ikke
+                    simulert mot økonomi for å se eventuelle avvik. Det er derfor viktig at du selv
+                    sjekker at det ikke har vært noen utbetalinger fra Infotrygd i disse periodene.
+                </StyledBeløpsgrenseAlert>
+            )}
+            {behandlingErEndreMigreringsdato &&
+                (behandlingErMigreringMedAvvikInnenforBeløpsgrenser ||
+                    behandlingErMigreringMedAvvikUtenforBeløpsgrenser) && (
+                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                        Simuleringen viser en feilutbetaling eller etterbetaling. Du trenger ikke
+                        sende oppgave til NØS, da beløpet ikke sendes til oppdrag. Hvis bruker skal
+                        ha en etterbetaling eller feilutbetaling må dette behandles i en egen
+                        revurderingsbehandling med vedtaksbrev til bruker.
+                    </StyledBeløpsgrenseAlert>
+                )}
+            {!behandlingErEndreMigreringsdato &&
+                behandlingErMigreringMedAvvikInnenforBeløpsgrenser && (
+                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                        Behandlingen medfører avvik i simulering. Ved avvik på mindre enn totalt 100
+                        kroner, kan du gå videre i behandlingen uten totrinnskontroll. Du må huske å
+                        sende oppgave til NØS om at det ikke skal etterbetales / opprettes
+                        kravgrunnlag.
+                    </StyledBeløpsgrenseAlert>
+                )}
+            {!behandlingErEndreMigreringsdato &&
+                behandlingErMigreringMedAvvikUtenforBeløpsgrenser && (
+                    <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                        Simuleringen viser en feilutbetaling eller etterbetaling. Hvis du velger å
+                        gå videre i behandlingen kreves det totrinnskontroll. Det må sendes manuell
+                        oppgave til NØS for å sikre at det ikke går ut etterbetaling eller blir
+                        opprettet feilutbetalingssak i migreringsbehandlingen. Hvis bruker skal ha
+                        en etterbetaling eller feilutbetaling, må dette behandles i en egen
+                        revurderingsbehandling med vedtaksbrev til bruker.
+                    </StyledBeløpsgrenseAlert>
+                )}
+            {!behandlingErEndreMigreringsdato && behandlingErMigreringMedManuellePosteringer && (
+                <StyledBeløpsgrenseAlert variant="warning" size="medium">
+                    Det finnes manuelle posteringer tilknyttet tidligere behandling. Hvis du velger
+                    å gå videre i behandlingen kreves det totrinnskontroll.
+                </StyledBeløpsgrenseAlert>
+            )}
+        </>
+    );
+};

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -4,13 +4,10 @@ import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
-import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer';
+import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
-import AvregningAlert from './AvregningAlert';
+import { MigreringAlerts } from './MigreringAlerts';
 import { useSimuleringContext } from './SimuleringContext';
-import SimuleringPanel from './SimuleringPanel';
-import SimuleringTabell from './SimuleringTabell';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
 import { useApp } from '../../../../../context/AppContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
@@ -21,6 +18,11 @@ import { ToggleNavn } from '../../../../../typer/toggles';
 import { hentSøkersMålform } from '../../../../../utils/behandling';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 import Skjemasteg from '../Skjemasteg';
+import SimuleringPanel from './SimuleringPanel';
+import SimuleringTabell from './SimuleringTabell';
+import AvregningAlert from './UlovfestetMotregning/AvregningAlert';
+import { ForenkletTilbakekrevingsvedtak } from './UlovfestetMotregning/ForenkletTilbakekrevingsvedtak';
+import { useForenkletTilbakekrevingsvedtak } from './UlovfestetMotregning/useForenkletTilbakekrevingsvedtak';
 
 interface ISimuleringProps {
     åpenBehandling: IBehandling;
@@ -28,11 +30,6 @@ interface ISimuleringProps {
 
 const StyledAlert = styled(Alert)`
     margin-bottom: 2rem;
-`;
-
-const StyledBeløpsgrenseAlert = styled(Alert)`
-    margin-top: 2rem;
-    width: fit-content;
 `;
 
 const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling }) => {
@@ -54,12 +51,21 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         behandlingErEndreMigreringsdato,
     } = useSimuleringContext();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
+    const erLesevisning = vurderErLesevisning();
+
+    const {
+        forenkletTilbakekrevingsvedtak,
+        slettForenkletTilbakekrevingsvedtak,
+        oppdaterForenkletTilbakekrevingSamtykke,
+        heleBeløpetSkalKrevesTilbake,
+        settHeleBeløpetSkalKrevesTilbake,
+    } = useForenkletTilbakekrevingsvedtak(åpenBehandling);
 
     const erAvregningOgToggleErPå =
         erAvregning && toggles[ToggleNavn.brukFunksjonalitetForUlovfestetMotregning];
 
     const nesteOnClick = () => {
-        if (vurderErLesevisning()) {
+        if (erLesevisning) {
             navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vedtak`);
         } else {
             onSubmit<ITilbakekreving | undefined>(
@@ -98,16 +104,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             nesteOnClick={nesteOnClick}
             maxWidthStyle={'80rem'}
             steg={BehandlingSteg.VURDER_TILBAKEKREVING}
-            skalDisableNesteKnapp={erAvregningOgToggleErPå}
+            skalDisableNesteKnapp={erAvregningOgToggleErPå && !heleBeløpetSkalKrevesTilbake}
         >
-            {behandlingErMigreringFraInfotrygdMedKun0Utbetalinger && (
-                <StyledAlert variant={'warning'}>
-                    Migrering av denne saken gir ingen utbetaling for periodene etter
-                    migreringsdato. Når behandlingsresultatet blir 0 kr i alle perioder, får vi ikke
-                    simulert mot økonomi for å se eventuelle avvik. Det er derfor viktig at du selv
-                    sjekker at det ikke har vært noen utbetalinger fra Infotrygd i disse periodene.
-                </StyledAlert>
-            )}
             {simuleringsresultat?.status === RessursStatus.SUKSESS ? (
                 simuleringsresultat.data.perioder.length === 0 ? (
                     <StyledAlert variant="info">
@@ -117,55 +115,55 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                     <>
                         <SimuleringPanel simulering={simuleringsresultat.data} />
                         <SimuleringTabell simulering={simuleringsresultat.data} />
-                        {behandlingErEndreMigreringsdato &&
-                            (behandlingErMigreringMedAvvikUtenforBeløpsgrenser ||
-                                behandlingErMigreringMedAvvikUtenforBeløpsgrenser) && (
-                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                    Simuleringen viser en feilutbetaling eller etterbetaling. Du
-                                    trenger ikke sende oppgave til NØS, da beløpet ikke sendes til
-                                    oppdrag. Hvis bruker skal ha en etterbetaling eller
-                                    feilutbetaling må dette behandles i en egen
-                                    revurderingsbehandling med vedtaksbrev til bruker.
-                                </StyledBeløpsgrenseAlert>
-                            )}
-                        {!behandlingErEndreMigreringsdato &&
-                            behandlingErMigreringMedAvvikInnenforBeløpsgrenser && (
-                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                    Behandlingen medfører avvik i simulering. Ved avvik på mindre
-                                    enn totalt 100 kroner, kan du gå videre i behandlingen uten
-                                    totrinnskontroll. Du må huske å sende oppgave til NØS om at det
-                                    ikke skal etterbetales / opprettes kravgrunnlag.
-                                </StyledBeløpsgrenseAlert>
-                            )}
-                        {!behandlingErEndreMigreringsdato &&
-                            behandlingErMigreringMedAvvikUtenforBeløpsgrenser && (
-                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                    Simuleringen viser en feilutbetaling eller etterbetaling. Hvis
-                                    du velger å gå videre i behandlingen kreves det
-                                    to-trinnskontroll. Det må sendes manuell oppgave til NØS for å
-                                    sikre at det ikke går ut etterbetaling eller blir opprettet
-                                    feilutbetalingssak i migreringsbehandlingen. Hvis bruker skal ha
-                                    en etterbetaling eller feilutbetaling, må dette behandles i en
-                                    egen revurderingsbehandling med vedtaksbrev til bruker.
-                                </StyledBeløpsgrenseAlert>
+
+                        <MigreringAlerts
+                            behandlingErEndreMigreringsdato={behandlingErEndreMigreringsdato}
+                            behandlingErMigreringMedAvvikInnenforBeløpsgrenser={
+                                behandlingErMigreringMedAvvikInnenforBeløpsgrenser
+                            }
+                            behandlingErMigreringMedAvvikUtenforBeløpsgrenser={
+                                behandlingErMigreringMedAvvikUtenforBeløpsgrenser
+                            }
+                            behandlingErMigreringMedManuellePosteringer={
+                                behandlingErMigreringMedManuellePosteringer
+                            }
+                            behandlingErMigreringFraInfotrygdMedKun0Utbetalinger={
+                                behandlingErMigreringFraInfotrygdMedKun0Utbetalinger
+                            }
+                        />
+
+                        {forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&
+                            forenkletTilbakekrevingsvedtak.data === null &&
+                            erAvregningOgToggleErPå && <AvregningAlert />}
+
+                        {!erLesevisning &&
+                            forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&
+                            forenkletTilbakekrevingsvedtak.data !== null && (
+                                <ForenkletTilbakekrevingsvedtak
+                                    forenkletTilbakekrevingsvedtak={
+                                        forenkletTilbakekrevingsvedtak.data
+                                    }
+                                    slettForenkletTilbakekrevingsvedtak={
+                                        slettForenkletTilbakekrevingsvedtak
+                                    }
+                                    oppdaterForenkletTilbakekrevingSamtykke={
+                                        oppdaterForenkletTilbakekrevingSamtykke
+                                    }
+                                    heleBeløpetSkalKrevesTilbake={heleBeløpetSkalKrevesTilbake}
+                                    settHeleBeløpetSkalKrevesTilbake={
+                                        settHeleBeløpetSkalKrevesTilbake
+                                    }
+                                />
                             )}
 
-                        {!behandlingErEndreMigreringsdato &&
-                            behandlingErMigreringMedManuellePosteringer && (
-                                <StyledBeløpsgrenseAlert variant="warning" size="medium">
-                                    Det finnes manuelle posteringer tilknyttet tidligere behandling.
-                                    Hvis du velger å gå videre i behandlingen kreves det
-                                    to-trinnskontroll.
-                                </StyledBeløpsgrenseAlert>
+                        {erFeilutbetaling &&
+                            (!erAvregningOgToggleErPå || heleBeløpetSkalKrevesTilbake) && (
+                                <TilbakekrevingSkjema
+                                    søkerMålform={hentSøkersMålform(åpenBehandling)}
+                                    harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
+                                    åpenBehandling={åpenBehandling}
+                                />
                             )}
-                        {erAvregningOgToggleErPå && <AvregningAlert />}
-                        {erFeilutbetaling && (
-                            <TilbakekrevingSkjema
-                                søkerMålform={hentSøkersMålform(åpenBehandling)}
-                                harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
-                                åpenBehandling={åpenBehandling}
-                            />
-                        )}
                     </>
                 )
             ) : (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
@@ -6,8 +6,8 @@ import styled from 'styled-components';
 import { Alert, BodyLong, Button, Link, List } from '@navikt/ds-react';
 
 import { SettBehandlingPåVentModalMotregning } from './SettBehandlingPåVentModalMotregning';
-import { erProd } from '../../../../../utils/miljø';
-import { useBehandlingContext } from '../../context/BehandlingContext';
+import { erProd } from '../../../../../../utils/miljø';
+import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const StyledAlert = styled(Alert)`
     margin-top: 2rem;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeOmMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeOmMotregning.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { Alert, BodyLong, Button, HStack, Modal } from '@navikt/ds-react';
+
+const StyledAlert = styled(Alert)`
+    margin-top: 2rem;
+    width: fit-content;
+`;
+
+interface IProps {
+    slettForenkletTilbakekrevingsvedtak: () => Promise<void>;
+    oppdaterForenkletTilbakekrevingSamtykke: (samtykke: boolean) => Promise<void>;
+}
+
+export const BekreftSamtykkeOmMotregning = ({
+    slettForenkletTilbakekrevingsvedtak,
+    oppdaterForenkletTilbakekrevingSamtykke,
+}: IProps) => {
+    const [visBekreftSlettingModal, settVisBekreftSlettingModal] = useState<boolean>(false);
+    const åpneModal = () => settVisBekreftSlettingModal(true);
+    const lukkModal = () => settVisBekreftSlettingModal(false);
+
+    const [oppdaterer, settOppdaterer] = useState(false);
+    const [sletter, settSletter] = useState(false);
+
+    return (
+        <>
+            <StyledAlert variant={'info'}>
+                <BodyLong spacing>
+                    Bruker har samtykket til at vi venter med etterbetalingen til vi har vurdert
+                    feilutbetalingen
+                </BodyLong>
+                <HStack gap="4" justify="center">
+                    <Button onClick={åpneModal} disabled={oppdaterer}>
+                        Nei
+                    </Button>
+                    <Button
+                        onClick={() => {
+                            settOppdaterer(true);
+                            oppdaterForenkletTilbakekrevingSamtykke(true).finally(() => {
+                                settOppdaterer(false);
+                            });
+                        }}
+                        loading={oppdaterer}
+                        disabled={oppdaterer}
+                    >
+                        Ja
+                    </Button>
+                </HStack>
+            </StyledAlert>
+            <Modal
+                open={visBekreftSlettingModal}
+                onClose={lukkModal}
+                header={{
+                    heading: 'Er du sikker på at du vil slette forenklet tilbakekrevingsvedtak?',
+                    size: 'small',
+                    closeButton: false,
+                }}
+                width={'35rem'}
+            >
+                <Modal.Footer>
+                    <Button
+                        key={'bekreft'}
+                        onClick={() => {
+                            settSletter(true);
+                            slettForenkletTilbakekrevingsvedtak().finally(() => {
+                                settSletter(false);
+                                settVisBekreftSlettingModal(false);
+                            });
+                        }}
+                        disabled={sletter}
+                        loading={sletter}
+                    >
+                        Bekreft
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        key={'avbryt'}
+                        onClick={lukkModal}
+                        disabled={sletter}
+                    >
+                        Avbryt
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        </>
+    );
+};

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/ForenkletTilbakekrevingsvedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/ForenkletTilbakekrevingsvedtak.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Alert, Box, Checkbox, CheckboxGroup, Heading, VStack } from '@navikt/ds-react';
+
+import { BekreftSamtykkeOmMotregning } from './BekreftSamtykkeOmMotregning';
+import type { ForenkletTilbakekrevingsvedtakDTO } from './ForenkletTilbakekrevingsvedtakDTO';
+
+const StyledBox = styled(Box)`
+    margin-top: 2.5rem;
+    width: 90%;
+    max-width: 40rem;
+`;
+
+interface ForenkletTilbakekrevingsvedtakProps {
+    forenkletTilbakekrevingsvedtak: ForenkletTilbakekrevingsvedtakDTO;
+    slettForenkletTilbakekrevingsvedtak: () => Promise<void>;
+    oppdaterForenkletTilbakekrevingSamtykke: (samtykke: boolean) => Promise<void>;
+    heleBeløpetSkalKrevesTilbake: boolean;
+    settHeleBeløpetSkalKrevesTilbake: (value: boolean) => void;
+}
+
+export const ForenkletTilbakekrevingsvedtak = ({
+    forenkletTilbakekrevingsvedtak,
+    slettForenkletTilbakekrevingsvedtak,
+    oppdaterForenkletTilbakekrevingSamtykke,
+    heleBeløpetSkalKrevesTilbake,
+    settHeleBeløpetSkalKrevesTilbake,
+}: ForenkletTilbakekrevingsvedtakProps) => {
+    const toggleHeleBeløpetSkalKrevesTilbake = (value: boolean[]) => {
+        settHeleBeløpetSkalKrevesTilbake(value.includes(true));
+    };
+
+    return (
+        <StyledBox>
+            <Heading size="medium" level="2" spacing>
+                Tilbakekreving - ulovfestet motregning
+            </Heading>
+            {!forenkletTilbakekrevingsvedtak.samtykke ? (
+                <BekreftSamtykkeOmMotregning
+                    slettForenkletTilbakekrevingsvedtak={slettForenkletTilbakekrevingsvedtak}
+                    oppdaterForenkletTilbakekrevingSamtykke={
+                        oppdaterForenkletTilbakekrevingSamtykke
+                    }
+                />
+            ) : (
+                <VStack gap="2">
+                    <Alert variant="info" style={{ marginBottom: '1rem' }}>
+                        Du må ha kjennskap til regelverk for tilbakekreving for å kunne fortsette
+                        saksbehandlingen.
+                    </Alert>
+                    <CheckboxGroup
+                        legend="Hele beløpet skal kreves tilbake"
+                        size="medium"
+                        hideLegend
+                        onChange={toggleHeleBeløpetSkalKrevesTilbake}
+                    >
+                        <Checkbox value={true}>Hele beløpet skal kreves tilbake</Checkbox>
+                    </CheckboxGroup>
+                    {!heleBeløpetSkalKrevesTilbake && (
+                        <Alert variant="warning">
+                            Dersom ikke hele beløpet skal kreves tilbake må du splitte saken
+                        </Alert>
+                    )}
+                </VStack>
+            )}
+        </StyledBox>
+    );
+};

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/ForenkletTilbakekrevingsvedtakDTO.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/ForenkletTilbakekrevingsvedtakDTO.ts
@@ -1,0 +1,12 @@
+export interface ForenkletTilbakekrevingsvedtakDTO {
+    fritekst: string;
+    samtykke: boolean;
+}
+
+export interface OppdaterForenkletTilbakekrevingsvedtakFritekstDTO {
+    fritekst: string;
+}
+
+export interface OppdaterForenkletTilbakekrevingsvedtakSamtykkeDTO {
+    samtykke: boolean;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
@@ -25,10 +25,10 @@ import {
     type ISettPåVent,
     SettPåVentÅrsak,
     settPåVentÅrsaker,
-} from '../../../../../typer/behandling';
-import { dagensDato, dateTilIsoDatoString } from '../../../../../utils/dato';
-import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../context/BehandlingContext';
+} from '../../../../../../typer/behandling';
+import { dagensDato, dateTilIsoDatoString } from '../../../../../../utils/dato';
+import { hentFrontendFeilmelding } from '../../../../../../utils/ressursUtils';
+import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const Feltmargin = styled.div`
     margin-bottom: 2rem;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useForenkletTilbakekrevingsvedtak.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useForenkletTilbakekrevingsvedtak.ts
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+
+import type { AxiosError } from 'axios';
+
+import { useHttp } from '@navikt/familie-http';
+import {
+    byggDataRessurs,
+    byggFeiletRessurs,
+    byggHenterRessurs,
+    byggTomRessurs,
+    type Ressurs,
+    RessursStatus,
+} from '@navikt/familie-typer';
+
+import type {
+    ForenkletTilbakekrevingsvedtakDTO,
+    OppdaterForenkletTilbakekrevingsvedtakFritekstDTO,
+    OppdaterForenkletTilbakekrevingsvedtakSamtykkeDTO,
+} from './ForenkletTilbakekrevingsvedtakDTO';
+import type { IBehandling } from '../../../../../../typer/behandling';
+
+export const useForenkletTilbakekrevingsvedtak = (åpenBehandling: IBehandling) => {
+    const { request } = useHttp();
+
+    const forenkletTilbakekrevingsvedtakUrl = `/familie-ba-sak/api/behandling/${åpenBehandling.behandlingId}/forenklet-tilbakekrevingsvedtak`;
+
+    const [forenkletTilbakekrevingsvedtak, settForenkletTilbakekrevingsvedtak] =
+        useState<Ressurs<ForenkletTilbakekrevingsvedtakDTO | null>>(byggTomRessurs());
+
+    const [heleBeløpetSkalKrevesTilbake, settHeleBeløpetSkalKrevesTilbake] =
+        useState<boolean>(false);
+
+    const hentForenkletTilbakekrevingsvedtak = () => {
+        settForenkletTilbakekrevingsvedtak(byggHenterRessurs());
+        request<void, ForenkletTilbakekrevingsvedtakDTO>({
+            method: 'GET',
+            url: forenkletTilbakekrevingsvedtakUrl,
+        })
+            .then((response: Ressurs<ForenkletTilbakekrevingsvedtakDTO>) => {
+                settForenkletTilbakekrevingsvedtak(response);
+            })
+            .catch((_error: AxiosError) => {
+                settForenkletTilbakekrevingsvedtak(
+                    byggFeiletRessurs(
+                        'Ukjent feil, klarte ikke å hente forenklet tilbakekrevingsvedtak.'
+                    )
+                );
+            });
+    };
+
+    const slettForenkletTilbakekrevingsvedtak = (): Promise<void> =>
+        request<void, string>({
+            method: 'DELETE',
+            url: forenkletTilbakekrevingsvedtakUrl,
+        })
+            .then(response => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    settForenkletTilbakekrevingsvedtak(byggDataRessurs(null));
+                }
+            })
+            .catch((_error: AxiosError) => {
+                settForenkletTilbakekrevingsvedtak(
+                    byggFeiletRessurs(
+                        'Ukjent feil, klarte ikke å slette forenklet tilbakekrevingsvedtak.'
+                    )
+                );
+            });
+
+    const oppdaterForenkletTilbakekrevingFritekst = (fritekst: string): Promise<void> =>
+        request<
+            OppdaterForenkletTilbakekrevingsvedtakFritekstDTO,
+            ForenkletTilbakekrevingsvedtakDTO
+        >({
+            method: 'PATCH',
+            data: { fritekst: fritekst },
+            url: `${forenkletTilbakekrevingsvedtakUrl}/fritekst`,
+        })
+            .then((response: Ressurs<ForenkletTilbakekrevingsvedtakDTO>) => {
+                settForenkletTilbakekrevingsvedtak(response);
+            })
+            .catch((_error: AxiosError) => {
+                settForenkletTilbakekrevingsvedtak(
+                    byggFeiletRessurs(
+                        'Ukjent feil, klarte ikke å oppdatere fritekst i forenklet tilbakekrevingsvedtak.'
+                    )
+                );
+            });
+
+    const oppdaterForenkletTilbakekrevingSamtykke = (samtykke: boolean): Promise<void> =>
+        request<
+            OppdaterForenkletTilbakekrevingsvedtakSamtykkeDTO,
+            ForenkletTilbakekrevingsvedtakDTO
+        >({
+            method: 'PATCH',
+            data: { samtykke: samtykke },
+            url: `${forenkletTilbakekrevingsvedtakUrl}/samtykke`,
+        })
+            .then((response: Ressurs<ForenkletTilbakekrevingsvedtakDTO>) => {
+                settForenkletTilbakekrevingsvedtak(response);
+            })
+            .catch((_error: AxiosError) => {
+                settForenkletTilbakekrevingsvedtak(
+                    byggFeiletRessurs(
+                        'Ukjent feil, klarte ikke å oppdatere samtykke i forenklet tilbakekrevingsvedtak.'
+                    )
+                );
+            });
+
+    useEffect(() => {
+        hentForenkletTilbakekrevingsvedtak();
+    }, [åpenBehandling]);
+
+    return {
+        forenkletTilbakekrevingsvedtak,
+        slettForenkletTilbakekrevingsvedtak,
+        oppdaterForenkletTilbakekrevingFritekst,
+        oppdaterForenkletTilbakekrevingSamtykke,
+        heleBeløpetSkalKrevesTilbake,
+        settHeleBeløpetSkalKrevesTilbake,
+    };
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-24697, NAV-24698

Når en behandling som er satt på vent for å vente på samtykke fra bruker for ulovfestet motregning tas av vent, skal det vises en boks der saksbehandler velger om bruker har gitt samtykke eller ikke.
Når saksbehandler trykker 'Nei' kommer det opp en modal med bekreftelse på at det forenklede tilbakekrevingsvedtaket skal slettes.
Når saksbehandler trykker 'Ja' kommer det opp en infoboks om at man må kjenne tilbakekrevingsregelverk for å gå videre, og en checkbox om at hele beløpet skal kreves tilbake.

Dette er work in progress, så det skjer nok flere designendringer, men for å kunne jobbe flere på det parallelt er det greit å få merget det. Funksjonaliteten er togglet.

### 👀 Screen shots

![a6296b8762848e9864da6d3f459958c8](https://github.com/user-attachments/assets/24d4b57a-34a1-4084-8dcb-ad2c0f172dcb)
![6f67be37b64dd0a6d6ef2988020660ca](https://github.com/user-attachments/assets/f5881797-bdf6-4d06-b5b6-d68495712d98)
![defa064c47cb162ec5e2798a4c06f8b9](https://github.com/user-attachments/assets/ae56fe37-a610-4390-9d46-1dee726bba54)
