### PR TITLE
Legger til HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG

### DIFF
--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -225,6 +225,7 @@ export enum BehandlingResultat {
     HENLAGT_FEILAKTIG_OPPRETTET = 'HENLAGT_FEILAKTIG_OPPRETTET',
     HENLAGT_SØKNAD_TRUKKET = 'HENLAGT_SØKNAD_TRUKKET',
     HENLAGT_AUTOMATISK_FØDSELSHENDELSE = 'HENLAGT_AUTOMATISK_FØDSELSHENDELSE',
+    HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG = 'HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG',
     HENLAGT_TEKNISK_VEDLIKEHOLD = 'HENLAGT_TEKNISK_VEDLIKEHOLD',
 
     IKKE_VURDERT = 'IKKE_VURDERT',
@@ -250,6 +251,7 @@ export const erBehandlingHenlagt = (behandlingsresultat?: BehandlingResultat) =>
         behandlingsresultat === BehandlingResultat.HENLAGT_FEILAKTIG_OPPRETTET ||
         behandlingsresultat === BehandlingResultat.HENLAGT_SØKNAD_TRUKKET ||
         behandlingsresultat === BehandlingResultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE ||
+        behandlingsresultat === BehandlingResultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG ||
         behandlingsresultat === BehandlingResultat.HENLAGT_TEKNISK_VEDLIKEHOLD
     );
 };
@@ -398,6 +400,7 @@ export const behandlingsresultater: Record<
     HENLAGT_FEILAKTIG_OPPRETTET: 'Henlagt (feilaktig opprettet)',
     HENLAGT_SØKNAD_TRUKKET: 'Henlagt (søknad trukket)',
     HENLAGT_AUTOMATISK_FØDSELSHENDELSE: 'Henlagt automatisk fødselshendelse',
+    HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG: 'Henlagt automatisk småbarnstillegg',
     HENLAGT_TEKNISK_VEDLIKEHOLD: 'Henlagt teknisk vedlikehold',
     IKKE_VURDERT: 'Ikke vurdert',
     /** De neste er resultat for tilbakekrevingsbehandlinger **/


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25451

Per nå bruker vi BehandlingResultat.HENLAGT_AUTOMATISK_FØDSELSHENDELSE, til og med på småbarnstillegg som er feil. Vi legger til BehandlingResultat.HENLAGT_AUTOMATISK_SMÅBARNSTILLEGG, da dette er ønsket.