### PR TITLE
NAV-24909: Invaliderer queries slik at de henter inn ny data ved oppretting av behandlinger

### DIFF
--- a/src/frontend/hooks/useHentBarnetrygdbehandlinger.ts
+++ b/src/frontend/hooks/useHentBarnetrygdbehandlinger.ts
@@ -4,10 +4,12 @@ import { useHttp } from '@navikt/familie-http';
 
 import { hentBarnetrygdbehandlinger } from '../api/hentBarnetrygdbehandlinger';
 
+export const BARNETRYGDBEHANDLINGER_QUERY_KEY_PREFIX = 'barnetrygdbehandlinger';
+
 export function useHentBarnetrygdbehandlinger(fagsakId: number) {
     const { request } = useHttp();
     return useQuery({
-        queryKey: ['barnetrygdbehandlinger', fagsakId],
+        queryKey: [BARNETRYGDBEHANDLINGER_QUERY_KEY_PREFIX, fagsakId],
         queryFn: () => hentBarnetrygdbehandlinger(request, fagsakId),
     });
 }

--- a/src/frontend/hooks/useHentKlagebehandlinger.ts
+++ b/src/frontend/hooks/useHentKlagebehandlinger.ts
@@ -4,10 +4,12 @@ import { useHttp } from '@navikt/familie-http';
 
 import { hentKlagebehandlinger } from '../api/hentKlagebehandlinger';
 
+export const KLAGEBEHANDLINGER_QUERY_KEY_PREFIX = 'klagebehandlinger';
+
 export function useHentKlagebehandlinger(fagsakId: number) {
     const { request } = useHttp();
     return useQuery({
-        queryKey: ['klagebehandlinger', fagsakId],
+        queryKey: [KLAGEBEHANDLINGER_QUERY_KEY_PREFIX, fagsakId],
         queryFn: () => hentKlagebehandlinger(request, fagsakId),
     });
 }

--- a/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
+++ b/src/frontend/hooks/useHentTilbakekrevingsbehandlinger.ts
@@ -4,10 +4,12 @@ import { useHttp } from '@navikt/familie-http';
 
 import { hentTilbakekrevingsbehandlinger } from '../api/hentTilbakekrevingsbehandlinger';
 
+export const TILBAKEKREVINGSBEHANDLINGER_QUERY_KEY_PREFIX = 'tilbakekrevingsbehandlinger';
+
 export function useHentTilbakekrevingsbehandlinger(fagsakId: number) {
     const { request } = useHttp();
     return useQuery({
-        queryKey: ['tilbakekrevingsbehandlinger', fagsakId],
+        queryKey: [TILBAKEKREVINGSBEHANDLINGER_QUERY_KEY_PREFIX, fagsakId],
         queryFn: () => hentTilbakekrevingsbehandlinger(request, fagsakId),
     });
 }

--- a/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/useOpprettBehandling.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
@@ -7,6 +8,9 @@ import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useAppContext } from '../../../../../context/AppContext';
+import { BARNETRYGDBEHANDLINGER_QUERY_KEY_PREFIX } from '../../../../../hooks/useHentBarnetrygdbehandlinger';
+import { KLAGEBEHANDLINGER_QUERY_KEY_PREFIX } from '../../../../../hooks/useHentKlagebehandlinger';
+import { TILBAKEKREVINGSBEHANDLINGER_QUERY_KEY_PREFIX } from '../../../../../hooks/useHentTilbakekrevingsbehandlinger';
 import type { IBehandling, IRestNyBehandling } from '../../../../../typer/behandling';
 import { BehandlingSteg, Behandlingstype, BehandlingÅrsak } from '../../../../../typer/behandling';
 import type { IBehandlingstema } from '../../../../../typer/behandlingstema';
@@ -45,6 +49,7 @@ const useOpprettBehandling = (
     const { innloggetSaksbehandler } = useAppContext();
     const navigate = useNavigate();
     const { oppdaterKlagebehandlingerPåFagsak } = useFagsakContext();
+    const queryClient = useQueryClient();
 
     const bruker = brukerRessurs.status === RessursStatus.SUKSESS ? brukerRessurs.data : undefined;
     const minimalFagsak =
@@ -186,6 +191,9 @@ const useOpprettBehandling = (
             },
             response => {
                 if (response.status === RessursStatus.SUKSESS) {
+                    queryClient.invalidateQueries({
+                        queryKey: [TILBAKEKREVINGSBEHANDLINGER_QUERY_KEY_PREFIX, fagsakId],
+                    });
                     nullstillSkjemaStatus();
                     onOpprettTilbakekrevingSuccess();
                 }
@@ -205,6 +213,9 @@ const useOpprettBehandling = (
             },
             response => {
                 if (response.status === RessursStatus.SUKSESS) {
+                    queryClient.invalidateQueries({
+                        queryKey: [KLAGEBEHANDLINGER_QUERY_KEY_PREFIX, fagsakId],
+                    });
                     oppdaterKlagebehandlingerPåFagsak();
                     lukkModal();
                     nullstillSkjema();
@@ -244,6 +255,10 @@ const useOpprettBehandling = (
             },
             response => {
                 if (response.status === RessursStatus.SUKSESS) {
+                    queryClient.invalidateQueries({
+                        queryKey: [BARNETRYGDBEHANDLINGER_QUERY_KEY_PREFIX, fagsakId],
+                    });
+
                     hentMinimalFagsak(fagsakId, true);
 
                     lukkModal();


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24909](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24909)

Når man oppretter en ny behandling ønsker man at den automatisk blir lagt til i saksoversikten. Ved å invalidere queries vil react-query kjøre nye GET-requester mot backend og hente den oppdaterte tilstanden. Uten å invalidere queries slik som nå vil man måtte manuelt trykke "refresh" i browseren. Det er mulig at dette kunne blitt løst bedre ved å ta i bruk `useMutation` hooken fra react-query til å gjøre selve opprettingen av behandlingene, men det er en mye større jobb så tenker dette får fungere enn så lenge.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Krever en del oppsett.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan ta ved behov.
  
### 👀 Screen shots
Ingen visuelle endringer. 