### PR TITLE
Vi fikser visning av svalbardtillegget

### DIFF
--- a/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
@@ -117,7 +117,7 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
 
     interface YtelseSplittForTidslinje {
         ytelseSomSkalSplittesOpp?: YtelseType;
-        ytelseSomSplitterOpp?: YtelseType;
+        ytelserSomSplitterOpp: YtelseType[];
     }
 
     const finnYtelserSomMåSplittes = (fagsakType?: FagsakType): YtelseSplittForTidslinje[] => {
@@ -127,29 +127,38 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
                 return [
                     {
                         ytelseSomSkalSplittesOpp: YtelseType.UTVIDET_BARNETRYGD,
-                        ytelseSomSplitterOpp: YtelseType.SMÅBARNSTILLEGG,
+                        ytelserSomSplitterOpp: [YtelseType.SMÅBARNSTILLEGG],
                     },
                     {
                         ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
-                        ytelseSomSplitterOpp: YtelseType.FINNMARKSTILLEGG,
+                        ytelserSomSplitterOpp: [
+                            YtelseType.FINNMARKSTILLEGG,
+                            YtelseType.SVALBARDTILLEGG,
+                        ],
                     },
                 ];
             case FagsakType.BARN_ENSLIG_MINDREÅRIG:
                 return [
                     {
                         ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
-                        ytelseSomSplitterOpp: YtelseType.UTVIDET_BARNETRYGD,
+                        ytelserSomSplitterOpp: [YtelseType.UTVIDET_BARNETRYGD],
                     },
                     {
                         ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
-                        ytelseSomSplitterOpp: YtelseType.FINNMARKSTILLEGG,
+                        ytelserSomSplitterOpp: [
+                            YtelseType.FINNMARKSTILLEGG,
+                            YtelseType.SVALBARDTILLEGG,
+                        ],
                     },
                 ];
             case FagsakType.INSTITUSJON:
                 return [
                     {
                         ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
-                        ytelseSomSplitterOpp: YtelseType.FINNMARKSTILLEGG,
+                        ytelserSomSplitterOpp: [
+                            YtelseType.FINNMARKSTILLEGG,
+                            YtelseType.SVALBARDTILLEGG,
+                        ],
                     },
                 ];
             case undefined:
@@ -190,8 +199,9 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
                                   const andelerSomSkalSplitteOpp =
                                       personMedAndelerTilkjentYtelse.ytelsePerioder.filter(
                                           ytelsePeriodeFilter =>
-                                              ytelsePeriodeFilter.ytelseType ===
-                                              ytelseSomMåSplittes.ytelseSomSplitterOpp
+                                              ytelseSomMåSplittes.ytelserSomSplitterOpp.includes(
+                                                  ytelsePeriodeFilter.ytelseType
+                                              )
                                       );
 
                                   return [
@@ -204,8 +214,9 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
                                   ];
                               } else if (
                                   ytelseSomMåSplittes &&
-                                  ytelsePeriode.ytelseType !==
-                                      ytelseSomMåSplittes.ytelseSomSplitterOpp
+                                  !ytelseSomMåSplittes.ytelserSomSplitterOpp.includes(
+                                      ytelsePeriode.ytelseType
+                                  )
                               ) {
                                   return [...acc, periode];
                               } else {

--- a/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
@@ -141,11 +141,8 @@ export const TidslinjeProvider = (props: PropsWithChildren) => {
                 return [
                     {
                         ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
-                        ytelserSomSplitterOpp: [YtelseType.UTVIDET_BARNETRYGD],
-                    },
-                    {
-                        ytelseSomSkalSplittesOpp: YtelseType.ORDINÆR_BARNETRYGD,
                         ytelserSomSplitterOpp: [
+                            YtelseType.UTVIDET_BARNETRYGD,
                             YtelseType.FINNMARKSTILLEGG,
                             YtelseType.SVALBARDTILLEGG,
                         ],

--- a/src/frontend/typer/beregning.ts
+++ b/src/frontend/typer/beregning.ts
@@ -22,6 +22,7 @@ export enum YtelseType {
     UTVIDET_BARNETRYGD = 'UTVIDET_BARNETRYGD',
     SMÅBARNSTILLEGG = 'SMÅBARNSTILLEGG',
     FINNMARKSTILLEGG = 'FINNMARKSTILLEGG',
+    SVALBARDTILLEGG = 'SVALBARDTILLEGG',
 }
 
 export const ytelsetype: INøkkelPar = {
@@ -40,5 +41,9 @@ export const ytelsetype: INøkkelPar = {
     FINNMARKSTILLEGG: {
         id: 'FINNMARKSTILLEGG',
         navn: 'Finnmarkstillegg',
+    },
+    SVALBARDTILLEGG: {
+        id: 'SVALBARDTILLEGG',
+        navn: 'Svalbardtillegg',
     },
 };


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25999

Fikser visning av tidslinje for svalbardtillegget.
Skrev om ytelseSomSplitterOpp til en liste da det kan være flere ytelser som splitter opp tidsliinja.

<img width="1174" height="852" alt="Screenshot 2025-08-19 at 10 54 13" src="https://github.com/user-attachments/assets/c3d85d93-e069-4a39-a84d-5b54e0779600" />