### PR TITLE
Oppdaterer ikon for person i personlinje, vilkår og søk med samme egen komponent og farge for skjermet person

### DIFF
--- a/src/frontend/ikoner/KontorIkonGrønn.tsx
+++ b/src/frontend/ikoner/KontorIkonGrønn.tsx
@@ -9,15 +9,17 @@ interface IKontorIkonGrønn {
     className?: string;
     height?: '32' | '24';
     width?: '32' | '24';
+    color?: string;
 }
 
 const IkonSirkel = styled.span<{
     $height: IKontorIkonGrønn['height'];
     $width: IKontorIkonGrønn['width'];
+    $color: IKontorIkonGrønn['color'];
 }>`
-    border-color: ${AGreen600};
+    border-color: ${props => props.$color};
     border-radius: 50%;
-    background-color: ${AGreen600};
+    background-color: ${props => props.$color};
     display: inline-grid;
     place-items: center;
     height: ${props => props.$height}px;
@@ -29,9 +31,10 @@ const KontorIkonGrønn: React.FunctionComponent<IKontorIkonGrønn> = ({
     className,
     height = '24',
     width = '24',
+    color = AGreen600,
 }) => {
     return (
-        <IkonSirkel $height={height} $width={width}>
+        <IkonSirkel $height={height} $width={width} $color={color}>
             <Buildings3Icon
                 height={height === '24' ? 20 : 28}
                 width={width === '24' ? 20 : 28}

--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 
 import { useNavigate } from 'react-router';
 
-import { PersonCircleFillIcon } from '@navikt/aksel-icons';
 import Endringslogg from '@navikt/familie-endringslogg';
 import type { ISøkeresultat } from '@navikt/familie-header';
-import { ikoner, Søk } from '@navikt/familie-header';
+import { Søk } from '@navikt/familie-header';
 import { useHttp } from '@navikt/familie-http';
-import type { Ressurs } from '@navikt/familie-typer';
 import {
     byggFeiletRessurs,
     byggFunksjonellFeilRessurs,
     byggHenterRessurs,
     byggTomRessurs,
     kjønnType,
+    type Ressurs,
     RessursStatus,
 } from '@navikt/familie-typer';
 import { idnr } from '@navikt/fnrvalidator';
@@ -21,24 +20,26 @@ import { idnr } from '@navikt/fnrvalidator';
 import { useAppContext } from '../../context/AppContext';
 import { ModalType } from '../../context/ModalContext';
 import { useModal } from '../../hooks/useModal';
-import KontorIkonGrønn from '../../ikoner/KontorIkonGrønn';
-import StatusIkon, { Status } from '../../ikoner/StatusIkon';
-import { FagsakType } from '../../typer/fagsak';
-import type { IFagsakDeltager, ISøkParam } from '../../typer/fagsakdeltager';
-import { fagsakdeltagerRoller } from '../../typer/fagsakdeltager';
+import {
+    FagsakDeltagerRolle,
+    fagsakdeltagerRoller,
+    type IFagsakDeltager,
+    type ISøkParam,
+} from '../../typer/fagsakdeltager';
 import { obfuskerFagsakDeltager } from '../../utils/obfuskerData';
+import { PersonIkon } from '../PersonIkon';
 
 function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactNode {
-    if (!fagsakDeltager.harTilgang) {
-        return <StatusIkon status={Status.FEIL} />;
-    }
-    if (fagsakDeltager.fagsakType === FagsakType.INSTITUSJON) {
-        return <KontorIkonGrønn height={'32'} width={'32'} />;
-    }
-    if (fagsakDeltager.fagsakType === FagsakType.SKJERMET_BARN) {
-        return <PersonCircleFillIcon color={'var(--a-orange-600)'} height={'35'} width={'35'} />;
-    }
-    return ikoner[`${fagsakDeltager.rolle}_${fagsakDeltager.kjønn}`];
+    return (
+        <PersonIkon
+            fagsakType={fagsakDeltager.fagsakType}
+            kjønn={fagsakDeltager.kjønn || kjønnType.UKJENT}
+            erBarn={fagsakDeltager.rolle === FagsakDeltagerRolle.Barn}
+            adresseBeskyttelse={fagsakDeltager.adressebeskyttelseGradering}
+            harTilgang={fagsakDeltager.harTilgang}
+            størrelse={'m'}
+        />
+    );
 }
 
 const FagsakDeltagerSøk: React.FC = () => {

--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -7,6 +7,7 @@ import type { ISøkeresultat } from '@navikt/familie-header';
 import { Søk } from '@navikt/familie-header';
 import { useHttp } from '@navikt/familie-http';
 import {
+    Adressebeskyttelsegradering,
     byggFeiletRessurs,
     byggFunksjonellFeilRessurs,
     byggHenterRessurs,
@@ -35,7 +36,10 @@ function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactN
             fagsakType={fagsakDeltager.fagsakType}
             kjønn={fagsakDeltager.kjønn || kjønnType.UKJENT}
             erBarn={fagsakDeltager.rolle === FagsakDeltagerRolle.Barn}
-            adresseBeskyttelse={fagsakDeltager.adressebeskyttelseGradering}
+            adresseBeskyttelse={
+                fagsakDeltager.adressebeskyttelseGradering !== null &&
+                fagsakDeltager.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
+            }
             harTilgang={fagsakDeltager.harTilgang}
             størrelse={'m'}
         />

--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -7,7 +7,6 @@ import type { ISøkeresultat } from '@navikt/familie-header';
 import { Søk } from '@navikt/familie-header';
 import { useHttp } from '@navikt/familie-http';
 import {
-    Adressebeskyttelsegradering,
     byggFeiletRessurs,
     byggFunksjonellFeilRessurs,
     byggHenterRessurs,
@@ -28,6 +27,7 @@ import {
     type ISøkParam,
 } from '../../typer/fagsakdeltager';
 import { obfuskerFagsakDeltager } from '../../utils/obfuskerData';
+import { erAdresseBeskyttet } from '../../utils/validators';
 import { PersonIkon } from '../PersonIkon';
 
 function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactNode {
@@ -36,10 +36,7 @@ function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactN
             fagsakType={fagsakDeltager.fagsakType}
             kjønn={fagsakDeltager.kjønn || kjønnType.UKJENT}
             erBarn={fagsakDeltager.rolle === FagsakDeltagerRolle.Barn}
-            adresseBeskyttelse={
-                fagsakDeltager.adressebeskyttelseGradering !== null &&
-                fagsakDeltager.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
-            }
+            erAdresseBeskyttet={erAdresseBeskyttet(fagsakDeltager.adressebeskyttelseGradering)}
             harTilgang={fagsakDeltager.harTilgang}
             størrelse={'m'}
         />

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -29,12 +29,19 @@ const StyledJenteIkon = styled(JenteIkon)<{ $adresseBeskyttet: boolean }>`
 
 const StyledKvinneIkon = styled(KvinneIkon)<{ $adresseBeskyttet: boolean }>`
     ${props => {
-        if (props.$adresseBeskyttet)
+        if (props.$adresseBeskyttet) {
             return `
             g {
                 fill: var(--a-orange-600);
             }
         `;
+        } else {
+            return `
+            g {
+                fill: var(--a-red-400);
+            }
+        `;
+        }
     }};
 `;
 

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
+import { PersonCircleFillIcon } from '@navikt/aksel-icons';
+import { AGreen400, AOrange600 } from '@navikt/ds-tokens/dist/tokens';
 import {
     GuttIkon,
     JenteIkon,
@@ -17,12 +19,19 @@ import { FagsakType } from '../typer/fagsak';
 
 const StyledJenteIkon = styled(JenteIkon)<{ $adresseBeskyttet: boolean }>`
     ${props => {
-        if (props.$adresseBeskyttet)
+        if (props.$adresseBeskyttet) {
             return `
             g {
                 fill: var(--a-orange-600);
             }
         `;
+        } else {
+            return `
+                g {
+                    fill: var(--a-purple-400);
+                }
+        `;
+        }
     }};
 `;
 
@@ -36,9 +45,9 @@ const StyledKvinneIkon = styled(KvinneIkon)<{ $adresseBeskyttet: boolean }>`
         `;
         } else {
             return `
-            g {
-                fill: var(--a-red-400);
-            }
+                g {
+                    fill: var(--a-purple-400);
+                }
         `;
         }
     }};
@@ -46,23 +55,39 @@ const StyledKvinneIkon = styled(KvinneIkon)<{ $adresseBeskyttet: boolean }>`
 
 const StyledGuttIkon = styled(GuttIkon)<{ $adresseBeskyttet: boolean }>`
     ${props => {
-        if (props.$adresseBeskyttet)
-            return `
+        if (props.$adresseBeskyttet) {
+            {
+                return `
             g {
                 fill: var(--a-orange-600);
             }
         `;
+            }
+        } else {
+            return `
+                g {
+                    fill: var(--a-blue-400);
+                }
+        `;
+        }
     }};
 `;
 
 const StyledMannIkon = styled(MannIkon)<{ $adresseBeskyttet: boolean }>`
     ${props => {
-        if (props.$adresseBeskyttet)
+        if (props.$adresseBeskyttet) {
             return `
             g {
                 fill: var(--a-orange-600);
             }
         `;
+        } else {
+            return `
+                g {
+                    fill: var(--a-blue-400);
+                }
+        `;
+        }
     }};
 `;
 
@@ -70,10 +95,27 @@ const StyledNøytralIkon = styled(NøytralPersonIkon)<{ $adresseBeskyttet: boole
     ${props => {
         if (props.$adresseBeskyttet)
             return `
-            g {
-                fill: var(--a-orange-600);
-            }
-        `;
+                path:first-of-type {
+                    fill: var(--a-orange-600);
+                }
+            `;
+    }}
+`;
+
+const StyledEnsligMindreårigIkon = styled(PersonCircleFillIcon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet) {
+            return `
+                path {
+                    fill: var(--a-orange-600);
+                }
+            `;
+        } else {
+            return `
+            path {
+                fill: var(--a-limegreen-700);
+            `;
+        }
     }};
 `;
 
@@ -100,12 +142,24 @@ export const PersonIkon = ({
 
     if (fagsakType === FagsakType.INSTITUSJON) {
         if (størrelse === 'm') {
-            return <KontorIkonGrønn height="32" width="32" />;
+            return (
+                <KontorIkonGrønn
+                    height="32"
+                    width="32"
+                    color={adresseBeskyttelse ? AOrange600 : AGreen400}
+                />
+            );
         }
-        return <KontorIkonGrønn height="24" width="24" />;
+        return (
+            <KontorIkonGrønn
+                height="24"
+                width="24"
+                color={adresseBeskyttelse ? AOrange600 : AGreen400}
+            />
+        );
     }
+    let ikonProps = størrelse === 's' ? { height: 28, width: 28 } : { height: 36, width: 36 };
     if (fagsakType === FagsakType.SKJERMET_BARN) {
-        const ikonProps = størrelse === 's' ? { height: 28, width: 28 } : { height: 36, width: 36 };
         if (kjønn === kjønnType.KVINNE) {
             return <StyledJenteIkon $adresseBeskyttet={true} {...ikonProps} />;
         }
@@ -114,7 +168,11 @@ export const PersonIkon = ({
         }
     }
 
-    const ikonProps = størrelse === 's' ? { height: 24, width: 24 } : { height: 32, width: 32 };
+    if (fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
+        return <StyledEnsligMindreårigIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />;
+    }
+
+    ikonProps = størrelse === 's' ? { height: 24, width: 24 } : { height: 32, width: 32 };
     if (kjønn === kjønnType.KVINNE) {
         return erBarn ? (
             <StyledJenteIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -124,7 +124,7 @@ interface PersonIkonProps {
     kjønn: kjønnType;
     erBarn: boolean;
     størrelse?: 's' | 'm';
-    adresseBeskyttelse?: boolean;
+    erAdresseBeskyttet?: boolean;
     harTilgang?: boolean;
 }
 
@@ -133,7 +133,7 @@ export const PersonIkon = ({
     kjønn,
     erBarn,
     størrelse = 's',
-    adresseBeskyttelse = false,
+    erAdresseBeskyttet = false,
     harTilgang = true,
 }: PersonIkonProps) => {
     if (!harTilgang) {
@@ -146,7 +146,7 @@ export const PersonIkon = ({
                 <KontorIkonGrønn
                     height="32"
                     width="32"
-                    color={adresseBeskyttelse ? AOrange600 : AGreen400}
+                    color={erAdresseBeskyttet ? AOrange600 : AGreen400}
                 />
             );
         }
@@ -154,7 +154,7 @@ export const PersonIkon = ({
             <KontorIkonGrønn
                 height="24"
                 width="24"
-                color={adresseBeskyttelse ? AOrange600 : AGreen400}
+                color={erAdresseBeskyttet ? AOrange600 : AGreen400}
             />
         );
     }
@@ -169,23 +169,23 @@ export const PersonIkon = ({
     }
 
     if (fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
-        return <StyledEnsligMindreårigIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />;
+        return <StyledEnsligMindreårigIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />;
     }
 
     ikonProps = størrelse === 's' ? { height: 24, width: 24 } : { height: 32, width: 32 };
     if (kjønn === kjønnType.KVINNE) {
         return erBarn ? (
-            <StyledJenteIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
+            <StyledJenteIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
         ) : (
-            <StyledKvinneIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
+            <StyledKvinneIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
         );
     }
     if (kjønn === kjønnType.MANN) {
         return erBarn ? (
-            <StyledGuttIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
+            <StyledGuttIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
         ) : (
-            <StyledMannIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
+            <StyledMannIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
         );
     }
-    return <StyledNøytralIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />;
+    return <StyledNøytralIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />;
 };

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import {
+    GuttIkon,
+    JenteIkon,
+    KvinneIkon,
+    MannIkon,
+    NøytralPersonIkon,
+} from '@navikt/familie-ikoner';
+import { kjønnType } from '@navikt/familie-typer';
+
+import KontorIkonGrønn from '../ikoner/KontorIkonGrønn';
+import StatusIkon, { Status } from '../ikoner/StatusIkon';
+import { FagsakType } from '../typer/fagsak';
+import { Adressebeskyttelsegradering } from '../typer/person';
+
+const StyledJenteIkon = styled(JenteIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet)
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+    }};
+`;
+
+const StyledKvinneIkon = styled(KvinneIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet)
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+    }};
+`;
+
+const StyledGuttIkon = styled(GuttIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet)
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+    }};
+`;
+
+const StyledMannIkon = styled(MannIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet)
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+    }};
+`;
+
+const StyledNøytralIkon = styled(NøytralPersonIkon)<{ $adresseBeskyttet: boolean }>`
+    ${props => {
+        if (props.$adresseBeskyttet)
+            return `
+            g {
+                fill: var(--a-orange-600);
+            }
+        `;
+    }};
+`;
+
+interface PersonIkonProps {
+    fagsakType?: FagsakType;
+    kjønn: kjønnType;
+    erBarn: boolean;
+    størrelse?: 's' | 'm';
+    adresseBeskyttelse?: Adressebeskyttelsegradering;
+    harTilgang?: boolean;
+}
+
+export const PersonIkon = ({
+    fagsakType,
+    kjønn,
+    erBarn,
+    størrelse = 's',
+    adresseBeskyttelse,
+    harTilgang = true,
+}: PersonIkonProps) => {
+    if (!harTilgang) {
+        return <StatusIkon status={Status.FEIL} />;
+    }
+    const erBeskyttet =
+        adresseBeskyttelse !== null && adresseBeskyttelse !== Adressebeskyttelsegradering.UGRADERT;
+
+    if (fagsakType === FagsakType.INSTITUSJON) {
+        if (størrelse === 'm') {
+            return <KontorIkonGrønn height="32" width="32" />;
+        }
+        return <KontorIkonGrønn height="24" width="24" />;
+    }
+    if (fagsakType === FagsakType.SKJERMET_BARN) {
+        const ikonProps = størrelse === 's' ? { height: 28, width: 28 } : { height: 36, width: 36 };
+        if (kjønn === kjønnType.KVINNE) {
+            return <StyledJenteIkon $adresseBeskyttet={true} {...ikonProps} />;
+        }
+        if (kjønn === kjønnType.MANN) {
+            return <StyledGuttIkon $adresseBeskyttet={true} {...ikonProps} />;
+        }
+    }
+
+    const ikonProps = størrelse === 's' ? { height: 24, width: 24 } : { height: 32, width: 32 };
+    if (kjønn === kjønnType.KVINNE) {
+        return erBarn ? (
+            <StyledJenteIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+        ) : (
+            <StyledKvinneIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+        );
+    }
+    if (kjønn === kjønnType.MANN) {
+        return erBarn ? (
+            <StyledGuttIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+        ) : (
+            <StyledMannIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+        );
+    }
+    return <StyledNøytralIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />;
+};

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -14,7 +14,6 @@ import { kjønnType } from '@navikt/familie-typer';
 import KontorIkonGrønn from '../ikoner/KontorIkonGrønn';
 import StatusIkon, { Status } from '../ikoner/StatusIkon';
 import { FagsakType } from '../typer/fagsak';
-import { Adressebeskyttelsegradering } from '../typer/person';
 
 const StyledJenteIkon = styled(JenteIkon)<{ $adresseBeskyttet: boolean }>`
     ${props => {
@@ -83,7 +82,7 @@ interface PersonIkonProps {
     kjønn: kjønnType;
     erBarn: boolean;
     størrelse?: 's' | 'm';
-    adresseBeskyttelse?: Adressebeskyttelsegradering;
+    adresseBeskyttelse?: boolean;
     harTilgang?: boolean;
 }
 
@@ -92,14 +91,12 @@ export const PersonIkon = ({
     kjønn,
     erBarn,
     størrelse = 's',
-    adresseBeskyttelse,
+    adresseBeskyttelse = false,
     harTilgang = true,
 }: PersonIkonProps) => {
     if (!harTilgang) {
         return <StatusIkon status={Status.FEIL} />;
     }
-    const erBeskyttet =
-        adresseBeskyttelse !== null && adresseBeskyttelse !== Adressebeskyttelsegradering.UGRADERT;
 
     if (fagsakType === FagsakType.INSTITUSJON) {
         if (størrelse === 'm') {
@@ -120,17 +117,17 @@ export const PersonIkon = ({
     const ikonProps = størrelse === 's' ? { height: 24, width: 24 } : { height: 32, width: 32 };
     if (kjønn === kjønnType.KVINNE) {
         return erBarn ? (
-            <StyledJenteIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+            <StyledJenteIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
         ) : (
-            <StyledKvinneIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+            <StyledKvinneIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
         );
     }
     if (kjønn === kjønnType.MANN) {
         return erBarn ? (
-            <StyledGuttIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+            <StyledGuttIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
         ) : (
-            <StyledMannIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />
+            <StyledMannIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />
         );
     }
-    return <StyledNøytralIkon $adresseBeskyttet={erBeskyttet} {...ikonProps} />;
+    return <StyledNøytralIkon $adresseBeskyttet={adresseBeskyttelse} {...ikonProps} />;
 };

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -8,13 +8,9 @@ import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import RegistrerDødsfallDato from './RegistrerDødsfallDato';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
-import {
-    Adressebeskyttelsegradering,
-    type IGrunnlagPerson,
-    type IPersonInfo,
-    personTypeMap,
-} from '../../typer/person';
+import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '../../typer/person';
 import { formaterIdent, hentAlder } from '../../utils/formatter';
+import { erAdresseBeskyttet } from '../../utils/validators';
 import DødsfallTag from '../DødsfallTag';
 import { PersonIkon } from '../PersonIkon';
 
@@ -47,16 +43,9 @@ const hentAdresseBeskyttelseGradering = (
             rel => rel.personIdent === personIdent
         );
         if (bruker.personIdent === personIdent) {
-            return (
-                bruker.adressebeskyttelseGradering !== null &&
-                bruker.adressebeskyttelseGradering !== Adressebeskyttelsegradering.UGRADERT
-            );
+            return erAdresseBeskyttet(bruker.adressebeskyttelseGradering);
         } else if (forelderBarnRelasjon?.personIdent === personIdent) {
-            return (
-                forelderBarnRelasjon.adressebeskyttelseGradering !== null &&
-                forelderBarnRelasjon.adressebeskyttelseGradering !==
-                    Adressebeskyttelsegradering.UGRADERT
-            );
+            return erAdresseBeskyttet(forelderBarnRelasjon.adressebeskyttelseGradering);
         }
     }
 };
@@ -84,10 +73,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
 
     const { bruker: brukerRessurs } = useFagsakContext();
 
-    const adresseBeskyttelseGradering = hentAdresseBeskyttelseGradering(
-        brukerRessurs,
-        person.personIdent
-    );
+    const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(brukerRessurs, person.personIdent);
 
     if (somOverskrift) {
         return (
@@ -97,7 +83,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
                     kjønn={person.kjønn}
                     erBarn={alder < 18}
                     størrelse={'m'}
-                    adresseBeskyttelse={adresseBeskyttelseGradering}
+                    erAdresseBeskyttet={erAdresseBeskyttet}
                 />
                 <HStack gap="4" align="center" wrap={false}>
                     <HeadingUtenOverflow level="2" size="medium" title={navnOgAlder}>
@@ -147,7 +133,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
                 kjønn={person.kjønn}
                 erBarn={alder < 18}
                 størrelse={'m'}
-                adresseBeskyttelse={adresseBeskyttelseGradering}
+                erAdresseBeskyttet={erAdresseBeskyttet}
             />
             <BodyShort className={'navn'} title={navnOgAlder}>
                 {navnOgAlder}

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -6,11 +6,13 @@ import { MenuElipsisHorizontalCircleIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button, CopyButton, Dropdown, Heading, HStack } from '@navikt/ds-react';
 import { FamilieIkonVelger } from '@navikt/familie-ikoner';
 
-import type { IGrunnlagPerson } from '../../typer/person';
-import { personTypeMap } from '../../typer/person';
+import RegistrerDødsfallDato from './RegistrerDødsfallDato';
+import { useHentPerson } from '../../hooks/useHentPerson';
+import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
+import { type IGrunnlagPerson, personTypeMap } from '../../typer/person';
 import { formaterIdent, hentAlder } from '../../utils/formatter';
 import DødsfallTag from '../DødsfallTag';
-import RegistrerDødsfallDato from './RegistrerDødsfallDato';
+import { PersonIkon } from '../PersonIkon';
 
 interface IProps {
     person: IGrunnlagPerson;
@@ -48,11 +50,19 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
     const alder = hentAlder(person.fødselsdato);
     const navnOgAlder = `${person.navn} (${alder} år)`;
     const formattertIdent = formaterIdent(person.personIdent);
+    const { minimalFagsak } = useFagsakContext();
+    const { data: søkerData } = useHentPerson(minimalFagsak?.søkerFødselsnummer);
 
     if (somOverskrift) {
         return (
             <HStack gap="6" wrap={false} align="center">
-                <FamilieIkonVelger alder={alder} kjønn={person.kjønn} />
+                <PersonIkon
+                    fagsakType={minimalFagsak?.fagsakType}
+                    kjønn={person.kjønn}
+                    erBarn={alder < 18}
+                    størrelse={'m'}
+                    adresseBeskyttelse={søkerData?.adressebeskyttelseGradering}
+                />
                 <HStack gap="4" align="center" wrap={false}>
                     <HeadingUtenOverflow level="2" size="medium" title={navnOgAlder}>
                         {navnOgAlder}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
@@ -29,6 +29,7 @@ const VilkårsvurderingSkjemaEnsligMindreårig: React.FC<IProps> = ({ visFeilmel
     const personResultat = vilkårsvurdering.find(
         (value: IPersonResultat) => value.person.type === PersonType.BARN
     );
+
     const opplysningsplikt = personResultat?.andreVurderinger.find(
         value => value.verdi.type === AnnenVurderingType.OPPLYSNINGSPLIKT
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -150,6 +150,7 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
                     vilkårResultat =>
                         vilkårResultat.verdi.vilkårType === VilkårType.UTVIDET_BARNETRYGD
                 );
+
                 return (
                     <div
                         key={`${index}_${personResultat.person.fødselsdato}`}

--- a/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
@@ -9,7 +9,7 @@ import { PersonIkon } from '../../../komponenter/PersonIkon';
 import type { IBehandling } from '../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakType } from '../../../typer/fagsak';
-import { type IPersonInfo } from '../../../typer/person';
+import { Adressebeskyttelsegradering, type IPersonInfo } from '../../../typer/person';
 import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 import { formaterIdent, hentAlder, millisekunderIEttÅr } from '../../../utils/formatter';
 
@@ -68,7 +68,11 @@ export const Personlinje = ({ bruker, minimalFagsak }: PersonlinjeProps) => {
                         fagsakType={minimalFagsak?.fagsakType}
                         kjønn={fagsakeier.kjønn}
                         erBarn={fagsakeier.alder < 18}
-                        adresseBeskyttelse={søkerData?.adressebeskyttelseGradering}
+                        adresseBeskyttelse={
+                            søkerData?.adressebeskyttelseGradering !== null &&
+                            søkerData?.adressebeskyttelseGradering !==
+                                Adressebeskyttelsegradering.UGRADERT
+                        }
                     />
                     <BodyShort as="span" weight="semibold">
                         {fagsakeier.navn} ({fagsakeier.alder} år)

--- a/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
@@ -9,9 +9,10 @@ import { PersonIkon } from '../../../komponenter/PersonIkon';
 import type { IBehandling } from '../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakType } from '../../../typer/fagsak';
-import { Adressebeskyttelsegradering, type IPersonInfo } from '../../../typer/person';
+import { type IPersonInfo } from '../../../typer/person';
 import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 import { formaterIdent, hentAlder, millisekunderIEttÅr } from '../../../utils/formatter';
+import { erAdresseBeskyttet } from '../../../utils/validators';
 
 interface PersonlinjeProps {
     bruker?: IPersonInfo;
@@ -68,11 +69,9 @@ export const Personlinje = ({ bruker, minimalFagsak }: PersonlinjeProps) => {
                         fagsakType={minimalFagsak?.fagsakType}
                         kjønn={fagsakeier.kjønn}
                         erBarn={fagsakeier.alder < 18}
-                        adresseBeskyttelse={
-                            søkerData?.adressebeskyttelseGradering !== null &&
-                            søkerData?.adressebeskyttelseGradering !==
-                                Adressebeskyttelsegradering.UGRADERT
-                        }
+                        erAdresseBeskyttet={erAdresseBeskyttet(
+                            søkerData?.adressebeskyttelseGradering
+                        )}
                     />
                     <BodyShort as="span" weight="semibold">
                         {fagsakeier.navn} ({fagsakeier.alder} år)

--- a/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/sider/Fagsak/Personlinje/Personlinje.tsx
@@ -1,23 +1,15 @@
 import React from 'react';
 
-import { PersonCircleFillIcon } from '@navikt/aksel-icons';
 import { BodyShort, Box, CopyButton, HStack, Tag } from '@navikt/ds-react';
-import {
-    GuttIkon,
-    JenteIkon,
-    KvinneIkon,
-    MannIkon,
-    NøytralPersonIkon,
-} from '@navikt/familie-ikoner';
 import { kjønnType } from '@navikt/familie-typer';
 
 import { useHentPerson } from '../../../hooks/useHentPerson';
-import KontorIkonGrønn from '../../../ikoner/KontorIkonGrønn';
 import DødsfallTag from '../../../komponenter/DødsfallTag';
+import { PersonIkon } from '../../../komponenter/PersonIkon';
 import type { IBehandling } from '../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { FagsakType } from '../../../typer/fagsak';
-import type { IPersonInfo } from '../../../typer/person';
+import { type IPersonInfo } from '../../../typer/person';
 import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 import { formaterIdent, hentAlder, millisekunderIEttÅr } from '../../../utils/formatter';
 
@@ -26,31 +18,6 @@ interface PersonlinjeProps {
     minimalFagsak?: IMinimalFagsak;
     behandling?: IBehandling;
 }
-
-interface PersonlinjeIkonProps {
-    fagsakType?: FagsakType;
-    kjønn: string;
-    alder: number;
-}
-
-const PersonlinjeIkon = ({ fagsakType, kjønn, alder }: PersonlinjeIkonProps) => {
-    if (fagsakType === FagsakType.INSTITUSJON) {
-        return <KontorIkonGrønn height="24" width="24" />;
-    }
-    if (fagsakType === FagsakType.SKJERMET_BARN) {
-        return <PersonCircleFillIcon color="var(--a-orange-600)" height={28} width={28} />;
-    }
-
-    const ikonProps = { height: 24, width: 24 };
-
-    if (kjønn === kjønnType.KVINNE) {
-        return alder < 18 ? <JenteIkon {...ikonProps} /> : <KvinneIkon {...ikonProps} />;
-    }
-    if (kjønn === kjønnType.MANN) {
-        return alder < 18 ? <GuttIkon {...ikonProps} /> : <MannIkon {...ikonProps} />;
-    }
-    return <NøytralPersonIkon {...ikonProps} />;
-};
 
 const InnholdContainer = ({ children }: React.PropsWithChildren) => {
     return (
@@ -97,10 +64,11 @@ export const Personlinje = ({ bruker, minimalFagsak }: PersonlinjeProps) => {
         <InnholdContainer>
             <HStack align="center" gap="3 4">
                 <HStack align="center" gap="3 4">
-                    <PersonlinjeIkon
+                    <PersonIkon
                         fagsakType={minimalFagsak?.fagsakType}
                         kjønn={fagsakeier.kjønn}
-                        alder={fagsakeier.alder}
+                        erBarn={fagsakeier.alder < 18}
+                        adresseBeskyttelse={søkerData?.adressebeskyttelseGradering}
                     />
                     <BodyShort as="span" weight="semibold">
                         {fagsakeier.navn} ({fagsakeier.alder} år)

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -1,17 +1,16 @@
 import { addYears, endOfMonth, isAfter, isBefore, isSameDay, isValid, parseISO } from 'date-fns';
 
-import { feil, ok, Valideringsstatus } from '@navikt/familie-skjema';
 import type { Avhengigheter, FeltState, ValiderFelt } from '@navikt/familie-skjema';
+import { feil, ok, Valideringsstatus } from '@navikt/familie-skjema';
 import { idnr } from '@navikt/fnrvalidator';
 
 import type { IIsoDatoPeriode } from './dato';
 import { dagensDato, isoStringTilDate } from './dato';
 import { bestemFeilmeldingForUtdypendeVilkårsvurdering } from './utdypendeVilkårsvurderinger';
-import type { IGrunnlagPerson } from '../typer/person';
-import { PersonType } from '../typer/person';
+import { Adressebeskyttelsegradering, type IGrunnlagPerson, PersonType } from '../typer/person';
 import type { VedtakBegrunnelse } from '../typer/vedtak';
 import type { UtdypendeVilkårsvurdering } from '../typer/vilkår';
-import { Regelverk, Resultat, VilkårType, ResultatBegrunnelse } from '../typer/vilkår';
+import { Regelverk, Resultat, ResultatBegrunnelse, VilkårType } from '../typer/vilkår';
 
 const harFyltInnIdent = (felt: FeltState<string>): FeltState<string> => {
     return /^\d{11}$/.test(felt.verdi.replace(' ', ''))
@@ -241,4 +240,14 @@ export const erLik0 = (string: string) => {
     const tall = Number(string);
 
     return Number.isInteger(tall) && tall === 0;
+};
+
+export const erAdresseBeskyttet = (
+    adresseBeskyttelsesGradering: Adressebeskyttelsegradering | undefined
+) => {
+    return (
+        adresseBeskyttelsesGradering !== undefined &&
+        adresseBeskyttelsesGradering !== null &&
+        adresseBeskyttelsesGradering !== Adressebeskyttelsegradering.UGRADERT
+    );
 };


### PR DESCRIPTION
[Favrokort NAV-25191](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25191)

### 💰 Hva forsøker du å løse i denne PR'en

- Legger til oransje farge på ikon for å indikere om bruker er skjermet.
- Lager felles ikon-komponent for delt bruk mellom personlinje, i søk og i vilkårsvurdering.
- Endret skjermet barn ikon til å spesifisere jente eller gutt ikon for barn.
- Diverse fargeoppdateringer: kvinne lilla, menn blå, lime på enslig forsørger. grå på ukjent.
- Skjermet barn får jente/gutt ikon
- Udefinert barn ikon blir brukt på enslig barn


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_

Jeg er usikker på kriterer på når og når ikke vi skal skrive tester. Har ikke fått gjennomgang ang. testdekning hvordan vi jobber med det enda.


### 🤷‍♀ ️Hvor er det lurt å starte?
commit for commit burde gå fint, men alt i ett går nok fint også.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
FØR
<img width="660" height="528" alt="image" src="https://github.com/user-attachments/assets/370d308d-50a3-4f6f-b882-4e968a0e0a1b" />

<img width="679" height="566" alt="image" src="https://github.com/user-attachments/assets/3b205ea6-370c-4627-8277-375361ab4345" />
<img width="569" height="582" alt="image" src="https://github.com/user-attachments/assets/6bd2e061-9821-420a-9aff-768cc219ebca" />


ETTER (forskjellige usecases) (Skjerming vises ikke i søk pga nevnt problematikk i søk)
Alle ikoner (for herre ikon er det gått for samme blåfarge på mann og gutt, fargen på mann i bilde var for testing)
<img width="407" height="99" alt="image" src="https://github.com/user-attachments/assets/657745e4-08d0-4f00-97df-a3faa4c6b699" />


<img width="797" height="565" alt="image" src="https://github.com/user-attachments/assets/77b9bbef-ce3f-49e5-9e2f-271379ba5538" />
<img width="417" height="478" alt="image" src="https://github.com/user-attachments/assets/d85b2dd5-0477-43c0-b484-2c3533a5f6e6" />
<img width="532" height="499" alt="image" src="https://github.com/user-attachments/assets/278337f3-0090-49c7-8fd6-d21832350f51" />
<img width="831" height="421" alt="image" src="https://github.com/user-attachments/assets/be0e3c1a-718e-4913-9142-9e79501a906d" />
<img width="812" height="367" alt="image" src="https://github.com/user-attachments/assets/e5dd3d26-fcc4-4d56-994f-cbf683396592" />
