### PR TITLE
Legg til id-token permission i scan-vulnerabilities

### DIFF
--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -19,5 +19,6 @@ jobs:
     permissions:
       contents: write # to write sarif
       security-events: write # push sarif to github security
+      id-token: write # nais/login
     uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@main # ratchet:exclude
     secrets: inherit


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Legger til id-token permission i scan-vulnerabilities da dette er påkrevd for å hente riktig image for scanning