### PR TITLE
Legger til bosatt i finnmark nord troms for bosatt i riket vilkåret

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -36,6 +36,8 @@ interface Props {
 const utdypendeVilkårsvurderingTekst: Record<UtdypendeVilkårsvurdering, string> = {
     [UtdypendeVilkårsvurderingGenerell.VURDERING_ANNET_GRUNNLAG]: 'Vurdering annet grunnlag',
     [UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD]: 'Bosatt på Svalbard',
+    [UtdypendeVilkårsvurderingGenerell.BOSATT_I_FINNMARK_NORD_TROMS]:
+        'Bosatt i Finnmark/Nord Troms',
     [UtdypendeVilkårsvurderingNasjonal.VURDERT_MEDLEMSKAP]: 'Vurdert medlemskap',
     [UtdypendeVilkårsvurderingDeltBosted.DELT_BOSTED]: 'Delt bosted: skal deles',
     [UtdypendeVilkårsvurderingDeltBosted.DELT_BOSTED_SKAL_IKKE_DELES]:
@@ -108,14 +110,22 @@ export const UtdypendeVilkårsvurderingMultiselect: React.FC<Props> = ({
     };
 
     const bosattPåSvalbardToggleErPå = toggles[ToggleNavn.bosattSvalbard];
+    const bosattFinnmarkNordtromsToggleErPå = toggles[ToggleNavn.bosattFinnmarkNordtroms];
 
     const muligeUtdypendeVilkårsvurderinger = bestemMuligeUtdypendeVilkårsvurderinger(
         utdypendeVilkårsvurderingAvhengigheter
-    ).filter(
-        utdypendeVilkårsvurdering =>
-            bosattPåSvalbardToggleErPå ||
-            utdypendeVilkårsvurdering !== UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD
-    );
+    )
+        .filter(
+            utdypendeVilkårsvurdering =>
+                bosattPåSvalbardToggleErPå ||
+                utdypendeVilkårsvurdering !== UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD
+        )
+        .filter(
+            utdypendeVilkårsvurdering =>
+                bosattFinnmarkNordtromsToggleErPå ||
+                utdypendeVilkårsvurdering !==
+                    UtdypendeVilkårsvurderingGenerell.BOSATT_I_FINNMARK_NORD_TROMS
+        );
 
     const muligeComboboxValg = muligeUtdypendeVilkårsvurderinger.map(
         mapUtdypendeVilkårsvurderingTilOption

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -20,6 +20,7 @@ export enum ToggleNavn {
     tillattBehandlingAvSkjermetBarn = 'familie-ba-sak.tillatt-behandling-av-kode6-kode19',
     skalViseVarsellampeForManueltLagtTilBarn = 'familie-ba-sak.skal-vise-varsellampe-for-manuelt-lagt-til-barn',
     bosattSvalbard = 'familie-ba-sak.bosatt-svalbard',
+    bosattFinnmarkNordtroms = 'familie-ba-sak.bosatt-finnmark-nord-troms',
 }
 
 export const alleTogglerAv = (): IToggles => {

--- a/src/frontend/typer/vilkår.ts
+++ b/src/frontend/typer/vilkår.ts
@@ -237,6 +237,7 @@ export const annenVurderingConfig: Record<AnnenVurderingType, IAnnenVurderingCon
 export enum UtdypendeVilkårsvurderingGenerell {
     VURDERING_ANNET_GRUNNLAG = 'VURDERING_ANNET_GRUNNLAG',
     BOSATT_PÅ_SVALBARD = 'BOSATT_PÅ_SVALBARD',
+    BOSATT_I_FINNMARK_NORD_TROMS = 'BOSATT_I_FINNMARK_NORD_TROMS',
 }
 
 export enum UtdypendeVilkårsvurderingNasjonal {

--- a/src/frontend/utils/utdypendeVilkårsvurderinger.ts
+++ b/src/frontend/utils/utdypendeVilkårsvurderinger.ts
@@ -72,6 +72,7 @@ export const bestemMuligeUtdypendeVilkårsvurderinger = (
             ? [
                   UtdypendeVilkårsvurderingNasjonal.VURDERT_MEDLEMSKAP,
                   UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD,
+                  UtdypendeVilkårsvurderingGenerell.BOSATT_I_FINNMARK_NORD_TROMS,
               ]
             : []),
         ...(vilkårType === VilkårType.BOR_MED_SØKER


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25690

Vi legger til  bosatt i finnmark nord troms  som mulig valg i utdypende vilkårsvurdering.

Før / Uten Toggle
<img width="563" alt="uten togglette" src="https://github.com/user-attachments/assets/b13a3733-56ef-4874-98e1-86c5aeb72df2" />

Etter / Med Toggle
<img width="508" alt="med toglette" src="https://github.com/user-attachments/assets/91d14d11-36eb-45c5-b16e-725d24c51707" />
