### PR TITLE
Forbedringer av motregning

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 
-import { Alert, BodyShort, Box, ConfirmationPanel, Heading, VStack } from '@navikt/ds-react';
+import { ArrowUndoIcon } from '@navikt/aksel-icons';
+import {
+    Alert,
+    BodyShort,
+    Box,
+    Button,
+    ConfirmationPanel,
+    Heading,
+    VStack,
+} from '@navikt/ds-react';
 
 import { BekreftSamtykkeTilMotregning } from './BekreftSamtykkeTilMotregning';
 import type {
@@ -34,8 +43,8 @@ export const TilbakekrevingsvedtakMotregning = ({
                     }
                 />
             ) : (
-                <VStack gap="2">
-                    <Alert variant="info" style={{ marginBottom: '1rem' }}>
+                <VStack gap="4">
+                    <Alert variant="info">
                         Du må ha kjennskap til regelverk for tilbakekreving for å kunne fortsette
                         saksbehandlingen.
                     </Alert>
@@ -56,6 +65,16 @@ export const TilbakekrevingsvedtakMotregning = ({
                             Dersom ikke hele beløpet skal kreves tilbake må du splitte saken.
                         </BodyShort>
                     </ConfirmationPanel>
+                    <Box>
+                        <Button
+                            onClick={slettTilbakekrevingsvedtakMotregning}
+                            variant="secondary"
+                            size="small"
+                            icon={<ArrowUndoIcon />}
+                        >
+                            Angre bruk av ulovfestet motregning
+                        </Button>
+                    </Box>
                 </VStack>
             )}
         </Box>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/utils.ts
@@ -25,9 +25,9 @@ export const utledTekstTilModia = (avregningsperioder: IAvregningsperiode[]) => 
 
         return (
             `Du har rett til etterbetaling av barnetrygd for ${periode} på ${etterbetaling} kroner.\n\n` +
-            `Samtidig ser vi at du kan ha fått en feilutbetaling på ${feilutbetaling} kroner for mye barnetrygd i ${periode}. Grunnen til dette er FRITEKST.\n\n` +
-            `Er det greit at vi venter med etterbetalingen til vi har vurdert om du må betale tilbake? Hvis du gjør det, kan vi trekke feilutbetalt beløp fra etterbetalingen din.\n\n` +
-            `Svar på om du samtykker ved å logge deg inn på MinSide. I svaret kan du samtidig uttale deg om feilutbetalingen. Dette må du gjøre innen ${dagerFristForAvventerSamtykkeUlovfestetMotregning} dager.`
+            `Samtidig ser vi at du har fått en feilutbetaling på ${feilutbetaling} kroner i ${periode}.\n\n` +
+            `Er det greit at vi venter med etterbetaling til vi har vurdert om vi skal kreve tilbake feilutbetalt beløp? Hvis du samtykker, kan vi trekke eventuell tilbakekreving fra etterbetalingen din.\n\n` +
+            `Gi samtykke ved å svare JA på denne meldingen. I svaret kan du samtidig uttale deg om feilutbetalingen. Dette må du gjøre innen ${dagerFristForAvventerSamtykkeUlovfestetMotregning} dager.`
         );
     } else {
         const formaterPerioder = (felt: 'totalEtterbetaling' | 'totalFeilutbetaling') =>
@@ -56,10 +56,10 @@ export const utledTekstTilModia = (avregningsperioder: IAvregningsperiode[]) => 
         return (
             `Du har rett til etterbetaling av barnetrygd for periodene:\n` +
             etterbetalingsperioderFormatert.join('\n') +
-            `\n\nSamtidig ser vi at du kan ha fått feilutbetalinger i periodene:\n` +
+            `\n\nSamtidig ser vi at du har fått feilutbetalinger i periodene:\n` +
             feilutbetalingsperioderFormatert.join('\n') +
-            `\n\nEr det greit at vi venter med etterbetalingen til vi har vurdert om du må betale tilbake? Hvis du gjør det, kan vi trekke feilutbetalt beløp fra etterbetalingen din.\n\n` +
-            `Svar på om du samtykker ved å logge deg inn på MinSide. I svaret kan du samtidig uttale deg om feilutbetalingen. Dette må du gjøre innen ${dagerFristForAvventerSamtykkeUlovfestetMotregning} dager.`
+            `\n\nEr det greit at vi venter med etterbetaling til vi har vurdert om vi skal kreve tilbake feilutbetalt beløp? Hvis du samtykker, kan vi trekke eventuell tilbakekreving fra etterbetalingen din.\n\n` +
+            `Gi samtykke ved å svare JA på denne meldingen. I svaret kan du samtidig uttale deg om feilutbetalingen. Dette må du gjøre innen ${dagerFristForAvventerSamtykkeUlovfestetMotregning} dager.`
         );
     }
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-25099

- Endrer formulering i tekst som saksbehandler skal kopiere og sende til Modia
- Legger til knapp på simuleringssteget _Angre bruk av ulovfestet motregning_, som sletter `TilbakekrevingsvedtakMotregning` som hører til behandlingen

### 👀 Screen shots
![image](https://github.com/user-attachments/assets/aa6769e5-ecde-488d-9cd7-a2e439b68c72)

