### PR TITLE
Fikser trippel scroll på behandlingsvisningen

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -33,7 +33,7 @@ const VenstremenyContainer = styled.div`
 `;
 
 const HovedinnholdContainer = styled.div`
-    height: calc(100vh - 6rem);
+    height: calc(100vh - 146px);
     flex: 1;
     overflow: auto;
 `;
@@ -42,6 +42,7 @@ const HøyremenyContainer = styled.div`
     border-left: 1px solid ${ABorderDivider};
     overflow-x: hidden;
     overflow-y: scroll;
+    height: calc(100vh - 146px);
 `;
 
 const BehandlingContainer: React.FC<Props> = ({ bruker, fagsak }) => {

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
@@ -34,7 +34,6 @@ const ToggleVisningHøyremeny = styled(Button)<{ $åpenhøyremeny: boolean }>`
 
 const Container = styled.div<{ $erÅpen: boolean }>`
     width: ${props => props.$erÅpen && '25rem'};
-    height: ${props => props.$erÅpen && `calc(100vh - 8rem)`};
 `;
 
 const Høyremeny: React.FunctionComponent<Props> = ({ bruker }) => {


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26134

### 💰 Hva forsøker du å løse i denne PR'en
Fjernet en tredje scrollbar som gjorde slik at saksbehandlingslinjen med fnr og kommune på søker forsvant hvis saksbehandler scrollet seg helt ned på siden.

Problemet er at vi eksplisitt setter høyde på hovedinnhold og høyremenyen basert på at det kun fantes en header (den sorte) og én personlinje. Nå har vi en ytterligere linje under personlinjen med lenker til saken. Dermed måtte kalkulasjonen av høyde basert på enheten `vh` bli litt annerledes. Jeg legger også begge høydestilene på samme sted slik at verdiene blir like. Før lå høyremenyen sin høyde lenger inn i hierarkiet og på et element som lå lenger nede visuelt, som gjorde at disse to høydeverdiene ble litt forskjellige og veldig forvirrende

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen bekymringer

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før (merk tre scrollbarer):
<img width="1814" height="1211" alt="image" src="https://github.com/user-attachments/assets/46c1bb0d-2556-4964-a49f-cdb92ce4e555" />

Når vi scrollet oss helt ned vil den ytterste scrollbaren også scrolles helt ned, og personlinja vil da skjules:
<img width="1809" height="1205" alt="image" src="https://github.com/user-attachments/assets/e6183f72-c26b-4bc3-b221-8ceb3ec6726a" />


Etter (kun to scrollbarer siden hovedinnholdet og høyremenyen ikke tar opp mer plass enn høyden på vinduet):
<img width="1808" height="1198" alt="image" src="https://github.com/user-attachments/assets/0950d539-8128-4a2a-85a6-aed54b1bd4d5" />


Og når vi scroller helt ned er alt fremdeles A-OK:
<img width="1812" height="1208" alt="image" src="https://github.com/user-attachments/assets/4c0bbb2f-9232-427d-8160-6a18f9295722" />
