### PR TITLE
Vi tilgjengeliggjør finnmarkstillegg og svalbardstillegg i eøs saker

### DIFF
--- a/src/frontend/utils/test/utdypendeVilkårsvurderinger.test.ts
+++ b/src/frontend/utils/test/utdypendeVilkårsvurderinger.test.ts
@@ -88,7 +88,9 @@ describe('Utdypende Vilkårsvurderinger', () => {
             ],
             { ...avhengigheter, vurderesEtter: Regelverk.EØS_FORORDNINGEN }
         );
-        expect(actualForMangeValg).toBe('Du kan kun velge ett alternativ');
+        expect(actualForMangeValg).toBe(
+            'Du kan kun velge ett av disse alternativene: OMFATTET_AV_NORSK_LOVGIVNING,OMFATTET_AV_NORSK_LOVGIVNING_UTLAND'
+        );
     });
 
     it('EØS - Lovlig opphold - Skal ikke fylles ut', () => {

--- a/src/frontend/utils/utdypendeVilkårsvurderinger.ts
+++ b/src/frontend/utils/utdypendeVilkårsvurderinger.ts
@@ -42,7 +42,6 @@ export const bestemMuligeUtdypendeVilkårsvurderinger = (
                 UtdypendeVilkårsvurderingEøsSøkerBosattIRiket.OMFATTET_AV_NORSK_LOVGIVNING,
                 UtdypendeVilkårsvurderingEøsSøkerBosattIRiket.OMFATTET_AV_NORSK_LOVGIVNING_UTLAND,
                 UtdypendeVilkårsvurderingEøsSøkerBosattIRiket.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING,
-                UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD,
                 UtdypendeVilkårsvurderingGenerell.BOSATT_I_FINNMARK_NORD_TROMS,
             ];
         }
@@ -51,7 +50,6 @@ export const bestemMuligeUtdypendeVilkårsvurderinger = (
                 UtdypendeVilkårsvurderingEøsBarnBosattIRiket.BARN_BOR_I_NORGE,
                 UtdypendeVilkårsvurderingEøsBarnBosattIRiket.BARN_BOR_I_EØS,
                 UtdypendeVilkårsvurderingEøsBarnBosattIRiket.BARN_BOR_I_STORBRITANNIA,
-                UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD,
                 UtdypendeVilkårsvurderingGenerell.BOSATT_I_FINNMARK_NORD_TROMS,
             ];
         }

--- a/src/frontend/utils/utdypendeVilkårsvurderinger.ts
+++ b/src/frontend/utils/utdypendeVilkårsvurderinger.ts
@@ -42,6 +42,8 @@ export const bestemMuligeUtdypendeVilkårsvurderinger = (
                 UtdypendeVilkårsvurderingEøsSøkerBosattIRiket.OMFATTET_AV_NORSK_LOVGIVNING,
                 UtdypendeVilkårsvurderingEøsSøkerBosattIRiket.OMFATTET_AV_NORSK_LOVGIVNING_UTLAND,
                 UtdypendeVilkårsvurderingEøsSøkerBosattIRiket.ANNEN_FORELDER_OMFATTET_AV_NORSK_LOVGIVNING,
+                UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD,
+                UtdypendeVilkårsvurderingGenerell.BOSATT_I_FINNMARK_NORD_TROMS,
             ];
         }
         if (vilkårType === VilkårType.BOSATT_I_RIKET && personType === PersonType.BARN) {
@@ -49,6 +51,8 @@ export const bestemMuligeUtdypendeVilkårsvurderinger = (
                 UtdypendeVilkårsvurderingEøsBarnBosattIRiket.BARN_BOR_I_NORGE,
                 UtdypendeVilkårsvurderingEøsBarnBosattIRiket.BARN_BOR_I_EØS,
                 UtdypendeVilkårsvurderingEøsBarnBosattIRiket.BARN_BOR_I_STORBRITANNIA,
+                UtdypendeVilkårsvurderingGenerell.BOSATT_PÅ_SVALBARD,
+                UtdypendeVilkårsvurderingGenerell.BOSATT_I_FINNMARK_NORD_TROMS,
             ];
         }
         if (vilkårType === VilkårType.BOR_MED_SØKER) {
@@ -111,11 +115,20 @@ export const bestemFeilmeldingForUtdypendeVilkårsvurdering = (
 
     if (avhengigheter.vurderesEtter === Regelverk.EØS_FORORDNINGEN) {
         if (avhengigheter.vilkårType === VilkårType.BOSATT_I_RIKET) {
-            if (utdypendeVilkårsvurderinger.length === 0) {
+            const antallValgteEøsAlternativerForBosattIRiket = utdypendeVilkårsvurderinger.filter(
+                item =>
+                    item in UtdypendeVilkårsvurderingEøsSøkerBosattIRiket ||
+                    item in UtdypendeVilkårsvurderingEøsBarnBosattIRiket
+            );
+
+            if (antallValgteEøsAlternativerForBosattIRiket.length === 0) {
                 return 'Du må velge ett alternativ';
             }
-            if (utdypendeVilkårsvurderinger.length > 1) {
-                return 'Du kan kun velge ett alternativ';
+            if (antallValgteEøsAlternativerForBosattIRiket.length > 1) {
+                return (
+                    'Du kan kun velge ett av disse alternativene: ' +
+                    antallValgteEøsAlternativerForBosattIRiket
+                );
             }
         }
         if (avhengigheter.vilkårType === VilkårType.BOR_MED_SØKER) {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25814

Vi må tilgjengeliggjøre bosatt i finnmark og svalbard i utdypende for eøs saker.
I tillegg må vi justere på valideringen slik at det er lov med flere utdypende valg, men bare 1 av UtdypendeVilkårsvurderingEøsBarnBosattIRiket og UtdypendeVilkårsvurderingEøsSøkerBosattIRiket

Ved valideringsfeil:
<img width="702" height="176" alt="valideringsfeil" src="https://github.com/user-attachments/assets/5bdb2746-8533-47e8-aea0-7114d4f3d4c1" />

