### PR TITLE
Vi ønsker å bruke fagsak eier som 'bruker' ved skjermet barn

### DIFF
--- a/src/frontend/sider/Fagsak/FagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContext.tsx
@@ -21,8 +21,12 @@ import {
 import { useFagsakApi } from '../../api/useFagsakApi';
 import { useAppContext } from '../../context/AppContext';
 import { useSettAktivBrukerIModiaContext } from '../../hooks/useSettAktivBrukerIModiaContext';
-import type { IBaseFagsak, IMinimalFagsak } from '../../typer/fagsak';
-import { mapMinimalFagsakTilBaseFagsak } from '../../typer/fagsak';
+import {
+    FagsakType,
+    type IBaseFagsak,
+    type IMinimalFagsak,
+    mapMinimalFagsakTilBaseFagsak,
+} from '../../typer/fagsak';
 import { type IPersonInfo } from '../../typer/person';
 import { ToggleNavn } from '../../typer/toggles';
 import { sjekkTilgangTilPerson } from '../../utils/commons';
@@ -80,17 +84,14 @@ export const FagsakProvider = (props: PropsWithChildren) => {
 
     const oppdaterBrukerHvisFagsakEndres = (
         bruker: Ressurs<IPersonInfo>,
-        søkerFødselsnummer?: string
+        fødselsnummer?: string
     ): void => {
-        if (søkerFødselsnummer === undefined) {
+        if (fødselsnummer === undefined) {
             return;
         }
 
-        if (
-            bruker.status !== RessursStatus.SUKSESS ||
-            søkerFødselsnummer !== bruker.data.personIdent
-        ) {
-            hentBruker(søkerFødselsnummer);
+        if (bruker.status !== RessursStatus.SUKSESS || fødselsnummer !== bruker.data.personIdent) {
+            hentBruker(fødselsnummer);
         }
     };
 
@@ -128,10 +129,14 @@ export const FagsakProvider = (props: PropsWithChildren) => {
         ) {
             settBruker(byggTomRessurs());
         } else {
-            oppdaterBrukerHvisFagsakEndres(
-                bruker,
-                hentDataFraRessurs(minimalFagsakRessurs)?.søkerFødselsnummer
-            );
+            const minimalFagsak = hentDataFraRessurs(minimalFagsakRessurs);
+
+            const brukerFødselsnummer =
+                minimalFagsak?.fagsakType === FagsakType.SKJERMET_BARN
+                    ? minimalFagsak?.fagsakeier
+                    : minimalFagsak?.søkerFødselsnummer;
+
+            oppdaterBrukerHvisFagsakEndres(bruker, brukerFødselsnummer);
         }
         settManuelleBrevmottakerePåFagsak([]);
     }, [minimalFagsakRessurs]);


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25658

Per nå er det flere steder i frontend som viser feil når det gjelder hvem 'bruker' på fagsak er.
Dette har konsekvenser for hvor brevet rutes, og hvem det står brevet rutes til.
Når fagsak type er skjermet barn ønsker vi at barn er bruker på fagsak, og dermed så skal relasjoner, fagsaker, og brev ta barnet som utgangspunkt.