### PR TITLE
NAV-25496: Sjekker at søkeresultat ikke er null/undefined

### DIFF
--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -124,7 +124,10 @@ const FagsakDeltagerSøk: React.FC = () => {
                 placeholder={'Fødsels- eller D-nummer (11 siffer)'}
                 nullstillSøkeresultater={() => settFagsakDeltagere(byggTomRessurs())}
                 søkeresultater={mapTilSøkeresultater()}
-                søkeresultatOnClick={(søkeresultat: ISøkeresultat) => {
+                søkeresultatOnClick={søkeresultat => {
+                    if (!søkeresultat) {
+                        return;
+                    }
                     if (toggles[ToggleNavn.brukNyOpprettFagsakModal]) {
                         if (søkeresultat.fagsakId) {
                             navigate(`/fagsak/${søkeresultat.fagsakId}/saksoversikt`);


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-25496](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25496)

Feil oppstod i prod: https://sentry.gc.nav.no/organizations/nav/issues/622729/?alert_rule_id=27&alert_type=issue&environment=barnetrygd.intern.nav.no&notification_uuid=79c06505-b8a3-4641-a57d-6a27f8c0ced3&project=26&referrer=slack

Legger inn sjekk som sjekker at `søkeresultat` ikke er `null` / `undefined`. I mitt hode burde dette egentlig aldri skje, så her burde man på sikt kanskje ta en titt inne i `<Søk />` komponenten og finne ut hvorfor den ble satt til `undefined`. 

Ser dette har skjedd tidligere også: https://sentry.gc.nav.no/organizations/nav/issues/611983/?environment=barnetrygd.intern.nav.no&project=26&query=Cannot+read+properties+of+undefined&referrer=issue-stream&statsPeriod=90d&stream_index=4

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer.
