### PR TITLE
Vi fikser lesevisningen av tilbakekrevingsvedtak motregning

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Datovelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Datovelger.tsx
@@ -15,7 +15,7 @@ interface Props {
     feltnavn: string;
     tittel: string;
     beskrivelse?: string;
-    lesevisning?: boolean;
+    erLesevisning?: boolean;
     kanKunVelgeFortid?: boolean;
     minDatoAvgrensning?: Date;
     maksDatoAvgrensning?: Date;
@@ -25,7 +25,7 @@ const Datovelger = ({
     feltnavn,
     tittel,
     beskrivelse,
-    lesevisning = false,
+    erLesevisning = false,
     minDatoAvgrensning = tidligsteRelevanteDato,
     maksDatoAvgrensning = senesteRelevanteDato,
 }: Props) => {
@@ -60,7 +60,7 @@ const Datovelger = ({
                 description={beskrivelse}
                 placeholder={'DD.MM.ÅÅÅÅ'}
                 error={fieldState.error?.message}
-                readOnly={lesevisning || formState.isSubmitting}
+                readOnly={erLesevisning || formState.isSubmitting}
             />
         </DatePicker>
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Tekstfelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Tekstfelt.tsx
@@ -10,12 +10,14 @@ interface TilbakekrevingsvedtakMotregningFritekstProps {
     feltnavn: keyof Omit<TilbakekrevingsvedtakMotregningSkjemaverdier, 'varselDato'>;
     tittel: string;
     beskrivelse?: string;
+    erLesevisning: boolean;
 }
 
 export const Tekstfelt = ({
     feltnavn,
     tittel,
     beskrivelse,
+    erLesevisning,
 }: TilbakekrevingsvedtakMotregningFritekstProps) => {
     const { field, fieldState, formState } = useController({
         name: feltnavn,
@@ -30,7 +32,7 @@ export const Tekstfelt = ({
             onBlur={field.onBlur}
             onChange={field.onChange}
             error={fieldState.error?.message}
-            readOnly={formState.isSubmitting}
+            readOnly={erLesevisning || formState.isSubmitting}
         />
     );
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -27,6 +27,7 @@ interface TilbakekrevingsvedtakMotregningExpansionCardProps {
     settVisDokumentModal: (vis: boolean) => void;
     hentBrevForTilbakekrevingsvedtakMotregning: () => void;
     hentetDokument: Ressurs<string>;
+    erLesevisning: boolean;
 }
 
 export const TilbakekrevingsvedtakMotregning = ({
@@ -35,6 +36,7 @@ export const TilbakekrevingsvedtakMotregning = ({
     settVisDokumentModal,
     hentBrevForTilbakekrevingsvedtakMotregning,
     hentetDokument,
+    erLesevisning,
 }: TilbakekrevingsvedtakMotregningExpansionCardProps) => {
     const [lagrer, settLagrer] = useState(false);
     const [expansionCardErÅpen, settExpansionCardErÅpen] = useState(false);
@@ -90,29 +92,35 @@ export const TilbakekrevingsvedtakMotregning = ({
                                         feltnavn="varselDato"
                                         tittel="Varseldato"
                                         beskrivelse="Dato bruker fikk varsel om feilutbetaling."
+                                        erLesevisning={erLesevisning}
                                     />
                                     <Tekstfelt
                                         feltnavn="årsakTilFeilutbetaling"
                                         tittel="Årsak til feilutbetaling"
                                         beskrivelse="Hva var grunnen til feilutbetalingen?"
+                                        erLesevisning={erLesevisning}
                                     />
                                     <Tekstfelt
                                         feltnavn="vurderingAvSkyld"
                                         tittel="Vurdering av skyld"
                                         beskrivelse="I hvilken grad har bruker forstått at det var en feilutbetaling?"
+                                        erLesevisning={erLesevisning}
                                     />
-                                    <Box width="fit-content">
-                                        <Button
-                                            size="medium"
-                                            type="submit"
-                                            variant="secondary"
-                                            disabled={lagrer}
-                                            loading={lagrer}
-                                            icon={<FloppydiskIcon aria-hidden />}
-                                        >
-                                            Lagre
-                                        </Button>
-                                    </Box>
+
+                                    {!erLesevisning && (
+                                        <Box width="fit-content">
+                                            <Button
+                                                size="medium"
+                                                type="submit"
+                                                variant="secondary"
+                                                disabled={lagrer || erLesevisning}
+                                                loading={lagrer}
+                                                icon={<FloppydiskIcon aria-hidden />}
+                                            >
+                                                Lagre
+                                            </Button>
+                                        </Box>
+                                    )}
                                 </VStack>
                             </ExpansionCard.Content>
                         </ExpansionCard>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -218,6 +218,7 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
                                 hentBrevForTilbakekrevingsvedtakMotregning
                             }
                             hentetDokument={hentetDokument}
+                            erLesevisning={erLesevisning}
                         />
                     )}
             </div>


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25098

FØR: 
<img width="643" alt="før" src="https://github.com/user-attachments/assets/42560c21-2c28-4ebc-8870-f571e02131fa" />

ETTER:
<img width="664" alt="etter" src="https://github.com/user-attachments/assets/515eed54-9572-4570-8838-5d3af01dd279" />

