### PR TITLE
Fjerner rolle navn i fagsakdeltaker søk

### DIFF
--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -22,7 +22,6 @@ import { ModalType } from '../../context/ModalContext';
 import { useModal } from '../../hooks/useModal';
 import {
     FagsakDeltagerRolle,
-    fagsakdeltagerRoller,
     type IFagsakDeltager,
     type ISøkParam,
 } from '../../typer/fagsakdeltager';
@@ -109,9 +108,6 @@ const FagsakDeltagerSøk: React.FC = () => {
                           navn: fagsakDeltager.navn,
                           ident: fagsakDeltager.ident,
                           ikon: mapFagsakDeltagerTilIkon(fagsakDeltager),
-                          rolle: fagsakdeltagerRoller[fagsakDeltager.rolle][
-                              fagsakDeltager.kjønn ?? kjønnType.UKJENT
-                          ],
                       };
                   }),
               }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fjerner rolle-tekst i fagsakdeltaker søke resultat liste. 

De nye ikonene viser viser for det meste fagsaktype, kjønn  og alder som er veldig beskrivende som vi tenker er nok informasjon.
  
### 👀 Screen shots
FØR 
<img width="821" height="372" alt="image" src="https://github.com/user-attachments/assets/f64afe46-3427-41ac-9782-e9f96ac6e3d3" />

<img width="792" height="530" alt="image" src="https://github.com/user-attachments/assets/411a51fc-d736-41d8-a7ef-73810ed1cff0" />

ETTER
<img width="425" height="321" alt="image" src="https://github.com/user-attachments/assets/76651594-5572-4d4a-9f01-4847095a5413" />
<img width="737" height="419" alt="image" src="https://github.com/user-attachments/assets/d1084f4a-8c7c-44b6-89cf-52778da72905" />

