### PR TITLE
Fjern modal for bekrefting av sletting av TilbakekrevingsvedtakMotregning

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Alert, BodyLong, Button, HStack, Modal } from '@navikt/ds-react';
+import { Alert, BodyLong, Button, HStack } from '@navikt/ds-react';
 
 const StyledAlert = styled(Alert)`
     margin-top: 2rem;
@@ -18,10 +18,6 @@ export const BekreftSamtykkeTilMotregning = ({
     slettTilbakekrevingsvedtakMotregning,
     bekreftSamtykkeTilMotregning,
 }: IProps) => {
-    const [visBekreftSlettingModal, settVisBekreftSlettingModal] = useState<boolean>(false);
-    const åpneModal = () => settVisBekreftSlettingModal(true);
-    const lukkModal = () => settVisBekreftSlettingModal(false);
-
     const [oppdaterer, settOppdaterer] = useState(false);
     const [sletter, settSletter] = useState(false);
 
@@ -33,7 +29,17 @@ export const BekreftSamtykkeTilMotregning = ({
                     feilutbetalingen
                 </BodyLong>
                 <HStack gap="4" justify="center">
-                    <Button onClick={åpneModal} disabled={oppdaterer}>
+                    <Button
+                        onClick={() => {
+                            settSletter(true);
+                            slettTilbakekrevingsvedtakMotregning().finally(() =>
+                                settSletter(false)
+                            );
+                        }}
+                        loading={sletter}
+                        disabled={sletter || oppdaterer}
+                        variant="secondary"
+                    >
                         Nei
                     </Button>
                     <Button
@@ -42,48 +48,12 @@ export const BekreftSamtykkeTilMotregning = ({
                             bekreftSamtykkeTilMotregning().finally(() => settOppdaterer(false));
                         }}
                         loading={oppdaterer}
-                        disabled={oppdaterer}
+                        disabled={oppdaterer || sletter}
                     >
                         Ja
                     </Button>
                 </HStack>
             </StyledAlert>
-            <Modal
-                open={visBekreftSlettingModal}
-                onClose={lukkModal}
-                header={{
-                    heading:
-                        'Er du sikker på at du vil slette tilbakekrevingsvedtak for motregning?',
-                    size: 'small',
-                    closeButton: false,
-                }}
-                width={'35rem'}
-            >
-                <Modal.Footer>
-                    <Button
-                        key={'bekreft'}
-                        onClick={() => {
-                            settSletter(true);
-                            slettTilbakekrevingsvedtakMotregning().finally(() => {
-                                settSletter(false);
-                                settVisBekreftSlettingModal(false);
-                            });
-                        }}
-                        disabled={sletter}
-                        loading={sletter}
-                    >
-                        Bekreft
-                    </Button>
-                    <Button
-                        variant="secondary"
-                        key={'avbryt'}
-                        onClick={lukkModal}
-                        disabled={sletter}
-                    >
-                        Avbryt
-                    </Button>
-                </Modal.Footer>
-            </Modal>
         </>
     );
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-22552

Fjerner modal for bekrefting av sletting når man trykker 'Nei' på om bruker har gitt samtykke til ulovfestet motregning. Flyten går da fra 
- trykk `Nei` -> åpne modal -> trykk `Bekreft` -> slett tilbakekrevingsvedtak
til
- trykk `Nei` -> slett tilbakekrevingsvedtak 

Endrer også 'Nei'-knappen til secondary

### 👀 Screen shots

#### Fjerner denne modalen:
![2dc58090aefbd0939ab77c2d902efe49](https://github.com/user-attachments/assets/92510896-5944-48e0-8f9b-2fe879475e1f)

![4e0f3e32cb540a69e1f86d5953843248](https://github.com/user-attachments/assets/22359bea-5f09-47c3-bf18-dc1234fb1623)
