### PR TITLE
NAV-26066: Legger til varsel ved manglende Svalbardmerking

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Varsel/ManglendeSvalbardmerkingVarsel.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Varsel/ManglendeSvalbardmerkingVarsel.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { Alert, Heading } from '@navikt/ds-react';
+
+import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
+import { slåSammenListeTilStreng } from '../../../../../../utils/formatter';
+import { useBehandlingContext } from '../../../context/BehandlingContext';
+
+export const ManglendeSvalbardmerkingVarsel: React.FC = () => {
+    const { behandling } = useBehandlingContext();
+
+    const skalViseVarsel = behandling.manglendeSvalbardmerking.length > 0;
+
+    if (!skalViseVarsel) {
+        return null;
+    } else {
+        return (
+            <Alert variant={'warning'}>
+                <Heading spacing size="small" level="3">
+                    Bosatt på Svalbard
+                </Heading>
+                <p>
+                    Personer i behandlingen har oppholdsadresse på Svalbard i en periode hvor
+                    «bosatt på Svalbard» ikke er lagt til i bosatt i riket vilkåret. Dette gjelder
+                    (person/periode):
+                </p>
+                <ul>
+                    {behandling.manglendeSvalbardmerking.map(manglendeSvalbardmerking => {
+                        const perioder = slåSammenListeTilStreng(
+                            manglendeSvalbardmerking.manglendeSvalbardmerkingPerioder.map(
+                                manglendeSvalbardmerkingPeriode =>
+                                    isoDatoPeriodeTilFormatertString({
+                                        fom: manglendeSvalbardmerkingPeriode.fom,
+                                        tom: manglendeSvalbardmerkingPeriode.tom,
+                                    })
+                            )
+                        );
+                        return <li>{`${manglendeSvalbardmerking.ident}: ${perioder}`}</li>;
+                    })}
+                </ul>
+            </Alert>
+        );
+    }
+};

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -19,13 +19,18 @@ import { useVilkårsvurderingContext } from './VilkårsvurderingContext';
 import useSakOgBehandlingParams from '../../../../../hooks/useSakOgBehandlingParams';
 import type { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingSteg, BehandlingÅrsak } from '../../../../../typer/behandling';
-import type { IAnnenVurdering, IVilkårResultat } from '../../../../../typer/vilkår';
-import { annenVurderingConfig, vilkårConfig } from '../../../../../typer/vilkår';
+import {
+    annenVurderingConfig,
+    type IAnnenVurdering,
+    type IVilkårResultat,
+    vilkårConfig,
+} from '../../../../../typer/vilkår';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
 import { erProd } from '../../../../../utils/miljø';
 import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 import Skjemasteg from '../Skjemasteg';
+import { ManglendeSvalbardmerkingVarsel } from './Varsel/ManglendeSvalbardmerkingVarsel';
 
 const UregistrerteBarnListe = styled.ol`
     margin: ${ASpacing2} 0;
@@ -213,6 +218,7 @@ const Vilkårsvurdering: React.FunctionComponent<IProps> = ({ åpenBehandling })
             {skjemaFeilmelding !== '' && skjemaFeilmelding !== undefined && (
                 <ErrorMessage>{skjemaFeilmelding}</ErrorMessage>
             )}
+            <ManglendeSvalbardmerkingVarsel />
         </Skjemasteg>
     );
 };

--- a/src/frontend/typer/ManglendeSvalbardmerkingPeriode.ts
+++ b/src/frontend/typer/ManglendeSvalbardmerkingPeriode.ts
@@ -1,0 +1,9 @@
+export interface ManglendeSvalbardmerking {
+    ident: string;
+    manglendeSvalbardmerkingPerioder: ManglendeSvalbardmerkingPeriode[];
+}
+
+export interface ManglendeSvalbardmerkingPeriode {
+    fom?: string;
+    tom?: string;
+}

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -5,6 +5,7 @@ import type { IRestFeilutbetaltValuta } from './eøs-feilutbetalt-valuta';
 import type { IRestKompetanse, IRestUtenlandskPeriodeBeløp, IRestValutakurs } from './eøsPerioder';
 import type { IFødselshendelsefiltreringResultat } from './fødselshendelser';
 import type { KlageResultat, KlageStatus, KlageÅrsak } from './klage';
+import type { ManglendeSvalbardmerking } from './ManglendeSvalbardmerkingPeriode';
 import type { IGrunnlagPerson } from './person';
 import type { IRestRefusjonEøs } from './refusjon-eøs';
 import type { ITilbakekreving } from './simulering';
@@ -314,6 +315,7 @@ export interface IBehandling {
     brevmottakere: IRestBrevmottaker[];
     vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser | null;
     tilbakekrevingsvedtakMotregning: TilbakekrevingsvedtakMotregningDTO | null;
+    manglendeSvalbardmerking: ManglendeSvalbardmerking[];
 }
 
 export enum VurderingsstrategiForValutakurser {


### PR DESCRIPTION
Favro: [NAV-26066](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26066)

### 💰 Hva forsøker du å løse i denne PR'en
Dersom en av aktørene i vilkårsvurderingen har oppholdsadresse på Svalbard og ikke har markert tilsvarende "Bosatt i riket"-perioder med utdypende vilkårsvurdering "Bosatt på Svalbard" skal vi vise et varsel til Saksbehandler om dette.

* Opprettet ny komponent `ManglendeSvalbardmerkingVarsel`
* Komponenten vises dersom det nye feltet `manglendeSvalbardmerking` inneholder elementer

Se screenshots lenger ned.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett
  
### 👀 Screen shots
<img width="1154" height="668" alt="image" src="https://github.com/user-attachments/assets/711cad84-7ccc-473e-a512-9f93269e281f" />
