### PR TITLE
Endre returtype fra kall for å oppdatere og slettet TilbakekrevingsvedtakMotregning

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -55,11 +55,8 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
     const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
-    const {
-        tilbakekrevingsvedtakMotregning,
-        slettTilbakekrevingsvedtakMotregning,
-        oppdaterTilbakekrevingsvedtakMotregning,
-    } = useTilbakekrevingsvedtakMotregning(åpenBehandling);
+    const { slettTilbakekrevingsvedtakMotregning, oppdaterTilbakekrevingsvedtakMotregning } =
+        useTilbakekrevingsvedtakMotregning(åpenBehandling);
 
     const erAvregningOgToggleErPå =
         avregningsperioder.length > 0 &&
@@ -99,9 +96,10 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
         return <div />;
     }
 
+    const tilbakekrevingsvedtakMotregning = åpenBehandling.tilbakekrevingsvedtakMotregning;
+
     const heleBeløpetSkalKrevesTilbake =
-        tilbakekrevingsvedtakMotregning.status === RessursStatus.SUKSESS &&
-        tilbakekrevingsvedtakMotregning.data?.heleBeløpetSkalKrevesTilbake === true;
+        tilbakekrevingsvedtakMotregning?.heleBeløpetSkalKrevesTilbake === true;
 
     const skalDisableNesteKnapp = erAvregningOgToggleErPå && !heleBeløpetSkalKrevesTilbake;
 
@@ -155,32 +153,26 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                     </Alert>
                                 )}
 
-                                {tilbakekrevingsvedtakMotregning.status === RessursStatus.SUKSESS &&
-                                    tilbakekrevingsvedtakMotregning.data === null && (
-                                        <AvregningAlert
-                                            avregningsperioder={avregningsperioder}
-                                            harÅpenTilbakekrevingRessurs={
-                                                harÅpenTilbakekrevingRessurs
-                                            }
-                                        />
-                                    )}
+                                {tilbakekrevingsvedtakMotregning === null && (
+                                    <AvregningAlert
+                                        avregningsperioder={avregningsperioder}
+                                        harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
+                                    />
+                                )}
 
-                                {!erLesevisning &&
-                                    tilbakekrevingsvedtakMotregning.status ===
-                                        RessursStatus.SUKSESS &&
-                                    tilbakekrevingsvedtakMotregning.data !== null && (
-                                        <TilbakekrevingsvedtakMotregning
-                                            tilbakekrevingsvedtakMotregning={
-                                                tilbakekrevingsvedtakMotregning.data
-                                            }
-                                            slettTilbakekrevingsvedtakMotregning={
-                                                slettTilbakekrevingsvedtakMotregning
-                                            }
-                                            oppdaterTilbakekrevingsvedtakMotregning={
-                                                oppdaterTilbakekrevingsvedtakMotregning
-                                            }
-                                        />
-                                    )}
+                                {!erLesevisning && tilbakekrevingsvedtakMotregning !== null && (
+                                    <TilbakekrevingsvedtakMotregning
+                                        tilbakekrevingsvedtakMotregning={
+                                            tilbakekrevingsvedtakMotregning
+                                        }
+                                        slettTilbakekrevingsvedtakMotregning={
+                                            slettTilbakekrevingsvedtakMotregning
+                                        }
+                                        oppdaterTilbakekrevingsvedtakMotregning={
+                                            oppdaterTilbakekrevingsvedtakMotregning
+                                        }
+                                    />
+                                )}
                             </Box>
                         )}
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -57,7 +57,7 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
 
     const { erSammensattKontrollsak } = useSammensattKontrollsakContext();
 
-    const { tilbakekrevingsvedtakMotregning, oppdaterTilbakekrevingsvedtakMotregning } =
+    const { oppdaterTilbakekrevingsvedtakMotregning } =
         useTilbakekrevingsvedtakMotregning(åpenBehandling);
 
     const erLesevisning = vurderErLesevisning();
@@ -206,21 +206,22 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
                     Vis vedtaksbrev
                 </Button>
 
-                {tilbakekrevingsvedtakMotregning.status === RessursStatus.SUKSESS &&
-                    tilbakekrevingsvedtakMotregning.data !== null && (
-                        <TilbakekrevingsvedtakMotregning
-                            tilbakekrevingsvedtakMotregning={tilbakekrevingsvedtakMotregning.data}
-                            oppdaterTilbakekrevingsvedtakMotregning={
-                                oppdaterTilbakekrevingsvedtakMotregning
-                            }
-                            settVisDokumentModal={settVisDokumentModal}
-                            hentBrevForTilbakekrevingsvedtakMotregning={
-                                hentBrevForTilbakekrevingsvedtakMotregning
-                            }
-                            hentetDokument={hentetDokument}
-                            erLesevisning={erLesevisning}
-                        />
-                    )}
+                {åpenBehandling.tilbakekrevingsvedtakMotregning !== null && (
+                    <TilbakekrevingsvedtakMotregning
+                        tilbakekrevingsvedtakMotregning={
+                            åpenBehandling.tilbakekrevingsvedtakMotregning
+                        }
+                        oppdaterTilbakekrevingsvedtakMotregning={
+                            oppdaterTilbakekrevingsvedtakMotregning
+                        }
+                        settVisDokumentModal={settVisDokumentModal}
+                        hentBrevForTilbakekrevingsvedtakMotregning={
+                            hentBrevForTilbakekrevingsvedtakMotregning
+                        }
+                        hentetDokument={hentetDokument}
+                        erLesevisning={erLesevisning}
+                    />
+                )}
             </div>
         </>
     );

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -23,6 +23,7 @@ import type {
 } from './vedtak';
 import type { Utbetalingsperiode } from './vedtaksperiode';
 import type { IRestPersonResultat, IRestStegTilstand } from './vilkår';
+import type { TilbakekrevingsvedtakMotregningDTO } from '../sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregningDTO';
 import type { IRestBrevmottaker } from '../sider/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IsoDatoString } from '../utils/dato';
 
@@ -297,6 +298,7 @@ export interface IBehandling {
     refusjonEøs: IRestRefusjonEøs[];
     brevmottakere: IRestBrevmottaker[];
     vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser | null;
+    tilbakekrevingsvedtakMotregning: TilbakekrevingsvedtakMotregningDTO | null;
 }
 
 export enum VurderingsstrategiForValutakurser {

--- a/src/frontend/utils/test/behandling/behandling.mock.ts
+++ b/src/frontend/utils/test/behandling/behandling.mock.ts
@@ -96,6 +96,7 @@ export const mockBehandling = ({
         brevmottakere: [],
         refusjonEøs: [],
         vurderingsstrategiForValutakurser: null,
+        tilbakekrevingsvedtakMotregning: null,
     };
 };
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-25099

`PATCH`- og `DELETE`-endepunkt for `TilbakekrevingsvedtakMotregning` returnerer nå `RestUtvidetBehandling`[[1]](https://github.com/navikt/familie-ba-sak/pull/5288), så speiler endringene ved å legge til nytt felt i `IBehandling` og endre funksjoner for oppdatering og sletting til at responsen er `IBehandling`.

Fjerner også egen state og bruker heller `IBehandling::tilbakekrevingsvedtakMotregning`
