### PR TITLE
NAV-24802: Oppretter egen ManuelleBrevmottakerePåFagsakContext, flytter det ut fra FagsakContext

### DIFF
--- a/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnIBrevSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnIBrevSkjema.tsx
@@ -10,7 +10,7 @@ import { useAppContext } from '../../../../context/AppContext';
 import LeggTilBarn from '../../../../komponenter/LeggTilBarn/LeggTilBarn';
 import type { IBarnMedOpplysninger } from '../../../../typer/søknad';
 import { isoStringTilDate } from '../../../../utils/dato';
-import { useFagsakContext } from '../../FagsakContext';
+import { useManuelleBrevmottakerePåFagsakContext } from '../../ManuelleBrevmottakerePåFagsakContext';
 
 interface IProps {
     barnIBrevFelt: Felt<IBarnMedOpplysninger[]>;
@@ -20,7 +20,7 @@ interface IProps {
 }
 
 const BarnIBrevSkjema = (props: IProps) => {
-    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
     const { barnIBrevFelt, visFeilmeldinger, settVisFeilmeldinger } = props;
     const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
@@ -25,6 +25,7 @@ import {
     opplysningsdokumenter,
 } from '../Behandling/Høyremeny/Hendelsesoversikt/BrevModul/typer';
 import { useFagsakContext } from '../FagsakContext';
+import { useManuelleBrevmottakerePåFagsakContext } from '../ManuelleBrevmottakerePåFagsakContext';
 import { Mottaker } from '../Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 
 export enum DokumentÅrsakPerson {
@@ -112,12 +113,9 @@ const DokumentutsendingContext = createContext<DokumentutsendingContextValue | u
 );
 
 export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
-    const {
-        bruker,
-        manuelleBrevmottakerePåFagsak,
-        settManuelleBrevmottakerePåFagsak,
-        minimalFagsak,
-    } = useFagsakContext();
+    const { bruker, minimalFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
+        useManuelleBrevmottakerePåFagsakContext();
     const [visInnsendtBrevModal, settVisInnsendtBrevModal] = useState(false);
     const { hentForhåndsvisning, hentetDokument, distribusjonskanal, hentDistribusjonskanal } =
         useDokument();

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -15,14 +15,14 @@ import {
     type DokumentÅrsak,
 } from './DokumentutsendingContext';
 import FritekstAvsnitt from './FritekstAvsnitt/FritekstAvsnitt';
+import KanSøkeSkjema from './KanSøke/KanSøkeSkjema';
 import { useAppContext } from '../../../context/AppContext';
 import { BrevmottakereAlert } from '../../../komponenter/Brevmottaker/BrevmottakereAlert';
 import MålformVelger from '../../../komponenter/MålformVelger';
 import { Distribusjonskanal } from '../../../typer/dokument';
 import type { IPersonInfo } from '../../../typer/person';
 import { ToggleNavn } from '../../../typer/toggles';
-import { useFagsakContext } from '../FagsakContext';
-import KanSøkeSkjema from './KanSøke/KanSøkeSkjema';
+import { useManuelleBrevmottakerePåFagsakContext } from '../ManuelleBrevmottakerePåFagsakContext';
 
 interface Props {
     bruker: IPersonInfo;
@@ -85,7 +85,7 @@ const DokumentutsendingSkjema: React.FC<Props> = ({ bruker }) => {
     } = useDokumentutsendingContext();
     const { harInnloggetSaksbehandlerSkrivetilgang, toggles } = useAppContext();
 
-    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
 
     const finnBarnIBrevÅrsak = (årsak: DokumentÅrsak | undefined): BarnIBrevÅrsak | undefined => {
         switch (årsak) {

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -14,6 +14,7 @@ import { FagsakProvider, useFagsakContext } from './FagsakContext';
 import { FagsakLinje } from './FagsakLinje';
 import { InfotrygdFagsak } from './Infotrygd/InfotrygdFagsak';
 import JournalpostListe from './journalposter/JournalpostListe';
+import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
 import { Personlinje } from './Personlinje/Personlinje';
 import Saksoversikt from './Saksoversikt/Saksoversikt';
 import useSakOgBehandlingParams from '../../hooks/useSakOgBehandlingParams';
@@ -48,92 +49,96 @@ const FagsakContainerInnhold: React.FunctionComponent = () => {
             switch (brukerRessurs.status) {
                 case RessursStatus.SUKSESS:
                     return (
-                        <HovedInnhold>
-                            <Personlinje
-                                bruker={brukerRessurs.data}
-                                minimalFagsak={minimalFagsakRessurs.data}
-                            />
-                            <Routes>
-                                <Route
-                                    path="/saksoversikt"
-                                    element={
-                                        <>
-                                            <FagsakLinje
-                                                bruker={brukerRessurs.data}
-                                                minimalFagsak={minimalFagsakRessurs.data}
-                                            />
-                                            <Saksoversikt
-                                                bruker={brukerRessurs.data}
-                                                minimalFagsak={minimalFagsakRessurs.data}
-                                            />
-                                        </>
-                                    }
+                        <ManuelleBrevmottakerePåFagsakProvider key={fagsakId}>
+                            <HovedInnhold>
+                                <Personlinje
+                                    bruker={brukerRessurs.data}
+                                    minimalFagsak={minimalFagsakRessurs.data}
                                 />
-                                <Route
-                                    path="/dokumentutsending"
-                                    element={
-                                        <>
-                                            <FagsakLinje
-                                                bruker={brukerRessurs.data}
-                                                minimalFagsak={minimalFagsakRessurs.data}
-                                            />
-                                            <DokumentutsendingProvider
-                                                fagsakId={minimalFagsakRessurs.data.id}
-                                            >
-                                                <Dokumentutsending bruker={brukerRessurs.data} />
-                                            </DokumentutsendingProvider>
-                                        </>
-                                    }
-                                />
-                                <Route
-                                    path="/dokumenter"
-                                    element={
-                                        <>
-                                            <FagsakLinje
-                                                bruker={brukerRessurs.data}
-                                                minimalFagsak={minimalFagsakRessurs.data}
-                                            />
-                                            <JournalpostListe bruker={brukerRessurs.data} />
-                                        </>
-                                    }
-                                />
-                                <Route
-                                    path="/infotrygd"
-                                    element={
-                                        <>
-                                            <FagsakLinje
-                                                bruker={brukerRessurs.data}
-                                                minimalFagsak={minimalFagsakRessurs.data}
-                                            />
-                                            <InfotrygdFagsak
-                                                minimalFagsak={minimalFagsakRessurs.data}
-                                            />
-                                        </>
-                                    }
-                                />
-                                <Route
-                                    path="/:behandlingId/*"
-                                    element={
-                                        <HentOgSettBehandlingProvider
-                                            fagsak={minimalFagsakRessurs.data}
-                                        >
-                                            <BehandlingContainer
-                                                bruker={brukerRessurs.data}
+                                <Routes>
+                                    <Route
+                                        path="/saksoversikt"
+                                        element={
+                                            <>
+                                                <FagsakLinje
+                                                    bruker={brukerRessurs.data}
+                                                    minimalFagsak={minimalFagsakRessurs.data}
+                                                />
+                                                <Saksoversikt
+                                                    bruker={brukerRessurs.data}
+                                                    minimalFagsak={minimalFagsakRessurs.data}
+                                                />
+                                            </>
+                                        }
+                                    />
+                                    <Route
+                                        path="/dokumentutsending"
+                                        element={
+                                            <>
+                                                <FagsakLinje
+                                                    bruker={brukerRessurs.data}
+                                                    minimalFagsak={minimalFagsakRessurs.data}
+                                                />
+                                                <DokumentutsendingProvider
+                                                    fagsakId={minimalFagsakRessurs.data.id}
+                                                >
+                                                    <Dokumentutsending
+                                                        bruker={brukerRessurs.data}
+                                                    />
+                                                </DokumentutsendingProvider>
+                                            </>
+                                        }
+                                    />
+                                    <Route
+                                        path="/dokumenter"
+                                        element={
+                                            <>
+                                                <FagsakLinje
+                                                    bruker={brukerRessurs.data}
+                                                    minimalFagsak={minimalFagsakRessurs.data}
+                                                />
+                                                <JournalpostListe bruker={brukerRessurs.data} />
+                                            </>
+                                        }
+                                    />
+                                    <Route
+                                        path="/infotrygd"
+                                        element={
+                                            <>
+                                                <FagsakLinje
+                                                    bruker={brukerRessurs.data}
+                                                    minimalFagsak={minimalFagsakRessurs.data}
+                                                />
+                                                <InfotrygdFagsak
+                                                    minimalFagsak={minimalFagsakRessurs.data}
+                                                />
+                                            </>
+                                        }
+                                    />
+                                    <Route
+                                        path="/:behandlingId/*"
+                                        element={
+                                            <HentOgSettBehandlingProvider
                                                 fagsak={minimalFagsakRessurs.data}
-                                            />
-                                        </HentOgSettBehandlingProvider>
-                                    }
-                                />
-                                <Route
-                                    path="/"
-                                    element={
-                                        <>
-                                            <Navigate to={`/fagsak/${fagsakId}/saksoversikt`} />
-                                        </>
-                                    }
-                                />
-                            </Routes>
-                        </HovedInnhold>
+                                            >
+                                                <BehandlingContainer
+                                                    bruker={brukerRessurs.data}
+                                                    fagsak={minimalFagsakRessurs.data}
+                                                />
+                                            </HentOgSettBehandlingProvider>
+                                        }
+                                    />
+                                    <Route
+                                        path="/"
+                                        element={
+                                            <>
+                                                <Navigate to={`/fagsak/${fagsakId}/saksoversikt`} />
+                                            </>
+                                        }
+                                    />
+                                </Routes>
+                            </HovedInnhold>
+                        </ManuelleBrevmottakerePåFagsakProvider>
                     );
                 case RessursStatus.FEILET:
                 case RessursStatus.FUNKSJONELL_FEIL:

--- a/src/frontend/sider/Fagsak/FagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContext.tsx
@@ -1,10 +1,4 @@
-import React, {
-    createContext,
-    type PropsWithChildren,
-    useContext,
-    useEffect,
-    useState,
-} from 'react';
+import React, { createContext, type PropsWithChildren, useContext, useEffect } from 'react';
 
 import type { AxiosError } from 'axios';
 
@@ -31,7 +25,6 @@ import { type IPersonInfo } from '../../typer/person';
 import { ToggleNavn } from '../../typer/toggles';
 import { sjekkTilgangTilPerson } from '../../utils/commons';
 import { obfuskerFagsak, obfuskerPersonInfo } from '../../utils/obfuskerData';
-import type { SkjemaBrevmottaker } from './Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 
 interface IFagsakContext {
     bruker: Ressurs<IPersonInfo>;
@@ -40,8 +33,6 @@ interface IFagsakContext {
     minimalFagsakRessurs: Ressurs<IMinimalFagsak>;
     settMinimalFagsakRessurs: (fagsak: Ressurs<IMinimalFagsak>) => void;
     minimalFagsak: IMinimalFagsak | undefined;
-    manuelleBrevmottakerePåFagsak: SkjemaBrevmottaker[];
-    settManuelleBrevmottakerePåFagsak: (brevmottakere: SkjemaBrevmottaker[]) => void;
 }
 
 const FagsakContext = createContext<IFagsakContext | undefined>(undefined);
@@ -52,9 +43,6 @@ export const FagsakProvider = (props: PropsWithChildren) => {
 
     const [bruker, settBruker] = React.useState<Ressurs<IPersonInfo>>(byggTomRessurs());
     const [fagsakerPåBruker, settFagsakerPåBruker] = React.useState<IBaseFagsak[]>();
-    const [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak] = useState<
-        SkjemaBrevmottaker[]
-    >([]);
 
     const { request } = useHttp();
     const { skalObfuskereData, toggles } = useAppContext();
@@ -138,7 +126,6 @@ export const FagsakProvider = (props: PropsWithChildren) => {
 
             oppdaterBrukerHvisFagsakEndres(bruker, brukerFødselsnummer);
         }
-        settManuelleBrevmottakerePåFagsak([]);
     }, [minimalFagsakRessurs]);
 
     return (
@@ -150,8 +137,6 @@ export const FagsakProvider = (props: PropsWithChildren) => {
                 minimalFagsakRessurs,
                 settMinimalFagsakRessurs,
                 minimalFagsak: hentDataFraRessurs(minimalFagsakRessurs),
-                manuelleBrevmottakerePåFagsak,
-                settManuelleBrevmottakerePåFagsak,
             }}
         >
             {props.children}

--- a/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.test.tsx
+++ b/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React, { type PropsWithChildren } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+
+import {
+    ManuelleBrevmottakerePåFagsakProvider,
+    useManuelleBrevmottakerePåFagsakContext,
+} from './ManuelleBrevmottakerePåFagsakContext';
+import { lagBrevmottaker } from '../../testdata/brevmottakerTestdata';
+
+function Provider({ children }: PropsWithChildren) {
+    return (
+        <ManuelleBrevmottakerePåFagsakProvider>{children}</ManuelleBrevmottakerePåFagsakProvider>
+    );
+}
+
+describe('ManuelleBrevmottakerePåFagsakContext', () => {
+    test('skal kaste feil om context hooken brukes uten en provider', () => {
+        // Act & expect
+        expect(() => {
+            renderHook(() => useManuelleBrevmottakerePåFagsakContext());
+        }).toThrow(
+            'useManuelleBrevmottakerePåFagsakContext må brukes innenfor en ManuelleBrevmottakerePåFagsakProvider'
+        );
+    });
+
+    test('skal ha en tom liste med brevmottakere om ingen er satt manuelt', () => {
+        // Act
+        const { result } = renderHook(() => useManuelleBrevmottakerePåFagsakContext(), {
+            wrapper: Provider,
+        });
+
+        // Expect
+        expect(result.current.manuelleBrevmottakerePåFagsak).toHaveLength(0);
+    });
+
+    test('skal kunne sette brevmottakere på fagsak', () => {
+        // Arrange
+        const brevmottakere = [lagBrevmottaker()];
+        const { result } = renderHook(() => useManuelleBrevmottakerePåFagsakContext(), {
+            wrapper: Provider,
+        });
+
+        // Act
+        act(() => result.current.settManuelleBrevmottakerePåFagsak(brevmottakere));
+
+        // Expect
+        expect(result.current.manuelleBrevmottakerePåFagsak).toBe(brevmottakere);
+    });
+});

--- a/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, type PropsWithChildren, useContext, useMemo, useState } from 'react';
+
+import type { SkjemaBrevmottaker } from './Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
+
+interface ManuelleBrevmottakerePåFagsakContext {
+    manuelleBrevmottakerePåFagsak: SkjemaBrevmottaker[];
+    settManuelleBrevmottakerePåFagsak: (brevmottakere: SkjemaBrevmottaker[]) => void;
+}
+
+const ManuelleBrevmottakerePåFagsakContext = createContext<
+    ManuelleBrevmottakerePåFagsakContext | undefined
+>(undefined);
+
+export function ManuelleBrevmottakerePåFagsakProvider({ children }: PropsWithChildren) {
+    const [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak] = useState<
+        SkjemaBrevmottaker[]
+    >([]);
+
+    const value = useMemo(
+        () => ({
+            manuelleBrevmottakerePåFagsak,
+            settManuelleBrevmottakerePåFagsak,
+        }),
+        [manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak]
+    );
+
+    return (
+        <ManuelleBrevmottakerePåFagsakContext.Provider value={value}>
+            {children}
+        </ManuelleBrevmottakerePåFagsakContext.Provider>
+    );
+}
+
+export function useManuelleBrevmottakerePåFagsakContext() {
+    const context = useContext(ManuelleBrevmottakerePåFagsakContext);
+    if (context === undefined) {
+        throw new Error(
+            'useManuelleBrevmottakerePåFagsakContext må brukes innenfor en ManuelleBrevmottakerePåFagsakProvider'
+        );
+    }
+    return context;
+}

--- a/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
@@ -3,13 +3,15 @@ import React from 'react';
 import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
 import type { BrevmottakerUseSkjema, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import { felterTilSkjemaBrevmottaker } from './useBrevmottakerSkjema';
-import { useFagsakContext } from '../../../FagsakContext';
+import { useManuelleBrevmottakerePåFagsakContext } from '../../../ManuelleBrevmottakerePåFagsakContext';
 
 interface IFagsakModalProps {
     lukkModal: () => void;
 }
+
 export const LeggTilBrevmottakerModalFagsak: React.FC<IFagsakModalProps> = ({ lukkModal }) => {
-    const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
+        useManuelleBrevmottakerePåFagsakContext();
 
     const lagreMottaker = (useSkjema: BrevmottakerUseSkjema) => {
         if (useSkjema.kanSendeSkjema()) {

--- a/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Dropdown } from '@navikt/ds-react';
 
 import { LeggTilBrevmottakerModalFagsak } from './LeggTilBrevmottakerModalFagsak';
-import { useFagsakContext } from '../../../FagsakContext';
+import { useManuelleBrevmottakerePåFagsakContext } from '../../../ManuelleBrevmottakerePåFagsakContext';
 
 const utledMenyinnslag = (antallMottakere: number) => {
     if (antallMottakere === 0) {
@@ -18,7 +18,7 @@ const utledMenyinnslag = (antallMottakere: number) => {
 export function LeggTilEllerFjernBrevmottakerePåFagsak() {
     const [visModal, settVisModal] = useState(false);
 
-    const { manuelleBrevmottakerePåFagsak } = useFagsakContext();
+    const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
 
     const menyinnslag = utledMenyinnslag(manuelleBrevmottakerePåFagsak.length);
 

--- a/src/frontend/testdata/brevmottakerTestdata.ts
+++ b/src/frontend/testdata/brevmottakerTestdata.ts
@@ -1,0 +1,19 @@
+import {
+    Mottaker,
+    type SkjemaBrevmottaker,
+} from '../sider/Fagsak/Personlinje/Behandlingsmeny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
+
+export function lagBrevmottaker(brevmottaker?: Partial<SkjemaBrevmottaker>): SkjemaBrevmottaker {
+    return {
+        type: Mottaker.FULLMEKTIG,
+        navn: 'Navn Navnesen',
+        adresselinje1: 'Adresselinje 1',
+        adresselinje2: undefined,
+        postnummer: '0001',
+        poststed: 'Oslo',
+        landkode: 'NO',
+        ...(brevmottaker ?? {}),
+    };
+}
+
+export * as BrevmottakerTestdata from './brevmottakerTestdata';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-24802](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24802)

Flytter manuelle brevmottakere på fagsak ut i en egen context. 

`ManuelleBrevmottakerePåFagsakProvider` tilbakestilles hver gang `fagsakId` endres pga. `key` parameteret. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer. 