### PR TITLE
NAV-24802: Refaktorer fagsakId og behandlingId hook til enklere mer spesifikke hooks

### DIFF
--- a/src/frontend/hooks/useBehandlingId.test.tsx
+++ b/src/frontend/hooks/useBehandlingId.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+import { useBehandlingId } from './useBehandlingId';
+
+function Router(entry: string) {
+    return ({ children }: PropsWithChildren) => {
+        return (
+            <MemoryRouter initialEntries={[entry]}>
+                <Routes>
+                    <Route path={'/fagsak/:fagsakId'} element={children} />
+                    <Route path={'/behandling/:behandlingId'} element={children} />
+                    <Route path={'/url'} element={children} />
+                </Routes>
+            </MemoryRouter>
+        );
+    };
+}
+
+describe('useBehandlingId', () => {
+    it('skal returnere behandlingId for gyldig URL sti', () => {
+        const behandlingId = '1234';
+        const { result } = renderHook(() => useBehandlingId(), {
+            wrapper: Router(`/behandling/${behandlingId}`),
+        });
+        expect(result.current).toEqual('1234');
+    });
+
+    it('skal returnere undefined of behandlingId er undefined', () => {
+        const behandlingId = undefined;
+        const { result } = renderHook(() => useBehandlingId(), {
+            wrapper: Router(`/behandling/${behandlingId}`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+
+    it('skal returnere undefined for en behandlingId som ikke er et tall', () => {
+        const behandlingId = '123a';
+        const { result } = renderHook(() => useBehandlingId(), {
+            wrapper: Router(`/behandling/${behandlingId}`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+
+    it('skal returnere undefined for URL sti uten behandlingId', () => {
+        const fagsakId = '1234';
+        const { result } = renderHook(() => useBehandlingId(), {
+            wrapper: Router(`/fagsak/${fagsakId}`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+
+    it('skal returnere undefined for URL sti uten noen parameter', () => {
+        const { result } = renderHook(() => useBehandlingId(), {
+            wrapper: Router(`/url`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+});

--- a/src/frontend/hooks/useBehandlingId.ts
+++ b/src/frontend/hooks/useBehandlingId.ts
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router';
+
+export function useBehandlingId() {
+    const { behandlingId } = useParams();
+    const erTall = behandlingId !== undefined && !isNaN(Number(behandlingId));
+    return erTall ? behandlingId : undefined;
+}

--- a/src/frontend/hooks/useFagsakId.test.tsx
+++ b/src/frontend/hooks/useFagsakId.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+import { useFagsakId } from './useFagsakId';
+
+function Router(entry: string) {
+    return ({ children }: PropsWithChildren) => {
+        return (
+            <MemoryRouter initialEntries={[entry]}>
+                <Routes>
+                    <Route path={'/fagsak/:fagsakId'} element={children} />
+                    <Route path={'/behandling/:behandlingId'} element={children} />
+                    <Route path={'/url'} element={children} />
+                </Routes>
+            </MemoryRouter>
+        );
+    };
+}
+
+describe('useFagsakId', () => {
+    it('skal returnere fagsakId for gyldig URL sti', () => {
+        const fagsakId = '1234';
+        const { result } = renderHook(() => useFagsakId(), {
+            wrapper: Router(`/fagsak/${fagsakId}`),
+        });
+        expect(result.current).toEqual('1234');
+    });
+
+    it('skal returnere undefined of fagsakId er undefined', () => {
+        const fagsakId = undefined;
+        const { result } = renderHook(() => useFagsakId(), {
+            wrapper: Router(`/fagsak/${fagsakId}`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+
+    it('skal returnere undefined for en fagsakid som ikke er et tall', () => {
+        const fagsakId = '123a';
+        const { result } = renderHook(() => useFagsakId(), {
+            wrapper: Router(`/fagsak/${fagsakId}`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+
+    it('skal returnere undefined for URL sti uten fagsakid', () => {
+        const behandlingId = '1234';
+        const { result } = renderHook(() => useFagsakId(), {
+            wrapper: Router(`/behandling/${behandlingId}`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+
+    it('skal returnere undefined for URL sti uten noen parameter', () => {
+        const { result } = renderHook(() => useFagsakId(), {
+            wrapper: Router(`/url`),
+        });
+        expect(result.current).toEqual(undefined);
+    });
+});

--- a/src/frontend/hooks/useFagsakId.ts
+++ b/src/frontend/hooks/useFagsakId.ts
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router';
+
+export function useFagsakId() {
+    const { fagsakId } = useParams();
+    const erTall = fagsakId !== undefined && !isNaN(Number(fagsakId));
+    return erTall ? fagsakId : undefined;
+}

--- a/src/frontend/hooks/useSakOgBehandlingParams.ts
+++ b/src/frontend/hooks/useSakOgBehandlingParams.ts
@@ -1,5 +1,8 @@
 import { useMatch } from 'react-router';
 
+/**
+ * @Deprecated - Bruk {@link useFagsakId} eller {@link useBehandlingId}.
+ */
 const useSakOgBehandlingParams = (): { fagsakId?: string; behandlingId?: string } => {
     const matchFagsakIdOgBehandlingId = useMatch('/fagsak/:fagsakId/:behandlingId/*');
     const matchBareFagsakId = useMatch('/fagsak/:fagsakId/*');


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24802](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24802)

I forbindelse med refaktoreringen av `FagsakContext` forenkler jeg litt params hooken. 

Nå man man skrive `const fagsakId = useFagsakId()` eller `const behandlingId = useBehandlingId()`.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer. 