### PR TITLE
NAV-26327: Legger inn korrekt sjekk på brevmalverdi for å vise delt bosted barn skjema

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Hendelsesoversikt/BrevModul/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Hendelsesoversikt/BrevModul/Brevskjema.tsx
@@ -376,7 +376,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                             settVisFeilmeldinger={settVisfeilmeldinger}
                         />
                     )}
-                    {skjema.felter.brevmal.verdi !== Brevmal.VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14 && (
+                    {skjema.felter.brevmal.verdi === Brevmal.VARSEL_OM_REVURDERING_DELT_BOSTED_PARAGRAF_14 && (
                         <>
                             <DeltBostedSkjema
                                 avtalerOmDeltBostedPerBarnFelt={skjema.felter.avtalerOmDeltBostedPerBarn}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro:  https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26327

Oppdaget en liten bug jeg hadde innført. La sikkert til `!==` for å teste lokalt men det skal fortsatt være `===`.

Ble innført her: https://github.com/navikt/familie-ba-sak-frontend/pull/4054/files#diff-eb1e86730c09b7f36f56b26cd0710809c4d829eef50ae3db54784c4a43a49bfaR379

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer.