### PR TITLE
Vis lyspære på vilkår og barn

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
@@ -186,6 +186,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
                                 ),
                                 endringAvOpplysningerBegrunnelse:
                                     skjema.felter.endringAvOpplysningerBegrunnelse.verdi,
+                                erAutomatiskRegistrert: false,
                             },
                             bekreftEndringerViaFrontend,
                         },

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/FyllUtVilkårsvurderingITestmiljøKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/FyllUtVilkårsvurderingITestmiljøKnapp.tsx
@@ -11,6 +11,7 @@ import { erProd } from '../../../../../utils/miljø';
 
 const StyledButton = styled(Button)`
     margin-top: 2rem;
+    margin-bottom: 2rem;
 `;
 
 interface IProps {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -115,6 +115,12 @@ const GeneriskVilkår: React.FC<IProps> = ({
         );
     };
 
+    const skalViseLyspære =
+        toggles[ToggleNavn.skalViseVarsellampeForManueltLagtTilBarn] &&
+        vilkårResultater.some(
+            vilkårResultat => !!vilkårResultat.verdi.begrunnelseForManuellKontroll
+        );
+
     return (
         <Container>
             <Fieldset
@@ -122,11 +128,10 @@ const GeneriskVilkår: React.FC<IProps> = ({
                 legend={vilkårFraConfig.tittel}
                 hideLegend
             >
-                <HStack>
-                    {toggles[ToggleNavn.skalViseVarsellampeForManueltLagtTilBarn] &&
-                        person.erManueltLagtTilISøknad && (
-                            <LightBulbFillIcon fontSize="1.5rem" color="var(--a-icon-warning)" />
-                        )}
+                <HStack gap="4" align="center">
+                    {skalViseLyspære && (
+                        <LightBulbFillIcon fontSize="1.5rem" color="var(--a-icon-warning)" />
+                    )}
                     <Heading size="medium" level="3">
                         {vilkårFraConfig.tittel}
                     </Heading>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { useHttp } from '@navikt/familie-http';
-import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { FeltState } from '@navikt/familie-skjema';
+import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 
 import { mapFraRestVilkårsvurderingTilUi } from './utils';
@@ -106,6 +106,8 @@ export const VilkårsvurderingProvider = ({ åpenBehandling, children }: IProps)
                         vurderesEtter: redigerbartVilkår.verdi.vurderesEtter,
                         utdypendeVilkårsvurderinger:
                             redigerbartVilkår.verdi.utdypendeVilkårsvurderinger.verdi,
+                        begrunnelseForManuellKontroll:
+                            redigerbartVilkår.verdi.begrunnelseForManuellKontroll,
                     },
                 ],
                 andreVurderinger: [],

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
@@ -118,6 +118,8 @@ export const mapFraRestPersonResultatTilPersonResultat = (
                                         vilkårResultat.utdypendeVilkårsvurderinger,
                                         erUtdypendeVilkårsvurderingerGyldig
                                     ),
+                                    begrunnelseForManuellKontroll:
+                                        vilkårResultat.begrunnelseForManuellKontroll,
                                 },
                                 validerVilkår
                             )

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -11,6 +11,7 @@ export interface ISøknadDTO {
     søkerMedOpplysninger: ISøkerMedOpplysninger;
     barnaMedOpplysninger: IBarnMedOpplysningerBackend[];
     endringAvOpplysningerBegrunnelse: string;
+    erAutomatiskRegistrert?: boolean;
 }
 
 export interface ISøkerMedOpplysninger {

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -87,6 +87,7 @@ export interface IVilkårResultat {
     vurderesEtter: Regelverk | null;
     utdypendeVilkårsvurderinger: FeltState<UtdypendeVilkårsvurdering[]>;
     resultatBegrunnelse: ResultatBegrunnelse | null;
+    begrunnelseForManuellKontroll: string | null;
 }
 
 // Vilkårsvurdering typer for api
@@ -118,6 +119,7 @@ export interface IRestVilkårResultat {
     vilkårType: VilkårType;
     vurderesEtter: Regelverk | null;
     utdypendeVilkårsvurderinger: UtdypendeVilkårsvurdering[];
+    begrunnelseForManuellKontroll: string | null;
 }
 
 export interface IRestAnnenVurdering {

--- a/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
+++ b/src/frontend/utils/test/vilkårsvurdering/vilkår.mock.ts
@@ -46,6 +46,7 @@ const mockRestVilkårResultat = ({
     vurderesEtter: erIkkeGenereltVilkår(vilkårType) ? vurderesEtter : null,
     utdypendeVilkårsvurderinger: [],
     resultatBegrunnelse: null,
+    begrunnelseForManuellKontroll: null,
 });
 
 export const mockRestPersonResultat = ({


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-25346

- Vis lyspære foran navn på vilkår dersom saksbehandler må kontrollere vilkåret.
- Vis oppsummering per person av vilkår som må manuelt kontrolleres av saksbehandler og om barnet er manuelt lagt til i søknaden.

Tilhørende [backend-PR](https://github.com/navikt/familie-ba-sak/pull/5453)

### 👀 Screen shots
![image](https://github.com/user-attachments/assets/8e5ad7e8-64c1-4db0-83a4-ce67b32722ff)
![image](https://github.com/user-attachments/assets/47ca8186-6767-433d-b049-8d096a6834f3)
