### PR TITLE
NAV-28506 Refaktorer LeggTilBarnPåBehandling til react-query og react-hook-form

### DIFF
--- a/src/frontend/api/harSaksbehandlerTilgang.ts
+++ b/src/frontend/api/harSaksbehandlerTilgang.ts
@@ -1,0 +1,17 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import type { IRestTilgang } from '../typer/person';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface HarSaksbehandlerTilgangPayload {
+    brukerIdent: string;
+}
+
+export const harSaksbehandlerTilgang = async (request: FamilieRequest, brukerIdent: string) => {
+    const ressurs = await request<HarSaksbehandlerTilgangPayload, IRestTilgang>({
+        data: { brukerIdent: brukerIdent },
+        method: 'POST',
+        url: '/familie-ba-sak/api/tilgang',
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+};

--- a/src/frontend/api/leggTilBarnPåBehandling.ts
+++ b/src/frontend/api/leggTilBarnPåBehandling.ts
@@ -1,61 +1,17 @@
 import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
-import { byggFeiletRessurs, type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import type { IBehandling } from '../typer/behandling';
-import { adressebeskyttelsestyper, type IRestTilgang } from '../typer/person';
 import { RessursResolver } from '../utils/ressursResolver';
-
-export interface HarSaksbehandlerTilgangPayload {
-    brukerIdent: string;
-}
 
 export interface LeggTilBarnPåBehandlingPayload {
     barnIdent: string;
 }
 
-const harSaksbehandlerTilgang = async (request: FamilieRequest, brukerIdent: string) => {
-    const ressurs = RessursResolver.resolveToPromise(
-        await request<HarSaksbehandlerTilgangPayload, IRestTilgang>({
-            data: { brukerIdent: brukerIdent },
-            method: 'POST',
-            url: '/familie-ba-sak/api/tilgang',
-        })
-    );
-    return ressurs.data.saksbehandlerHarTilgang;
-};
-
 export const leggTilBarnPåBehandling = async (request: FamilieRequest, barnIdent: string, behandlingId: number) => {
-    // TODO: dobbeltsjekk om denne venter på responsen fra kallet før den kjører videre
-    const saksbehandlerHarTilgang = await harSaksbehandlerTilgang(request, barnIdent);
-
-    if (!saksbehandlerHarTilgang) {
-        settSubmitRessurs(
-            byggFeiletRessurs(
-                `Barnet kan ikke legges til på grunn av diskresjonskode ${
-                    adressebeskyttelsestyper[ressurs.data.adressebeskyttelsegradering] ?? 'ukjent'
-                }`
-            )
-        );
-    }
-
-    // TODO: gjør noe her så ikke kallet kjører videre hvis ikke saksbehandleren har tilgang
     const ressurs = await request<LeggTilBarnPåBehandlingPayload, IBehandling>({
         data: { barnIdent: barnIdent },
         method: 'POST',
         url: `/familie-ba-sak/api/behandlinger/${behandlingId}/legg-til-barn`,
-    }).then((respons: Ressurs<IBehandling>) => {
-        if (
-            respons.status === RessursStatus.FEILET ||
-            respons.status === RessursStatus.FUNKSJONELL_FEIL ||
-            respons.status === RessursStatus.IKKE_TILGANG
-        ) {
-            // TODO: dette henger igjen fra useSkjema. Kan vi bare fjerne det? Ev. håndtere det på den annen måte
-            settSubmitRessurs(byggFeiletRessurs(respons.frontendFeilmelding));
-        } else {
-            settÅpenBehandling(respons);
-            lukkModal();
-        }
     });
-
     return RessursResolver.resolveToPromise(ressurs);
 };

--- a/src/frontend/api/leggTilBarnPåBehandling.ts
+++ b/src/frontend/api/leggTilBarnPåBehandling.ts
@@ -1,0 +1,61 @@
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+import { byggFeiletRessurs, type Ressurs, RessursStatus } from '@navikt/familie-typer';
+
+import type { IBehandling } from '../typer/behandling';
+import { adressebeskyttelsestyper, type IRestTilgang } from '../typer/person';
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface HarSaksbehandlerTilgangPayload {
+    brukerIdent: string;
+}
+
+export interface LeggTilBarnPåBehandlingPayload {
+    barnIdent: string;
+}
+
+const harSaksbehandlerTilgang = async (request: FamilieRequest, brukerIdent: string) => {
+    const ressurs = RessursResolver.resolveToPromise(
+        await request<HarSaksbehandlerTilgangPayload, IRestTilgang>({
+            data: { brukerIdent: brukerIdent },
+            method: 'POST',
+            url: '/familie-ba-sak/api/tilgang',
+        })
+    );
+    return ressurs.data.saksbehandlerHarTilgang;
+};
+
+export const leggTilBarnPåBehandling = async (request: FamilieRequest, barnIdent: string, behandlingId: number) => {
+    // TODO: dobbeltsjekk om denne venter på responsen fra kallet før den kjører videre
+    const saksbehandlerHarTilgang = await harSaksbehandlerTilgang(request, barnIdent);
+
+    if (!saksbehandlerHarTilgang) {
+        settSubmitRessurs(
+            byggFeiletRessurs(
+                `Barnet kan ikke legges til på grunn av diskresjonskode ${
+                    adressebeskyttelsestyper[ressurs.data.adressebeskyttelsegradering] ?? 'ukjent'
+                }`
+            )
+        );
+    }
+
+    // TODO: gjør noe her så ikke kallet kjører videre hvis ikke saksbehandleren har tilgang
+    const ressurs = await request<LeggTilBarnPåBehandlingPayload, IBehandling>({
+        data: { barnIdent: barnIdent },
+        method: 'POST',
+        url: `/familie-ba-sak/api/behandlinger/${behandlingId}/legg-til-barn`,
+    }).then((respons: Ressurs<IBehandling>) => {
+        if (
+            respons.status === RessursStatus.FEILET ||
+            respons.status === RessursStatus.FUNKSJONELL_FEIL ||
+            respons.status === RessursStatus.IKKE_TILGANG
+        ) {
+            // TODO: dette henger igjen fra useSkjema. Kan vi bare fjerne det? Ev. håndtere det på den annen måte
+            settSubmitRessurs(byggFeiletRessurs(respons.frontendFeilmelding));
+        } else {
+            settÅpenBehandling(respons);
+            lukkModal();
+        }
+    });
+
+    return RessursResolver.resolveToPromise(ressurs);
+};

--- a/src/frontend/hooks/useHarSaksbehandlerTilgang.ts
+++ b/src/frontend/hooks/useHarSaksbehandlerTilgang.ts
@@ -1,0 +1,20 @@
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { harSaksbehandlerTilgang, type HarSaksbehandlerTilgangPayload } from '../api/harSaksbehandlerTilgang';
+import type { IRestTilgang } from '../typer/person';
+
+type Options = Omit<UseMutationOptions<IRestTilgang, DefaultError, HarSaksbehandlerTilgangPayload>, 'mutationFn'>;
+
+export const useHarSaksbehandlerTilgang = (options?: Options) => {
+    const { request } = useHttp();
+
+    return useMutation<IRestTilgang, Error, HarSaksbehandlerTilgangPayload>({
+        mutationFn: (parameters: HarSaksbehandlerTilgangPayload): Promise<IRestTilgang> => {
+            const { brukerIdent } = parameters;
+            return harSaksbehandlerTilgang(request, brukerIdent);
+        },
+        ...options,
+    });
+};

--- a/src/frontend/hooks/useLeggTilBarnPåBehandling.ts
+++ b/src/frontend/hooks/useLeggTilBarnPåBehandling.ts
@@ -1,0 +1,24 @@
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+import { leggTilBarnPåBehandling, type LeggTilBarnPåBehandlingPayload } from '../api/leggTilBarnPåBehandling';
+import type { IBehandling } from '../typer/behandling';
+
+interface LeggTilBarnPåBehandlingParameters extends LeggTilBarnPåBehandlingPayload {
+    behandlingId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, LeggTilBarnPåBehandlingParameters>, 'mutationFn'>;
+
+export const useLeggTilBarnPåBehandling = (options?: Options) => {
+    const { request } = useHttp();
+
+    return useMutation<IBehandling, Error, LeggTilBarnPåBehandlingParameters>({
+        mutationFn: (parameters: LeggTilBarnPåBehandlingParameters): Promise<IBehandling> => {
+            const { barnIdent, behandlingId } = parameters;
+            return leggTilBarnPåBehandling(request, barnIdent, behandlingId);
+        },
+        ...options,
+    });
+};

--- a/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
@@ -3,18 +3,10 @@ import React from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';
-import { idnr } from '@navikt/fnrvalidator';
 
 import { useLeggTilBarnModalContext } from './LeggTilBarnModalContext';
 import { Fields, type FormValues } from './useLeggTilBarnForm';
-
-function sjekkEr11Tall(verdi: string): boolean {
-    return /^\d{11}$/.test(verdi.replace(' ', ''));
-}
-
-function sjekkErGyldigIdent(verdi: string): boolean {
-    return idnr(verdi).status === 'valid';
-}
+import { sjekkEr11Tall, sjekkErGyldigIdent } from '../../../utils/validators';
 
 export function FødselsnummerField() {
     const { control } = useFormContext<FormValues>();
@@ -34,7 +26,7 @@ export function FødselsnummerField() {
                     return 'Barnet er allerede lagt til.';
                 }
                 if (!sjekkEr11Tall(value)) {
-                    return 'Fødselsnummer eller D-nummer er påkrevd har ikke 11 tall.';
+                    return 'Fødselsnummer eller D-nummer har ikke 11 tall.';
                 }
                 if (!sjekkErGyldigIdent(value)) {
                     return 'Fødselsnummer eller D-nummer er ugyldig.';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
@@ -42,9 +42,7 @@ export const LeggTilBarnFelt = ({ erLesevisning }: Props) => {
             label={'Fødselsnummer'}
             placeholder={'11 siffer'}
             value={value}
-            onChange={event => {
-                onChange(event.target.value);
-            }}
+            onChange={onChange}
             maxLength={11}
             error={error?.message}
             readOnly={erLesevisning || isSubmitting}

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
@@ -8,6 +8,7 @@ import {
     LeggTilBarnPåBehandlingFelt,
     type LeggTilBarnPåBehandlingFormValues,
 } from './useLeggTilBarnPåBehandlingSkjema';
+import { sjekkEr11Tall, sjekkErGyldigIdent } from '../../../../utils/validators';
 
 interface Props {
     erLesevisning: boolean;
@@ -24,10 +25,15 @@ export const LeggTilBarnFelt = ({ erLesevisning }: Props) => {
         name: LeggTilBarnPåBehandlingFelt.BARNIDENT,
         control,
         rules: {
-            required: 'Ident må oppgis.',
-            // TODO: stemmer dette, eller finnes det noen identtyper der lengden ikke er 11?
-            minLength: { value: 11, message: 'Ident må være på 11 siffer' },
-            maxLength: { value: 11, message: 'Ident må være på 11 siffer' },
+            required: 'Fødselsnummer eller D-nummer må oppgis.',
+            validate: value => {
+                if (!sjekkEr11Tall(value)) {
+                    return 'Fødselsnummer eller D-nummer må være 11 siffer.';
+                }
+                if (!sjekkErGyldigIdent(value)) {
+                    return 'Fødselsnummer eller D-nummer er ugyldig.';
+                }
+            },
         },
     });
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { useController, useFormContext } from 'react-hook-form';
+
+import { TextField } from '@navikt/ds-react';
+
+import {
+    LeggTilBarnPåBehandlingFelt,
+    type LeggTilBarnPåBehandlingFormValues,
+} from './useLeggTilBarnPåBehandlingSkjema';
+
+interface Props {
+    erLesevisning: boolean;
+}
+
+export const LeggTilBarnFelt = ({ erLesevisning }: Props) => {
+    const { control } = useFormContext<LeggTilBarnPåBehandlingFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: LeggTilBarnPåBehandlingFelt.BARNIDENT,
+        control,
+        rules: {
+            required: 'Ident må oppgis.',
+            // TODO: stemmer dette, eller finnes det noen identtyper der lengden ikke er 11?
+            minLength: { value: 11, message: 'Ident må være på 11 siffer' },
+            maxLength: { value: 11, message: 'Ident må være på 11 siffer' },
+        },
+    });
+
+    return (
+        <TextField
+            label={'Fødselsnummer'}
+            placeholder={'11 siffer'}
+            value={value}
+            onChange={event => {
+                onChange(event.target.value);
+            }}
+            maxLength={11}
+            error={error?.message}
+            readOnly={erLesevisning || isSubmitting}
+        />
+    );
+};

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
 
+import { FormProvider } from 'react-hook-form';
 import styled from 'styled-components';
 
 import { Alert, Button, Fieldset, Heading, HelpText, Modal, TextField } from '@navikt/ds-react';
-import { useHttp } from '@navikt/familie-http';
-import { useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import type { IBehandling } from '../../../../typer/behandling';
-import type { IPersonInfo, IRestTilgang } from '../../../../typer/person';
-import { adressebeskyttelsestyper } from '../../../../typer/person';
-import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
-import { identValidator } from '../../../../utils/validators';
+import { useLeggTilBarnPåBehandlingSkjema } from './useLeggTilBarnPåBehandlingSkjema';
 
 const LeggTilBarnLegend = styled.div`
     margin-top: 1rem;
@@ -24,120 +16,63 @@ interface Props {
     lukkModal: () => void;
 }
 
-export function LeggTilBarnPåBehandlingModal({ lukkModal }: Props) {
-    const { request } = useHttp();
-    const { settÅpenBehandling, behandling } = useBehandlingContext();
+export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
+    const { form, onSubmit } = useLeggTilBarnPåBehandlingSkjema({ lukkModal });
 
-    const { skjema, settSubmitRessurs, kanSendeSkjema, nullstillSkjema } = useSkjema<
-        {
-            ident: string;
-        },
-        IPersonInfo
-    >({
-        felter: {
-            ident: useFelt<string>({
-                verdi: '',
-                valideringsfunksjon: identValidator,
-            }),
-        },
-        skjemanavn: 'Legg til barn',
-    });
+    const {
+        handleSubmit,
+        formState: { isSubmitting, errors },
+        reset,
+    } = form;
 
-    const onAvbryt = () => {
+    const onClose = () => {
         lukkModal();
-        settSubmitRessurs(byggTomRessurs());
-    };
-
-    const leggTilOnClick = () => {
-        const erSkjemaOk = kanSendeSkjema();
-        if (erSkjemaOk) {
-            settSubmitRessurs(byggHenterRessurs());
-            request<{ brukerIdent: string }, IRestTilgang>({
-                method: 'POST',
-                url: '/familie-ba-sak/api/tilgang',
-                data: { brukerIdent: skjema.felter.ident.verdi },
-            }).then((ressurs: Ressurs<IRestTilgang>) => {
-                nullstillSkjema();
-                if (ressurs.status === RessursStatus.SUKSESS) {
-                    if (ressurs.data.saksbehandlerHarTilgang) {
-                        request<{ barnIdent: string }, IBehandling>({
-                            method: 'POST',
-                            data: { barnIdent: skjema.felter.ident.verdi },
-                            url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/legg-til-barn`,
-                        }).then((leggTilRespons: Ressurs<IBehandling>) => {
-                            if (
-                                leggTilRespons.status === RessursStatus.FEILET ||
-                                leggTilRespons.status === RessursStatus.FUNKSJONELL_FEIL ||
-                                leggTilRespons.status === RessursStatus.IKKE_TILGANG
-                            ) {
-                                settSubmitRessurs(byggFeiletRessurs(leggTilRespons.frontendFeilmelding));
-                            } else {
-                                settÅpenBehandling(leggTilRespons);
-                                lukkModal();
-                            }
-                        });
-                    } else {
-                        settSubmitRessurs(
-                            byggFeiletRessurs(
-                                `Barnet kan ikke legges til på grunn av diskresjonskode ${
-                                    adressebeskyttelsestyper[ressurs.data.adressebeskyttelsegradering] ?? 'ukjent'
-                                }`
-                            )
-                        );
-                    }
-                } else if (
-                    [RessursStatus.FEILET, RessursStatus.FUNKSJONELL_FEIL, RessursStatus.IKKE_TILGANG].includes(
-                        ressurs.status
-                    )
-                ) {
-                    settSubmitRessurs(ressurs);
-                }
-            });
-        }
+        reset();
     };
 
     return (
-        <Modal open onClose={onAvbryt} aria-label={'Legg til barn'} width={'35rem'} portal>
-            <Modal.Header>
-                <Heading level="2" size="small">
-                    <LeggTilBarnLegend>
-                        Legg til barn
-                        <HelpText style={{ marginLeft: '0.5rem' }}>
-                            Her kan du, ved klage eller ettersendt dokumentasjon, legge til barn som ikke lenger ligger
-                            på behandlingen fordi vi tidligere har avslått eller opphørt.
-                        </HelpText>
-                    </LeggTilBarnLegend>
-                </Heading>
-            </Modal.Header>
-            <Modal.Body>
-                <Fieldset
-                    error={hentFrontendFeilmelding(skjema.submitRessurs)}
-                    errorPropagation={false}
-                    legend="Legg til barn på behandling"
-                    hideLegend
-                >
-                    <TextField
-                        {...skjema.felter.ident.hentNavInputProps(skjema.visFeilmeldinger)}
-                        label={'Fødselsnummer'}
-                        placeholder={'11 siffer'}
-                    />
-                    <Alert variant="info" inline={true}>
-                        Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke reverseres uten å
-                        henlegge.
-                    </Alert>
-                </Fieldset>
-            </Modal.Body>
-            <Modal.Footer>
-                <Button
-                    key={'Legg til'}
-                    variant="primary"
-                    size="small"
-                    onClick={leggTilOnClick}
-                    children={'Legg til'}
-                    loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                />
-                <Button key={'Avbryt'} variant="tertiary" size="small" onClick={onAvbryt} children={'Avbryt'} />
-            </Modal.Footer>
+        <Modal open onClose={onClose} aria-label={'Legg til barn'} width={'35rem'} portal>
+            <FormProvider {...form}>
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <Modal.Header>
+                        <Heading level="2" size="small">
+                            <LeggTilBarnLegend>
+                                Legg til barn
+                                <HelpText style={{ marginLeft: '0.5rem' }}>
+                                    Her kan du, ved klage eller ettersendt dokumentasjon, legge til barn som ikke lenger
+                                    ligger på behandlingen fordi vi tidligere har avslått eller opphørt.
+                                </HelpText>
+                            </LeggTilBarnLegend>
+                        </Heading>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <Fieldset
+                            error={errors.root?.message}
+                            errorPropagation={false}
+                            legend="Legg til barn på behandling"
+                            hideLegend
+                        >
+                            <TextField label={'Fødselsnummer'} placeholder={'11 siffer'} />
+                            <Alert variant="info" inline={true}>
+                                Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke reverseres
+                                uten å henlegge.
+                            </Alert>
+                        </Fieldset>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button
+                            key={'Legg til'}
+                            type={'submit'}
+                            variant="primary"
+                            size="small"
+                            children={'Legg til'}
+                            loading={isSubmitting}
+                            disabled={isSubmitting}
+                        />
+                        <Button key={'Avbryt'} variant="tertiary" size="small" onClick={onClose} children={'Avbryt'} />
+                    </Modal.Footer>
+                </form>
+            </FormProvider>
         </Modal>
     );
-}
+};

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -3,9 +3,11 @@ import React from 'react';
 import { FormProvider } from 'react-hook-form';
 import styled from 'styled-components';
 
-import { Alert, Button, Fieldset, Heading, HelpText, Modal, TextField } from '@navikt/ds-react';
+import { Alert, Button, Fieldset, Heading, HelpText, Modal } from '@navikt/ds-react';
 
+import { LeggTilBarnFelt } from './LeggTilBarnFelt';
 import { useLeggTilBarnPåBehandlingSkjema } from './useLeggTilBarnPåBehandlingSkjema';
+import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 
 const LeggTilBarnLegend = styled.div`
     margin-top: 1rem;
@@ -17,21 +19,18 @@ interface Props {
 }
 
 export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
+    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = vurderErLesevisning();
+
     const { form, onSubmit } = useLeggTilBarnPåBehandlingSkjema({ lukkModal });
 
     const {
         handleSubmit,
         formState: { isSubmitting, errors },
-        reset,
     } = form;
 
-    const onClose = () => {
-        lukkModal();
-        reset();
-    };
-
     return (
-        <Modal open onClose={onClose} aria-label={'Legg til barn'} width={'35rem'} portal>
+        <Modal open onClose={lukkModal} aria-label={'Legg til barn'} width={'35rem'} portal>
             <FormProvider {...form}>
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <Modal.Header>
@@ -52,7 +51,7 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
                             legend="Legg til barn på behandling"
                             hideLegend
                         >
-                            <TextField label={'Fødselsnummer'} placeholder={'11 siffer'} />
+                            <LeggTilBarnFelt erLesevisning={erLesevisning} />
                             <Alert variant="info" inline={true}>
                                 Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke reverseres
                                 uten å henlegge.
@@ -61,15 +60,17 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
                     </Modal.Body>
                     <Modal.Footer>
                         <Button
-                            key={'Legg til'}
                             type={'submit'}
                             variant="primary"
                             size="small"
-                            children={'Legg til'}
                             loading={isSubmitting}
-                            disabled={isSubmitting}
-                        />
-                        <Button key={'Avbryt'} variant="tertiary" size="small" onClick={onClose} children={'Avbryt'} />
+                            disabled={erLesevisning}
+                        >
+                            Legg til
+                        </Button>
+                        <Button variant="tertiary" size="small" onClick={lukkModal}>
+                            Avbryt
+                        </Button>
                     </Modal.Footer>
                 </form>
             </FormProvider>

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -26,7 +26,7 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
 
     const {
         handleSubmit,
-        formState: { isSubmitting, errors },
+        formState: { isValid, isSubmitting, errors },
     } = form;
 
     return (
@@ -64,7 +64,7 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
                             variant="primary"
                             size="small"
                             loading={isSubmitting}
-                            disabled={erLesevisning}
+                            disabled={erLesevisning || !isValid}
                         >
                             Legg til
                         </Button>

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
 
 import { FormProvider } from 'react-hook-form';
-import styled from 'styled-components';
 
-import { Alert, Button, Fieldset, Heading, HelpText, Modal } from '@navikt/ds-react';
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { Button, Fieldset, Heading, HelpText, HStack, InfoCard, Modal } from '@navikt/ds-react';
 
 import { LeggTilBarnFelt } from './LeggTilBarnFelt';
 import { useLeggTilBarnPåBehandlingSkjema } from './useLeggTilBarnPåBehandlingSkjema';
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-
-const LeggTilBarnLegend = styled.div`
-    margin-top: 1rem;
-    display: flex;
-`;
 
 interface Props {
     lukkModal: () => void;
@@ -26,7 +21,7 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
 
     const {
         handleSubmit,
-        formState: { isValid, isSubmitting, errors },
+        formState: { isSubmitting, errors },
     } = form;
 
     return (
@@ -35,13 +30,13 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <Modal.Header>
                         <Heading level="2" size="small">
-                            <LeggTilBarnLegend>
+                            <HStack margin={'space-8'} marginInline={'space-4'}>
                                 Legg til barn
                                 <HelpText style={{ marginLeft: '0.5rem' }}>
                                     Her kan du, ved klage eller ettersendt dokumentasjon, legge til barn som ikke lenger
                                     ligger på behandlingen fordi vi tidligere har avslått eller opphørt.
                                 </HelpText>
-                            </LeggTilBarnLegend>
+                            </HStack>
                         </Heading>
                     </Modal.Header>
                     <Modal.Body>
@@ -51,11 +46,15 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
                             legend="Legg til barn på behandling"
                             hideLegend
                         >
+                            <InfoCard data-color="info">
+                                <InfoCard.Header icon={<InformationSquareIcon aria-hidden />}>
+                                    <InfoCard.Title>
+                                        Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke
+                                        reverseres uten å henlegge.
+                                    </InfoCard.Title>
+                                </InfoCard.Header>
+                            </InfoCard>
                             <LeggTilBarnFelt erLesevisning={erLesevisning} />
-                            <Alert variant="info" inline={true}>
-                                Du er i ferd med å legge til et barn på behandlingen. Handlingen kan ikke reverseres
-                                uten å henlegge.
-                            </Alert>
                         </Fieldset>
                     </Modal.Body>
                     <Modal.Footer>
@@ -64,7 +63,7 @@ export const LeggTilBarnPåBehandlingModal = ({ lukkModal }: Props) => {
                             variant="primary"
                             size="small"
                             loading={isSubmitting}
-                            disabled={erLesevisning || !isValid}
+                            disabled={erLesevisning}
                         >
                             Legg til
                         </Button>

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -1,0 +1,58 @@
+import { useForm } from 'react-hook-form';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+import { useLeggTilBarnPåBehandling } from '../../../../hooks/useLeggTilBarnPåBehandling';
+import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
+
+export enum LeggTilBarnPåBehandlingFelt {
+    BARNIDENT = 'barnIdent',
+}
+
+export interface LeggTilBarnPåBehandlingFormValues {
+    [LeggTilBarnPåBehandlingFelt.BARNIDENT]: string;
+}
+
+interface Props {
+    lukkModal: () => void;
+}
+
+export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
+    const { settÅpenBehandling, behandling } = useBehandlingContext();
+    const { mutateAsync: leggTilBarnPåBehandling } = useLeggTilBarnPåBehandling();
+
+    // TODO: bruk eksisterende identValidator?
+    const form = useForm<LeggTilBarnPåBehandlingFormValues, unknown, LeggTilBarnPåBehandlingFormValues>({
+        defaultValues: {
+            [LeggTilBarnPåBehandlingFelt.BARNIDENT]: undefined,
+        },
+    });
+
+    const { setError } = form;
+
+    const onSubmit = async (values: LeggTilBarnPåBehandlingFormValues) => {
+        const { barnIdent } = values;
+
+        const leggTilBarnPåBehandlingParameters = {
+            barnIdent: barnIdent,
+            behandlingId: behandling.behandlingId,
+        };
+
+        return leggTilBarnPåBehandling(leggTilBarnPåBehandlingParameters)
+            .then(behandling => {
+                settÅpenBehandling(byggSuksessRessurs(behandling));
+                lukkModal();
+            })
+            .catch((e: unknown) => {
+                setError('root', {
+                    // TODO: fiks feilmeldingen
+                    message: e instanceof Error ? e.message : 'Teknisk feil ved tileggelse av barn på behandling.',
+                });
+            });
+    };
+
+    return {
+        form,
+        onSubmit,
+    };
+};

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -21,11 +21,12 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
     const { settÅpenBehandling, behandling } = useBehandlingContext();
     const { mutateAsync: leggTilBarnPåBehandling } = useLeggTilBarnPåBehandling();
 
-    // TODO: bruk eksisterende identValidator?
-    const form = useForm<LeggTilBarnPåBehandlingFormValues, unknown, LeggTilBarnPåBehandlingFormValues>({
+    const form = useForm<LeggTilBarnPåBehandlingFormValues>({
         defaultValues: {
             [LeggTilBarnPåBehandlingFelt.BARNIDENT]: undefined,
         },
+        // TODO: validate
+        // TODO: bruk eksisterende identValidator?
     });
 
     const { setError } = form;
@@ -45,8 +46,8 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
             })
             .catch((e: unknown) => {
                 setError('root', {
-                    // TODO: fiks feilmeldingen
-                    message: e instanceof Error ? e.message : 'Teknisk feil ved tileggelse av barn på behandling.',
+                    message:
+                        e instanceof Error ? e.message : 'Teknisk feil ved forsøk på å legge til barn på behandling.',
                 });
             });
     };

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -2,8 +2,10 @@ import { useForm } from 'react-hook-form';
 
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
+import { useHarSaksbehandlerTilgang } from '../../../../hooks/useHarSaksbehandlerTilgang';
 import { useLeggTilBarnPåBehandling } from '../../../../hooks/useLeggTilBarnPåBehandling';
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
+import { adressebeskyttelsestyper } from '../../../../typer/person';
 
 export enum LeggTilBarnPåBehandlingFelt {
     BARNIDENT = 'barnIdent',
@@ -19,6 +21,7 @@ interface Props {
 
 export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
     const { settÅpenBehandling, behandling } = useBehandlingContext();
+    const { mutateAsync: harSaksbehandlerTilgang } = useHarSaksbehandlerTilgang();
     const { mutateAsync: leggTilBarnPåBehandling } = useLeggTilBarnPåBehandling();
 
     const form = useForm<LeggTilBarnPåBehandlingFormValues>({
@@ -26,7 +29,6 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
             [LeggTilBarnPåBehandlingFelt.BARNIDENT]: undefined,
         },
         // TODO: validate
-        // TODO: bruk eksisterende identValidator?
     });
 
     const { setError } = form;
@@ -34,22 +36,46 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
     const onSubmit = async (values: LeggTilBarnPåBehandlingFormValues) => {
         const { barnIdent } = values;
 
-        const leggTilBarnPåBehandlingParameters = {
-            barnIdent: barnIdent,
-            behandlingId: behandling.behandlingId,
+        const harSaksbehandlerTilgangParameters = {
+            brukerIdent: barnIdent,
         };
 
-        return leggTilBarnPåBehandling(leggTilBarnPåBehandlingParameters)
-            .then(behandling => {
-                settÅpenBehandling(byggSuksessRessurs(behandling));
-                lukkModal();
+        harSaksbehandlerTilgang(harSaksbehandlerTilgangParameters)
+            .then(res => {
+                if (res.saksbehandlerHarTilgang) {
+                    const leggTilBarnPåBehandlingParameters = {
+                        barnIdent: barnIdent,
+                        behandlingId: behandling.behandlingId,
+                    };
+
+                    leggTilBarnPåBehandling(leggTilBarnPåBehandlingParameters)
+                        .then(behandling => {
+                            settÅpenBehandling(byggSuksessRessurs(behandling));
+                            lukkModal();
+                        })
+                        .catch((e: unknown) => {
+                            setError('root', {
+                                message:
+                                    e instanceof Error
+                                        ? e.message
+                                        : 'Teknisk feil ved forsøk på å legge til barn på behandling.',
+                            });
+                        });
+                } else {
+                    setError('root', {
+                        message: `Barnet kan ikke legges til på grunn av diskresjonskode ${
+                            adressebeskyttelsestyper[res.adressebeskyttelsegradering] ?? 'ukjent'
+                        }`,
+                    });
+                }
             })
             .catch((e: unknown) => {
                 setError('root', {
                     message:
-                        e instanceof Error ? e.message : 'Teknisk feil ved forsøk på å legge til barn på behandling.',
+                        e instanceof Error ? e.message : 'Det skjedde en feil ved sjekk av tilgangen til saksbehandler',
                 });
             });
+        return;
     };
 
     return {

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -35,46 +35,32 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
     const onSubmit = async (values: LeggTilBarnPåBehandlingFormValues) => {
         const { barnIdent } = values;
 
-        const harSaksbehandlerTilgangParameters = {
-            brukerIdent: barnIdent,
-        };
-
-        harSaksbehandlerTilgang(harSaksbehandlerTilgangParameters)
-            .then(res => {
-                if (res.saksbehandlerHarTilgang) {
-                    const leggTilBarnPåBehandlingParameters = {
-                        barnIdent: barnIdent,
-                        behandlingId: behandling.behandlingId,
-                    };
-
-                    leggTilBarnPåBehandling(leggTilBarnPåBehandlingParameters)
-                        .then(behandling => {
-                            settÅpenBehandling(byggSuksessRessurs(behandling));
-                            lukkModal();
-                            return;
-                        })
-                        .catch((e: unknown) => {
-                            setError('root', {
-                                message:
-                                    e instanceof Error
-                                        ? e.message
-                                        : 'Teknisk feil ved forsøk på å legge til barn på behandling.',
-                            });
-                        });
-                } else {
-                    setError('root', {
-                        message: `Barnet kan ikke legges til på grunn av diskresjonskode ${
-                            adressebeskyttelsestyper[res.adressebeskyttelsegradering] ?? 'ukjent'
-                        }`,
-                    });
-                }
-            })
-            .catch((e: unknown) => {
-                setError('root', {
-                    message: e instanceof Error ? e.message : 'Teknisk feil ved sjekk av tilgangen til saksbehandler',
-                });
+        try {
+            const tilgangRes = await harSaksbehandlerTilgang({
+                brukerIdent: barnIdent,
             });
-        return;
+
+            if (!tilgangRes.saksbehandlerHarTilgang) {
+                setError('root', {
+                    message: `Barnet kan ikke legges til på grunn av diskresjonskode ${
+                        adressebeskyttelsestyper[tilgangRes.adressebeskyttelsegradering] ?? 'ukjent'
+                    }`,
+                });
+                return;
+            }
+
+            const behandlingResult = await leggTilBarnPåBehandling({
+                barnIdent,
+                behandlingId: behandling.behandlingId,
+            });
+
+            settÅpenBehandling(byggSuksessRessurs(behandlingResult));
+            lukkModal();
+        } catch (e: unknown) {
+            setError('root', {
+                message: e instanceof Error ? e.message : 'Teknisk feil ved forsøk på å legge til barn på behandling.',
+            });
+        }
     };
 
     return {

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -52,6 +52,7 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
                         .then(behandling => {
                             settÅpenBehandling(byggSuksessRessurs(behandling));
                             lukkModal();
+                            return;
                         })
                         .catch((e: unknown) => {
                             setError('root', {
@@ -71,8 +72,7 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
             })
             .catch((e: unknown) => {
                 setError('root', {
-                    message:
-                        e instanceof Error ? e.message : 'Det skjedde en feil ved sjekk av tilgangen til saksbehandler',
+                    message: e instanceof Error ? e.message : 'Teknisk feil ved sjekk av tilgangen til saksbehandler',
                 });
             });
         return;

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/useLeggTilBarnPåBehandlingSkjema.ts
@@ -26,9 +26,8 @@ export const useLeggTilBarnPåBehandlingSkjema = ({ lukkModal }: Props) => {
 
     const form = useForm<LeggTilBarnPåBehandlingFormValues>({
         defaultValues: {
-            [LeggTilBarnPåBehandlingFelt.BARNIDENT]: undefined,
+            [LeggTilBarnPåBehandlingFelt.BARNIDENT]: '',
         },
-        // TODO: validate
     });
 
     const { setError } = form;

--- a/src/frontend/utils/validators.ts
+++ b/src/frontend/utils/validators.ts
@@ -29,6 +29,14 @@ export const identValidator = (identFelt: FeltState<string>): FeltState<string> 
     return validerIdent(identFelt);
 };
 
+export const sjekkEr11Tall = (verdi: string): boolean => {
+    return /^\d{11}$/.test(verdi.replace(' ', ''));
+};
+
+export const sjekkErGyldigIdent = (verdi: string): boolean => {
+    return idnr(verdi).status === 'valid';
+};
+
 const harFyltInnOrgnr = (felt: FeltState<string>): FeltState<string> => {
     return /^\d{9}$/.test(felt.verdi.replace(' ', '')) ? ok(felt) : feil(felt, 'Orgnummer har ikke 9 tall');
 };


### PR DESCRIPTION
### 📮 Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-28506

### 💰 Hva skal gjøres, og hvorfor?
Refaktorer LeggTilBarnPåBehandling til å bruke react-query og react-hook-form for å skrive oss over fra egenlagd funksjonalitet til å bruke moderne rammeverk.

Abstraher eksisterende valideringsfunksjoner for å gjenbruke disse - fra LeggTilBarn.

<Alert /> byttes ut med <InfoCard /> ifm. oppdatering til Aksel v8. Som en midlertidig løsning brukes derfor <InfoCard.Header /> og <InfoCard.Title />, i påvente av å kunne bytte til <InfoCard.Message /> når oppdateringen er fullført.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️

_Jeg har ikke skrevet tester fordi:_ ingen funksjonelle endringer

### 👀 Screen shots
_Har det visuelle endret seg?_ Ja, pga. midlertidig Aksel-oppdatering. I tillegg flyttes infoteksten til over feltet, for å samkjøres med uformingen ellers i applikasjonen.

Før: 
<img width="560" height="304" alt="image" src="https://github.com/user-attachments/assets/7a3919b1-8a81-43ce-9e57-3b4f30b40614" />

Midlertidig/nåværende endring:
<img width="552" height="321" alt="Screenshot 2026-04-28 at 12 33 28" src="https://github.com/user-attachments/assets/3d13c764-1252-4eb7-a2ae-397c98f7d43e" />

Fremtidig endring:
<img width="551" height="298" alt="image" src="https://github.com/user-attachments/assets/3104cb91-f0ad-45a7-b0fb-e07903eed80e" />
