### PR TITLE
Ulovfestetet motregning - Oppdater varsel når saken er satt på vent for samtykke 

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 
-import { Alert } from '@navikt/ds-react';
+import { Alert, Box } from '@navikt/ds-react';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { MigreringAlerts } from './MigreringAlerts';
@@ -11,8 +11,7 @@ import { useSimuleringContext } from './SimuleringContext';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
 import { useAppContext } from '../../../../../context/AppContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { BehandlingSteg } from '../../../../../typer/behandling';
+import { BehandlingSteg, type IBehandling, SettPåVentÅrsak } from '../../../../../typer/behandling';
 import type { ITilbakekreving } from '../../../../../typer/simulering';
 import { ToggleNavn } from '../../../../../typer/toggles';
 import { hentSøkersMålform } from '../../../../../utils/behandling';
@@ -63,6 +62,9 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
 
     const erAvregningOgToggleErPå =
         erAvregning && toggles[ToggleNavn.brukFunksjonalitetForUlovfestetMotregning];
+    const erBehandlingSattPåVentMedÅrsakAvventerSamtykke =
+        åpenBehandling.aktivSettPåVent?.årsak ===
+        SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING;
 
     const nesteOnClick = () => {
         if (erLesevisning) {
@@ -131,34 +133,49 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                 behandlingErMigreringFraInfotrygdMedKun0Utbetalinger
                             }
                         />
+                        {erAvregningOgToggleErPå && (
+                            <Box marginBlock={'8 0'}>
+                                {erBehandlingSattPåVentMedÅrsakAvventerSamtykke && (
+                                    <Alert variant="info">
+                                        Saken venter på samtykke fra bruker for ulovfestet
+                                        motregning. Hvis bruker har gitt samtykke før det har gått
+                                        14 dager, kan saken tas av vent manuelt.
+                                    </Alert>
+                                )}
 
-                        {forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&
-                            forenkletTilbakekrevingsvedtak.data === null &&
-                            erAvregningOgToggleErPå && (
-                                <AvregningAlert
-                                    harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
-                                />
-                            )}
+                                {forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&
+                                    forenkletTilbakekrevingsvedtak.data === null && (
+                                        <AvregningAlert
+                                            harÅpenTilbakekrevingRessurs={
+                                                harÅpenTilbakekrevingRessurs
+                                            }
+                                        />
+                                    )}
 
-                        {!erLesevisning &&
-                            forenkletTilbakekrevingsvedtak.status === RessursStatus.SUKSESS &&
-                            forenkletTilbakekrevingsvedtak.data !== null && (
-                                <ForenkletTilbakekrevingsvedtak
-                                    forenkletTilbakekrevingsvedtak={
-                                        forenkletTilbakekrevingsvedtak.data
-                                    }
-                                    slettForenkletTilbakekrevingsvedtak={
-                                        slettForenkletTilbakekrevingsvedtak
-                                    }
-                                    oppdaterForenkletTilbakekrevingSamtykke={
-                                        oppdaterForenkletTilbakekrevingSamtykke
-                                    }
-                                    heleBeløpetSkalKrevesTilbake={heleBeløpetSkalKrevesTilbake}
-                                    settHeleBeløpetSkalKrevesTilbake={
-                                        settHeleBeløpetSkalKrevesTilbake
-                                    }
-                                />
-                            )}
+                                {!erLesevisning &&
+                                    forenkletTilbakekrevingsvedtak.status ===
+                                        RessursStatus.SUKSESS &&
+                                    forenkletTilbakekrevingsvedtak.data !== null && (
+                                        <ForenkletTilbakekrevingsvedtak
+                                            forenkletTilbakekrevingsvedtak={
+                                                forenkletTilbakekrevingsvedtak.data
+                                            }
+                                            slettForenkletTilbakekrevingsvedtak={
+                                                slettForenkletTilbakekrevingsvedtak
+                                            }
+                                            oppdaterForenkletTilbakekrevingSamtykke={
+                                                oppdaterForenkletTilbakekrevingSamtykke
+                                            }
+                                            heleBeløpetSkalKrevesTilbake={
+                                                heleBeløpetSkalKrevesTilbake
+                                            }
+                                            settHeleBeløpetSkalKrevesTilbake={
+                                                settHeleBeløpetSkalKrevesTilbake
+                                            }
+                                        />
+                                    )}
+                            </Box>
+                        )}
 
                         {erFeilutbetaling &&
                             (!erAvregningOgToggleErPå || heleBeløpetSkalKrevesTilbake) && (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -65,6 +65,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
     const erBehandlingSattPåVentMedÅrsakAvventerSamtykke =
         åpenBehandling.aktivSettPåVent?.årsak ===
         SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING;
+    const dagerFristForAvventerSamtykkeUlovfestetMotregning = 14;
 
     const nesteOnClick = () => {
         if (erLesevisning) {
@@ -139,7 +140,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                     <Alert variant="info">
                                         Saken venter på samtykke fra bruker for ulovfestet
                                         motregning. Hvis bruker har gitt samtykke før det har gått
-                                        14 dager, kan saken tas av vent manuelt.
+                                        {dagerFristForAvventerSamtykkeUlovfestetMotregning} dager,
+                                        kan saken tas av vent manuelt.
                                     </Alert>
                                 )}
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
@@ -42,7 +42,7 @@ interface IProps {
     behandling: IBehandling;
 }
 
-const dagerFristForAvventerSamtykkeUlovfestetMotregning = 5;
+const dagerFristForAvventerSamtykkeUlovfestetMotregning = 14;
 
 export const SettBehandlingPåVentModalMotregning: React.FC<IProps> = ({
     lukkModal,
@@ -104,7 +104,9 @@ export const SettBehandlingPåVentModalMotregning: React.FC<IProps> = ({
                     )}
 
                     <StyledBodyShort>
-                        Behandlingen settes på vent i 5 dager mens vi venter på svar fra bruker.
+                        Behandlingen settes på vent i{' '}
+                        {dagerFristForAvventerSamtykkeUlovfestetMotregning} dager mens vi venter på
+                        svar fra bruker.
                     </StyledBodyShort>
 
                     <Feltmargin>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24716)
 
Når en sak har blitt satt på vent med årsak `AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING` viser vi en blå infoboks  om at saken er satt på vent for å få samtykke av bruker, og kan tas av vent manuelt om bruker har gitt samtykke innen 14 dager.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Liten endring

### 🤷‍♀ ️Hvor er det lurt å starte?
Liten endring, alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<img width="707" alt="Screenshot 2025-04-10 at 14 58 13" src="https://github.com/user-attachments/assets/29a60ca4-0a2f-4eb0-8fbf-47c3488c0cfc" />

