### PR TITLE
NAV-28170: Legger til manglende "height" på skrollbar stack

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
@@ -1,4 +1,5 @@
 .skrollbarStack {
+    height: 100%;
     min-height: 0; /* CRITICAL: Allows children to scroll instead of stretching this container, it's a flexbox quirk */
 }
 


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
Mangler "height: 100%" på kontainer stacken. Slik som den er nå vil den ikke alltid ta 100% av høyden som kan se litt rart ut hvis det oppstår naturlig. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant. 

### 👀 Screen shots
Ser stort sett likt ut. Sørger bare for at høyden alltid er 100%. 