### PR TITLE
Legg til Finnmarkstillegg i tidslinje på behandlingsresultat

### DIFF
--- a/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
@@ -120,25 +120,30 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
         ytelseSomSplitterOpp?: YtelseType;
     }
 
-    const ytelserSomMåSplittes = (fagsakType?: FagsakType): YtelseSplittForTidslinje => {
+    const finnYtelserSomMåSplittes = (fagsakType?: FagsakType): YtelseSplittForTidslinje[] => {
         switch (fagsakType) {
             case FagsakType.SKJERMET_BARN:
             case FagsakType.NORMAL:
-                return {
-                    ytelseSomSkalSplittesOpp: YtelseType.UTVIDET_BARNETRYGD,
-                    ytelseSomSplitterOpp: YtelseType.SMÅBARNSTILLEGG,
-                };
+                return [
+                    {
+                        ytelseSomSkalSplittesOpp: YtelseType.UTVIDET_BARNETRYGD,
+                        ytelseSomSplitterOpp: YtelseType.SMÅBARNSTILLEGG,
+                    },
+                    {
+                        ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
+                        ytelseSomSplitterOpp: YtelseType.FINNMARKSTILLEGG,
+                    },
+                ];
             case FagsakType.BARN_ENSLIG_MINDREÅRIG:
-                return {
-                    ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
-                    ytelseSomSplitterOpp: YtelseType.UTVIDET_BARNETRYGD,
-                };
+                return [
+                    {
+                        ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
+                        ytelseSomSplitterOpp: YtelseType.UTVIDET_BARNETRYGD,
+                    },
+                ];
             case FagsakType.INSTITUSJON:
             case undefined:
-                return {
-                    ytelseSomSkalSplittesOpp: undefined,
-                    ytelseSomSplitterOpp: undefined,
-                };
+                return [];
         }
     };
 
@@ -146,7 +151,7 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
         fagsakType?: FagsakType,
         personerMedAndelerTilkjentYtelse?: IPersonMedAndelerTilkjentYtelse[]
     ): Periode[][] => {
-        const ytelseSomMåSplittes = ytelserSomMåSplittes(fagsakType);
+        const ytelserSomMåSplittes = finnYtelserSomMåSplittes(fagsakType);
         return personerMedAndelerTilkjentYtelse
             ? personerMedAndelerTilkjentYtelse.map(
                   (personMedAndelerTilkjentYtelse: IPersonMedAndelerTilkjentYtelse) => {
@@ -162,9 +167,15 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
                                   status: ytelsePeriode.skalUtbetales ? 'suksess' : 'feil',
                               };
 
+                              const ytelseSomMåSplittes = ytelserSomMåSplittes.find(
+                                  ytelse =>
+                                      ytelse.ytelseSomSkalSplittesOpp === ytelsePeriode.ytelseType
+                              );
+
                               if (
+                                  ytelseSomMåSplittes &&
                                   ytelsePeriode.ytelseType ===
-                                  ytelseSomMåSplittes.ytelseSomSkalSplittesOpp
+                                      ytelseSomMåSplittes.ytelseSomSkalSplittesOpp
                               ) {
                                   const andelerSomSkalSplitteOpp =
                                       personMedAndelerTilkjentYtelse.ytelsePerioder.filter(
@@ -182,8 +193,9 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
                                       ),
                                   ];
                               } else if (
+                                  ytelseSomMåSplittes &&
                                   ytelsePeriode.ytelseType !==
-                                  ytelseSomMåSplittes.ytelseSomSplitterOpp
+                                      ytelseSomMåSplittes.ytelseSomSplitterOpp
                               ) {
                                   return [...acc, periode];
                               } else {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { PlusCircleIcon, TrashIcon, XMarkIcon } from '@navikt/aksel-icons';
-import { Alert, BodyShort, Box, Button, HGrid, Heading, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, Box, Button, Heading, HGrid, VStack } from '@navikt/ds-react';
 import { ASpacing10, ASpacing4, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { useHttp } from '@navikt/familie-http';
 import type { Etikett } from '@navikt/familie-tidslinje';
@@ -48,7 +48,7 @@ const UtbetalingsbeløpStack = styled(VStack)`
 `;
 
 const UtbetalingsbeløpRad: React.FC<React.PropsWithChildren> = ({ children }) => (
-    <HGrid columns="1fr 5rem 5rem" gap={'4'}>
+    <HGrid columns="1fr 8rem 5rem" gap={'2'}>
         {children}
     </HGrid>
 );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-25760

Gjør at Finnmarkstillegg splitter ordinære andeler for barn, på samme måte som småbarnstillegg gjør for utvidet.
Endrer bredden på kolonne slik at ordet "Finnmarkstillegg" får plass i oppsummeringsboksen.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<img width="276" height="220" alt="image" src="https://github.com/user-attachments/assets/88afa045-e0fd-44ed-8378-de1abab5f96a" />
<img width="1205" height="376" alt="image" src="https://github.com/user-attachments/assets/be563de7-121f-4348-bf09-a6a3a260b0cc" />