### PR TITLE
Eslint skal ikke kræsje webpack når den feiler lokalt

### DIFF
--- a/src/webpack/webpack.common.js
+++ b/src/webpack/webpack.common.js
@@ -37,6 +37,7 @@ const baseConfig = {
             eslintPath: require.resolve('eslint'),
             extensions: ['ts', 'tsx'],
             configType: 'flat',
+            failOnError: process.env.NODE_ENV === 'production',
         }),
     ],
     devtool: 'inline-source-map',


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Når vi oppgraderte `eslint-webpack-plugin` til v5.0.1 endret det måten eslint fungerte lokalt. Den begynte å kræsje webpack-serveren når vi hadde en lint-feil. Det er ikke heldig og sakket utviklingsfarten. Dette fikser det.

Kilde på endringen: https://github.com/webpack-contrib/eslint-webpack-plugin/releases/tag/v5.0.1

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen store bekymringer her, alt burde være bænkers.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei

### 👀 Screen shots
Ingen endringer, men her var feilen vi fikk når det kræsjet:
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/4f5524e0-f29e-4912-b2ed-faf532335bd8" />

Etter denne endringen vil vi få denne feilen, som ikke kræsjer noe som helst: 
<img width="923" alt="image" src="https://github.com/user-attachments/assets/7f2aa4e8-4fc7-43fb-9244-a017a4a7793c" />
