### PR TITLE
Hent samhandler journalføring må hente info basert på orgNr

### DIFF
--- a/src/frontend/komponenter/Samhandler/useSamhandler.ts
+++ b/src/frontend/komponenter/Samhandler/useSamhandler.ts
@@ -27,7 +27,7 @@ export const useSamhandlerSkjema = (onSuccess?: () => void, onError?: (error: st
 
     const onSubmitWrapper = () => {
         onSubmit(
-            hentSamhandlerdataForBehandlingConfig(skjema.felter.orgnr.verdi),
+            hentSamhandlerdataForOrgNrConfig(skjema.felter.orgnr.verdi),
             (ressurs: Ressurs<ISamhandlerInfo>) => {
                 settSubmitRessurs(ressurs);
                 if (onSuccess) {
@@ -48,15 +48,15 @@ export const useSamhandlerSkjema = (onSuccess?: () => void, onError?: (error: st
     };
 };
 
-export const useSamhandlerRequest = () => {
+export const useSamhandlerRequest = (erIEnBehandling: boolean) => {
     const { request } = useHttp();
     const [samhandlerRessurs, settSamhandlerRessurs] = useState<Ressurs<ISamhandlerInfo>>(byggTomRessurs());
 
     const { skalObfuskereData } = useAppContext();
 
-    const hentOgSettSamhandler = (behandlingId: number) => {
+    const hentOgSettSamhandler = (behandlingIdEllerOrgnr: string | number) => {
         settSamhandlerRessurs(byggHenterRessurs<ISamhandlerInfo>());
-        hentSamhandler(behandlingId.toString()).then((ressurs: Ressurs<ISamhandlerInfo>) => {
+        hentSamhandler(String(behandlingIdEllerOrgnr)).then((ressurs: Ressurs<ISamhandlerInfo>) => {
             if (skalObfuskereData) {
                 obfuskerSamhandler(ressurs);
             }
@@ -64,8 +64,11 @@ export const useSamhandlerRequest = () => {
         });
     };
 
-    const hentSamhandler = async (behandlingId: string): Promise<Ressurs<ISamhandlerInfo>> => {
-        return request<ISamhandlerInfoRequest, ISamhandlerInfo>(hentSamhandlerdataForBehandlingConfig(behandlingId))
+    const hentSamhandler = async (behandlingIdEllerOrgnr: string): Promise<Ressurs<ISamhandlerInfo>> => {
+        const config = erIEnBehandling
+            ? hentSamhandlerdataForBehandlingConfig(behandlingIdEllerOrgnr)
+            : hentSamhandlerdataForOrgNrConfig(behandlingIdEllerOrgnr);
+        return request<ISamhandlerInfoRequest, ISamhandlerInfo>(config)
             .then((ressurs: Ressurs<ISamhandlerInfo>) => {
                 return ressurs;
             })
@@ -85,5 +88,12 @@ const hentSamhandlerdataForBehandlingConfig = (behandlingId: string): FamilieReq
     return {
         method: 'GET',
         url: '/familie-ba-sak/api/samhandler/behandling/' + behandlingId,
+    };
+};
+
+const hentSamhandlerdataForOrgNrConfig = (orgNr: string): FamilieRequestConfig<ISamhandlerInfoRequest> => {
+    return {
+        method: 'GET',
+        url: '/familie-ba-sak/api/samhandler/orgnr/' + orgNr,
     };
 };

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -91,7 +91,7 @@ const StyledCombobox = styled(UNSAFE_Combobox)`
 
 const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
     const { behandling, settÅpenBehandling, vurderErLesevisning, hentLogg } = useBehandlingContext();
-    const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest();
+    const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);
 
     const {
         skjema,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
@@ -22,7 +22,7 @@ interface IProps {
 
 const RegistrerInstitusjon: React.FC<IProps> = ({ åpenBehandling }) => {
     const { institusjon, onSubmitMottaker, submitFeilmelding } = useInstitusjon(åpenBehandling);
-    const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest();
+    const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);
     const { behandlingsstegSubmitressurs, vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
@@ -44,7 +44,7 @@ interface IProps {
 const VilkårsvurderingSkjemaInstitusjon: React.FunctionComponent<IProps> = ({ visFeilmeldinger }) => {
     const { behandling, vurderErLesevisning } = useBehandlingContext();
     const { vilkårsvurdering } = useVilkårsvurderingContext();
-    const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest();
+    const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);
 
     if (samhandlerRessurs.status === RessursStatus.IKKE_HENTET) {
         hentOgSettSamhandler(behandling.behandlingId);

--- a/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
@@ -72,7 +72,7 @@ export const BrukerPanel: React.FC = () => {
         verdi: '',
         valideringsfunksjon: identValidator,
     });
-    const { hentSamhandler } = useSamhandlerRequest();
+    const { hentSamhandler } = useSamhandlerRequest(false);
     const [valgtInstitusjon, settValgtInstitusjon] = useState<string>('');
     const [samhandlerFeilmelding, settSamhandlerFeilmelding] = useState<string>('');
     const [erFagsaktypePanelÅpnet, settErFagsaktypePanelÅpnet] = useState<boolean>(false);


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
[NAV-26299](https://favro.com/organization/98c34fb974ce445eac854de0/?card=NAV-26299).
Ved omskriving av å bruke registerdata på en behandling for institusjon så ble journalføring brukket. Saksbehandler får ikke knyttet dokumentet til en fagsak for institusjon, fordi den prøvde å hente infoen fra endepunktet /samhandler/behandling/{behandlingId} men akkurat her er man ikke i en kontekst av behandlingen så man må bruke /samhandler/orgnr/{orgNr}. Samme feil på /samhandler fanen

Test i preprod
<img width="246" height="647" alt="image" src="https://github.com/user-attachments/assets/c6544390-10c2-42a8-8177-baa68ff523bb" />


### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
