### PR TITLE
NAV-24802: Tar i bruk react-query for å håndtere fagsak state

### DIFF
--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -12,7 +12,7 @@ import UgyldigSesjon from './komponenter/Modal/SesjonUtløpt';
 import SystemetLaster from './komponenter/SystemetLaster/SystemetLaster';
 import { TidslinjeProvider } from './komponenter/Tidslinje/TidslinjeContext';
 import Toasts from './komponenter/Toast/Toasts';
-import FagsakContainer from './sider/Fagsak/FagsakContainer';
+import { FagsakContainer } from './sider/Fagsak/FagsakContainer';
 import { Infotrygd } from './sider/Infotrygd/Infotrygd';
 import Internstatistikk from './sider/internstatistikk/Internstatistikk';
 import ManuellJournalføring from './sider/ManuellJournalføring/ManuellJournalføring';

--- a/src/frontend/api/hentFagsak.ts
+++ b/src/frontend/api/hentFagsak.ts
@@ -1,0 +1,13 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { IMinimalFagsak } from '../typer/fagsak';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function hentFagsak(request: FamilieRequest, fagsakId: number) {
+    const ressurs = await request<void, IMinimalFagsak>({
+        method: 'GET',
+        url: `/familie-ba-sak/api/fagsaker/minimal/${fagsakId}`,
+        påvirkerSystemLaster: true,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useFagsakId.test.tsx
+++ b/src/frontend/hooks/useFagsakId.test.tsx
@@ -22,11 +22,11 @@ function Router(entry: string) {
 
 describe('useFagsakId', () => {
     it('skal returnere fagsakId for gyldig URL sti', () => {
-        const fagsakId = '1234';
+        const fagsakId = 1234;
         const { result } = renderHook(() => useFagsakId(), {
             wrapper: Router(`/fagsak/${fagsakId}`),
         });
-        expect(result.current).toEqual('1234');
+        expect(result.current).toEqual(1234);
     });
 
     it('skal returnere undefined of fagsakId er undefined', () => {

--- a/src/frontend/hooks/useFagsakId.ts
+++ b/src/frontend/hooks/useFagsakId.ts
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router';
 
-export function useFagsakId() {
+export function useFagsakId(): number | undefined {
     const { fagsakId } = useParams();
     const erTall = fagsakId !== undefined && !isNaN(Number(fagsakId));
-    return erTall ? fagsakId : undefined;
+    return erTall ? Number(fagsakId) : undefined;
 }

--- a/src/frontend/hooks/useHentFagsak.ts
+++ b/src/frontend/hooks/useHentFagsak.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { hentFagsak } from '../api/hentFagsak';
+import { useAppContext } from '../context/AppContext';
+import type { IMinimalFagsak } from '../typer/fagsak';
+import { PersonType } from '../typer/person';
+
+// TODO : Refactor so it does not mutate fagsak object, but return a new object instead
+function obfuskerFagsak(fagsak: IMinimalFagsak) {
+    fagsak.gjeldendeUtbetalingsperioder.forEach(gup => {
+        let indeks = 1;
+        gup.utbetalingsperiodeDetaljer
+            .sort((a, b) => b.person.fødselsdato.localeCompare(a.person.fødselsdato))
+            .forEach(upd => {
+                if (upd.person.type === PersonType.SØKER) {
+                    upd.person.navn = 'Søker Søkersen';
+                } else {
+                    upd.person.navn = '[' + indeks++ + '] Barn Barnesen';
+                }
+            });
+    });
+}
+
+export const HentFagsakQueryKeyFactory = {
+    fagsak: (fagsakId: number | undefined) => ['fagsak', fagsakId],
+};
+
+export function useHentFagsak(fagsakId: number | undefined) {
+    const { request } = useHttp();
+    const { skalObfuskereData } = useAppContext();
+    return useQuery({
+        queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId),
+        queryFn: async () => {
+            if (fagsakId === undefined) {
+                return Promise.reject(new Error('Kan ikke hente fagsak uten fagsakId.'));
+            }
+            const fagsak = await hentFagsak(request, fagsakId);
+            return Promise.resolve(fagsak);
+        },
+        select: fagsak => {
+            if (skalObfuskereData) {
+                obfuskerFagsak(fagsak);
+            }
+            return fagsak;
+        },
+        enabled: fagsakId !== undefined,
+    });
+}

--- a/src/frontend/komponenter/Brevmottaker/BrevmottakerListe.tsx
+++ b/src/frontend/komponenter/Brevmottaker/BrevmottakerListe.tsx
@@ -13,9 +13,9 @@ interface IProps {
 }
 
 const BrevmottakerListe: React.FC<IProps> = ({ bruker, brevmottakere }) => {
-    const { minimalFagsak } = useFagsakContext();
-    const institusjon = minimalFagsak?.institusjon;
-    const fagsakType = minimalFagsak?.fagsakType;
+    const { fagsak } = useFagsakContext();
+    const institusjon = fagsak.institusjon;
+    const fagsakType = fagsak.fagsakType;
 
     const skalViseInstitusjon = !!institusjon;
     const harUtenlandskAdresse = brevmottakere.some(

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -69,9 +69,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
     const alder = hentAlder(person.fødselsdato);
     const navnOgAlder = `${person.navn} (${alder} år)`;
     const formattertIdent = formaterIdent(person.personIdent);
-    const { minimalFagsak } = useFagsakContext();
-
-    const { bruker: brukerRessurs } = useFagsakContext();
+    const { fagsak, bruker: brukerRessurs } = useFagsakContext();
 
     const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(brukerRessurs, person.personIdent);
 
@@ -79,7 +77,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
         return (
             <HStack gap="6" wrap={false} align="center">
                 <PersonIkon
-                    fagsakType={minimalFagsak?.fagsakType}
+                    fagsakType={fagsak.fagsakType}
                     kjønn={person.kjønn}
                     erBarn={alder < 18}
                     størrelse={'m'}
@@ -129,7 +127,7 @@ const PersonInformasjon: React.FunctionComponent<IProps> = ({
     return (
         <HStack gap="2" align="center" wrap={false}>
             <PersonIkon
-                fagsakType={minimalFagsak?.fagsakType}
+                fagsakType={fagsak.fagsakType}
                 kjønn={person.kjønn}
                 erBarn={alder < 18}
                 størrelse={'m'}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort.tsx
@@ -76,8 +76,8 @@ const StyledHeading = styled(Heading)`
 `;
 
 const Behandlingskort: React.FC<IBehandlingskortProps> = ({ åpenBehandling }) => {
-    const { minimalFagsak } = useFagsakContext();
-    const behandlinger = minimalFagsak?.behandlinger ?? [];
+    const { fagsak } = useFagsakContext();
+    const behandlinger = fagsak.behandlinger;
 
     const antallBehandlinger = behandlinger.length;
     const åpenBehandlingIndex =

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Hendelsesoversikt/BrevModul/useBrevModul.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Hendelsesoversikt/BrevModul/useBrevModul.ts
@@ -32,7 +32,7 @@ import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 export const useBrevModul = () => {
     const { behandling } = useBehandlingContext();
-    const { minimalFagsak } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
 
     const maksAntallKulepunkter = 20;
     const makslengdeFritekstHvertKulepunkt = 220;
@@ -44,13 +44,13 @@ export const useBrevModul = () => {
 
     const personer = behandling?.personer ?? [];
     const brevmottakere = behandling?.brevmottakere ?? [];
-    const institusjon = minimalFagsak?.institusjon;
+    const institusjon = fagsak.institusjon;
 
     const velgMottaker = (): string | undefined => {
-        if (minimalFagsak?.fagsakType === FagsakType.INSTITUSJON && institusjon) {
+        if (fagsak.fagsakType === FagsakType.INSTITUSJON && institusjon) {
             return institusjon.orgNummer;
         }
-        if (minimalFagsak?.fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
+        if (fagsak.fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
             return personer[0].personIdent;
         }
         return personer.find(person => person.type === PersonType.SØKER)?.personIdent;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
@@ -65,7 +65,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
 }) => {
     const navigate = useNavigate();
     const { fagsakId } = useSakOgBehandlingParams();
-    const { minimalFagsak } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
 
     const {
         opprettEndretUtbetaling,
@@ -174,7 +174,7 @@ const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = 
             <TilkjentYtelseTidslinje
                 grunnlagPersoner={grunnlagPersoner}
                 tidslinjePersoner={tidslinjePersoner}
-                fagsakType={minimalFagsak?.fagsakType}
+                fagsakType={fagsak.fagsakType}
             />
             {!erLesevisning && (
                 <EndretUtbetalingAndel>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
@@ -16,17 +16,12 @@ const StyledSkjemasteg = styled(Skjemasteg)`
     max-width: 40rem;
 `;
 
-const StyledAlert = styled(Alert)`
-    margin: 2rem;
-`;
-
 interface IProps {
     åpenBehandling: IBehandling;
 }
 
 const RegistrerInstitusjon: React.FC<IProps> = ({ åpenBehandling }) => {
-    const { institusjon, fagsakFeilmelding, onSubmitMottaker, submitFeilmelding } =
-        useInstitusjon(åpenBehandling);
+    const { institusjon, onSubmitMottaker, submitFeilmelding } = useInstitusjon(åpenBehandling);
     const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest();
     const { behandlingsstegSubmitressurs, vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
@@ -36,28 +31,23 @@ const RegistrerInstitusjon: React.FC<IProps> = ({ åpenBehandling }) => {
     }
 
     return (
-        <>
-            {!fagsakFeilmelding && (
-                <StyledSkjemasteg
-                    className={'mottaker'}
-                    tittel={'Registrer institusjon'}
-                    nesteOnClick={onSubmitMottaker}
-                    nesteKnappTittel={erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
-                    senderInn={behandlingsstegSubmitressurs.status === RessursStatus.HENTER}
-                    steg={BehandlingSteg.REGISTRERE_INSTITUSJON}
-                >
-                    {samhandlerRessurs.status === RessursStatus.SUKSESS && (
-                        <SamhandlerTabell samhandler={samhandlerRessurs.data} />
-                    )}
-                    {(samhandlerRessurs.status === RessursStatus.FUNKSJONELL_FEIL ||
-                        samhandlerRessurs.status === RessursStatus.FEILET) && (
-                        <Alert children={samhandlerRessurs.frontendFeilmelding} variant={'error'} />
-                    )}
-                    {submitFeilmelding && <Alert variant="error" children={submitFeilmelding} />}
-                </StyledSkjemasteg>
+        <StyledSkjemasteg
+            className={'mottaker'}
+            tittel={'Registrer institusjon'}
+            nesteOnClick={onSubmitMottaker}
+            nesteKnappTittel={erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
+            senderInn={behandlingsstegSubmitressurs.status === RessursStatus.HENTER}
+            steg={BehandlingSteg.REGISTRERE_INSTITUSJON}
+        >
+            {samhandlerRessurs.status === RessursStatus.SUKSESS && (
+                <SamhandlerTabell samhandler={samhandlerRessurs.data} />
             )}
-            {fagsakFeilmelding && <StyledAlert variant="info" children={fagsakFeilmelding} />}
-        </>
+            {(samhandlerRessurs.status === RessursStatus.FUNKSJONELL_FEIL ||
+                samhandlerRessurs.status === RessursStatus.FEILET) && (
+                <Alert children={samhandlerRessurs.frontendFeilmelding} variant={'error'} />
+            )}
+            {submitFeilmelding && <Alert variant="error" children={submitFeilmelding} />}
+        </StyledSkjemasteg>
     );
 };
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/useInstitusjon.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/useInstitusjon.ts
@@ -17,20 +17,12 @@ import { useBehandlingContext } from '../../context/BehandlingContext';
 export const useInstitusjon = (åpenBehandling: IBehandling) => {
     const { request } = useHttp();
     const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
-    const { minimalFagsakRessurs } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
     const { fagsakId } = useSakOgBehandlingParams();
     const navigate = useNavigate();
     const [submitFeilmelding, settSubmitFeilmelding] = useState<string | undefined>('');
 
-    const fagsak =
-        minimalFagsakRessurs.status === RessursStatus.SUKSESS
-            ? minimalFagsakRessurs.data
-            : undefined;
-    const fagsakFeilmelding =
-        minimalFagsakRessurs.status !== RessursStatus.SUKSESS
-            ? hentFrontendFeilmelding(minimalFagsakRessurs) || 'Ukjent feil ved henting av fagsak'
-            : '';
-    const institusjon = fagsak?.institusjon;
+    const institusjon = fagsak.institusjon;
 
     const onSubmitMottaker = () => {
         if (
@@ -61,7 +53,6 @@ export const useInstitusjon = (åpenBehandling: IBehandling) => {
     };
 
     return {
-        fagsakFeilmelding,
         onSubmitMottaker,
         institusjon,
         submitFeilmelding,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
@@ -56,13 +56,10 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
     } = useBehandlingContext();
     const { fagsakId } = useSakOgBehandlingParams();
     const navigate = useNavigate();
-    const { bruker, minimalFagsakRessurs } = useFagsakContext();
+    const { bruker, fagsak } = useFagsakContext();
     const [visBekreftModal, settVisBekreftModal] = React.useState<boolean>(false);
 
-    const barnMedLøpendeUtbetaling =
-        minimalFagsakRessurs.status === RessursStatus.SUKSESS
-            ? hentBarnMedLøpendeUtbetaling(minimalFagsakRessurs.data)
-            : new Set<string>();
+    const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
 
     const { skjema, nullstillSkjema, onSubmit, hentFeilTilOppsummering } = useSkjema<
         SøknadSkjema,
@@ -173,11 +170,6 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
             if (vurderErLesevisning()) {
                 navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vilkaarsvurdering`);
             } else {
-                const søkerIdent =
-                    minimalFagsakRessurs.status === RessursStatus.SUKSESS
-                        ? minimalFagsakRessurs.data.søkerFødselsnummer
-                        : bruker.data.personIdent;
-
                 onSubmit<IRestRegistrerSøknad>(
                     {
                         method: 'POST',
@@ -185,7 +177,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
                             søknad: {
                                 underkategori: skjema.felter.underkategori.verdi,
                                 søkerMedOpplysninger: {
-                                    ident: søkerIdent,
+                                    ident: fagsak.søkerFødselsnummer,
                                     målform: skjema.felter.målform.verdi,
                                 },
                                 barnaMedOpplysninger: skjema.felter.barnaMedOpplysninger.verdi.map(

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksmeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksmeny.tsx
@@ -44,7 +44,7 @@ const Vedtaksmeny: React.FunctionComponent<IVedtakmenyProps> = ({
     visFeilutbetaltValuta,
     visRefusjonEøs,
 }) => {
-    const { minimalFagsak } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
     const { vurderErLesevisning } = useBehandlingContext();
     const {
         erSammensattKontrollsak,
@@ -58,7 +58,7 @@ const Vedtaksmeny: React.FunctionComponent<IVedtakmenyProps> = ({
 
     const visSammensattKontrollsakMenyValg = skalViseSammensattKontrollsakMenyValg();
 
-    const fagsakType = minimalFagsak?.fagsakType;
+    const fagsakType = fagsak.fagsakType;
 
     return (
         <Dropdown>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjema.tsx
@@ -12,17 +12,14 @@ interface IProps {
 }
 
 const VilkårsvurderingSkjema: React.FC<IProps> = ({ visFeilmeldinger }) => {
-    const { minimalFagsak } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
 
     const { samhandlerOrgnr } = useBehandlingContext();
 
-    if (
-        minimalFagsak?.fagsakType === FagsakType.NORMAL ||
-        minimalFagsak?.fagsakType === FagsakType.SKJERMET_BARN
-    ) {
+    if (fagsak.fagsakType === FagsakType.NORMAL || fagsak.fagsakType === FagsakType.SKJERMET_BARN) {
         return <VilkårsvurderingSkjemaNormal visFeilmeldinger={visFeilmeldinger} />;
     }
-    if (minimalFagsak?.fagsakType === FagsakType.INSTITUSJON && samhandlerOrgnr) {
+    if (fagsak.fagsakType === FagsakType.INSTITUSJON && samhandlerOrgnr) {
         return (
             <VilkårsvurderingSkjemaInstitusjon
                 visFeilmeldinger={visFeilmeldinger}
@@ -30,7 +27,7 @@ const VilkårsvurderingSkjema: React.FC<IProps> = ({ visFeilmeldinger }) => {
             />
         );
     }
-    if (minimalFagsak?.fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
+    if (fagsak.fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
         return <VilkårsvurderingSkjemaEnsligMindreårig visFeilmeldinger={visFeilmeldinger} />;
     }
     return null;

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router';
 
-import { RessursStatus, type Ressurs } from '@navikt/familie-typer';
+import { type Ressurs } from '@navikt/familie-typer';
 
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
 import useBehandlingApi from './useBehandlingApi';
@@ -90,7 +90,7 @@ const BehandlingContext = createContext<BehandlingContextValue | undefined>(unde
 
 export const BehandlingProvider = ({ behandling, children }: Props) => {
     const { fagsakId } = useSakOgBehandlingParams();
-    const { minimalFagsakRessurs } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
     const { settBehandlingRessurs } = useHentOgSettBehandlingContext();
     const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
     const [åpenVenstremeny, settÅpenVenstremeny] = useState(true);
@@ -249,21 +249,11 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
 
     const erBehandlingAvsluttet = behandling.status === BehandlingStatus.AVSLUTTET;
 
-    const gjelderInstitusjon =
-        minimalFagsakRessurs.status === RessursStatus.SUKSESS &&
-        minimalFagsakRessurs.data.fagsakType === FagsakType.INSTITUSJON;
+    const gjelderInstitusjon = fagsak.fagsakType === FagsakType.INSTITUSJON;
+    const gjelderEnsligMindreårig = fagsak.fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG;
+    const gjelderSkjermetBarn = fagsak.fagsakType === FagsakType.SKJERMET_BARN;
 
-    const gjelderEnsligMindreårig =
-        minimalFagsakRessurs.status === RessursStatus.SUKSESS &&
-        minimalFagsakRessurs.data.fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG;
-
-    const gjelderSkjermetBarn =
-        minimalFagsakRessurs.status === RessursStatus.SUKSESS &&
-        minimalFagsakRessurs.data.fagsakType === FagsakType.SKJERMET_BARN;
-
-    const samhandlerOrgnr = gjelderInstitusjon
-        ? minimalFagsakRessurs.data.institusjon?.orgNummer
-        : undefined;
+    const samhandlerOrgnr = gjelderInstitusjon ? fagsak.institusjon?.orgNummer : undefined;
 
     return (
         <BehandlingContext.Provider

--- a/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import { useNavigate } from 'react-router';
 
@@ -7,11 +8,11 @@ import { useHttp } from '@navikt/familie-http';
 import { byggFeiletRessurs, byggTomRessurs, type Ressurs } from '@navikt/familie-typer';
 
 import { useAppContext } from '../../../../context/AppContext';
+import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
 import useSakOgBehandlingParams from '../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../../typer/fagsak';
 import { obfuskerBehandling } from '../../../../utils/obfuskerData';
-import { useFagsakContext } from '../../FagsakContext';
 
 interface Props extends React.PropsWithChildren {
     fagsak: IMinimalFagsak;
@@ -29,7 +30,7 @@ const HentOgSettBehandlingContext = createContext<HentOgSettBehandlingContextVal
 export const HentOgSettBehandlingProvider = ({ fagsak, children }: Props) => {
     const { request } = useHttp();
     const { behandlingId } = useSakOgBehandlingParams();
-    const { hentMinimalFagsak } = useFagsakContext();
+    const queryClient = useQueryClient();
     const [behandlingRessurs, privatSettBehandlingRessurs] =
         useState<Ressurs<IBehandling>>(byggTomRessurs());
     const navigate = useNavigate();
@@ -43,8 +44,11 @@ export const HentOgSettBehandlingProvider = ({ fagsak, children }: Props) => {
         navigate(`/fagsak/${fagsak.id}`);
     }
 
-    const settBehandlingRessurs = (behandling: Ressurs<IBehandling>) => {
-        hentMinimalFagsak(fagsak.id, false);
+    const settBehandlingRessurs = async (behandling: Ressurs<IBehandling>) => {
+        queryClient.invalidateQueries({
+            queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
+        });
+
         if (skalObfuskereData) {
             obfuskerBehandling(behandling);
         }

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
@@ -113,7 +113,7 @@ const DokumentutsendingContext = createContext<DokumentutsendingContextValue | u
 );
 
 export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
-    const { bruker, minimalFagsak } = useFagsakContext();
+    const { bruker, fagsak } = useFagsakContext();
     const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
         useManuelleBrevmottakerePåFagsakContext();
     const [visInnsendtBrevModal, settVisInnsendtBrevModal] = useState(false);
@@ -124,7 +124,7 @@ export const DokumentutsendingProvider = ({ fagsakId, children }: Props) => {
         IManueltBrevRequestPåFagsak | undefined
     >(undefined);
 
-    const erInstitusjon = minimalFagsak?.fagsakType === FagsakType.INSTITUSJON;
+    const erInstitusjon = fagsak.fagsakType === FagsakType.INSTITUSJON;
     const dokumentÅrsaker = erInstitusjon
         ? Object.values(DokumentÅrsakInstitusjon)
         : Object.values(DokumentÅrsakPerson);

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { Navigate, Route, Routes } from 'react-router';
 import styled from 'styled-components';
 
-import { Alert } from '@navikt/ds-react';
+import { Alert, HStack, Loader } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import BehandlingContainer from './Behandling/BehandlingContainer';
@@ -17,158 +17,142 @@ import JournalpostListe from './journalposter/JournalpostListe';
 import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
 import { Personlinje } from './Personlinje/Personlinje';
 import Saksoversikt from './Saksoversikt/Saksoversikt';
-import useSakOgBehandlingParams from '../../hooks/useSakOgBehandlingParams';
+import { useFagsakId } from '../../hooks/useFagsakId';
+import { useHentFagsak } from '../../hooks/useHentFagsak';
 import { useScrollTilAnker } from '../../hooks/useScrollTilAnker';
+import type { IMinimalFagsak } from '../../typer/fagsak';
 
 const HovedInnhold = styled.div`
     height: calc(100vh - 3rem);
     overflow: auto;
 `;
 
-const FagsakContainerInnhold: React.FunctionComponent = () => {
-    const { fagsakId } = useSakOgBehandlingParams();
-    useScrollTilAnker();
+function FagsakContainerInnhold({ fagsak }: { fagsak: IMinimalFagsak }) {
+    const { bruker: brukerRessurs } = useFagsakContext();
 
-    const { bruker: brukerRessurs, minimalFagsakRessurs, hentMinimalFagsak } = useFagsakContext();
-
-    useEffect(() => {
-        if (fagsakId !== undefined) {
-            if (minimalFagsakRessurs.status !== RessursStatus.SUKSESS) {
-                hentMinimalFagsak(fagsakId);
-            } else if (
-                minimalFagsakRessurs.status === RessursStatus.SUKSESS &&
-                minimalFagsakRessurs.data.id !== parseInt(fagsakId, 10)
-            ) {
-                hentMinimalFagsak(fagsakId);
-            }
-        }
-    }, [fagsakId]);
-
-    switch (minimalFagsakRessurs.status) {
+    switch (brukerRessurs.status) {
         case RessursStatus.SUKSESS:
-            switch (brukerRessurs.status) {
-                case RessursStatus.SUKSESS:
-                    return (
-                        <ManuelleBrevmottakerePåFagsakProvider key={fagsakId}>
-                            <HovedInnhold>
-                                <Personlinje
-                                    bruker={brukerRessurs.data}
-                                    minimalFagsak={minimalFagsakRessurs.data}
-                                />
-                                <Routes>
-                                    <Route
-                                        path="/saksoversikt"
-                                        element={
-                                            <>
-                                                <Fagsaklinje
-                                                    bruker={brukerRessurs.data}
-                                                    minimalFagsak={minimalFagsakRessurs.data}
-                                                />
-                                                <Saksoversikt
-                                                    bruker={brukerRessurs.data}
-                                                    minimalFagsak={minimalFagsakRessurs.data}
-                                                />
-                                            </>
-                                        }
-                                    />
-                                    <Route
-                                        path="/dokumentutsending"
-                                        element={
-                                            <>
-                                                <Fagsaklinje
-                                                    bruker={brukerRessurs.data}
-                                                    minimalFagsak={minimalFagsakRessurs.data}
-                                                />
-                                                <DokumentutsendingProvider
-                                                    fagsakId={minimalFagsakRessurs.data.id}
-                                                >
-                                                    <Dokumentutsending
-                                                        bruker={brukerRessurs.data}
-                                                    />
-                                                </DokumentutsendingProvider>
-                                            </>
-                                        }
-                                    />
-                                    <Route
-                                        path="/dokumenter"
-                                        element={
-                                            <>
-                                                <Fagsaklinje
-                                                    bruker={brukerRessurs.data}
-                                                    minimalFagsak={minimalFagsakRessurs.data}
-                                                />
-                                                <JournalpostListe bruker={brukerRessurs.data} />
-                                            </>
-                                        }
-                                    />
-                                    <Route
-                                        path="/infotrygd"
-                                        element={
-                                            <>
-                                                <Fagsaklinje
-                                                    bruker={brukerRessurs.data}
-                                                    minimalFagsak={minimalFagsakRessurs.data}
-                                                />
-                                                <InfotrygdFagsak
-                                                    minimalFagsak={minimalFagsakRessurs.data}
-                                                />
-                                            </>
-                                        }
-                                    />
-                                    <Route
-                                        path="/:behandlingId/*"
-                                        element={
-                                            <HentOgSettBehandlingProvider
-                                                fagsak={minimalFagsakRessurs.data}
-                                            >
-                                                <BehandlingContainer
-                                                    bruker={brukerRessurs.data}
-                                                    fagsak={minimalFagsakRessurs.data}
-                                                />
-                                            </HentOgSettBehandlingProvider>
-                                        }
-                                    />
-                                    <Route
-                                        path="/"
-                                        element={
-                                            <>
-                                                <Navigate to={`/fagsak/${fagsakId}/saksoversikt`} />
-                                            </>
-                                        }
-                                    />
-                                </Routes>
-                            </HovedInnhold>
-                        </ManuelleBrevmottakerePåFagsakProvider>
-                    );
-                case RessursStatus.FEILET:
-                case RessursStatus.FUNKSJONELL_FEIL:
-                case RessursStatus.IKKE_TILGANG:
-                    return <Alert children={brukerRessurs.frontendFeilmelding} variant="error" />;
-                default:
-                    return <div />;
-            }
-        case RessursStatus.IKKE_TILGANG:
             return (
-                <Alert
-                    children={minimalFagsakRessurs.frontendFeilmelding}
-                    variant="error"
-                    contentMaxWidth={false}
-                />
+                <ManuelleBrevmottakerePåFagsakProvider key={fagsak.id}>
+                    <HovedInnhold>
+                        <Personlinje bruker={brukerRessurs.data} minimalFagsak={fagsak} />
+                        <Routes>
+                            <Route
+                                path="/saksoversikt"
+                                element={
+                                    <>
+                                        <Fagsaklinje
+                                            bruker={brukerRessurs.data}
+                                            minimalFagsak={fagsak}
+                                        />
+                                        <Saksoversikt
+                                            bruker={brukerRessurs.data}
+                                            minimalFagsak={fagsak}
+                                        />
+                                    </>
+                                }
+                            />
+                            <Route
+                                path="/dokumentutsending"
+                                element={
+                                    <>
+                                        <Fagsaklinje
+                                            bruker={brukerRessurs.data}
+                                            minimalFagsak={fagsak}
+                                        />
+                                        <DokumentutsendingProvider fagsakId={fagsak.id}>
+                                            <Dokumentutsending bruker={brukerRessurs.data} />
+                                        </DokumentutsendingProvider>
+                                    </>
+                                }
+                            />
+                            <Route
+                                path="/dokumenter"
+                                element={
+                                    <>
+                                        <Fagsaklinje
+                                            bruker={brukerRessurs.data}
+                                            minimalFagsak={fagsak}
+                                        />
+                                        <JournalpostListe bruker={brukerRessurs.data} />
+                                    </>
+                                }
+                            />
+                            <Route
+                                path="/infotrygd"
+                                element={
+                                    <>
+                                        <Fagsaklinje
+                                            bruker={brukerRessurs.data}
+                                            minimalFagsak={fagsak}
+                                        />
+                                        <InfotrygdFagsak minimalFagsak={fagsak} />
+                                    </>
+                                }
+                            />
+                            <Route
+                                path="/:behandlingId/*"
+                                element={
+                                    <HentOgSettBehandlingProvider fagsak={fagsak}>
+                                        <BehandlingContainer
+                                            bruker={brukerRessurs.data}
+                                            fagsak={fagsak}
+                                        />
+                                    </HentOgSettBehandlingProvider>
+                                }
+                            />
+                            <Route
+                                path="/"
+                                element={
+                                    <>
+                                        <Navigate to={`/fagsak/${fagsak.id}/saksoversikt`} />
+                                    </>
+                                }
+                            />
+                        </Routes>
+                    </HovedInnhold>
+                </ManuelleBrevmottakerePåFagsakProvider>
             );
         case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
-            return <Alert children={minimalFagsakRessurs.frontendFeilmelding} variant="error" />;
+        case RessursStatus.IKKE_TILGANG:
+            return <Alert children={brukerRessurs.frontendFeilmelding} variant="error" />;
         default:
             return <div />;
     }
-};
+}
 
-const FagsakContainer: React.FC = () => {
+export function FagsakContainer() {
+    const fagsakId = useFagsakId();
+
+    useScrollTilAnker();
+
+    const {
+        data: fagsak,
+        isPending: isPendingFagsak,
+        error: fagsakError,
+    } = useHentFagsak(fagsakId);
+
+    if (isPendingFagsak) {
+        return (
+            <HStack gap={'4'} margin={'space-16'}>
+                <Loader size={'small'} />
+                Laster fagsak...
+            </HStack>
+        );
+    }
+
+    if (fagsakError) {
+        return (
+            <Alert variant={'error'}>
+                Feil oppstod ved innlasting av fagsak: {fagsakError.message}
+            </Alert>
+        );
+    }
+
     return (
-        <FagsakProvider>
-            <FagsakContainerInnhold />
+        <FagsakProvider fagsak={fagsak}>
+            <FagsakContainerInnhold fagsak={fagsak} />
         </FagsakProvider>
     );
-};
-
-export default FagsakContainer;
+}

--- a/src/frontend/sider/Fagsak/FagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContext.tsx
@@ -1,16 +1,8 @@
 import React, { createContext, type PropsWithChildren, useContext, useEffect } from 'react';
 
-import type { AxiosError } from 'axios';
-
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
-import {
-    byggFeiletRessurs,
-    byggHenterRessurs,
-    byggTomRessurs,
-    hentDataFraRessurs,
-    RessursStatus,
-} from '@navikt/familie-typer';
+import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useAppContext } from '../../context/AppContext';
 import { useSettAktivBrukerIModiaContext } from '../../hooks/useSettAktivBrukerIModiaContext';
@@ -18,61 +10,30 @@ import { FagsakType, type IMinimalFagsak } from '../../typer/fagsak';
 import { type IPersonInfo } from '../../typer/person';
 import { ToggleNavn } from '../../typer/toggles';
 import { sjekkTilgangTilPerson } from '../../utils/commons';
-import { obfuskerFagsak, obfuskerPersonInfo } from '../../utils/obfuskerData';
+import { obfuskerPersonInfo } from '../../utils/obfuskerData';
 
 interface IFagsakContext {
     bruker: Ressurs<IPersonInfo>;
-    hentMinimalFagsak: (fagsakId: string | number, påvirkerSystemLaster?: boolean) => void;
-    minimalFagsakRessurs: Ressurs<IMinimalFagsak>;
-    settMinimalFagsakRessurs: (fagsak: Ressurs<IMinimalFagsak>) => void;
-    minimalFagsak: IMinimalFagsak | undefined;
+    fagsak: IMinimalFagsak;
 }
 
 const FagsakContext = createContext<IFagsakContext | undefined>(undefined);
 
-export const FagsakProvider = (props: PropsWithChildren) => {
-    const [minimalFagsakRessurs, settMinimalFagsakRessurs] =
-        React.useState<Ressurs<IMinimalFagsak>>(byggTomRessurs());
+interface Props extends PropsWithChildren {
+    fagsak: IMinimalFagsak;
+}
 
+export function FagsakProvider({ fagsak, children }: Props) {
     const [bruker, settBruker] = React.useState<Ressurs<IPersonInfo>>(byggTomRessurs());
 
     const { request } = useHttp();
     const { skalObfuskereData, toggles } = useAppContext();
     const { mutate: settAktivBrukerIModiaContext } = useSettAktivBrukerIModiaContext();
 
-    const hentMinimalFagsak = (fagsakId: string | number, påvirkerSystemLaster = true): void => {
-        if (påvirkerSystemLaster) {
-            settMinimalFagsakRessurs(byggHenterRessurs());
-        }
-
-        request<void, IMinimalFagsak>({
-            method: 'GET',
-            url: `/familie-ba-sak/api/fagsaker/minimal/${fagsakId}`,
-            påvirkerSystemLaster,
-        })
-            .then((hentetFagsak: Ressurs<IMinimalFagsak>) => {
-                if (skalObfuskereData) {
-                    obfuskerFagsak(hentetFagsak);
-                }
-                settMinimalFagsakRessurs(hentetFagsak);
-            })
-            .catch((_error: AxiosError) => {
-                settMinimalFagsakRessurs(byggFeiletRessurs('Ukjent ved innhenting av fagsak'));
-            });
-    };
-
-    const oppdaterBrukerHvisFagsakEndres = (
-        bruker: Ressurs<IPersonInfo>,
-        fødselsnummer?: string
-    ): void => {
-        if (fødselsnummer === undefined) {
-            return;
-        }
-
-        if (bruker.status !== RessursStatus.SUKSESS || fødselsnummer !== bruker.data.personIdent) {
-            hentBruker(fødselsnummer);
-        }
-    };
+    const brukerFødselsnummer =
+        fagsak.fagsakType === FagsakType.SKJERMET_BARN
+            ? fagsak.fagsakeier
+            : fagsak.søkerFødselsnummer;
 
     const hentBruker = (personIdent: string): void => {
         settBruker(byggHenterRessurs());
@@ -97,37 +58,11 @@ export const FagsakProvider = (props: PropsWithChildren) => {
     };
 
     useEffect(() => {
-        if (
-            minimalFagsakRessurs.status !== RessursStatus.SUKSESS &&
-            minimalFagsakRessurs.status !== RessursStatus.HENTER
-        ) {
-            settBruker(byggTomRessurs());
-        } else {
-            const minimalFagsak = hentDataFraRessurs(minimalFagsakRessurs);
+        hentBruker(brukerFødselsnummer);
+    }, [brukerFødselsnummer]);
 
-            const brukerFødselsnummer =
-                minimalFagsak?.fagsakType === FagsakType.SKJERMET_BARN
-                    ? minimalFagsak?.fagsakeier
-                    : minimalFagsak?.søkerFødselsnummer;
-
-            oppdaterBrukerHvisFagsakEndres(bruker, brukerFødselsnummer);
-        }
-    }, [minimalFagsakRessurs]);
-
-    return (
-        <FagsakContext.Provider
-            value={{
-                bruker,
-                hentMinimalFagsak,
-                minimalFagsakRessurs,
-                settMinimalFagsakRessurs,
-                minimalFagsak: hentDataFraRessurs(minimalFagsakRessurs),
-            }}
-        >
-            {props.children}
-        </FagsakContext.Provider>
-    );
-};
+    return <FagsakContext.Provider value={{ bruker, fagsak }}>{children}</FagsakContext.Provider>;
+}
 
 export const useFagsakContext = () => {
     const context = useContext(FagsakContext);

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstema.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/EndreBehandling/EndreBehandlingstema.tsx
@@ -15,7 +15,7 @@ const EndreBehandlingstema: React.FC = () => {
     const { skjema, endreBehandlingstema, ressurs, nullstillSkjema } = useEndreBehandlingstema(() =>
         settVisModal(false)
     );
-    const { minimalFagsak } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
 
     const lukkEndreBehandlingModal = () => {
         nullstillSkjema();
@@ -46,7 +46,7 @@ const EndreBehandlingstema: React.FC = () => {
                         >
                             <BehandlingstemaSelect
                                 behandlingstema={skjema.felter.behandlingstema}
-                                fagsakType={minimalFagsak?.fagsakType}
+                                fagsakType={fagsak.fagsakType}
                                 erLesevisning={vurderErLesevisning()}
                             />
                         </Fieldset>

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandling.ts
@@ -16,7 +16,7 @@ const useHenleggBehandling = (lukkModal: () => void) => {
     const [årsak, settÅrsak] = useState('');
     const { settÅpenBehandling } = useBehandlingContext();
 
-    const { minimalFagsak } = useFagsakContext();
+    const { fagsak } = useFagsakContext();
 
     const { onSubmit, skjema, nullstillSkjema } = useSkjema<
         {
@@ -66,7 +66,7 @@ const useHenleggBehandling = (lukkModal: () => void) => {
         );
     };
 
-    const institusjon = minimalFagsak?.institusjon;
+    const institusjon = fagsak.institusjon;
 
     const brevmalSomSkalBrukes = institusjon
         ? Brevmal.HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON

--- a/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
 
 import { Button, ErrorMessage } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
 
+import { HentFagsakQueryKeyFactory } from '../../../hooks/useHentFagsak';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
-import { useFagsakContext } from '../FagsakContext';
 
 interface Props {
     fagsakId: number;
@@ -19,7 +20,7 @@ const StyledButton = styled(Button)`
 
 export const GjennomførValutajusteringKnapp: React.FunctionComponent<Props> = ({ fagsakId }) => {
     const { request } = useHttp();
-    const { settMinimalFagsakRessurs } = useFagsakContext();
+    const queryClient = useQueryClient();
     const [visFeilmelidng, settVisFeilmelding] = useState(false);
 
     const gjenomførValutajustering = () => {
@@ -31,7 +32,8 @@ export const GjennomførValutajusteringKnapp: React.FunctionComponent<Props> = (
             påvirkerSystemLaster: true,
         }).then(response => {
             if (response.status === RessursStatus.SUKSESS) {
-                settMinimalFagsakRessurs(response);
+                const fagsak = response.data;
+                queryClient.setQueryData(HentFagsakQueryKeyFactory.fagsak(fagsakId), fagsak);
             } else {
                 settVisFeilmelding(true);
             }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24802

Flytter håndtering av fagsak state over til react-query.

Obs! `Bruker` objektet blir fortsatt ikke håndtert av react-query, men vil komme i en senere PR.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Fortsatt en del refaktorering som må gjøres før jeg føler det er vits å skrive tester. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer.
