### PR TITLE
Nav 25514 bruk react router komponent i links

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -227,7 +227,9 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
                 erViPåUlovligSteg(location.pathname, sideForSteg)) &&
             sideForSteg
         ) {
-            navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/${sideForSteg.href}`);
+            navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/${sideForSteg.href}`, {
+                replace: true,
+            });
         }
     };
 

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
+import { Link as ReactRouterLink } from 'react-router';
 import styled from 'styled-components';
 
-import { Alert, BodyShort, Box, HStack, LinkPanel } from '@navikt/ds-react';
+import { Alert, BodyShort, Box, HStack, Link, LinkCard, VStack } from '@navikt/ds-react';
 import {
     AFontSizeHeadingMedium,
     AFontSizeXlarge,
@@ -38,12 +39,6 @@ const HeaderTekst = styled(BodyShort)`
 
 const BodyTekst = styled(BodyShort)`
     font-size: ${AFontSizeHeadingMedium};
-`;
-
-const FagsakPanelMedAktivBehandling = styled(LinkPanel)`
-    width: ${SaksoversiktPanelBredde};
-    margin-top: ${ASpacing8};
-    padding: ${ASpacing8};
 `;
 
 const FagsakPanel = styled(Box)`
@@ -103,14 +98,25 @@ const FagsakLenkepanel: React.FC<IBehandlingLenkepanel> = ({ minimalFagsak }) =>
     return (
         <>
             {aktivBehandling ? (
-                <FagsakPanelMedAktivBehandling
-                    title={genererHoverTekst(aktivBehandling)}
-                    href={`/fagsak/${minimalFagsak.id}/${aktivBehandling.behandlingId}`}
-                >
-                    <LinkPanel.Description>
-                        <Innholdstabell minimalFagsak={minimalFagsak} />
-                    </LinkPanel.Description>
-                </FagsakPanelMedAktivBehandling>
+                <Box width={SaksoversiktPanelBredde} marginBlock={'8 0'}>
+                    <LinkCard>
+                        <LinkCard.Title>
+                            <LinkCard.Anchor asChild={true}>
+                                <Link
+                                    as={ReactRouterLink}
+                                    to={`/fagsak/${minimalFagsak.id}/${aktivBehandling.behandlingId}`}
+                                >
+                                    {genererHoverTekst(aktivBehandling)}
+                                </Link>
+                            </LinkCard.Anchor>
+                        </LinkCard.Title>
+                        <LinkCard.Description>
+                            <VStack paddingBlock={'4 0'}>
+                                <Innholdstabell minimalFagsak={minimalFagsak} />
+                            </VStack>
+                        </LinkCard.Description>
+                    </LinkCard>
+                </Box>
             ) : (
                 <FagsakPanel
                     borderColor="border-strong"

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { addMonths, differenceInMilliseconds, format } from 'date-fns';
+import { Link as ReactRouterLink } from 'react-router';
 import styled from 'styled-components';
 
 import { Alert, Box, Heading, Link, VStack } from '@navikt/ds-react';
@@ -75,7 +76,8 @@ const Saksoversikt: React.FunctionComponent<IProps> = ({ minimalFagsak }) => {
         return (
             aktivBehandling && (
                 <Link
-                    href={`/fagsak/${minimalFagsak.id}/${aktivBehandling.behandlingId}/tilkjent-ytelse`}
+                    as={ReactRouterLink}
+                    to={`/fagsak/${minimalFagsak.id}/${aktivBehandling.behandlingId}/tilkjent-ytelse`}
                 >
                     Se detaljer
                 </Link>

--- a/src/frontend/sider/Fagsak/Saksoversikt/utils.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/utils.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 
 import { differenceInMilliseconds } from 'date-fns';
+import { Link as ReactRouterLink } from 'react-router';
 
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { HStack, Link, Tooltip } from '@navikt/ds-react';
@@ -164,7 +165,7 @@ export const lagLenkePåType = (
                 return behandlingstyper[behandling.type].navn;
             }
             return (
-                <Link href={`/fagsak/${fagsakId}/${behandling.behandlingId}`}>
+                <Link as={ReactRouterLink} to={`/fagsak/${fagsakId}/${behandling.behandlingId}`}>
                     {behandlingstyper[behandling.type].navn}
                 </Link>
             );
@@ -204,7 +205,10 @@ export const lagLenkePåResultat = (
         case Saksoversiktbehandlingstype.BARNETRYGD:
             if (behandling.status === BehandlingStatus.AVSLUTTET) {
                 return (
-                    <Link href={`/fagsak/${fagsakId}/${behandling.behandlingId}`}>
+                    <Link
+                        as={ReactRouterLink}
+                        to={`/fagsak/${fagsakId}/${behandling.behandlingId}`}
+                    >
                         {behandling ? behandlingsresultater[behandling.resultat] : '-'}
                     </Link>
                 );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25514

Tar i bruk react-router sin `<Link />` komponent i `<LinkCard />` og `<Link />` som kommer fra Aksel. 

Hensikten med endringer er å forhindre applikasjonen i å gjøre en "full" refresh av nettsiden når man navigerer via en link. Dette vil gjøre slik at man ikke trenger å hente fagsak på nytt når man navigerer seg videre. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
LinkdCard: 

<img width="1007" height="390" alt="image" src="https://github.com/user-attachments/assets/fcddadca-1fb1-49f9-a9a8-c282d0ebe686" />
