### PR TITLE
Fjerner casting til react router link på lenker i venstremenyen

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { NavLink, Link as ReactRouterLink } from 'react-router';
+import { NavLink } from 'react-router';
 import styled from 'styled-components';
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
@@ -104,7 +104,6 @@ const Venstremeny: React.FunctionComponent = () => {
                         return (
                             <VStack key={sideId}>
                                 <MenyLenke
-                                    as={ReactRouterLink}
                                     id={sideId}
                                     to={tilPath}
                                     $erLenkenAktiv={sidenErAktiv}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Trenger ikke caste denne til en react router link, den brukte allerede navlink fra react router. Jeg mistok linken benyttet for å være fra Aksel, men der tok jeg feil.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen bekymringer, dette går tilbake til slik det var. 😊 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer