### PR TITLE
NAV-25961: Refactor HenleggBehandling modal til react-hook-form

### DIFF
--- a/src/frontend/api/henleggBehandling.ts
+++ b/src/frontend/api/henleggBehandling.ts
@@ -1,0 +1,24 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { HenleggÅrsak } from '../typer/behandling';
+import { type IBehandling } from '../typer/behandling';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface HenleggBehandlingPayload {
+    årsak: HenleggÅrsak;
+    begrunnelse: string;
+}
+
+export async function henleggBehandling(
+    request: FamilieRequest,
+    behandling: IBehandling,
+    payload: HenleggBehandlingPayload
+) {
+    const ressurs = await request<HenleggBehandlingPayload, IBehandling>({
+        data: payload,
+        method: 'PUT',
+        url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/steg/henlegg`,
+        påvirkerSystemLaster: false,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/context/ModalContext.tsx
+++ b/src/frontend/context/ModalContext.tsx
@@ -6,26 +6,34 @@ import React, {
     useReducer,
 } from 'react';
 
+import type { HenleggÅrsak } from '../typer/behandling';
+
 interface ModalContext {
     hentTittel: (type: ModalType) => string;
     settTittel: (type: ModalType, tittel: string) => void;
-    åpneModal: <T extends keyof Args>(type: T, args: Args[T]) => void;
+    åpneModal: <T extends keyof typeof ModalType>(
+        type: T,
+        args: T extends keyof Args ? Args[T] : void
+    ) => void;
     lukkModal: (type: ModalType) => void;
     erModalÅpen: (type: ModalType) => boolean;
-    hentArgs: <T extends keyof Args>(type: T) => Args[T] | undefined;
+    hentArgs: <T extends keyof typeof ModalType>(
+        type: T
+    ) => T extends keyof Args ? Args[T] : undefined;
     hentBredde: (type: ModalType) => `${number}${string}`;
     settBredde: (type: ModalType, bredde: `${number}${string}`) => void;
 }
 
 export enum ModalType {
+    HENLEGG_BEHANDLING_VEIVALG = 'HENLEGG_BEHANDLING_VEIVALG',
+    HENLEGG_BEHANDLING = 'HENLEGG_BEHANDLING',
     OPPRETT_FAGSAK = 'OPPRETT_FAGSAK',
-    EXAMPLE_MODAL = 'EXAMPLE_MODAL',
     FEILMELDING = 'FEILMELDING',
 }
 
 export interface Args {
+    [ModalType.HENLEGG_BEHANDLING_VEIVALG]: { årsak: HenleggÅrsak };
     [ModalType.OPPRETT_FAGSAK]: { ident: string };
-    [ModalType.EXAMPLE_MODAL]: { fagsak: string };
     [ModalType.FEILMELDING]: { feilmelding: string | React.ReactNode };
 }
 
@@ -35,29 +43,28 @@ interface BaseState {
     bredde: `${number}${string}`;
 }
 
-interface State {
-    [ModalType.OPPRETT_FAGSAK]: BaseState & {
-        args: Args[ModalType.OPPRETT_FAGSAK] | undefined;
-    };
-    [ModalType.EXAMPLE_MODAL]: BaseState & {
-        args: Args[ModalType.EXAMPLE_MODAL] | undefined;
-    };
-    [ModalType.FEILMELDING]: BaseState & {
-        args: Args[ModalType.FEILMELDING] | undefined;
-    };
-}
+type State = {
+    [key in ModalType]: key extends keyof Args
+        ? BaseState & { args: Args[key] | undefined }
+        : BaseState;
+};
 
-const initialState: { [key in ModalType]: State[key] } = {
+const initialState: State = {
+    [ModalType.HENLEGG_BEHANDLING_VEIVALG]: {
+        tittel: 'Behandling henlagt',
+        åpen: false,
+        bredde: '35rem',
+        args: undefined,
+    },
+    [ModalType.HENLEGG_BEHANDLING]: {
+        tittel: 'Henlegg behandling',
+        åpen: false,
+        bredde: '37rem',
+    },
     [ModalType.OPPRETT_FAGSAK]: {
         tittel: 'Opprett fagsak',
         åpen: false,
         bredde: '50rem',
-        args: undefined,
-    },
-    [ModalType.EXAMPLE_MODAL]: {
-        tittel: 'Example modal',
-        åpen: false,
-        bredde: '80rem',
         args: undefined,
     },
     [ModalType.FEILMELDING]: {
@@ -80,9 +87,9 @@ interface SettTittelAction {
     payload: { type: ModalType; tittel: string };
 }
 
-interface ÅpneModalAction<T extends keyof Args> {
+interface ÅpneModalAction<T extends keyof typeof ModalType> {
     type: ActionType.ÅPNE_MODAL;
-    payload: { type: ModalType; args: Args[T] };
+    payload: { type: T; args: T extends keyof Args ? Args[T] : void };
 }
 
 interface LukkModalAction {
@@ -95,20 +102,20 @@ interface SettBreddeAction {
     payload: { type: ModalType; bredde: `${number}${string}` };
 }
 
-type Action<T extends keyof Args> =
+type Action<T extends keyof typeof ModalType> =
     | ÅpneModalAction<T>
     | LukkModalAction
     | SettBreddeAction
     | SettTittelAction;
 
-function reducer<T extends keyof Args>(state: State, action: Action<T>) {
+function reducer<T extends keyof typeof ModalType>(state: State, action: Action<T>) {
     const { type, payload } = action;
     switch (type) {
         case ActionType.ÅPNE_MODAL:
             return {
                 ...state,
                 [payload.type]: {
-                    ...state[payload.type],
+                    ...state[ModalType[payload.type]],
                     åpen: true,
                     args: payload.args,
                 },
@@ -165,7 +172,10 @@ export function ModalProvider({ children }: PropsWithChildren) {
     );
 
     const åpneModal = useCallback(
-        <T extends keyof Args>(type: ModalType, args: Args[T]) => {
+        <T extends keyof typeof ModalType>(
+            type: T,
+            args: T extends keyof Args ? Args[T] : void
+        ) => {
             dispatch({ type: ActionType.ÅPNE_MODAL, payload: { type, args } });
         },
         [dispatch]
@@ -186,8 +196,10 @@ export function ModalProvider({ children }: PropsWithChildren) {
     );
 
     const hentArgs = useCallback(
-        <T extends keyof Args>(type: T) => {
-            return state[type].args as Args[T];
+        <T extends keyof typeof ModalType>(type: T) => {
+            const stateFromType = state[ModalType[type]];
+            const value = 'args' in stateFromType ? stateFromType.args : undefined;
+            return value as T extends keyof Args ? Args[T] : undefined;
         },
         [state]
     );

--- a/src/frontend/hooks/useHenleggBehandling.ts
+++ b/src/frontend/hooks/useHenleggBehandling.ts
@@ -1,0 +1,27 @@
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { henleggBehandling, type HenleggBehandlingPayload } from '../api/henleggBehandling';
+import type { IBehandling } from '../typer/behandling';
+
+interface Parameters extends HenleggBehandlingPayload {
+    behandling: IBehandling;
+}
+
+type Options = Omit<
+    UseMutationOptions<IBehandling, DefaultError, Parameters, unknown>,
+    'mutationFn'
+>;
+
+export function useHenleggBehandling(options?: Options) {
+    const { request } = useHttp();
+    return useMutation({
+        mutationFn: (parameters: Parameters) => {
+            const { behandling, årsak, begrunnelse } = parameters;
+            const payload = { årsak, begrunnelse };
+            return henleggBehandling(request, behandling, payload);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useModal.ts
+++ b/src/frontend/hooks/useModal.ts
@@ -1,39 +1,39 @@
 import { useCallback } from 'react';
 
-import { type Args, useModalContext } from '../context/ModalContext';
+import { type Args, ModalType, useModalContext } from '../context/ModalContext';
 
-export function useModal<T extends keyof Args>(type: T) {
+export function useModal<T extends keyof typeof ModalType>(type: T) {
     const context = useModalContext();
 
     const settTittel = useCallback(
         (tittel: string) => {
-            context.settTittel(type, tittel);
+            context.settTittel(ModalType[type], tittel);
         },
         [context.settTittel, type]
     );
 
     const åpneModal = useCallback(
-        (args: Args[T]) => {
+        (args: T extends keyof Args ? Args[T] : void) => {
             context.åpneModal(type, args);
         },
         [context.åpneModal, type]
     );
 
     const lukkModal = useCallback(() => {
-        context.lukkModal(type);
+        context.lukkModal(ModalType[type]);
     }, [context.lukkModal, type]);
 
     const settBredde = useCallback(
         (bredde: `${number}${string}`) => {
-            context.settBredde(type, bredde);
+            context.settBredde(ModalType[type], bredde);
         },
         [context.settBredde, type]
     );
 
-    const tittel = context.hentTittel(type);
-    const erModalÅpen = context.erModalÅpen(type);
+    const tittel = context.hentTittel(ModalType[type]);
+    const erModalÅpen = context.erModalÅpen(ModalType[type]);
     const args = context.hentArgs(type);
-    const bredde = context.hentBredde(type);
+    const bredde = context.hentBredde(ModalType[type]);
 
     return { tittel, settTittel, åpneModal, lukkModal, erModalÅpen, args, bredde, settBredde };
 }

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -13,6 +13,7 @@ import Høyremeny from './Høyremeny/Høyremeny';
 import Venstremeny from './Venstremeny/Venstremeny';
 import type { IMinimalFagsak } from '../../../typer/fagsak';
 import type { IPersonInfo } from '../../../typer/person';
+import { HenleggBehandlingVeivalgModal } from '../Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingVeivalgModal';
 import { Fagsaklinje } from '../Fagsaklinje/Fagsaklinje';
 
 interface Props {
@@ -49,6 +50,7 @@ const BehandlingContainer: React.FC<Props> = ({ bruker, fagsak }) => {
         case RessursStatus.SUKSESS:
             return (
                 <BehandlingProvider behandling={behandlingRessurs.data}>
+                    <HenleggBehandlingVeivalgModal />
                     <Fagsaklinje
                         bruker={bruker}
                         minimalFagsak={fagsak}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/BegrunnelseFelt.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/BegrunnelseFelt.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Textarea } from '@navikt/ds-react';
+
+import {
+    HenleggBehandlingFormFields,
+    type HenleggBehandlingFormValues,
+} from './useHenleggBehandlingForm';
+
+export function BegrunnelseFelt() {
+    const { control } = useFormContext<HenleggBehandlingFormValues>();
+
+    const { field, fieldState, formState } = useController({
+        name: HenleggBehandlingFormFields.BEGRUNNELSE,
+        control,
+        rules: {
+            validate: verdi => {
+                if (verdi.length < 5) {
+                    return 'Skriv en begrunnelse som forklarer henleggelsen med minst 5 tegn.';
+                }
+            },
+        },
+    });
+
+    return (
+        <Textarea
+            label={'Begrunnelse'}
+            maxLength={4000}
+            value={field.value}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={fieldState.error?.message}
+            readOnly={formState.isSubmitting}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisBrevLenke.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisBrevLenke.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Link } from '@navikt/ds-react';
+
+import type { FamilieAxiosRequestConfig } from '../../../../../context/AppContext';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+import { Brevmal } from '../../../Behandling/Høyremeny/Hendelsesoversikt/BrevModul/typer';
+import { useFagsakContext } from '../../../FagsakContext';
+
+interface Props {
+    hentForhåndsvisning: <T>(familieAxiosRequestConfig: FamilieAxiosRequestConfig<T>) => void;
+}
+
+export function ForhåndsvisBrevLenke({ hentForhåndsvisning }: Props) {
+    const { fagsak } = useFagsakContext();
+    const { behandling } = useBehandlingContext();
+
+    const brevmalSomSkalBrukes = fagsak.institusjon
+        ? Brevmal.HENLEGGE_TRUKKET_SØKNAD_INSTITUSJON
+        : Brevmal.HENLEGGE_TRUKKET_SØKNAD;
+
+    function onClick() {
+        hentForhåndsvisning({
+            method: 'POST',
+            data: {
+                multiselectVerdier: [],
+                brevmal: brevmalSomSkalBrukes,
+                barnIBrev: [],
+            },
+            url: `/familie-ba-sak/api/dokument/forhaandsvis-brev/${behandling.behandlingId}`,
+        });
+    }
+
+    return (
+        <Link href={'#'} onClick={onClick}>
+            Forhåndsvis
+        </Link>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
@@ -32,6 +32,9 @@ const StyledLenke = styled(Link)`
     margin-right: auto;
 `;
 
+/**
+ * @Deprecated - Erstattes av {@link HenleggBehandlingNy}.
+ */
 const HenleggBehandling: React.FC<IProps> = ({ fagsakId }) => {
     const { behandling, vurderErLesevisning } = useBehandlingContext();
 

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+
+import { FormProvider } from 'react-hook-form';
+
+import { Alert, BodyLong, Button, Fieldset, Modal, VStack } from '@navikt/ds-react';
+import { type Ressurs } from '@navikt/familie-typer';
+
+import { BegrunnelseFelt } from './BegrunnelseFelt';
+import { ForhåndsvisBrevLenke } from './ForhåndsvisBrevLenke';
+import {
+    HENLEGG_BEHANDLING_FORM_ID,
+    HenleggBehandlingFormFields,
+    HenleggBehandlingServerErrors,
+    useHenleggBehandlingForm,
+} from './useHenleggBehandlingForm';
+import { ÅrsakFelt } from './ÅrsakFelt';
+import { type FamilieAxiosRequestConfig } from '../../../../../context/AppContext';
+import { ModalType } from '../../../../../context/ModalContext';
+import { useModal } from '../../../../../hooks/useModal';
+import { HenleggÅrsak } from '../../../../../typer/behandling';
+import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
+
+interface Props {
+    hentetDokument: Ressurs<string>;
+    nullstillDokument: () => void;
+    hentForhåndsvisning: <T>(familieAxiosRequestConfig: FamilieAxiosRequestConfig<T>) => void;
+}
+
+// TODO : Flytt instansieringen av denne til BehandlingContainer når man kan fjerne props avhengigheten til dokument.
+export function HenleggBehandlingModal({
+    hentetDokument,
+    nullstillDokument,
+    hentForhåndsvisning,
+}: Props) {
+    const { erModalÅpen, tittel, lukkModal, bredde } = useModal(ModalType.HENLEGG_BEHANDLING);
+
+    function onClose() {
+        nullstillDokument();
+        lukkModal();
+    }
+
+    return (
+        <Modal
+            open={erModalÅpen}
+            width={bredde}
+            onClose={onClose}
+            header={{ heading: tittel, size: 'medium' }}
+            portal={true}
+        >
+            {erModalÅpen && (
+                <Innhold
+                    hentetDokument={hentetDokument}
+                    hentForhåndsvisning={hentForhåndsvisning}
+                />
+            )}
+        </Modal>
+    );
+}
+
+interface InnholdProps {
+    hentetDokument: Ressurs<string>;
+    hentForhåndsvisning: <T>(familieAxiosRequestConfig: FamilieAxiosRequestConfig<T>) => void;
+}
+
+function Innhold({ hentetDokument, hentForhåndsvisning }: InnholdProps) {
+    const { lukkModal } = useModal(ModalType.HENLEGG_BEHANDLING);
+
+    const { form, onSubmit } = useHenleggBehandlingForm();
+
+    const {
+        watch,
+        handleSubmit,
+        formState: { errors },
+    } = form;
+
+    const valgtÅrsak = watch(HenleggBehandlingFormFields.ÅRSAK);
+
+    const dokumentError = hentFrontendFeilmelding(hentetDokument);
+    const submitError = HenleggBehandlingServerErrors.onSubmitError.lookup(errors);
+
+    return (
+        <>
+            <Modal.Body>
+                <VStack gap={'4'}>
+                    <Alert variant={'info'}>
+                        <BodyLong>
+                            Skriv en begrunnelse som forklarer hvorfor behandlingen henlegges. Dette
+                            kan gi andre saksbehandlere bedre grunnlag hvis de gjenopptar saken, og
+                            kan gjøre det lettere for teamet å feilsøke.
+                        </BodyLong>
+                    </Alert>
+                    <FormProvider {...form}>
+                        <form id={HENLEGG_BEHANDLING_FORM_ID} onSubmit={handleSubmit(onSubmit)}>
+                            <Fieldset
+                                legend={'Henlegg behandling'}
+                                hideLegend={true}
+                                error={dokumentError || submitError}
+                            >
+                                <VStack gap={'4'}>
+                                    <ÅrsakFelt />
+                                    <BegrunnelseFelt />
+                                </VStack>
+                            </Fieldset>
+                        </form>
+                    </FormProvider>
+                </VStack>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    form={HENLEGG_BEHANDLING_FORM_ID}
+                    variant={'primary'}
+                    size={'small'}
+                    type={'submit'}
+                    loading={form.formState.isSubmitting}
+                    disabled={form.formState.isSubmitting}
+                >
+                    {valgtÅrsak === HenleggÅrsak.SØKNAD_TRUKKET
+                        ? 'Bekreft og send brev'
+                        : 'Bekreft'}
+                </Button>
+                <Button variant={'tertiary'} size={'small'} onClick={() => lukkModal()}>
+                    Avbryt
+                </Button>
+                {valgtÅrsak === HenleggÅrsak.SØKNAD_TRUKKET && (
+                    <ForhåndsvisBrevLenke hentForhåndsvisning={hentForhåndsvisning} />
+                )}
+            </Modal.Footer>
+        </>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingNy.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingNy.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { Dropdown } from '@navikt/ds-react';
+
+import { HenleggBehandlingModal } from './HenleggBehandlingModal';
+import { useAppContext } from '../../../../../context/AppContext';
+import { ModalType } from '../../../../../context/ModalContext';
+import useDokument from '../../../../../hooks/useDokument';
+import { useModal } from '../../../../../hooks/useModal';
+import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
+import { erPåHenleggbartSteg } from '../../../../../typer/behandling';
+import { ToggleNavn } from '../../../../../typer/toggles';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+export function HenleggBehandlingNy() {
+    const { toggles } = useAppContext();
+    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const { åpneModal } = useModal(ModalType.HENLEGG_BEHANDLING);
+
+    const {
+        visDokumentModal,
+        hentetDokument,
+        settVisDokumentModal,
+        hentForhåndsvisning,
+        nullstillDokument,
+    } = useDokument();
+
+    const harTilgangTilTekniskVedlikeholdHenleggelse =
+        toggles[ToggleNavn.tekniskVedlikeholdHenleggelse];
+
+    const kanHenlegge =
+        harTilgangTilTekniskVedlikeholdHenleggelse ||
+        (!vurderErLesevisning() && erPåHenleggbartSteg(behandling.steg));
+
+    if (!kanHenlegge) {
+        return null;
+    }
+
+    return (
+        <>
+            <Dropdown.Menu.List.Item onClick={() => åpneModal()}>
+                Henlegg behandling
+            </Dropdown.Menu.List.Item>
+            <HenleggBehandlingModal
+                hentetDokument={hentetDokument}
+                nullstillDokument={nullstillDokument}
+                hentForhåndsvisning={hentForhåndsvisning}
+            />
+            {visDokumentModal && (
+                <PdfVisningModal
+                    onRequestClose={() => settVisDokumentModal(false)}
+                    pdfdata={hentetDokument}
+                />
+            )}
+        </>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingVeivalgModal.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingVeivalgModal.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { useNavigate } from 'react-router';
+
+import { Alert, BodyShort, Button, Modal } from '@navikt/ds-react';
+
+import { ModalType } from '../../../../../context/ModalContext';
+import { useModal } from '../../../../../hooks/useModal';
+import { HenleggÅrsak } from '../../../../../typer/behandling';
+import { useFagsakContext } from '../../../FagsakContext';
+
+export function HenleggBehandlingVeivalgModal() {
+    const { args, erModalÅpen, tittel, lukkModal, bredde } = useModal(
+        ModalType.HENLEGG_BEHANDLING_VEIVALG
+    );
+
+    return (
+        <Modal
+            open={erModalÅpen}
+            width={bredde}
+            header={{ heading: tittel, size: 'medium' }}
+            onClose={() => lukkModal()}
+            portal={true}
+        >
+            {erModalÅpen && (
+                <>
+                    {args === undefined && (
+                        <Modal.Body>
+                            <Alert variant={'error'}>
+                                En feil oppstod ved innlasting av modalen.
+                            </Alert>
+                        </Modal.Body>
+                    )}
+                    {args !== undefined && <Innhold årsak={args.årsak} />}
+                </>
+            )}
+        </Modal>
+    );
+}
+
+interface InnholdProps {
+    årsak: HenleggÅrsak;
+}
+
+function Innhold({ årsak }: InnholdProps) {
+    const { fagsak } = useFagsakContext();
+    const { lukkModal } = useModal(ModalType.HENLEGG_BEHANDLING_VEIVALG);
+    const navigate = useNavigate();
+
+    function gåTilSaksoversikt() {
+        lukkModal();
+        navigate(`/fagsak/${fagsak.id}/saksoversikt`);
+    }
+
+    function gåTilOppgaver() {
+        lukkModal();
+        navigate('/oppgaver');
+    }
+
+    return (
+        <>
+            <Modal.Body>
+                <BodyShort>
+                    {årsak === HenleggÅrsak.SØKNAD_TRUKKET
+                        ? 'Behandlingen er henlagt og brev til bruker er sendt.'
+                        : 'Behandlingen er henlagt.'}
+                </BodyShort>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant={'secondary'} size={'medium'} onClick={gåTilSaksoversikt}>
+                    Se saksoversikt
+                </Button>
+                <Button variant={'secondary'} size={'medium'} onClick={gåTilOppgaver}>
+                    Se oppgavebenk
+                </Button>
+            </Modal.Footer>
+        </>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandling.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandling.ts
@@ -10,6 +10,9 @@ import { useBehandlingContext } from '../../../Behandling/context/BehandlingCont
 import { Brevmal } from '../../../Behandling/Høyremeny/Hendelsesoversikt/BrevModul/typer';
 import { useFagsakContext } from '../../../FagsakContext';
 
+/**
+ * @Deprecated - Erstattes av {@link HenleggBehandlingNy} og {@link useHenleggBehandlingForm}.
+ */
 const useHenleggBehandling = (lukkModal: () => void) => {
     const [visVeivalgModal, settVisVeivalgModal] = useState(false);
     const [begrunnelse, settBegrunnelse] = useState('');

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandlingForm.ts
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/useHenleggBehandlingForm.ts
@@ -1,0 +1,75 @@
+import { type FieldErrors, useForm } from 'react-hook-form';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { ModalType } from '../../../../../context/ModalContext';
+import { useHenleggBehandling } from '../../../../../hooks/useHenleggBehandling';
+import { useModal } from '../../../../../hooks/useModal';
+import type { HenleggÅrsak } from '../../../../../typer/behandling';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+export const HenleggBehandlingServerErrors: Record<
+    'onSubmitError',
+    {
+        id: `root.${string}`;
+        lookup: (errors: FieldErrors<HenleggBehandlingFormValues>) => string | undefined;
+    }
+> = {
+    onSubmitError: {
+        id: 'root.onSubmitError',
+        lookup: errors => errors?.root?.onSubmitError?.message,
+    },
+};
+
+export enum HenleggBehandlingFormFields {
+    ÅRSAK = 'årsak',
+    BEGRUNNELSE = 'begrunnelse',
+}
+
+export interface HenleggBehandlingFormValues {
+    [HenleggBehandlingFormFields.ÅRSAK]: HenleggÅrsak | '';
+    [HenleggBehandlingFormFields.BEGRUNNELSE]: string;
+}
+
+export const HENLEGG_BEHANDLING_FORM_ID = 'henlegg_behandling_modal_form';
+
+export function useHenleggBehandlingForm() {
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+
+    const { lukkModal } = useModal(ModalType.HENLEGG_BEHANDLING);
+    const { åpneModal } = useModal(ModalType.HENLEGG_BEHANDLING_VEIVALG);
+
+    const { mutateAsync } = useHenleggBehandling();
+
+    const form = useForm<HenleggBehandlingFormValues>({
+        defaultValues: {
+            [HenleggBehandlingFormFields.ÅRSAK]: '',
+            [HenleggBehandlingFormFields.BEGRUNNELSE]: '',
+        },
+    });
+
+    const { setError } = form;
+
+    async function onSubmit(values: HenleggBehandlingFormValues) {
+        const { årsak, begrunnelse } = values;
+        if (årsak === '') {
+            setError(HenleggBehandlingServerErrors.onSubmitError.id, {
+                message: 'Årsak er påkrevd.',
+            });
+            return;
+        }
+        return mutateAsync({ behandling, årsak, begrunnelse })
+            .then(behandling => {
+                settÅpenBehandling(byggSuksessRessurs(behandling));
+                lukkModal();
+                åpneModal({ årsak });
+            })
+            .catch(error =>
+                setError(HenleggBehandlingServerErrors.onSubmitError.id, {
+                    message: error.message ?? 'En feil oppstod.',
+                })
+            );
+    }
+
+    return { form, onSubmit };
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ÅrsakFelt.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/HenleggBehandling/ÅrsakFelt.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Select } from '@navikt/ds-react';
+
+import {
+    HenleggBehandlingFormFields,
+    type HenleggBehandlingFormValues,
+} from './useHenleggBehandlingForm';
+import { useAppContext } from '../../../../../context/AppContext';
+import { erPåHenleggbartSteg, henleggÅrsak, HenleggÅrsak } from '../../../../../typer/behandling';
+import { ToggleNavn } from '../../../../../typer/toggles';
+import { useBehandlingContext } from '../../../Behandling/context/BehandlingContext';
+
+export function ÅrsakFelt() {
+    const { behandling } = useBehandlingContext();
+
+    const { toggles } = useAppContext();
+
+    const { control } = useFormContext<HenleggBehandlingFormValues>();
+
+    const { field, fieldState, formState } = useController({
+        name: HenleggBehandlingFormFields.ÅRSAK,
+        control,
+        rules: { required: 'Årsak er påkrevd.' },
+    });
+
+    const harTilgangTilTekniskVedlikeholdHenleggelse =
+        toggles[ToggleNavn.tekniskVedlikeholdHenleggelse];
+
+    const valgmuligheter = Object.values(HenleggÅrsak)
+        .filter(årsak => årsak !== HenleggÅrsak.FØDSELSHENDELSE_UGYLDIG_UTFALL)
+        .filter(
+            årsak =>
+                (årsak !== HenleggÅrsak.TEKNISK_VEDLIKEHOLD &&
+                    erPåHenleggbartSteg(behandling.steg)) ||
+                (årsak === HenleggÅrsak.TEKNISK_VEDLIKEHOLD &&
+                    harTilgangTilTekniskVedlikeholdHenleggelse)
+        )
+        .map(årsak => (
+            <option key={årsak} aria-selected={field.value === årsak} value={årsak}>
+                {henleggÅrsak[årsak]}
+            </option>
+        ));
+
+    return (
+        <Select
+            label={'Velg årsak'}
+            name={field.name}
+            value={field.value}
+            ref={field.ref}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={fieldState.error?.message}
+            readOnly={formState.isSubmitting}
+        >
+            <option disabled={true} value={''}>
+                Velg
+            </option>
+            {valgmuligheter}
+        </Select>
+    );
+}

--- a/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/MenyvalgBehandling.tsx
+++ b/src/frontend/sider/Fagsak/Fagsaklinje/Behandlingsmeny/MenyvalgBehandling.tsx
@@ -4,14 +4,17 @@ import { AInntekt } from './AInntekt/AInntekt';
 import EndreBehandlendeEnhet from './EndreBehandlendeEnhet/EndreBehandlendeEnhet';
 import EndreBehandlingstema from './EndreBehandling/EndreBehandlingstema';
 import HenleggBehandling from './HenleggBehandling/HenleggBehandling';
+import { HenleggBehandlingNy } from './HenleggBehandling/HenleggBehandlingNy';
 import SettEllerOppdaterVenting from './LeggBehandlingPåVent/SettEllerOppdaterVenting';
 import TaBehandlingAvVent from './LeggBehandlingPåVent/TaBehandlingAvVent';
 import LeggTilBarnPåBehandling from './LeggTilBarnPåBehandling/LeggTilBarnPåBehandling';
 import { LeggTilEllerFjernBrevmottakerePåBehandling } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling';
+import { useAppContext } from '../../../../context/AppContext';
 import type { IBehandling } from '../../../../typer/behandling';
 import { BehandlingStatus, Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../../typer/fagsak';
 import { FagsakType } from '../../../../typer/fagsak';
+import { ToggleNavn } from '../../../../typer/toggles';
 import { useBehandlingContext } from '../../Behandling/context/BehandlingContext';
 
 interface IProps {
@@ -20,12 +23,16 @@ interface IProps {
 }
 
 const MenyvalgBehandling = ({ minimalFagsak, åpenBehandling }: IProps) => {
+    const { toggles } = useAppContext();
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
     return (
         <>
-            <HenleggBehandling fagsakId={minimalFagsak.id} />
+            {toggles[ToggleNavn.brukNyHenleggModal] && <HenleggBehandlingNy />}
+            {!toggles[ToggleNavn.brukNyHenleggModal] && (
+                <HenleggBehandling fagsakId={minimalFagsak.id} />
+            )}
             <EndreBehandlendeEnhet />
             {minimalFagsak.fagsakType !== FagsakType.INSTITUSJON && <EndreBehandlingstema />}
             {!vurderErLesevisning() &&

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -143,6 +143,17 @@ export enum BehandlingSteg {
     BEHANDLING_AVSLUTTET = 'BEHANDLING_AVSLUTTET',
 }
 
+export function erPåHenleggbartSteg(steg: BehandlingSteg) {
+    return [
+        BehandlingSteg.REGISTRERE_SØKNAD,
+        BehandlingSteg.REGISTRERE_PERSONGRUNNLAG,
+        BehandlingSteg.VILKÅRSVURDERING,
+        BehandlingSteg.BEHANDLINGSRESULTAT,
+        BehandlingSteg.VURDER_TILBAKEKREVING,
+        BehandlingSteg.SEND_TIL_BESLUTTER,
+    ].includes(steg);
+}
+
 export enum BehandlingStegStatus {
     UTFØRT = 'UTFØRT',
     IKKE_UTFØRT = 'IKKE_UTFØRT',

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -21,6 +21,7 @@ export enum ToggleNavn {
     bosattSvalbard = 'familie-ba-sak.bosatt-svalbard',
     bosattFinnmarkNordtroms = 'familie-ba-sak.bosatt-finnmark-nord-troms',
     skalViseOppholdsadresse = 'familie-ba-sak.skal-vise-oppholdsadresse',
+    brukNyHenleggModal = 'familie-ba-sak.bruk-ny-henlegg-modal',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25961

Refactorer modalen for å henlegge behandlinger. Har gjort følgende i PRen:
- Refaktorert til å bruke react-hook-form
- Refaktorert til å bruke react-query for henlegg behandling kallet
- Refaktorert modalen til å bruke `ModalContext` / `useModal`
- Refaktorert `ModalContext` / `useModal` slik at man kan ha både modaler med og uten "args". Nå kan man f.eks. kalle på `åpneModal()` med og uten args, avhengig av hva som er spesifisert i `ModalContext`

Endringen er lagt bak en feature toggle.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Hadde ikke så lyst til å skrive tester når det fortsatt er en del refaktorering knyttet til dokumenter / forhåndsvisning av brev igjen. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots

Ny henlegg behanding modal med infoboks og feilmeldinger: 
<img width="567" height="611" alt="image" src="https://github.com/user-attachments/assets/f9a6def9-9ae1-480a-aab0-d44277ac21d4" />

Ny henlegg behandling veivalg modal:
<img width="532" height="216" alt="image" src="https://github.com/user-attachments/assets/3dee5219-3d1d-42f5-8756-c9f1d467bc31" />
