### PR TITLE
Legger til finnmarkstillegg som årsak, men sperrer for manuelt valg i opprettelse meny

### DIFF
--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -81,7 +81,8 @@ const hentTilgjengeligeBehandlingsårsaker = (
                   årsak !== BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING &&
                   (årsak !== BehandlingÅrsak.IVERKSETTE_KA_VEDTAK ||
                       kanOppretteRevurderingMedÅrsakIverksetteKAVedtak) &&
-                  årsak !== BehandlingÅrsak.KLAGE
+                  årsak !== BehandlingÅrsak.KLAGE &&
+                  årsak !== BehandlingÅrsak.FINNMARKSTILLEGG
           );
 
 interface IProps {

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -78,6 +78,7 @@ export enum BehandlingÅrsak {
     SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID = 'SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID',
     MÅNEDLIG_VALUTAJUSTERING = 'MÅNEDLIG_VALUTAJUSTERING',
     IVERKSETTE_KA_VEDTAK = 'IVERKSETTE_KA_VEDTAK',
+    FINNMARKSTILLEGG = 'FINNMARKSTILLEGG',
 }
 
 export const behandlingÅrsak: Record<
@@ -111,6 +112,7 @@ export const behandlingÅrsak: Record<
         'Feilutbetalt beløp helt eller delvis bortfalt',
     MÅNEDLIG_VALUTAJUSTERING: 'Månedlig valutajustering',
     IVERKSETTE_KA_VEDTAK: 'Iverksette KA-vedtak',
+    FINNMARKSTILLEGG: 'Finnmarkstillegg',
 
     /** Klage: **/
     ANNET: 'Annet',


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25899

Behandlinger med årsak finnmarkstillegg må vises i saksoversikten, men det skal ikke være mulig å opprette en manuelt.

<img width="1012" height="420" alt="Screenshot 2025-08-12 at 08 55 38" src="https://github.com/user-attachments/assets/9efec201-4164-4359-88fb-1335e423a2db" />
