### PR TITLE
Endre refusjoneøs tekst til å vise hver mnd

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøs.tsx
@@ -11,7 +11,7 @@ import RefusjonEøsPeriode from './RefusjonEøsPeriode';
 import type { IRestRefusjonEøs } from '../../../../../../typer/refusjon-eøs';
 import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
-import { summerBeløpForPerioder } from '../utils';
+import { summerTotalBeløpForPerioder } from '../utils';
 
 interface IRefusjonEøs {
     behandlingId: number;
@@ -62,7 +62,7 @@ const RefusjonEøs: React.FC<IRefusjonEøs> = ({
         skjulRefusjonEøs();
     }
 
-    const totaltRefusjonsbeløp = summerBeløpForPerioder(
+    const totaltRefusjonsbeløp = summerTotalBeløpForPerioder(
         refusjonEøsListe.map(it => ({ fom: it.fom, tom: it.tom, beløp: it.refusjonsbeløp }))
     );
 
@@ -75,7 +75,7 @@ const RefusjonEøs: React.FC<IRefusjonEøs> = ({
                 `${isoDatoPeriodeTilFormatertString({
                     fom: refusjonEøs.fom,
                     tom: refusjonEøs.tom,
-                })} kroner ${refusjonEøs.refusjonsbeløp}`
+                })} kroner ${refusjonEøs.refusjonsbeløp} per måned`
         )
         .join('\n')}`;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsPeriode.tsx
@@ -102,7 +102,7 @@ const RefusjonEøsPeriode: React.FC<IRefusjonEøsPeriode> = ({ refusjonEøs, beh
                     tom: refusjonEøs.tom,
                 })}
             </Table.DataCell>
-            <Table.DataCell align="right">{refusjonEøs.refusjonsbeløp} kr</Table.DataCell>
+            <Table.DataCell align="right">{refusjonEøs.refusjonsbeløp} kr/mnd</Table.DataCell>
             <Table.DataCell align="center">
                 {!erLesevisning && (
                     <Tooltip content="Fjern periode">

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsSkjema.tsx
@@ -117,7 +117,7 @@ const RefusjonEøsSkjema: React.FunctionComponent<IRefusjonEøsSkjemaProps> = ({
             <StyledTextField
                 {...skjema.felter.refusjonsbeløp.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                 size="small"
-                label="Refusjonsbeløp (kr)"
+                label="Refusjonsbeløp (kr/mnd)"
                 value={skjema.felter.refusjonsbeløp.verdi}
                 type="text"
                 inputMode="numeric"

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/utils.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/utils.test.ts
@@ -1,4 +1,8 @@
-import { antallMånederIPeriode, summerBeløpForPerioder } from './utils';
+import {
+    antallMånederIPeriode,
+    summerBeløpForPerioder,
+    summerTotalBeløpForPerioder,
+} from './utils';
 
 const REFUSJONSPERIODE_FIRE_MÅNEDER = {
     fom: '2022-06-01',
@@ -57,5 +61,38 @@ describe('Vedtakutils', () => {
         expect(antallMånederIPeriode(REFUSJONSPERIODE_FIRE_MÅNEDER)).toBe(4);
         expect(antallMånederIPeriode(REFUSJONSPERIODE_TRE_MÅNEDER)).toBe(3);
         expect(antallMånederIPeriode(REFUSJONSPERIODE_EN_MÅNED)).toBe(1);
+    });
+    test('summerTotalBeløpForPerioder skal finne totalt refusjonsbeløp for alle perioder', () => {
+        expect(
+            summerTotalBeløpForPerioder([
+                REFUSJONSPERIODE_FIRE_MÅNEDER,
+                REFUSJONSPERIODE_TRE_MÅNEDER,
+                REFUSJONSPERIODE_EN_MÅNED,
+            ])
+        ).toBe(950);
+        expect(
+            summerTotalBeløpForPerioder([
+                {
+                    fom: '2021-01-01',
+                    tom: '2021-08-31',
+                    beløp: 62,
+                },
+                {
+                    fom: '2021-09-01',
+                    tom: '2021-09-30',
+                    beløp: 81,
+                },
+                {
+                    fom: '2021-10-01',
+                    tom: '2022-04-30',
+                    beløp: 152,
+                },
+                {
+                    fom: '2022-05-01',
+                    tom: '2022-09-30',
+                    beløp: 108,
+                },
+            ])
+        ).toBe(2181);
     });
 });

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/utils.ts
@@ -7,8 +7,16 @@ interface PeriodeMedBeløp {
     tom: IsoDatoString;
     beløp: number;
 }
+
 export const summerBeløpForPerioder = (periodeListe: PeriodeMedBeløp[]): number => {
     return periodeListe.reduce((sum, periode) => sum + periode.beløp, 0);
+};
+
+export const summerTotalBeløpForPerioder = (periodeListe: PeriodeMedBeløp[]): number => {
+    return periodeListe.reduce(
+        (sum, periode) => sum + periode.beløp * antallMånederIPeriode(periode),
+        0
+    );
 };
 
 export const antallMånederIPeriode = (periode: PeriodeMedBeløp): number => {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24701

NFP skal innføre ny felles rutine for refusjon EØS, og i den anledning ber de om at vi endrer tekst i periodevisningen, til beløp per måned. Det er fordi NØS vil ha beløp oppgitt per måned i den manuelle oppgaven som sendes via Gosys. 

Teksten var opprinnelig satt opp som månedsbeløp. Dette ble endret når vi innførte automatisk valutajustering, fordi det ville medføre at saksbehandler må legge inn veldig mange perioder i skjema siden beløpet endrer seg for hver måned. Dette mener NFP ikke lenger blir et problem, og ønsker derfor at dette endres tilbake.

NFP venter med å lansere den nye rutinen til vi har lagt inn endringen i systemet. 