### PR TITLE
Knapp for å kopiere tekst til Modia

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -151,6 +151,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                 {forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&
                                     forenkletTilbakekrevingsvedtak.data === null && (
                                         <AvregningAlert
+                                            avregningsperioder={avregningsperioder}
                                             harÅpenTilbakekrevingRessurs={
                                                 harÅpenTilbakekrevingRessurs
                                             }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -142,7 +142,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                 {erBehandlingSattPåVentMedÅrsakAvventerSamtykke && (
                                     <Alert variant="info">
                                         Saken venter på samtykke fra bruker for ulovfestet
-                                        motregning. Hvis bruker har gitt samtykke før det har gått
+                                        motregning. Hvis bruker har gitt samtykke før det har gått{' '}
                                         {dagerFristForAvventerSamtykkeUlovfestetMotregning} dager,
                                         kan saken tas av vent manuelt.
                                     </Alert>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -21,7 +21,10 @@ import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
 import AvregningAlert from './UlovfestetMotregning/AvregningAlert';
 import { ForenkletTilbakekrevingsvedtak } from './UlovfestetMotregning/ForenkletTilbakekrevingsvedtak';
-import { useForenkletTilbakekrevingsvedtak } from './UlovfestetMotregning/useForenkletTilbakekrevingsvedtak';
+import {
+    dagerFristForAvventerSamtykkeUlovfestetMotregning,
+    useForenkletTilbakekrevingsvedtak,
+} from './UlovfestetMotregning/useForenkletTilbakekrevingsvedtak';
 
 interface ISimuleringProps {
     åpenBehandling: IBehandling;
@@ -42,7 +45,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         tilbakekrevingSkjema,
         harÅpenTilbakekrevingRessurs,
         erFeilutbetaling,
-        erAvregning,
+        avregningsperioder,
         behandlingErMigreringMedAvvikInnenforBeløpsgrenser,
         behandlingErMigreringMedAvvikUtenforBeløpsgrenser,
         behandlingErMigreringMedManuellePosteringer,
@@ -61,11 +64,11 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
     } = useForenkletTilbakekrevingsvedtak(åpenBehandling);
 
     const erAvregningOgToggleErPå =
-        erAvregning && toggles[ToggleNavn.brukFunksjonalitetForUlovfestetMotregning];
+        avregningsperioder.length > 0 &&
+        toggles[ToggleNavn.brukFunksjonalitetForUlovfestetMotregning];
     const erBehandlingSattPåVentMedÅrsakAvventerSamtykke =
         åpenBehandling.aktivSettPåVent?.årsak ===
         SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING;
-    const dagerFristForAvventerSamtykkeUlovfestetMotregning = 14;
 
     const nesteOnClick = () => {
         if (erLesevisning) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { isAfter, isBefore } from 'date-fns';
 
-import { useHttp, type FamilieRequestConfig } from '@navikt/familie-http';
+import { type FamilieRequestConfig, useHttp } from '@navikt/familie-http';
 import type { Avhengigheter, FeiloppsummeringFeil, ISkjema } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
@@ -13,6 +13,7 @@ import type { IBehandling } from '../../../../../typer/behandling';
 import { Behandlingstype, BehandlingÅrsak } from '../../../../../typer/behandling';
 import { PersonType } from '../../../../../typer/person';
 import type {
+    IAvregningsperiode,
     ISimuleringDTO,
     ISimuleringPeriode,
     ITilbakekreving,
@@ -44,7 +45,7 @@ interface SimuleringContextValue {
     ) => void;
     hentFeilTilOppsummering: () => FeiloppsummeringFeil[];
     erFeilutbetaling: boolean | undefined;
-    erAvregning: boolean | undefined;
+    avregningsperioder: IAvregningsperiode[];
     hentSkjemadata: () => ITilbakekreving | undefined;
     maksLengdeTekst: number;
     harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
@@ -128,7 +129,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
         0
     );
 
-    const erAvregning = simResultat && simResultat.avregningsperioder.length > 0;
+    const avregningsperioder = simResultat?.avregningsperioder ?? [];
     const erFeilutbetaling = simResultat && simResultat.feilutbetaling > 0;
     const erEtterutbetaling = totalEtterbetalingFørMars2023 > 0;
 
@@ -292,7 +293,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
                 onSubmit,
                 hentFeilTilOppsummering,
                 erFeilutbetaling,
-                erAvregning,
+                avregningsperioder,
                 hentSkjemadata,
                 maksLengdeTekst,
                 harÅpenTilbakekrevingRessurs,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
@@ -3,10 +3,12 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, BodyLong, Button, Link, List } from '@navikt/ds-react';
+import { Alert, BodyLong, Button, CopyButton, Link, List } from '@navikt/ds-react';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { SettBehandlingPåVentModalMotregning } from './SettBehandlingPåVentModalMotregning';
+import { utledTekstTilModia } from './utils';
+import type { IAvregningsperiode } from '../../../../../../typer/simulering';
 import { erProd } from '../../../../../../utils/miljø';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
@@ -20,10 +22,14 @@ const StyledLink = styled(Link)`
 `;
 
 interface AvregningAlertProps {
+    avregningsperioder: IAvregningsperiode[];
     harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
 }
 
-const AvregningAlert = ({ harÅpenTilbakekrevingRessurs }: AvregningAlertProps) => {
+const AvregningAlert = ({
+    avregningsperioder,
+    harÅpenTilbakekrevingRessurs,
+}: AvregningAlertProps) => {
     const [visModal, settVisModal] = useState(false);
     const { behandling, vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
@@ -31,6 +37,8 @@ const AvregningAlert = ({ harÅpenTilbakekrevingRessurs }: AvregningAlertProps) 
     const modiaPersonoversiktUrl = erProd()
         ? 'https://modiapersonoversikt.intern.nav.no'
         : 'https://modiapersonoversikt.intern.dev.nav.no';
+
+    const tekstTilModia = utledTekstTilModia(avregningsperioder);
 
     return (
         <StyledAlert variant="warning">
@@ -50,6 +58,11 @@ const AvregningAlert = ({ harÅpenTilbakekrevingRessurs }: AvregningAlertProps) 
                     Be bruker om samtykke til å holde på etterbetalingen mens Nav vurderer t-sak
                     («ulovfestet motregning»). Hvis det ikke er åpenbart at hele beløpet skal kreves
                     tilbake, må du splitte saken.
+                    <CopyButton
+                        copyText={tekstTilModia}
+                        text="Kopier standardtekst til Modia"
+                        activeText="Kopiert!"
+                    />
                 </List.Item>
             </List>
             {!erLesevisning && (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import styled from 'styled-components';
 
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { Alert, BodyLong, Button, CopyButton, Link, List } from '@navikt/ds-react';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
@@ -38,8 +39,6 @@ const AvregningAlert = ({
         ? 'https://modiapersonoversikt.intern.nav.no'
         : 'https://modiapersonoversikt.intern.dev.nav.no';
 
-    const tekstTilModia = utledTekstTilModia(avregningsperioder);
-
     return (
         <StyledAlert variant="warning">
             <BodyLong spacing>
@@ -59,7 +58,7 @@ const AvregningAlert = ({
                     («ulovfestet motregning»). Hvis det ikke er åpenbart at hele beløpet skal kreves
                     tilbake, må du splitte saken.
                     <CopyButton
-                        copyText={tekstTilModia}
+                        copyText={utledTekstTilModia(avregningsperioder)}
                         text="Kopier standardtekst til Modia"
                         activeText="Kopiert!"
                     />
@@ -71,7 +70,12 @@ const AvregningAlert = ({
                     target={'_blank'}
                     style={{ textDecoration: 'none' }}
                 >
-                    <Button variant={'secondary-neutral'} onClick={() => settVisModal(true)}>
+                    <Button
+                        variant={'secondary-neutral'}
+                        onClick={() => settVisModal(true)}
+                        icon={<ExternalLinkIcon />}
+                        iconPosition="right"
+                    >
                         Be om samtykke fra bruker
                     </Button>
                 </StyledLink>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
@@ -20,6 +20,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { dagerFristForAvventerSamtykkeUlovfestetMotregning } from './useForenkletTilbakekrevingsvedtak';
 import {
     type IBehandling,
     type ISettPåVent,
@@ -41,8 +42,6 @@ interface IProps {
     lukkModal: () => void;
     behandling: IBehandling;
 }
-
-const dagerFristForAvventerSamtykkeUlovfestetMotregning = 14;
 
 export const SettBehandlingPåVentModalMotregning: React.FC<IProps> = ({
     lukkModal,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useForenkletTilbakekrevingsvedtak.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useForenkletTilbakekrevingsvedtak.ts
@@ -19,6 +19,8 @@ import type {
 } from './ForenkletTilbakekrevingsvedtakDTO';
 import type { IBehandling } from '../../../../../../typer/behandling';
 
+export const dagerFristForAvventerSamtykkeUlovfestetMotregning = 14;
+
 export const useForenkletTilbakekrevingsvedtak = (åpenBehandling: IBehandling) => {
     const { request } = useHttp();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/utils.ts
@@ -17,7 +17,8 @@ export const utledTekstTilModia = (avregningsperioder: IAvregningsperiode[]) => 
             tilFormat: Datoformat.MÅNED_ÅR_NAVN,
         });
 
-        const periode = fom === tom ? fom : `perioden fra ${fom} til ${tom}`;
+        const erFomOgTomLike = fom === tom;
+        const periode = erFomOgTomLike ? fom : `perioden fra ${fom} til ${tom}`;
 
         const etterbetaling = formaterBeløpUtenValutakode(avregningsperiode.totalEtterbetaling);
         const feilutbetaling = formaterBeløpUtenValutakode(avregningsperiode.totalFeilutbetaling);
@@ -41,10 +42,12 @@ export const utledTekstTilModia = (avregningsperioder: IAvregningsperiode[]) => 
                     tilFormat: Datoformat.MÅNED_ÅR_NAVN,
                 });
 
-                const periode = fom === tom ? fom : `${fom} til ${tom}`;
+                const erFomOgTomLike = fom === tom;
+                const periode = erFomOgTomLike ? fom : `${fom} til ${tom}`;
                 const beløp = formaterBeløpUtenValutakode(avregningsperiode[felt]);
 
-                return `\u2022 ${periode} på ${beløp} kroner`;
+                const kulepunkt = `\u2022`;
+                return `${kulepunkt} ${periode} på ${beløp} kroner`;
             });
 
         const etterbetalingsperioderFormatert = formaterPerioder('totalEtterbetaling');

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/utils.ts
@@ -1,0 +1,62 @@
+import type { IAvregningsperiode } from '../../../../../../typer/simulering';
+import { Datoformat, isoStringTilFormatertString } from '../../../../../../utils/dato';
+import { formaterBeløpUtenValutakode } from '../simuleringUtil';
+import { dagerFristForAvventerSamtykkeUlovfestetMotregning } from './useForenkletTilbakekrevingsvedtak';
+
+export const utledTekstTilModia = (avregningsperioder: IAvregningsperiode[]) => {
+    if (avregningsperioder.length === 1) {
+        const avregningsperiode = avregningsperioder[0];
+
+        const fom = isoStringTilFormatertString({
+            isoString: avregningsperiode.fom,
+            tilFormat: Datoformat.MÅNED_ÅR_NAVN,
+        });
+
+        const tom = isoStringTilFormatertString({
+            isoString: avregningsperiode.tom,
+            tilFormat: Datoformat.MÅNED_ÅR_NAVN,
+        });
+
+        const periode = fom === tom ? fom : `perioden fra ${fom} til ${tom}`;
+
+        const etterbetaling = formaterBeløpUtenValutakode(avregningsperiode.totalEtterbetaling);
+        const feilutbetaling = formaterBeløpUtenValutakode(avregningsperiode.totalFeilutbetaling);
+
+        return (
+            `Du har rett til etterbetaling av barnetrygd for ${periode} på ${etterbetaling} kroner.\n\n` +
+            `Samtidig ser vi at du kan ha fått en feilutbetaling på ${feilutbetaling} kroner for mye barnetrygd i ${periode}. Grunnen til dette er FRITEKST.\n\n` +
+            `Er det greit at vi venter med etterbetalingen til vi har vurdert om du må betale tilbake? Hvis du gjør det, kan vi trekke feilutbetalt beløp fra etterbetalingen din.\n\n` +
+            `Svar på om du samtykker ved å logge deg inn på MinSide. I svaret kan du samtidig uttale deg om feilutbetalingen. Dette må du gjøre innen ${dagerFristForAvventerSamtykkeUlovfestetMotregning} dager.`
+        );
+    } else {
+        const formaterPerioder = (felt: 'totalEtterbetaling' | 'totalFeilutbetaling') =>
+            avregningsperioder.map(avregningsperiode => {
+                const fom = isoStringTilFormatertString({
+                    isoString: avregningsperiode.fom,
+                    tilFormat: Datoformat.MÅNED_ÅR_NAVN,
+                });
+
+                const tom = isoStringTilFormatertString({
+                    isoString: avregningsperiode.tom,
+                    tilFormat: Datoformat.MÅNED_ÅR_NAVN,
+                });
+
+                const periode = fom === tom ? fom : `${fom} til ${tom}`;
+                const beløp = formaterBeløpUtenValutakode(avregningsperiode[felt]);
+
+                return `\u2022 ${periode} på ${beløp} kroner`;
+            });
+
+        const etterbetalingsperioderFormatert = formaterPerioder('totalEtterbetaling');
+        const feilutbetalingsperioderFormatert = formaterPerioder('totalFeilutbetaling');
+
+        return (
+            `Du har rett til etterbetaling av barnetrygd for periodene:\n` +
+            etterbetalingsperioderFormatert.join('\n') +
+            `\n\nSamtidig ser vi at du kan ha fått feilutbetalinger i periodene:\n` +
+            feilutbetalingsperioderFormatert.join('\n') +
+            `\n\nEr det greit at vi venter med etterbetalingen til vi har vurdert om du må betale tilbake? Hvis du gjør det, kan vi trekke feilutbetalt beløp fra etterbetalingen din.\n\n` +
+            `Svar på om du samtykker ved å logge deg inn på MinSide. I svaret kan du samtidig uttale deg om feilutbetalingen. Dette må du gjøre innen ${dagerFristForAvventerSamtykkeUlovfestetMotregning} dager.`
+        );
+    }
+};


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-24696

Dersom en behadling inneholder perioder som blir avregnet, skal saksbehandler kunne kopiere en standardtekst som skal sendes til bruker i Modia. I denne teksten skal periodene flettes inn med fom- og tom-dato med etterbetaling og feilutbetaling.

Det er tre forskjellige caser:
- Én periode med avregning som strekker seg over én måned
- Én periode med avregning som strekker seg over flere måneder
- Flere perioder med avregning som strekker seg over en eller flere måneder

Beskrivelsen av perioden(e) for de tre tilfellene er:

```
Du har rett til etterbetaling av barnetrygd for januar 2025 på 1 766 kroner.

Samtidig ser vi at du kan ha fått en feilutbetaling på 1 766 kroner for mye barnetrygd i januar 2025. Grunnen til dette er FRITEKST.
```

```
Du har rett til etterbetaling av barnetrygd for perioden fra desember 2024 til januar 2025 på 3 532 kroner.

Samtidig ser vi at du kan ha fått en feilutbetaling på 3 532 kroner for mye barnetrygd i perioden fra desember 2024 til januar 2025. Grunnen til dette er FRITEKST.
```

```
Du har rett til etterbetaling av barnetrygd for periodene:
• oktober 2024 til november 2024 på 7 064 kroner
• januar 2025 på 1 766 kroner

Samtidig ser vi at du kan ha fått feilutbetalinger i periodene:
• oktober 2024 til november 2024 på 3 532 kroner
• januar 2025 på 1 766 kroner
```

Endrer også frist fra 5 til 14 dager ref [denne](NAV-24918)

### 👀 Screen shots
![b6a2e2b266c490ae1335de3021f1b07a](https://github.com/user-attachments/assets/adb99a3d-a439-4aa8-b94c-be395ab1989e)
