### PR TITLE
Setter permissions på bygging av PR til contents: read

### DIFF
--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -1,5 +1,8 @@
 name: Build PR
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sikkerhetsgreie, vi burde sette permissions på bygging av PRer. Vi har det på alle andre actions, men ikke denne.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Jeg kommer sannsynligvis til å eksperimentere noe med hva minste permission er her. Jeg ser vi har mer permissions på bygging av applikasjonen, men trenger man egentlig det?
Det bygging av applikasjon-jobben i deploy har av permissions:
```
permissions:
      contents: read
      id-token: write
```

Det jeg har satt nå av permissions for alle jobber i bygging av PR:
```
permissions:
      contents: read
```

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer