### PR TITLE
Ulovfestet motregning - Endre varsel om det er en åpen t-sak

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -134,7 +134,11 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
 
                         {forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&
                             forenkletTilbakekrevingsvedtak.data === null &&
-                            erAvregningOgToggleErPå && <AvregningAlert />}
+                            erAvregningOgToggleErPå && (
+                                <AvregningAlert
+                                    harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
+                                />
+                            )}
 
                         {!erLesevisning &&
                             forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { Alert, BodyLong, Button, Link, List } from '@navikt/ds-react';
+import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { SettBehandlingPåVentModalMotregning } from './SettBehandlingPåVentModalMotregning';
 import { erProd } from '../../../../../../utils/miljø';
@@ -18,7 +19,11 @@ const StyledLink = styled(Link)`
     margin-top: 1rem;
 `;
 
-const AvregningAlert = () => {
+interface AvregningAlertProps {
+    harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
+}
+
+const AvregningAlert = ({ harÅpenTilbakekrevingRessurs }: AvregningAlertProps) => {
     const [visModal, settVisModal] = useState(false);
     const { behandling, vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
@@ -36,8 +41,10 @@ const AvregningAlert = () => {
             <BodyLong>Du må derfor velge 1 eller 2:</BodyLong>
             <List as={'ol'}>
                 <List.Item>
-                    Først gjøre vedtak om etterbetalingen, og deretter gjøre nytt vedtak om
-                    feilutbetalingen og opprette t-sak («splitte saken»).
+                    {harÅpenTilbakekrevingRessurs.status == RessursStatus.SUKSESS &&
+                    harÅpenTilbakekrevingRessurs.data
+                        ? 'Ferdigstille t-saken, og deretter gjøre nytt vedtak om etterbetaling'
+                        : 'Først gjøre vedtak om etterbetalingen, og deretter gjøre nytt vedtak om feilutbetalingen og opprette t-sak («splitte saken»).'}
                 </List.Item>
                 <List.Item>
                     Be bruker om samtykke til å holde på etterbetalingen mens Nav vurderer t-sak


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24693)

I saker der det både er en etterbetaling og en feilutbetaling, og det allerede er opprettet en t-sak som er under behandling, kan man ikke velge løsning 1 ("splitte saken" - etterbetaling først, så t-sak). Man må velge løsning 2 ("ulovfestet motregning), eller gjøre ferdig t-saken først, og så gjøre ferdig revurdering som gir etterbetaling. Endrer teksten i varselet i løsning 1 til _Ferdigstille t-saken, og deretter gjøre nytt vedtak om etterbetaling_ i caser hvor det er en åpen t-sak. 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Trenger funksjonell test med en åpen tilbakekrevingssak

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Liten endring, alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
