### PR TITLE
Motregning: oppdater backend ved avhuking av checkbox

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -58,9 +58,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
     const {
         tilbakekrevingsvedtakMotregning,
         slettTilbakekrevingsvedtakMotregning,
-        bekreftSamtykkeTilMotregning,
-        heleBeløpetSkalKrevesTilbake,
-        settHeleBeløpetSkalKrevesTilbake,
+        oppdaterTilbakekrevingsvedtakMotregning,
     } = useTilbakekrevingsvedtakMotregning(åpenBehandling);
 
     const erAvregningOgToggleErPå =
@@ -101,6 +99,15 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         return <div />;
     }
 
+    const heleBeløpetSkalKrevesTilbake =
+        tilbakekrevingsvedtakMotregning.status === RessursStatus.SUKSESS &&
+        tilbakekrevingsvedtakMotregning.data?.heleBeløpetSkalKrevesTilbake === true;
+
+    const skalDisableNesteKnapp = erAvregningOgToggleErPå && !heleBeløpetSkalKrevesTilbake;
+
+    const skalViseTilbakekrevingSkjema =
+        erFeilutbetaling && (!erAvregningOgToggleErPå || heleBeløpetSkalKrevesTilbake);
+
     return (
         <Skjemasteg
             senderInn={tilbakekrevingSkjema.submitRessurs.status === RessursStatus.HENTER}
@@ -110,7 +117,7 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
             nesteOnClick={nesteOnClick}
             maxWidthStyle={'80rem'}
             steg={BehandlingSteg.VURDER_TILBAKEKREVING}
-            skalDisableNesteKnapp={erAvregningOgToggleErPå && !heleBeløpetSkalKrevesTilbake}
+            skalDisableNesteKnapp={skalDisableNesteKnapp}
         >
             {simuleringsresultat?.status === RessursStatus.SUKSESS ? (
                 simuleringsresultat.data.perioder.length === 0 ? (
@@ -169,28 +176,21 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                             slettTilbakekrevingsvedtakMotregning={
                                                 slettTilbakekrevingsvedtakMotregning
                                             }
-                                            bekreftSamtykkeTilMotregning={
-                                                bekreftSamtykkeTilMotregning
-                                            }
-                                            heleBeløpetSkalKrevesTilbake={
-                                                heleBeløpetSkalKrevesTilbake
-                                            }
-                                            settHeleBeløpetSkalKrevesTilbake={
-                                                settHeleBeløpetSkalKrevesTilbake
+                                            oppdaterTilbakekrevingsvedtakMotregning={
+                                                oppdaterTilbakekrevingsvedtakMotregning
                                             }
                                         />
                                     )}
                             </Box>
                         )}
 
-                        {erFeilutbetaling &&
-                            (!erAvregningOgToggleErPå || heleBeløpetSkalKrevesTilbake) && (
-                                <TilbakekrevingSkjema
-                                    søkerMålform={hentSøkersMålform(åpenBehandling)}
-                                    harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
-                                    åpenBehandling={åpenBehandling}
-                                />
-                            )}
+                        {skalViseTilbakekrevingSkjema && (
+                            <TilbakekrevingSkjema
+                                søkerMålform={hentSøkersMålform(åpenBehandling)}
+                                harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
+                                åpenBehandling={åpenBehandling}
+                            />
+                        )}
                     </>
                 )
             ) : (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
@@ -1,13 +1,6 @@
 import React, { useState } from 'react';
 
-import styled from 'styled-components';
-
-import { Alert, BodyLong, Button, HStack } from '@navikt/ds-react';
-
-const StyledAlert = styled(Alert)`
-    margin-top: 2rem;
-    width: fit-content;
-`;
+import { Alert, BodyLong, Box, Button, HStack } from '@navikt/ds-react';
 
 interface IProps {
     slettTilbakekrevingsvedtakMotregning: () => Promise<void>;
@@ -22,8 +15,8 @@ export const BekreftSamtykkeTilMotregning = ({
     const [sletter, settSletter] = useState(false);
 
     return (
-        <>
-            <StyledAlert variant={'info'}>
+        <Box marginBlock="8 0" width="fit-content">
+            <Alert variant={'info'}>
                 <BodyLong spacing>
                     Bruker har samtykket til at vi venter med etterbetalingen til vi har vurdert
                     feilutbetalingen
@@ -53,7 +46,7 @@ export const BekreftSamtykkeTilMotregning = ({
                         Ja
                     </Button>
                 </HStack>
-            </StyledAlert>
-        </>
+            </Alert>
+        </Box>
     );
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
@@ -2,14 +2,18 @@ import React, { useState } from 'react';
 
 import { Alert, BodyLong, Box, Button, HStack } from '@navikt/ds-react';
 
+import type { OppdaterTilbakekrevingsvedtakMotregningDTO } from './TilbakekrevingsvedtakMotregningDTO';
+
 interface IProps {
     slettTilbakekrevingsvedtakMotregning: () => Promise<void>;
-    bekreftSamtykkeTilMotregning: () => Promise<void>;
+    oppdaterTilbakekrevingsvedtakMotregning: (
+        dto: OppdaterTilbakekrevingsvedtakMotregningDTO
+    ) => Promise<void>;
 }
 
 export const BekreftSamtykkeTilMotregning = ({
     slettTilbakekrevingsvedtakMotregning,
-    bekreftSamtykkeTilMotregning,
+    oppdaterTilbakekrevingsvedtakMotregning,
 }: IProps) => {
     const [oppdaterer, settOppdaterer] = useState(false);
     const [sletter, settSletter] = useState(false);
@@ -38,7 +42,9 @@ export const BekreftSamtykkeTilMotregning = ({
                     <Button
                         onClick={() => {
                             settOppdaterer(true);
-                            bekreftSamtykkeTilMotregning().finally(() => settOppdaterer(false));
+                            oppdaterTilbakekrevingsvedtakMotregning({ samtykke: true }).finally(
+                                () => settOppdaterer(false)
+                            );
                         }}
                         loading={oppdaterer}
                         disabled={oppdaterer || sletter}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -3,22 +3,23 @@ import React from 'react';
 import { Alert, BodyShort, Box, ConfirmationPanel, Heading, VStack } from '@navikt/ds-react';
 
 import { BekreftSamtykkeTilMotregning } from './BekreftSamtykkeTilMotregning';
-import type { TilbakekrevingsvedtakMotregningDTO } from './TilbakekrevingsvedtakMotregningDTO';
+import type {
+    OppdaterTilbakekrevingsvedtakMotregningDTO,
+    TilbakekrevingsvedtakMotregningDTO,
+} from './TilbakekrevingsvedtakMotregningDTO';
 
 interface TilbakekrevingsvedtakMotregningProps {
     tilbakekrevingsvedtakMotregning: TilbakekrevingsvedtakMotregningDTO;
     slettTilbakekrevingsvedtakMotregning: () => Promise<void>;
-    bekreftSamtykkeTilMotregning: () => Promise<void>;
-    heleBeløpetSkalKrevesTilbake: boolean;
-    settHeleBeløpetSkalKrevesTilbake: (value: boolean) => void;
+    oppdaterTilbakekrevingsvedtakMotregning: (
+        dto: OppdaterTilbakekrevingsvedtakMotregningDTO
+    ) => Promise<void>;
 }
 
 export const TilbakekrevingsvedtakMotregning = ({
     tilbakekrevingsvedtakMotregning,
     slettTilbakekrevingsvedtakMotregning,
-    bekreftSamtykkeTilMotregning,
-    heleBeløpetSkalKrevesTilbake,
-    settHeleBeløpetSkalKrevesTilbake,
+    oppdaterTilbakekrevingsvedtakMotregning,
 }: TilbakekrevingsvedtakMotregningProps) => {
     return (
         <Box marginBlock="10 0" width="90%" maxWidth="40rem">
@@ -28,7 +29,9 @@ export const TilbakekrevingsvedtakMotregning = ({
             {!tilbakekrevingsvedtakMotregning.samtykke ? (
                 <BekreftSamtykkeTilMotregning
                     slettTilbakekrevingsvedtakMotregning={slettTilbakekrevingsvedtakMotregning}
-                    bekreftSamtykkeTilMotregning={bekreftSamtykkeTilMotregning}
+                    oppdaterTilbakekrevingsvedtakMotregning={
+                        oppdaterTilbakekrevingsvedtakMotregning
+                    }
                 />
             ) : (
                 <VStack gap="2">
@@ -37,10 +40,13 @@ export const TilbakekrevingsvedtakMotregning = ({
                         saksbehandlingen.
                     </Alert>
                     <ConfirmationPanel
-                        checked={heleBeløpetSkalKrevesTilbake}
+                        checked={tilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake}
                         label="Hele beløpet skal kreves tilbake"
                         onChange={() =>
-                            settHeleBeløpetSkalKrevesTilbake(!heleBeløpetSkalKrevesTilbake)
+                            oppdaterTilbakekrevingsvedtakMotregning({
+                                heleBeløpetSkalKrevesTilbake:
+                                    !tilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake,
+                            })
                         }
                     >
                         <Heading level="2" size="xsmall" spacing>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregningDTO.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregningDTO.ts
@@ -3,6 +3,7 @@ export interface TilbakekrevingsvedtakMotregningDTO {
     vurderingAvSkyld: string | null;
     varselDato: string;
     samtykke: boolean;
+    heleBeløpetSkalKrevesTilbake: boolean;
 }
 
 export interface OppdaterTilbakekrevingsvedtakMotregningDTO {
@@ -10,4 +11,5 @@ export interface OppdaterTilbakekrevingsvedtakMotregningDTO {
     vurderingAvSkyld?: string;
     varselDato?: string;
     samtykke?: boolean;
+    heleBeløpetSkalKrevesTilbake?: boolean;
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useTilbakekrevingsvedtakMotregning.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useTilbakekrevingsvedtakMotregning.ts
@@ -1,11 +1,8 @@
 import { useEffect, useState } from 'react';
 
-import type { AxiosError } from 'axios';
-
 import { useHttp } from '@navikt/familie-http';
 import {
     byggDataRessurs,
-    byggFeiletRessurs,
     byggHenterRessurs,
     byggTomRessurs,
     type Ressurs,
@@ -31,44 +28,27 @@ export const useTilbakekrevingsvedtakMotregning = (åpenBehandling: IBehandling)
     const [tilbakekrevingsvedtakMotregning, settTilbakekrevingsvedtakMotregning] =
         useState<Ressurs<TilbakekrevingsvedtakMotregningDTO | null>>(byggTomRessurs());
 
-    const [heleBeløpetSkalKrevesTilbake, settHeleBeløpetSkalKrevesTilbake] =
-        useState<boolean>(false);
-
     const hentTilbakekrevingsvedtakMotregning = () => {
         settTilbakekrevingsvedtakMotregning(byggHenterRessurs());
         request<void, TilbakekrevingsvedtakMotregningDTO>({
             method: 'GET',
             url: tilbakekrevingsvedtakMotregningUrl,
-        })
-            .then((response: Ressurs<TilbakekrevingsvedtakMotregningDTO>) => {
-                settTilbakekrevingsvedtakMotregning(response);
-            })
-            .catch((_error: AxiosError) => {
-                settTilbakekrevingsvedtakMotregning(
-                    byggFeiletRessurs(
-                        'Ukjent feil, klarte ikke å hente tilbakekrevingsvedtak for motregning.'
-                    )
-                );
-            });
+            påvirkerSystemLaster: true,
+        }).then((response: Ressurs<TilbakekrevingsvedtakMotregningDTO>) => {
+            settTilbakekrevingsvedtakMotregning(response);
+        });
     };
 
     const slettTilbakekrevingsvedtakMotregning = (): Promise<void> =>
         request<void, string>({
             method: 'DELETE',
             url: tilbakekrevingsvedtakMotregningUrl,
-        })
-            .then(response => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    settTilbakekrevingsvedtakMotregning(byggDataRessurs(null));
-                }
-            })
-            .catch((_error: AxiosError) => {
-                settTilbakekrevingsvedtakMotregning(
-                    byggFeiletRessurs(
-                        'Ukjent feil, klarte ikke å slette tilbakekrevingsvedtak for motregning.'
-                    )
-                );
-            });
+            påvirkerSystemLaster: true,
+        }).then(response => {
+            if (response.status === RessursStatus.SUKSESS) {
+                settTilbakekrevingsvedtakMotregning(byggDataRessurs(null));
+            }
+        });
 
     const oppdaterTilbakekrevingsvedtakMotregning = (
         tilbakekrevingsvedtakMotregning: OppdaterTilbakekrevingsvedtakMotregningDTO
@@ -76,26 +56,18 @@ export const useTilbakekrevingsvedtakMotregning = (åpenBehandling: IBehandling)
         request<OppdaterTilbakekrevingsvedtakMotregningDTO, TilbakekrevingsvedtakMotregningDTO>({
             method: 'PATCH',
             url: tilbakekrevingsvedtakMotregningUrl,
+            påvirkerSystemLaster: true,
             data: {
                 årsakTilFeilutbetaling: tilbakekrevingsvedtakMotregning.årsakTilFeilutbetaling,
                 vurderingAvSkyld: tilbakekrevingsvedtakMotregning.vurderingAvSkyld,
                 varselDato: tilbakekrevingsvedtakMotregning.varselDato,
                 samtykke: tilbakekrevingsvedtakMotregning.samtykke,
+                heleBeløpetSkalKrevesTilbake:
+                    tilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake,
             },
-        })
-            .then((response: Ressurs<TilbakekrevingsvedtakMotregningDTO>) => {
-                settTilbakekrevingsvedtakMotregning(response);
-            })
-            .catch((_error: AxiosError) => {
-                settTilbakekrevingsvedtakMotregning(
-                    byggFeiletRessurs(
-                        'Ukjent feil, klarte ikke å oppdatere tilbakekrevingsvedtak for motregning.'
-                    )
-                );
-            });
-
-    const bekreftSamtykkeTilMotregning = (): Promise<void> =>
-        oppdaterTilbakekrevingsvedtakMotregning({ samtykke: true });
+        }).then((response: Ressurs<TilbakekrevingsvedtakMotregningDTO>) => {
+            settTilbakekrevingsvedtakMotregning(response);
+        });
 
     useEffect(() => {
         if (toggles[ToggleNavn.brukFunksjonalitetForUlovfestetMotregning]) {
@@ -107,8 +79,5 @@ export const useTilbakekrevingsvedtakMotregning = (åpenBehandling: IBehandling)
         tilbakekrevingsvedtakMotregning,
         slettTilbakekrevingsvedtakMotregning,
         oppdaterTilbakekrevingsvedtakMotregning,
-        bekreftSamtykkeTilMotregning,
-        heleBeløpetSkalKrevesTilbake,
-        settHeleBeløpetSkalKrevesTilbake,
     };
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useTilbakekrevingsvedtakMotregning.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/useTilbakekrevingsvedtakMotregning.ts
@@ -70,7 +70,7 @@ export const useTilbakekrevingsvedtakMotregning = (åpenBehandling: IBehandling)
                 );
             });
 
-    const oppdaterTilbakekrevingMotregning = (
+    const oppdaterTilbakekrevingsvedtakMotregning = (
         tilbakekrevingsvedtakMotregning: OppdaterTilbakekrevingsvedtakMotregningDTO
     ): Promise<void> =>
         request<OppdaterTilbakekrevingsvedtakMotregningDTO, TilbakekrevingsvedtakMotregningDTO>({
@@ -95,7 +95,7 @@ export const useTilbakekrevingsvedtakMotregning = (åpenBehandling: IBehandling)
             });
 
     const bekreftSamtykkeTilMotregning = (): Promise<void> =>
-        oppdaterTilbakekrevingMotregning({ samtykke: true });
+        oppdaterTilbakekrevingsvedtakMotregning({ samtykke: true });
 
     useEffect(() => {
         if (toggles[ToggleNavn.brukFunksjonalitetForUlovfestetMotregning]) {
@@ -106,7 +106,7 @@ export const useTilbakekrevingsvedtakMotregning = (åpenBehandling: IBehandling)
     return {
         tilbakekrevingsvedtakMotregning,
         slettTilbakekrevingsvedtakMotregning,
-        oppdaterTilbakekrevingMotregning,
+        oppdaterTilbakekrevingsvedtakMotregning,
         bekreftSamtykkeTilMotregning,
         heleBeløpetSkalKrevesTilbake,
         settHeleBeløpetSkalKrevesTilbake,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -19,7 +19,7 @@ export type TilbakekrevingsvedtakMotregningSkjemaverdier = {
     varselDato: string;
 };
 
-interface TilbakekrevingsvedtakMotregningExpansionCardProps {
+interface TilbakekrevingsvedtakMotregningProps {
     tilbakekrevingsvedtakMotregning: TilbakekrevingsvedtakMotregningDTO;
     oppdaterTilbakekrevingsvedtakMotregning: (
         tilbakekrevingsvedtakMotregning: OppdaterTilbakekrevingsvedtakMotregningDTO
@@ -37,7 +37,7 @@ export const TilbakekrevingsvedtakMotregning = ({
     hentBrevForTilbakekrevingsvedtakMotregning,
     hentetDokument,
     erLesevisning,
-}: TilbakekrevingsvedtakMotregningExpansionCardProps) => {
+}: TilbakekrevingsvedtakMotregningProps) => {
     const [lagrer, settLagrer] = useState(false);
     const [expansionCardErÅpen, settExpansionCardErÅpen] = useState(false);
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -57,7 +57,7 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
 
     const { erSammensattKontrollsak } = useSammensattKontrollsakContext();
 
-    const { tilbakekrevingsvedtakMotregning, oppdaterTilbakekrevingMotregning } =
+    const { tilbakekrevingsvedtakMotregning, oppdaterTilbakekrevingsvedtakMotregning } =
         useTilbakekrevingsvedtakMotregning(åpenBehandling);
 
     const erLesevisning = vurderErLesevisning();
@@ -211,7 +211,7 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
                         <TilbakekrevingsvedtakMotregning
                             tilbakekrevingsvedtakMotregning={tilbakekrevingsvedtakMotregning.data}
                             oppdaterTilbakekrevingsvedtakMotregning={
-                                oppdaterTilbakekrevingMotregning
+                                oppdaterTilbakekrevingsvedtakMotregning
                             }
                             settVisDokumentModal={settVisDokumentModal}
                             hentBrevForTilbakekrevingsvedtakMotregning={


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-25099

I stedet for å lagre verdien til "Skal hele beløpet kreves tilbake"-checkboxen i en lokal state, gjøres det et kall mot backend når man huker av. Legger til dette for å forhindre at man kan ende opp i en state hvor frontend ikke er i sync med backend, ettersom verdien på dette feltet påvirker visningen.

Fjerner også `catch` på kallene til backend, ettersom `request` uansett wrapper httpstatus 400 og 500 inn i ressursobjekter med httpstatus 200 og ressursstatus `FEILET`. Legger til feilhåndtering på et senere tidspunkt.