### PR TITLE
Motregning refaktorering

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 
-import { Alert, Box } from '@navikt/ds-react';
+import { Alert } from '@navikt/ds-react';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { MigreringAlerts } from './MigreringAlerts';
@@ -11,7 +11,7 @@ import { useSimuleringContext } from './SimuleringContext';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
 import { useAppContext } from '../../../../../context/AppContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
-import { BehandlingSteg, type IBehandling, SettPåVentÅrsak } from '../../../../../typer/behandling';
+import { BehandlingSteg, type IBehandling } from '../../../../../typer/behandling';
 import type { ITilbakekreving } from '../../../../../typer/simulering';
 import { ToggleNavn } from '../../../../../typer/toggles';
 import { hentSøkersMålform } from '../../../../../utils/behandling';
@@ -19,12 +19,7 @@ import { useBehandlingContext } from '../../context/BehandlingContext';
 import Skjemasteg from '../Skjemasteg';
 import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
-import AvregningAlert from './UlovfestetMotregning/AvregningAlert';
 import { TilbakekrevingsvedtakMotregning } from './UlovfestetMotregning/TilbakekrevingsvedtakMotregning';
-import {
-    dagerFristForAvventerSamtykkeUlovfestetMotregning,
-    useTilbakekrevingsvedtakMotregning,
-} from './UlovfestetMotregning/useTilbakekrevingsvedtakMotregning';
 
 interface ISimuleringProps {
     åpenBehandling: IBehandling;
@@ -55,15 +50,9 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
     const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
-    const { slettTilbakekrevingsvedtakMotregning, oppdaterTilbakekrevingsvedtakMotregning } =
-        useTilbakekrevingsvedtakMotregning(åpenBehandling);
-
     const erAvregningOgToggleErPå =
         avregningsperioder.length > 0 &&
         toggles[ToggleNavn.brukFunksjonalitetForUlovfestetMotregning];
-    const erBehandlingSattPåVentMedÅrsakAvventerSamtykke =
-        åpenBehandling.aktivSettPåVent?.årsak ===
-        SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING;
 
     const nesteOnClick = () => {
         if (erLesevisning) {
@@ -142,39 +131,14 @@ const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling
                                 behandlingErMigreringFraInfotrygdMedKun0Utbetalinger
                             }
                         />
+
                         {erAvregningOgToggleErPå && (
-                            <Box marginBlock="8 0" width="fit-content">
-                                {erBehandlingSattPåVentMedÅrsakAvventerSamtykke && (
-                                    <Alert variant="info">
-                                        Saken venter på samtykke fra bruker for ulovfestet
-                                        motregning. Hvis bruker har gitt samtykke før det har gått{' '}
-                                        {dagerFristForAvventerSamtykkeUlovfestetMotregning} dager,
-                                        kan saken tas av vent manuelt.
-                                    </Alert>
-                                )}
-
-                                {tilbakekrevingsvedtakMotregning === null && (
-                                    <AvregningAlert
-                                        avregningsperioder={avregningsperioder}
-                                        harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
-                                    />
-                                )}
-
-                                {tilbakekrevingsvedtakMotregning !== null && (
-                                    <TilbakekrevingsvedtakMotregning
-                                        tilbakekrevingsvedtakMotregning={
-                                            tilbakekrevingsvedtakMotregning
-                                        }
-                                        slettTilbakekrevingsvedtakMotregning={
-                                            slettTilbakekrevingsvedtakMotregning
-                                        }
-                                        oppdaterTilbakekrevingsvedtakMotregning={
-                                            oppdaterTilbakekrevingsvedtakMotregning
-                                        }
-                                        erLesevisning={erLesevisning}
-                                    />
-                                )}
-                            </Box>
+                            <TilbakekrevingsvedtakMotregning
+                                åpenBehandling={åpenBehandling}
+                                tilbakekrevingsvedtakMotregning={tilbakekrevingsvedtakMotregning}
+                                avregningsperioder={avregningsperioder}
+                                harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
+                            />
                         )}
 
                         {skalViseTilbakekrevingSkjema && (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
@@ -14,7 +14,6 @@ import { erProd } from '../../../../../../utils/miljø';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const StyledAlert = styled(Alert)`
-    margin-top: 2rem;
     width: fit-content;
 `;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Alert, BodyLong, Box, Button, HStack } from '@navikt/ds-react';
+import { Alert, BodyLong, Button, HStack } from '@navikt/ds-react';
 
 import type { OppdaterTilbakekrevingsvedtakMotregningDTO } from '../../../../../../typer/tilbakekrevingsvedtakMotregning';
 
@@ -19,40 +19,36 @@ export const BekreftSamtykkeTilMotregning = ({
     const [sletter, settSletter] = useState(false);
 
     return (
-        <Box marginBlock="8 0" width="fit-content">
-            <Alert variant={'info'}>
-                <BodyLong spacing>
-                    Bruker har samtykket til at vi venter med etterbetalingen til vi har vurdert
-                    feilutbetalingen
-                </BodyLong>
-                <HStack gap="4" justify="center">
-                    <Button
-                        onClick={() => {
-                            settSletter(true);
-                            slettTilbakekrevingsvedtakMotregning().finally(() =>
-                                settSletter(false)
-                            );
-                        }}
-                        loading={sletter}
-                        disabled={sletter || oppdaterer}
-                        variant="secondary"
-                    >
-                        Nei
-                    </Button>
-                    <Button
-                        onClick={() => {
-                            settOppdaterer(true);
-                            oppdaterTilbakekrevingsvedtakMotregning({ samtykke: true }).finally(
-                                () => settOppdaterer(false)
-                            );
-                        }}
-                        loading={oppdaterer}
-                        disabled={oppdaterer || sletter}
-                    >
-                        Ja
-                    </Button>
-                </HStack>
-            </Alert>
-        </Box>
+        <Alert variant={'info'}>
+            <BodyLong spacing>
+                Bruker har samtykket til at vi venter med etterbetalingen til vi har vurdert
+                feilutbetalingen
+            </BodyLong>
+            <HStack gap="4" justify="center">
+                <Button
+                    onClick={() => {
+                        settSletter(true);
+                        slettTilbakekrevingsvedtakMotregning().finally(() => settSletter(false));
+                    }}
+                    loading={sletter}
+                    disabled={sletter || oppdaterer}
+                    variant="secondary"
+                >
+                    Nei
+                </Button>
+                <Button
+                    onClick={() => {
+                        settOppdaterer(true);
+                        oppdaterTilbakekrevingsvedtakMotregning({ samtykke: true }).finally(() =>
+                            settOppdaterer(false)
+                        );
+                    }}
+                    loading={oppdaterer}
+                    disabled={oppdaterer || sletter}
+                >
+                    Ja
+                </Button>
+            </HStack>
+        </Alert>
     );
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -10,78 +10,123 @@ import {
     Heading,
     VStack,
 } from '@navikt/ds-react';
+import type { Ressurs } from '@navikt/familie-typer';
 
+import AvregningAlert from './AvregningAlert';
 import { BekreftSamtykkeTilMotregning } from './BekreftSamtykkeTilMotregning';
-import type {
-    OppdaterTilbakekrevingsvedtakMotregningDTO,
-    TilbakekrevingsvedtakMotregningDTO,
-} from '../../../../../../typer/tilbakekrevingsvedtakMotregning';
+import {
+    dagerFristForAvventerSamtykkeUlovfestetMotregning,
+    useTilbakekrevingsvedtakMotregning,
+} from './useTilbakekrevingsvedtakMotregning';
+import { type IBehandling, SettPåVentÅrsak } from '../../../../../../typer/behandling';
+import type { IAvregningsperiode } from '../../../../../../typer/simulering';
+import type { TilbakekrevingsvedtakMotregningDTO } from '../../../../../../typer/tilbakekrevingsvedtakMotregning';
+import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface TilbakekrevingsvedtakMotregningProps {
-    tilbakekrevingsvedtakMotregning: TilbakekrevingsvedtakMotregningDTO;
-    slettTilbakekrevingsvedtakMotregning: () => Promise<void>;
-    oppdaterTilbakekrevingsvedtakMotregning: (
-        dto: OppdaterTilbakekrevingsvedtakMotregningDTO
-    ) => Promise<void>;
-    erLesevisning: boolean;
+    åpenBehandling: IBehandling;
+    tilbakekrevingsvedtakMotregning: TilbakekrevingsvedtakMotregningDTO | null;
+    avregningsperioder: IAvregningsperiode[];
+    harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
 }
 
 export const TilbakekrevingsvedtakMotregning = ({
+    åpenBehandling,
     tilbakekrevingsvedtakMotregning,
-    slettTilbakekrevingsvedtakMotregning,
-    oppdaterTilbakekrevingsvedtakMotregning,
-    erLesevisning,
+    avregningsperioder,
+    harÅpenTilbakekrevingRessurs,
 }: TilbakekrevingsvedtakMotregningProps) => {
+    const { slettTilbakekrevingsvedtakMotregning, oppdaterTilbakekrevingsvedtakMotregning } =
+        useTilbakekrevingsvedtakMotregning(åpenBehandling);
+
+    const { vurderErLesevisning } = useBehandlingContext();
+
+    const erLesevisning = vurderErLesevisning();
+
+    const erBehandlingSattPåVentMedÅrsakAvventerSamtykke =
+        åpenBehandling.aktivSettPåVent?.årsak ===
+        SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING;
+
     return (
-        <Box marginBlock="10 0" width="90%" maxWidth="40rem">
-            <Heading size="medium" level="2" spacing>
-                Tilbakekreving - ulovfestet motregning
-            </Heading>
-            {!tilbakekrevingsvedtakMotregning.samtykke ? (
-                <BekreftSamtykkeTilMotregning
-                    slettTilbakekrevingsvedtakMotregning={slettTilbakekrevingsvedtakMotregning}
-                    oppdaterTilbakekrevingsvedtakMotregning={
-                        oppdaterTilbakekrevingsvedtakMotregning
-                    }
+        <VStack marginBlock="10 0" width="90%" maxWidth="40rem" gap="4">
+            {tilbakekrevingsvedtakMotregning === null && (
+                <AvregningAlert
+                    avregningsperioder={avregningsperioder}
+                    harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
                 />
-            ) : (
-                <VStack gap="4">
-                    <Alert variant="info">
-                        Du må ha kjennskap til regelverk for tilbakekreving for å kunne fortsette
-                        saksbehandlingen.
-                    </Alert>
-                    <ConfirmationPanel
-                        checked={tilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake}
-                        label="Hele beløpet skal kreves tilbake"
-                        disabled={erLesevisning}
-                        onChange={() =>
-                            oppdaterTilbakekrevingsvedtakMotregning({
-                                heleBeløpetSkalKrevesTilbake:
-                                    !tilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake,
-                            })
-                        }
-                    >
-                        <Heading level="2" size="xsmall" spacing>
-                            Skal hele beløpet kreves tilbake?
-                        </Heading>
-                        <BodyShort>
-                            Dersom ikke hele beløpet skal kreves tilbake må du splitte saken.
-                        </BodyShort>
-                    </ConfirmationPanel>
-                    {!erLesevisning && (
-                        <Box>
-                            <Button
-                                onClick={slettTilbakekrevingsvedtakMotregning}
-                                variant="secondary"
-                                size="small"
-                                icon={<ArrowUndoIcon />}
-                            >
-                                Angre bruk av ulovfestet motregning
-                            </Button>
-                        </Box>
-                    )}
-                </VStack>
             )}
-        </Box>
+
+            {tilbakekrevingsvedtakMotregning !== null && (
+                <>
+                    <Heading size="medium" level="2">
+                        Tilbakekreving - ulovfestet motregning
+                    </Heading>
+
+                    {erBehandlingSattPåVentMedÅrsakAvventerSamtykke && (
+                        <Alert variant="info">
+                            Saken venter på samtykke fra bruker for ulovfestet motregning. Hvis
+                            bruker har gitt samtykke før det har gått{' '}
+                            {dagerFristForAvventerSamtykkeUlovfestetMotregning} dager, kan saken tas
+                            av vent manuelt.
+                        </Alert>
+                    )}
+
+                    {!tilbakekrevingsvedtakMotregning.samtykke && !erLesevisning && (
+                        <BekreftSamtykkeTilMotregning
+                            slettTilbakekrevingsvedtakMotregning={
+                                slettTilbakekrevingsvedtakMotregning
+                            }
+                            oppdaterTilbakekrevingsvedtakMotregning={
+                                oppdaterTilbakekrevingsvedtakMotregning
+                            }
+                        />
+                    )}
+
+                    {tilbakekrevingsvedtakMotregning.samtykke && (
+                        <VStack gap="4">
+                            <Alert variant="info">
+                                Du må ha kjennskap til regelverk for tilbakekreving for å kunne
+                                fortsette saksbehandlingen.
+                            </Alert>
+
+                            <ConfirmationPanel
+                                checked={
+                                    tilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake
+                                }
+                                label="Hele beløpet skal kreves tilbake"
+                                disabled={erLesevisning}
+                                onChange={() =>
+                                    oppdaterTilbakekrevingsvedtakMotregning({
+                                        heleBeløpetSkalKrevesTilbake:
+                                            !tilbakekrevingsvedtakMotregning.heleBeløpetSkalKrevesTilbake,
+                                    })
+                                }
+                            >
+                                <Heading level="2" size="xsmall" spacing>
+                                    Skal hele beløpet kreves tilbake?
+                                </Heading>
+                                <BodyShort>
+                                    Dersom ikke hele beløpet skal kreves tilbake må du splitte
+                                    saken.
+                                </BodyShort>
+                            </ConfirmationPanel>
+
+                            {!erLesevisning && (
+                                <Box>
+                                    <Button
+                                        onClick={slettTilbakekrevingsvedtakMotregning}
+                                        variant="secondary"
+                                        size="small"
+                                        icon={<ArrowUndoIcon />}
+                                    >
+                                        Angre bruk av ulovfestet motregning
+                                    </Button>
+                                </Box>
+                            )}
+                        </VStack>
+                    )}
+                </>
+            )}
+        </VStack>
     );
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-22569

Flytter alle komponenter relatert til avregning/motregning inn i `TilbakekrevingsvedtakMotregning`, for å holde logikken samlet

Skjuler `BekreftSamtykkeTilMotregning` dersom behandling er i lesevisning

Ingen andre visuelle endringer