### PR TITLE
Legg til oppholdsadresse i registeropplysningene

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -15,8 +15,10 @@ import { AFontWeightRegular, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 import { HentetLabel } from './HentetLabel';
 import RegisteropplysningerTabell from './RegisteropplysningerTabell';
+import { useAppContext } from '../../../../../../context/AppContext';
 import type { IRestRegisterhistorikk } from '../../../../../../typer/person';
 import { Registeropplysning } from '../../../../../../typer/registeropplysning';
+import { ToggleNavn } from '../../../../../../typer/toggles';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../../utils/dato';
 
 const Container = styled.div`
@@ -36,6 +38,7 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({
     registerHistorikk,
     fødselsdato,
 }) => {
+    const { toggles } = useAppContext();
     const manglerRegisteropplysninger = registerHistorikk.statsborgerskap.length === 0;
 
     const personErDød = registerHistorikk.dødsboadresse.length > 0;
@@ -119,6 +122,19 @@ const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({
                         ikon={<HouseIcon fontSize={'1.5rem'} title="Hjem-ikon" focusable="false" />}
                         historikk={registerHistorikk.bostedsadresse}
                     />
+                    {toggles[ToggleNavn.skalViseOppholdsadresse] && (
+                        <RegisteropplysningerTabell
+                            opplysningstype={Registeropplysning.OPPHOLDSADRESSE}
+                            ikon={
+                                <HouseIcon
+                                    fontSize={'1.5rem'}
+                                    title="Hjem-ikon"
+                                    focusable="false"
+                                />
+                            }
+                            historikk={registerHistorikk.oppholdsadresse}
+                        />
+                    )}
                 </Container>
             )}
         </>

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -96,6 +96,7 @@ export interface IRestRegisterhistorikk {
     oppholdstillatelse: IRestRegisteropplysning[];
     statsborgerskap: IRestRegisteropplysning[];
     bostedsadresse: IRestRegisteropplysning[];
+    oppholdsadresse: IRestRegisteropplysning[];
     dødsboadresse: IRestRegisteropplysning[];
 }
 

--- a/src/frontend/typer/registeropplysning.ts
+++ b/src/frontend/typer/registeropplysning.ts
@@ -3,6 +3,7 @@ export enum Registeropplysning {
     OPPHOLD = 'OPPHOLD',
     STATSBORGERSKAP = 'STATSBORGERSKAP',
     BOSTEDSADRESSE = 'BOSTEDSADRESSE',
+    OPPHOLDSADRESSE = 'OPPHOLDSADRESSE',
     DØDSBOADRESSE = 'DØDSBOADRESSE',
     FØDSELSDATO = 'FØDSELSDATO',
 }
@@ -12,6 +13,7 @@ export const registeropplysning: Record<Registeropplysning, string> = {
     OPPHOLD: 'Oppholdstillatelse',
     STATSBORGERSKAP: 'Statsborgerskap',
     BOSTEDSADRESSE: 'Adresse',
+    OPPHOLDSADRESSE: 'Oppholdsadresse',
     DØDSBOADRESSE: 'Dødsboadresse',
     FØDSELSDATO: 'Fødselsdato',
 };

--- a/src/frontend/typer/toggles.ts
+++ b/src/frontend/typer/toggles.ts
@@ -20,6 +20,7 @@ export enum ToggleNavn {
     skalViseVarsellampeForManueltLagtTilBarn = 'familie-ba-sak.skal-vise-varsellampe-for-manuelt-lagt-til-barn',
     bosattSvalbard = 'familie-ba-sak.bosatt-svalbard',
     bosattFinnmarkNordtroms = 'familie-ba-sak.bosatt-finnmark-nord-troms',
+    skalViseOppholdsadresse = 'familie-ba-sak.skal-vise-oppholdsadresse',
 }
 
 export const alleTogglerAv = (): IToggles => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en

Favro: NAV-26037

Henter oppholdsadresse per person sammen med behandlingen, og viser i registeropplysningene
Formatering er definert i backend.

Avhengig av [backend-PR](https://github.com/navikt/familie-ba-sak/pull/5601)

<img width="517" height="194" alt="image" src="https://github.com/user-attachments/assets/22b38066-a0b8-4dc5-a291-b98e2665bcb2" />