### PR TITLE
NAV-26109: Legger til gcTime: 0 på react query hooks som ikke viser den global system laster spinneren

### DIFF
--- a/src/frontend/api/hentFagsaker.ts
+++ b/src/frontend/api/hentFagsaker.ts
@@ -3,12 +3,16 @@ import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
 import type { IMinimalFagsak } from '../typer/fagsak';
 import { RessursResolver } from '../utils/ressursResolver';
 
-export async function hentFagsaker(request: FamilieRequest, personIdent: string) {
+export async function hentFagsaker(
+    request: FamilieRequest,
+    personIdent: string,
+    påvirkerSystemLaster: boolean = true
+) {
     const ressurs = await request<{ personIdent: string }, IMinimalFagsak[]>({
         method: 'POST',
         url: `/familie-ba-sak/api/fagsaker/hent-fagsaker-paa-person`,
         data: { personIdent },
-        påvirkerSystemLaster: false,
+        påvirkerSystemLaster,
     });
     return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/api/hentSamhandler.ts
+++ b/src/frontend/api/hentSamhandler.ts
@@ -3,11 +3,15 @@ import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
 import type { ISamhandlerInfo } from '../typer/samhandler';
 import { RessursResolver } from '../utils/ressursResolver';
 
-export async function hentSamhandler(request: FamilieRequest, orgnr: string) {
+export async function hentSamhandler(
+    request: FamilieRequest,
+    orgnr: string,
+    påvirkerSystemLaster: boolean = true
+) {
     const ressurs = await request<void, ISamhandlerInfo>({
         method: 'GET',
         url: '/familie-ba-sak/api/samhandler/orgnr/' + orgnr,
-        påvirkerSystemLaster: false,
+        påvirkerSystemLaster,
     });
     return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/hooks/useHentPersonEnkel.ts
+++ b/src/frontend/hooks/useHentPersonEnkel.ts
@@ -1,21 +1,32 @@
-import { useQuery } from '@tanstack/react-query';
+import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
 import { useAppContext } from '../context/AppContext';
+import type { IPersonInfo } from '../typer/person';
 import { RessursResolver } from '../utils/ressursResolver';
 
-interface Props {
-    personIdent: string;
-}
+export const HentPersonEnkelQueryKeyFactory = {
+    personEnkel: (personIdent: string) => ['person_enkel', personIdent],
+};
 
-export function useHentPersonEnkel({ personIdent }: Props) {
+type Parameters = Omit<
+    UseQueryOptions<IPersonInfo, DefaultError, IPersonInfo>,
+    'queryKey' | 'queryFn' | 'gcTime'
+> & {
+    personIdent: string;
+};
+
+export function useHentPersonEnkel({ personIdent, ...rest }: Parameters) {
     const { hentPerson } = useAppContext();
     return useQuery({
-        queryKey: ['person_enkel', personIdent],
+        queryKey: HentPersonEnkelQueryKeyFactory.personEnkel(personIdent),
         queryFn: async () => {
             // TODO : Flytt "hentPerson" metoden fra AppContext til api mappen og omdøp den til "hentPersonEnkel",
-            //  men må skrive om hvordan "AppInfoModal" fungerer først
+            //  men må skrive om hvordan "AppInfoModal" fungerer først. Da burde man også tillate å sende inn "gcTime"
+            //  og "påvirkerSystemLaster" som parameter.
             const ressurs = await hentPerson(personIdent);
             return RessursResolver.resolveToPromise(ressurs);
         },
+        gcTime: 0, // deaktiver cache da "påvirkerSystemLaster" er false.
+        ...rest,
     });
 }

--- a/src/frontend/komponenter/Modal/fagsak/hooks/useOpprettFagsakForm.ts
+++ b/src/frontend/komponenter/Modal/fagsak/hooks/useOpprettFagsakForm.ts
@@ -1,8 +1,10 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
 import type { OpprettFagsakPayload } from '../../../../api/opprettFagsak';
 import { ModalType } from '../../../../context/ModalContext';
+import { HentFagsakerQueryKeyFactory } from '../../../../hooks/useHentFagsaker';
 import { useModal } from '../../../../hooks/useModal';
 import { useOnFormSubmitSuccessful } from '../../../../hooks/useOnFormSubmitSuccessful';
 import { useOpprettFagsak } from '../../../../hooks/useOpprettFagsak';
@@ -21,6 +23,8 @@ interface Props {
 
 export function useOpprettFagsakForm({ personIdent, fagsaker }: Props) {
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
+
     const { lukkModal } = useModal(ModalType.OPPRETT_FAGSAK);
 
     const harNormalFagsak = sjekkHarNormalFagsak(fagsaker);
@@ -73,6 +77,9 @@ export function useOpprettFagsakForm({ personIdent, fagsaker }: Props) {
         };
         return mutateAsync(payload)
             .then(fagsak => {
+                queryClient.invalidateQueries({
+                    queryKey: HentFagsakerQueryKeyFactory.fagsaker(personIdent),
+                });
                 lukkModal();
                 const aktivBehandling = hentAktivBehandlingPåMinimalFagsak(fagsak);
                 if (aktivBehandling) {

--- a/src/frontend/komponenter/Modal/fagsak/hooks/useSamhandlerForm.ts
+++ b/src/frontend/komponenter/Modal/fagsak/hooks/useSamhandlerForm.ts
@@ -12,6 +12,8 @@ import {
     type SamhandlerFormValues,
 } from '../form/SamhandlerForm';
 
+const påvirkerSystemLaster = false;
+
 interface Props {
     settSamhandler: (samhandler: ISamhandlerInfo) => void;
 }
@@ -34,7 +36,7 @@ export function useSamhandlerForm({ settSamhandler }: Props) {
         return await queryClient
             .fetchQuery({
                 queryKey: ['samhandler', values.orgnr],
-                queryFn: () => hentSamhandler(request, values.orgnr),
+                queryFn: () => hentSamhandler(request, values.orgnr, påvirkerSystemLaster),
             })
             .then(samhandler => settSamhandler(samhandler))
             .catch(error => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26109

Når vi setter `gcTime` til 0 deaktivere vi cachen til react-query for den hooken. Det vil si at vi tvinger den til å alltid vise oppdatert informasjon, altså viser ingenting fra cache. Det burde vi gjøre i de tilfeller vi ikke viser en global "systemet laster" spinner. Det er ikke noe problem for de hookene som viser spinneren fordi den cachede dataen i GUI vil bli oppdatert via "background fetches" før den global "systemet laster" spinneren er borte.

Tar en runde på det på neste utviklerprat. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant. 

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer.