### PR TITLE
NAV-24909: Legger til react-query i saksoversikt

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@navikt/landvelger": "^9.0.7",
     "@sentry/browser": "^9.11.0",
     "@sentry/webpack-plugin": "^3.3.1",
+    "@tanstack/react-query": "^5.72.0",
     "axios": "^1.8.3",
     "babel-loader": "^9.2.1",
     "body-parser": "^1.20.3",
@@ -137,7 +138,9 @@
         "tsconfig": "<rootDir>/src/frontend/tsconfig.json"
       }
     },
-    "setupFiles": ["./jest-setup.js"],
+    "setupFiles": [
+      "./jest-setup.js"
+    ],
     "moduleNameMapper": {
       "\\.(css|svg)$": "<rootDir>/src/mockFile.js"
     },

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import '@navikt/ds-css';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 import type { ISaksbehandler } from '@navikt/familie-typer';
 
 import { hentInnloggetBruker } from './api/saksbehandler';
@@ -11,6 +13,8 @@ import { AuthOgHttpProvider } from './context/AuthContext';
 import { useStartUmami } from './hooks/useStartUmami';
 import ErrorBoundary from './komponenter/ErrorBoundary/ErrorBoundary';
 import { initGrafanaFaro } from './utils/grafanaFaro';
+
+const queryClient = new QueryClient();
 
 const App: React.FC = () => {
     const [autentisertSaksbehandler, settInnloggetSaksbehandler] = React.useState<
@@ -28,9 +32,11 @@ const App: React.FC = () => {
     return (
         <ErrorBoundary autentisertSaksbehandler={autentisertSaksbehandler}>
             <AuthOgHttpProvider autentisertSaksbehandler={autentisertSaksbehandler}>
-                <AppProvider>
-                    <Container />
-                </AppProvider>
+                <QueryClientProvider client={queryClient}>
+                    <AppProvider>
+                        <Container />
+                    </AppProvider>
+                </QueryClientProvider>
             </AuthOgHttpProvider>
         </ErrorBoundary>
     );

--- a/src/frontend/api/hentBarnetrygdbehandlinger.ts
+++ b/src/frontend/api/hentBarnetrygdbehandlinger.ts
@@ -1,0 +1,16 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { VisningBehandling } from '../sider/Fagsak/Saksoversikt/visningBehandling';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function hentBarnetrygdbehandlinger(
+    request: FamilieRequest,
+    fagsakId: number
+): Promise<VisningBehandling[]> {
+    const ressurs = await request<void, VisningBehandling[]>({
+        method: 'GET',
+        url: `/familie-ba-sak/api/behandlinger/fagsak/${fagsakId}`,
+        påvirkerSystemLaster: true,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/api/hentKlagebehandlinger.ts
+++ b/src/frontend/api/hentKlagebehandlinger.ts
@@ -1,0 +1,16 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { IKlagebehandling } from '../typer/klage';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function hentKlagebehandlinger(
+    request: FamilieRequest,
+    fagsakId: number
+): Promise<IKlagebehandling[]> {
+    const ressurs = await request<void, IKlagebehandling[]>({
+        method: 'GET',
+        url: `/familie-ba-sak/api/fagsaker/${fagsakId}/hent-klagebehandlinger`,
+        påvirkerSystemLaster: true,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/api/hentTilbakekrevingsbehandlinger.ts
+++ b/src/frontend/api/hentTilbakekrevingsbehandlinger.ts
@@ -1,0 +1,16 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { ITilbakekrevingsbehandling } from '../typer/tilbakekrevingsbehandling';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function hentTilbakekrevingsbehandlinger(
+    request: FamilieRequest,
+    fagsakId: number
+): Promise<ITilbakekrevingsbehandling[]> {
+    const ressurs = await request<void, ITilbakekrevingsbehandling[]>({
+        method: 'GET',
+        url: `/familie-ba-sak/api/tilbakekreving/fagsak/${fagsakId}`,
+        påvirkerSystemLaster: true,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useHentBarnetrygdbehandlinger.ts
+++ b/src/frontend/hooks/useHentBarnetrygdbehandlinger.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { hentBarnetrygdbehandlinger } from '../api/hentBarnetrygdbehandlinger';
+
+export function useHentBarnetrygdbehandlinger(fagsakId: number) {
+    const { request } = useHttp();
+    return useQuery({
+        queryKey: ['barnetrygdbehandlinger', fagsakId],
+        queryFn: () => hentBarnetrygdbehandlinger(request, fagsakId),
+    });
+}

--- a/src/frontend/hooks/useHentKlagebehandlinger.ts
+++ b/src/frontend/hooks/useHentKlagebehandlinger.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { hentKlagebehandlinger } from '../api/hentKlagebehandlinger';
+
+export function useHentKlagebehandlinger(fagsakId: number) {
+    const { request } = useHttp();
+    return useQuery({
+        queryKey: ['klagebehandlinger', fagsakId],
+        queryFn: () => hentKlagebehandlinger(request, fagsakId),
+    });
+}

--- a/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
+++ b/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { hentTilbakekrevingsbehandlinger } from '../api/hentTilbakekrevingsbehandlinger';
+
+export function useHentTilbakekrevingsbehandlinger(fagsakId: number) {
+    const { request } = useHttp();
+    return useQuery({
+        queryKey: ['tilbakekrevingsbehandlinger', fagsakId],
+        queryFn: () => hentTilbakekrevingsbehandlinger(request, fagsakId),
+    });
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandling.tsx
@@ -12,17 +12,16 @@ import {
     lagLenkePåType,
 } from './utils';
 import { behandlingsstatuser } from '../../../typer/behandling';
-import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 
 interface IBehandlingshistorikkProps {
-    minimalFagsak: IMinimalFagsak;
+    fagsakId: number;
     saksoversiktsbehandling: Saksoversiktsbehandling;
 }
 
 export const Behandling: React.FC<IBehandlingshistorikkProps> = ({
+    fagsakId,
     saksoversiktsbehandling,
-    minimalFagsak,
 }) => (
     <Table.Row key={hentBehandlingId(saksoversiktsbehandling)}>
         <Table.DataCell
@@ -32,7 +31,7 @@ export const Behandling: React.FC<IBehandlingshistorikkProps> = ({
             })}`}
         />
         <Table.DataCell>{finnÅrsak(saksoversiktsbehandling)}</Table.DataCell>
-        <Table.DataCell>{lagLenkePåType(minimalFagsak.id, saksoversiktsbehandling)}</Table.DataCell>
+        <Table.DataCell>{lagLenkePåType(fagsakId, saksoversiktsbehandling)}</Table.DataCell>
         <Table.DataCell>{hentBehandlingstema(saksoversiktsbehandling)?.navn ?? '-'}</Table.DataCell>
         <Table.DataCell>{behandlingsstatuser[saksoversiktsbehandling.status]}</Table.DataCell>
         <Table.DataCell
@@ -42,8 +41,6 @@ export const Behandling: React.FC<IBehandlingshistorikkProps> = ({
                 defaultString: '-',
             })}
         />
-        <Table.DataCell>
-            {lagLenkePåResultat(minimalFagsak, saksoversiktsbehandling)}
-        </Table.DataCell>
+        <Table.DataCell>{lagLenkePåResultat(fagsakId, saksoversiktsbehandling)}</Table.DataCell>
     </Table.Row>
 );

--- a/src/frontend/sider/Fagsak/Saksoversikt/BehandlingerOld.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/BehandlingerOld.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from 'react';
+
+import { differenceInMilliseconds } from 'date-fns';
+import styled from 'styled-components';
+
+import {
+    Alert,
+    BodyShort,
+    Fieldset,
+    Heading,
+    HStack,
+    Spacer,
+    Switch,
+    Table,
+    VStack,
+} from '@navikt/ds-react';
+
+import { Behandling } from './Behandling';
+import type { Saksoversiktsbehandling } from './utils';
+import {
+    hentBehandlingerTilSaksoversikten,
+    hentBehandlingId,
+    hentTidspunktforSortering,
+    skalVisesNårHenlagtBehandlingerSkjules,
+    skalVisesNårMånedligeValutajusteringerSkjules,
+} from './utils';
+import type { IMinimalFagsak } from '../../../typer/fagsak';
+import { isoStringTilDate } from '../../../utils/dato';
+import { ressursHarFeilet } from '../../../utils/ressursUtils';
+import { useFagsakContext } from '../FagsakContext';
+
+const StyledSwitch = styled(Switch)`
+    margin-right: 0.275rem;
+`;
+
+const StyledFieldSet = styled(Fieldset)`
+    display: flex;
+    flex-direction: column;
+`;
+
+const StyledDiv = styled.div`
+    margin-top: auto;
+`;
+
+const StyledOpprettetKolonne = styled(Table.HeaderCell)`
+    width: 10%;
+`;
+
+const StyledResultatKolonne = styled(Table.HeaderCell)`
+    width: 22%;
+`;
+
+interface IBehandlingshistorikkProps {
+    minimalFagsak: IMinimalFagsak;
+}
+
+const Behandlinger: React.FC<IBehandlingshistorikkProps> = ({ minimalFagsak }) => {
+    const { klagebehandlinger, klageStatus, tilbakekrevingsbehandlinger, tilbakekrevingStatus } =
+        useFagsakContext();
+
+    const behandlinger = hentBehandlingerTilSaksoversikten(
+        minimalFagsak.behandlinger,
+        klagebehandlinger,
+        tilbakekrevingsbehandlinger
+    );
+
+    const finnesHenlagteBehandlingerSomKanFiltreresBort = behandlinger.some(
+        (behandling: Saksoversiktsbehandling) =>
+            !skalVisesNårHenlagtBehandlingerSkjules(behandling, false)
+    );
+
+    const finnesMånedligValutajusteringerSomKanFiltreresBort = behandlinger.some(
+        (behandling: Saksoversiktsbehandling) =>
+            !skalVisesNårMånedligeValutajusteringerSkjules(behandling, false)
+    );
+
+    const [visHenlagteBehandlinger, setVisHenlagteBehandlinger] = useState(false);
+    const [visMånedligeValutajusteringer, setVisMånedligeValutajusteringer] = useState(false);
+
+    return (
+        <VStack gap="6">
+            {ressursHarFeilet(klageStatus) && (
+                <Alert variant="warning">
+                    <BodyShort>Klagebehandlinger er ikke tilgjengelig for øyeblikket.</BodyShort>
+                </Alert>
+            )}
+            {ressursHarFeilet(tilbakekrevingStatus) && (
+                <Alert variant="warning">
+                    <BodyShort>Tilbakekreving er ikke tilgjengelig for øyeblikket.</BodyShort>
+                </Alert>
+            )}
+            <div>
+                <HStack gap="3" wrap={false}>
+                    <Heading level="2" size={'medium'} spacing>
+                        Behandlinger
+                    </Heading>
+                    <Spacer />
+                    <StyledDiv>
+                        <StyledFieldSet legend="Filtreringer på behandlinger" hideLegend>
+                            {finnesHenlagteBehandlingerSomKanFiltreresBort && (
+                                <StyledSwitch
+                                    size="small"
+                                    position="left"
+                                    id={'vis-henlagte-behandlinger'}
+                                    checked={visHenlagteBehandlinger}
+                                    onChange={() => {
+                                        setVisHenlagteBehandlinger(!visHenlagteBehandlinger);
+                                    }}
+                                >
+                                    Vis henlagte behandlinger
+                                </StyledSwitch>
+                            )}
+                            {finnesMånedligValutajusteringerSomKanFiltreresBort && (
+                                <StyledSwitch
+                                    size="small"
+                                    position="left"
+                                    id={'vis-månedlig-valutajustering-behandlinger'}
+                                    checked={visMånedligeValutajusteringer}
+                                    onChange={() => {
+                                        setVisMånedligeValutajusteringer(
+                                            !visMånedligeValutajusteringer
+                                        );
+                                    }}
+                                >
+                                    Vis månedlige valutajusteringer
+                                </StyledSwitch>
+                            )}
+                        </StyledFieldSet>
+                    </StyledDiv>
+                </HStack>
+                {behandlinger.length > 0 ? (
+                    <Table size={'large'}>
+                        <Table.Header>
+                            <Table.Row>
+                                <StyledOpprettetKolonne scope="col">
+                                    Opprettet
+                                </StyledOpprettetKolonne>
+                                <Table.HeaderCell scope="col">Årsak</Table.HeaderCell>
+                                <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+                                <Table.HeaderCell scope="col">Behandlingstema</Table.HeaderCell>
+                                <Table.HeaderCell scope="col">Status</Table.HeaderCell>
+                                <Table.HeaderCell scope="col">Vedtaksdato</Table.HeaderCell>
+                                <StyledResultatKolonne scope="col">Resultat</StyledResultatKolonne>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {behandlinger
+                                .filter(
+                                    behandling =>
+                                        skalVisesNårHenlagtBehandlingerSkjules(
+                                            behandling,
+                                            visHenlagteBehandlinger
+                                        ) &&
+                                        skalVisesNårMånedligeValutajusteringerSkjules(
+                                            behandling,
+                                            visMånedligeValutajusteringer
+                                        )
+                                )
+                                .sort((a, b) =>
+                                    differenceInMilliseconds(
+                                        isoStringTilDate(hentTidspunktforSortering(b)),
+                                        isoStringTilDate(hentTidspunktforSortering(a))
+                                    )
+                                )
+                                .map((behandling: Saksoversiktsbehandling) => (
+                                    <Behandling
+                                        key={hentBehandlingId(behandling)}
+                                        saksoversiktsbehandling={behandling}
+                                        fagsakId={minimalFagsak.id}
+                                    />
+                                ))}
+                        </Table.Body>
+                    </Table>
+                ) : (
+                    <BodyShort children={'Ingen tidligere behandlinger'} />
+                )}
+            </div>
+        </VStack>
+    );
+};
+
+export default Behandlinger;

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -7,7 +7,8 @@ import { HouseIcon, MagnifyingGlassIcon } from '@navikt/aksel-icons';
 import { Alert, Heading, Link, Tabs, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import Behandlinger from './Behandlinger';
+import { Behandlinger } from './Behandlinger';
+import BehandlingerOld from './BehandlingerOld';
 import FagsakLenkepanel, { SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import { GjennomførValutajusteringKnapp } from './GjennomførValutajusteringKnapp';
 import Utbetalinger from './Utbetalinger';
@@ -193,7 +194,11 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
                                 {løpendeMånedligUtbetaling()}
                             </>
                         )}
-                        <Behandlinger minimalFagsak={minimalFagsak} />
+                        {toggles[ToggleNavn.brukReactQueryPaaSaksoversiktsiden] ? (
+                            <Behandlinger fagsakId={minimalFagsak.id} />
+                        ) : (
+                            <BehandlingerOld minimalFagsak={minimalFagsak} />
+                        )}
                     </VStack>
                 </SaksoversiktWrapper>{' '}
             </Tabs.Panel>

--- a/src/frontend/sider/Fagsak/Saksoversikt/VisHenlagtBehandlingerSwitch.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/VisHenlagtBehandlingerSwitch.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { Switch } from '@navikt/ds-react';
+
+import { type Saksoversiktsbehandling, skalVisesNårHenlagtBehandlingerSkjules } from './utils';
+
+type Props = {
+    saksoversiktbehandlinger: Saksoversiktsbehandling[];
+    visHenlagteBehandlinger: boolean;
+    setVisHenlagteBehandlinger: (visHenlagteBehandlinger: boolean) => void;
+};
+
+export function VisHenlagtBehandlingerSwitch({
+    saksoversiktbehandlinger,
+    visHenlagteBehandlinger,
+    setVisHenlagteBehandlinger,
+}: Props) {
+    const finnesHenlagteBehandlingerSomKanFiltreresBort = saksoversiktbehandlinger.some(
+        (behandling: Saksoversiktsbehandling) =>
+            !skalVisesNårHenlagtBehandlingerSkjules(behandling, false)
+    );
+
+    if (!finnesHenlagteBehandlingerSomKanFiltreresBort) {
+        return null;
+    }
+
+    return (
+        <Switch
+            size={'small'}
+            position={'left'}
+            id={'vis-henlagte-behandlinger'}
+            checked={visHenlagteBehandlinger}
+            onChange={() => setVisHenlagteBehandlinger(!visHenlagteBehandlinger)}
+        >
+            Vis henlagte behandlinger
+        </Switch>
+    );
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/VisMånedligValutajuseringBehandlingerSwitch.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/VisMånedligValutajuseringBehandlingerSwitch.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { Switch } from '@navikt/ds-react';
+
+import {
+    type Saksoversiktsbehandling,
+    skalVisesNårMånedligeValutajusteringerSkjules,
+} from './utils';
+
+type Props = {
+    saksoversiktbehandlinger: Saksoversiktsbehandling[];
+    visMånedligeValutajusteringer: boolean;
+    setVisMånedligeValutajusteringer: (visHenlagteBehandlinger: boolean) => void;
+};
+
+export function VisMånedligValutajuseringBehandlingerSwitch({
+    saksoversiktbehandlinger,
+    visMånedligeValutajusteringer,
+    setVisMånedligeValutajusteringer,
+}: Props) {
+    const finnesMånedligValutajusteringerSomKanFiltreresBort = saksoversiktbehandlinger.some(
+        (behandling: Saksoversiktsbehandling) =>
+            !skalVisesNårMånedligeValutajusteringerSkjules(behandling, false)
+    );
+
+    if (!finnesMånedligValutajusteringerSomKanFiltreresBort) {
+        return null;
+    }
+
+    return (
+        <Switch
+            size={'small'}
+            position={'left'}
+            id={'vis-månedlig-valutajustering-behandlinger'}
+            checked={visMånedligeValutajusteringer}
+            onChange={() => setVisMånedligeValutajusteringer(!visMånedligeValutajusteringer)}
+        >
+            Vis månedlige valutajusteringer
+        </Switch>
+    );
+}

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -17,6 +17,7 @@ export enum ToggleNavn {
     kanOppretteRevurderingMedAarsakIverksetteKaVedtak = 'familie-ba-sak.kan-opprette-revurdering-med-aarsak-iverksette-ka-vedtak',
     brukFunksjonalitetForUlovfestetMotregning = 'familie-ba-sak.ulovfestet-motregning',
     innhenteOpplysningerKlageBrev = 'familie-ba-sak.innhente-opplysninger-klage-brev',
+    brukReactQueryPaaSaksoversiktsiden = 'familie-ba-sak.bruk-react-query-paa-saksoversiktsiden',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/utils/ressursResolver.ts
+++ b/src/frontend/utils/ressursResolver.ts
@@ -1,0 +1,18 @@
+import type { Ressurs } from '@navikt/familie-typer';
+import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
+
+function resolveToPromise<T>(ressurs: Ressurs<T>): Promise<T> {
+    switch (ressurs.status) {
+        case RessursStatus.IKKE_HENTET:
+        case RessursStatus.HENTER:
+            return Promise.reject(`Uforventet response status: ${ressurs.status}`);
+        case RessursStatus.SUKSESS:
+            return Promise.resolve(ressurs.data);
+        case RessursStatus.IKKE_TILGANG:
+        case RessursStatus.FEILET:
+        case RessursStatus.FUNKSJONELL_FEIL:
+            return Promise.reject(ressurs.frontendFeilmelding);
+    }
+}
+
+export const RessursResolver = { resolveToPromise };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,6 +2344,18 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
+"@tanstack/query-core@5.72.0":
+  version "5.72.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.72.0.tgz#a3f35ff0ca290b2626e9b008d4a3f652ff022b7d"
+  integrity sha512-aa3p6Mou++JLLxxxVX9AB9uGeRIGc0JWkw96GASXuMG8K3D+JpYbSFcqXbkGFJ1eX2jKHPurmCBoO43RjjXJCA==
+
+"@tanstack/react-query@^5.72.0":
+  version "5.72.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.72.0.tgz#5174ddd887a127ca85f0c1604dbd2f04d18ec6af"
+  integrity sha512-4Dejq/IiXrPlr/0xxj4H2GbC6KckwfTCoHWbd02+UoIV0laC9yke0d0KegmFdXJA712I6UCuy8WpPM76uuPJ+w==
+  dependencies:
+    "@tanstack/query-core" "5.72.0"
+
 "@testing-library/dom@^10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.0.0.tgz#ae1ab88aad35a728a38264041163174cafd7e8dd"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24909](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24909)

Tar i bruk react-query for å håndtere server-state for barnetrygdbehandlinger, klagebehandlinger, og tilbakekrevingsbehandlinger.

Viser `<Skeleton />` komponent under første innlasting av data.

Rydder opp i `Behandling.tsx` komponenten. Fjerner blant annet flere `styled-components` komponenter. 

Når man bytter browser-tabs vil "Systemet laster" spinner-komponenten vises. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Er ikke skrevet tester fra før, krever en del innsats å få til så tenker det er bedre å ta det i en egen PR.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før:
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/26e0faac-4cbe-418b-843a-304dcbc5d0fc" />

Etter:

Data lastet inn:
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/8a5ced9b-1457-48bb-98a6-caf51a032bc4" />

Data laster inn første gang:
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/d44a2e79-4b98-45f7-b4c0-d3717874c2c6" />