### PR TITLE
Endre når varselboks for preutfylte vilkår vises

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -12,7 +12,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 import FjernUtvidetBarnetrygdVilkår from './FjernUtvidetBarnetrygdVilkår';
 import VilkårTabell from './VilkårTabell';
 import { useAppContext } from '../../../../../../context/AppContext';
-import type { IBehandling } from '../../../../../../typer/behandling';
+import { BehandlingSteg, type IBehandling } from '../../../../../../typer/behandling';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
 import { PersonType } from '../../../../../../typer/person';
 import { ToggleNavn } from '../../../../../../typer/toggles';
@@ -49,7 +49,7 @@ const GeneriskVilkår: React.FC<IProps> = ({
     generiskVilkårKey,
 }) => {
     const { toggles } = useAppContext();
-    const { vurderErLesevisning, settÅpenBehandling, erMigreringsbehandling } =
+    const { behandling, vurderErLesevisning, settÅpenBehandling, erMigreringsbehandling } =
         useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
     const { settVilkårSubmit, postVilkår, vilkårSubmit } = useVilkårsvurderingContext();
@@ -117,9 +117,8 @@ const GeneriskVilkår: React.FC<IProps> = ({
 
     const skalViseLyspære =
         toggles[ToggleNavn.skalViseVarsellampeForManueltLagtTilBarn] &&
-        vilkårResultater.some(
-            vilkårResultat => !!vilkårResultat.verdi.begrunnelseForManuellKontroll
-        );
+        behandling.steg == BehandlingSteg.VILKÅRSVURDERING &&
+        vilkårResultater.some(vilkår => !!vilkår.verdi.begrunnelseForManuellKontroll);
 
     return (
         <Container>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -12,8 +12,11 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useAppContext } from '../../../../../../context/AppContext';
 import PersonInformasjon from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import { BehandlingÅrsak } from '../../../../../../typer/behandling';
+import {
+    BehandlingSteg,
+    BehandlingÅrsak,
+    type IBehandling,
+} from '../../../../../../typer/behandling';
 import { PersonType } from '../../../../../../typer/person';
 import { ToggleNavn } from '../../../../../../typer/toggles';
 import type {
@@ -118,16 +121,24 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
     };
 
     const vilkårSomMåKontrolleresPerPerson = Object.entries(
-        toggles[ToggleNavn.skalViseVarsellampeForManueltLagtTilBarn]
-            ? utledVilkårSomMåKontrolleresPerPerson(behandling, vilkårsvurdering)
-            : {}
+        utledVilkårSomMåKontrolleresPerPerson(behandling, vilkårsvurdering)
     );
+
+    const skalViseVarselboksForVilkårSomMåKontrolleres =
+        toggles[ToggleNavn.skalViseVarsellampeForManueltLagtTilBarn] &&
+        vilkårSomMåKontrolleresPerPerson.length > 0 &&
+        (behandling.steg == BehandlingSteg.VILKÅRSVURDERING ||
+            behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK);
 
     return (
         <>
-            {vilkårSomMåKontrolleresPerPerson.length > 0 && (
+            {skalViseVarselboksForVilkårSomMåKontrolleres && (
                 <Alert variant="warning" contentMaxWidth={false} style={{ width: 'fit-content' }}>
-                    <BodyShort>Vær oppmerksom:</BodyShort>
+                    <BodyShort>
+                        {behandling.steg == BehandlingSteg.BESLUTTE_VEDTAK
+                            ? 'Automatisk utfylte vilkår som saksbehandler 1 ikke har gjort endringer på:'
+                            : 'Vær oppmerksom:'}
+                    </BodyShort>
                     <List as="ul">
                         {vilkårSomMåKontrolleresPerPerson.map(([navn, avvik]) => (
                             <List.Item key={navn}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
@@ -4,7 +4,7 @@ import type { FeltState } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { kjørValidering, validerAnnenVurdering, validerVilkår } from './validering';
-import type { IBehandling } from '../../../../../typer/behandling';
+import { BehandlingSteg, type IBehandling } from '../../../../../typer/behandling';
 import type { IGrunnlagPerson } from '../../../../../typer/person';
 import { PersonTypeVisningsRangering } from '../../../../../typer/person';
 import {
@@ -182,6 +182,7 @@ export const utledVilkårSomMåKontrolleresPerPerson = (
         const navn = personResultat.person.navn;
 
         if (
+            behandling.steg === BehandlingSteg.VILKÅRSVURDERING &&
             behandling.søknadsgrunnlag?.erAutomatiskRegistrert &&
             personResultat.person.erManueltLagtTilISøknad
         ) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-25733

Endrer logikken for når varselboks og lyspærer for preutfylte vilkår vises:
- Skal kun vises når behandlingen er på stegene `VILKÅRSVURDERING` og `BESLUTTE_VEDTAK`, med andre ord skjules når SB1 har gått videre til behandlingsresultatsiden, og når behandlingen er avsluttet
- Overskriften i varselboksen skal endres fra `Vær oppmerksom` for SB1 til `Automatisk utfylte vilkår som saksbehandler 1 ikke har gjort endringer på` for SB2
- Lyspærer skal kun vises når behandlingen er på steget `VILKÅRSVURDERING`
- Teksten `Har ikke relasjon til søker i PDL` skal skjules for SB2

### 👀 Screen shots

Varselboks for saksbehandler 1 på vilkårsvurderingsteget:
<img width="743" height="318" alt="ca7198364afd422dac25771b6fa53a87" src="https://github.com/user-attachments/assets/c6521270-2ca5-4af2-8b36-c6cfdd975a89" />

Varlseboks for saksbehandler 2:
<img width="743" height="286" alt="9f7307ffb69e8ee214426fc20a434ebe" src="https://github.com/user-attachments/assets/1daa75ec-78dc-49e1-8fce-926ac8fc607d" />
