### PR TITLE
NAV-25329: Tilpasser logikk for visning av skjermet barn i nedtrekkslisten basert på hvilket env man befinner seg i. Legger også til rollene i .nais filene

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -36,6 +36,7 @@ spec:
           - id: "d21e00a4-969d-4b28-8782-dc818abfae65"  # SAKSBEHANDLER_ROLLE
           - id: "9449c153-5a1e-44a7-84c6-7cc7a8867233"  # BESLUTTER_ROLLE
           - id: "314fa714-f13c-4cdc-ac5c-e13ce08e241c"  # SUPERBRUKER_ROLLE
+          - id: "5ef775f2-61f8-4283-bf3d-8d03f428aa14"  # 0000-GA-Strengt_Fortrolig_Adresse
   resources:
     limits:
       cpu: 2000m

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -40,6 +40,7 @@ spec:
           - id: "9cd89ac3-5587-46ba-b571-a625f2af481d"  # MEDLEM: 4833 NAV Familie- og pensjonsytelser Oslo 1
           - id: "7af5f216-6a5e-4228-9c99-687658c5b957"  # MEDLEM: 4842 NAV Familie- og pensjonsytelser Stord
           - id: "0feaea21-ada1-48c0-9300-3f6aec36b993"  # MEDLEM: 4817 NAV Familie- og pensjonsytelser Steinkjer
+          - id: "ad7b87a6-9180-467c-affc-20a566b0fec0"  # 0000-GA-Strengt_Fortrolig_Adresse
   resources:
     limits:
       cpu: 2000m

--- a/.nais/azure-ad-app-lokal.yaml
+++ b/.nais/azure-ad-app-lokal.yaml
@@ -25,3 +25,4 @@ spec:
       - id: "d21e00a4-969d-4b28-8782-dc818abfae65"  # SAKSBEHANDLER_ROLLE
       - id: "9449c153-5a1e-44a7-84c6-7cc7a8867233"  # BESLUTTER_ROLLE
       - id: "314fa714-f13c-4cdc-ac5c-e13ce08e241c"  # SUPERBRUKER_ROLLE
+      - id: "5ef775f2-61f8-4283-bf3d-8d03f428aa14"  # 0000-GA-Strengt_Fortrolig_Adresse

--- a/src/frontend/hooks/useEnvironment.ts
+++ b/src/frontend/hooks/useEnvironment.ts
@@ -1,0 +1,14 @@
+export enum Env {
+    PRODUCTION = 'production',
+    PREPROD = 'preprod',
+    LOKALT_MOT_PREPROD = 'lokalt-mot-preprod',
+    LOCAL = 'local',
+}
+
+export function useEnvironment() {
+    function isEnvironment(env: Env) {
+        return process.env.NODE_ENV === env;
+    }
+
+    return { environment: process.env.NODE_ENV, isEnvironment };
+}

--- a/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
@@ -6,12 +6,16 @@ import { Select } from '@navikt/ds-react';
 
 import { useAppContext } from '../../../../context/AppContext';
 import { useAuthContext } from '../../../../context/AuthContext';
+import { Env, useEnvironment } from '../../../../hooks/useEnvironment';
 import { FagsakType } from '../../../../typer/fagsak';
 import { ToggleNavn } from '../../../../typer/toggles';
 import { useFagsakerContext } from '../context/FagsakerContext';
 import { OpprettFagsakFeltnavn, type OpprettFagsakFormValues } from '../form/OpprettFagsakForm';
 
-const SKJERMET_BARN_GRUPPE = 'ad7b87a6-9180-467c-affc-20a566b0fec0';
+const SKJERMET_BARN_GRUPPE = {
+    PROD: 'ad7b87a6-9180-467c-affc-20a566b0fec0',
+    DEV: '5ef775f2-61f8-4283-bf3d-8d03f428aa14',
+};
 
 const fagsakTypeOptions = [
     {
@@ -39,6 +43,7 @@ interface Props {
 export function FagsaktypeFelt({ readOnly }: Props) {
     const { innloggetSaksbehandler } = useAuthContext();
     const { toggles } = useAppContext();
+    const { harNormalFagsak, harBarnEnsligMindreårigFagsak } = useFagsakerContext();
 
     const { control, setValue, resetField } = useFormContext<OpprettFagsakFormValues>();
 
@@ -48,13 +53,16 @@ export function FagsaktypeFelt({ readOnly }: Props) {
         rules: { required: `Fagsaktype er påkrevd.` },
     });
 
-    const { harNormalFagsak, harBarnEnsligMindreårigFagsak } = useFagsakerContext();
+    const { isEnvironment } = useEnvironment();
 
     const options = fagsakTypeOptions
         .filter(option => {
             if (option.value === FagsakType.SKJERMET_BARN) {
                 const groups = innloggetSaksbehandler?.groups ?? [];
-                const harTilgang = groups.some(group => group === SKJERMET_BARN_GRUPPE);
+                const aktuellGruppe = isEnvironment(Env.PRODUCTION)
+                    ? SKJERMET_BARN_GRUPPE.PROD
+                    : SKJERMET_BARN_GRUPPE.DEV;
+                const harTilgang = groups.some(group => group === aktuellGruppe);
                 return harTilgang && toggles[ToggleNavn.tillattBehandlingAvSkjermetBarn];
             }
             return true;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-25329](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25329)

Tilpasser logikken for å vise "skjermet barn" fagsaktype i nedtrekkslisten basert på hvilket `env` man befinner seg i. 

Legger til gruppen for skjermet barn i .nais filene. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett. 

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer. 