### PR TITLE
Vi må sende med riktig søkerIdent når vi fyller ut søkerMedOpplysninger

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
@@ -165,6 +165,11 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
 
     const nesteAction = (bekreftEndringerViaFrontend: boolean) => {
         if (bruker.status === RessursStatus.SUKSESS) {
+            const søkerIdent =
+                minimalFagsakRessurs.status === RessursStatus.SUKSESS
+                    ? minimalFagsakRessurs.data.søkerFødselsnummer
+                    : bruker.data.personIdent;
+
             if (vurderErLesevisning()) {
                 navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vilkaarsvurdering`);
             } else {
@@ -175,7 +180,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
                             søknad: {
                                 underkategori: skjema.felter.underkategori.verdi,
                                 søkerMedOpplysninger: {
-                                    ident: bruker.data.personIdent,
+                                    ident: søkerIdent,
                                     målform: skjema.felter.målform.verdi,
                                 },
                                 barnaMedOpplysninger: skjema.felter.barnaMedOpplysninger.verdi.map(


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25782

Vi må sende med riktig søkerIdent når vi fyller ut søkerMedOpplysninger.
Det brekker for skjermet barn saker nå pga at søkerIdent settes til å være barn.