### PR TITLE
NAV-24909: Resolver ressurser korrigeringer

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -14,7 +14,13 @@ import { useStartUmami } from './hooks/useStartUmami';
 import ErrorBoundary from './komponenter/ErrorBoundary/ErrorBoundary';
 import { initGrafanaFaro } from './utils/grafanaFaro';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            retry: false, // Fungerer ikke så bra med global "Systemet laster" spinner, på sikt kan vi kanskje enable retries
+        },
+    },
+});
 
 const App: React.FC = () => {
     const [autentisertSaksbehandler, settInnloggetSaksbehandler] = React.useState<

--- a/src/frontend/utils/ressursResolver.test.ts
+++ b/src/frontend/utils/ressursResolver.test.ts
@@ -1,0 +1,82 @@
+import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
+
+import { RessursResolver } from './ressursResolver';
+
+describe('RessursResolver', () => {
+    test('skal kaste error hvis man prøver å resolve HENTER ressurs', () => {
+        // Arrange
+        const henterRessurs: Ressurs<void> = {
+            status: RessursStatus.HENTER,
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(henterRessurs).catch((error: Error) =>
+            expect(error.message).toBe(`Uforventet ressurs status ${henterRessurs.status}.`)
+        );
+    });
+
+    test('skal kaste error hvis man prøver å resolve IKKE_HENTET ressurs', () => {
+        // Arrange
+        const ikkeHentetRessurs: Ressurs<void> = {
+            status: RessursStatus.IKKE_HENTET,
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(ikkeHentetRessurs).catch((error: Error) =>
+            expect(error.message).toBe(`Uforventet ressurs status ${ikkeHentetRessurs.status}.`)
+        );
+    });
+
+    test('skal resolve suksess ressurs til promise', () => {
+        // Arrange
+        const suksessRessurs: Ressurs<string> = {
+            status: RessursStatus.SUKSESS,
+            data: 'bla bla bla',
+        };
+
+        // Act
+        const promise = RessursResolver.resolveToPromise(suksessRessurs);
+
+        // Expect
+        promise.then(data => expect(data).toBe('bla bla bla'));
+    });
+
+    test('skal kaste error hvis man prøver å resolve IKKE_TILGANG ressurs', () => {
+        // Arrange
+        const ikkeTilgangRessurs: Ressurs<void> = {
+            status: RessursStatus.IKKE_TILGANG,
+            frontendFeilmelding: 'Du har ikke tilgang.',
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(ikkeTilgangRessurs).catch((error: Error) =>
+            expect(error.message).toBe('Du har ikke tilgang.')
+        );
+    });
+
+    test('skal kaste error hvis man prøver å resolve FEILET ressurs', () => {
+        // Arrange
+        const feiletRessurs: Ressurs<void> = {
+            status: RessursStatus.FEILET,
+            frontendFeilmelding: 'Ops! En feil oppstod.',
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(feiletRessurs).catch((error: Error) =>
+            expect(error.message).toBe('Ops! En feil oppstod.')
+        );
+    });
+
+    test('skal kaste error hvis man prøver å resolve FUNKSJONELL_FEIL ressurs', () => {
+        // Arrange
+        const funksjonellFeilRessurs: Ressurs<void> = {
+            status: RessursStatus.FUNKSJONELL_FEIL,
+            frontendFeilmelding: 'Ops! En funksjonell feil oppstod.',
+        };
+
+        // Act & expect
+        RessursResolver.resolveToPromise(funksjonellFeilRessurs).catch((error: Error) =>
+            expect(error.message).toBe('Ops! En funksjonell feil oppstod.')
+        );
+    });
+});

--- a/src/frontend/utils/ressursResolver.ts
+++ b/src/frontend/utils/ressursResolver.ts
@@ -1,18 +1,19 @@
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
 
-function resolveToPromise<T>(ressurs: Ressurs<T>): Promise<T> {
+export function resolveToPromise<T>(ressurs: Ressurs<T>): Promise<Awaited<T>> {
     switch (ressurs.status) {
         case RessursStatus.IKKE_HENTET:
         case RessursStatus.HENTER:
-            return Promise.reject(`Uforventet response status: ${ressurs.status}`);
+            // Dette burde egentlig aldri skje da ressursen burde allerede være hentet på dette tidspunktet.
+            return Promise.reject(new Error(`Uforventet ressurs status ${ressurs.status}.`));
         case RessursStatus.SUKSESS:
             return Promise.resolve(ressurs.data);
         case RessursStatus.IKKE_TILGANG:
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
-            return Promise.reject(ressurs.frontendFeilmelding);
+            return Promise.reject(new Error(ressurs.frontendFeilmelding));
     }
 }
 
-export const RessursResolver = { resolveToPromise };
+export * as RessursResolver from './ressursResolver';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24909](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24909)

Resolver ressurser som har feilet til et rejected promise med error slik at det samsvarer bedre med react-query dokumentasjon. Se https://tanstack.com/query/latest/docs/framework/react/guides/query-functions#handling-and-throwing-errors

Skrur også av retries på queries da saksbehandlingen ikke er bygd rundt retries enda.

Endret også exporten for å tillate "tree shaking". 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Nei