### PR TITLE
Håndter skjermet barn fra backend

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.tsx
@@ -31,7 +31,7 @@ export const EndretUtbetalingAndelSkjemaRHF = ({ form, onSubmit, lukkSkjema }: E
 
     const sletterEndretUtbetalingAndel = useSletterEndretUtbetalingAndelIsPending({ endretUtbetalingAndel });
     const oppdatererEndretUtbetalingAndel = useOppdatererEndretUtbetalingAndelIsPending({ endretUtbetalingAndel });
-    const erLesevisning = vurderErLesevisning() || endretUtbetalingAndel.inneholderSkjermetBarn;
+    const erLesevisning = vurderErLesevisning() || endretUtbetalingAndel.inneholderBarnSomSkalSkjermes;
     const låsFelter = erLesevisning || sletterEndretUtbetalingAndel || oppdatererEndretUtbetalingAndel;
 
     const {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.tsx
@@ -31,7 +31,7 @@ export const EndretUtbetalingAndelSkjemaRHF = ({ form, onSubmit, lukkSkjema }: E
 
     const sletterEndretUtbetalingAndel = useSletterEndretUtbetalingAndelIsPending({ endretUtbetalingAndel });
     const oppdatererEndretUtbetalingAndel = useOppdatererEndretUtbetalingAndelIsPending({ endretUtbetalingAndel });
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = vurderErLesevisning() || endretUtbetalingAndel.inneholderSkjermetBarn;
     const låsFelter = erLesevisning || sletterEndretUtbetalingAndel || oppdatererEndretUtbetalingAndel;
 
     const {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.tsx
@@ -23,7 +23,7 @@ export const Personvelger = ({ erLesevisning }: StandardFeltProps) => {
                 .map(personMedAndeler => personMedAndeler.personIdent)
                 .includes(person.personIdent)
         )
-        .filter(person => !person.skjermet)
+        .filter(person => !person.skjermesForBruker)
         .map(person => ({
             value: person.personIdent,
             label: lagPersonLabel(person.personIdent, behandling.personer),

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.tsx
@@ -23,6 +23,7 @@ export const Personvelger = ({ erLesevisning }: StandardFeltProps) => {
                 .map(personMedAndeler => personMedAndeler.personIdent)
                 .includes(person.personIdent)
         )
+        .filter(person => !person.skjermet)
         .map(person => ({
             value: person.personIdent,
             label: lagPersonLabel(person.personIdent, behandling.personer),

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
@@ -85,7 +85,7 @@ const KompetanseTabellRad: React.FC<IProps> = ({ kompetanse, åpenBehandling, vi
                         toggleForm={toggleForm}
                         slettKompetanse={slettKompetanse}
                         erAnnenForelderOmfattetAvNorskLovgivning={kompetanse.erAnnenForelderOmfattetAvNorskLovgivning}
-                        inneholderSkjermetBarn={kompetanse.inneholderSkjermetBarn}
+                        inneholderBarnSomSkalSkjermes={kompetanse.inneholderBarnSomSkalSkjermes}
                     />
                 )
             }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
@@ -85,6 +85,7 @@ const KompetanseTabellRad: React.FC<IProps> = ({ kompetanse, åpenBehandling, vi
                         toggleForm={toggleForm}
                         slettKompetanse={slettKompetanse}
                         erAnnenForelderOmfattetAvNorskLovgivning={kompetanse.erAnnenForelderOmfattetAvNorskLovgivning}
+                        inneholderSkjermetBarn={kompetanse.inneholderSkjermetBarn}
                     />
                 )
             }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -38,6 +38,7 @@ interface Props {
     toggleForm: (visAlert: boolean) => void;
     slettKompetanse: () => void;
     erAnnenForelderOmfattetAvNorskLovgivning?: boolean;
+    inneholderSkjermetBarn?: boolean;
 }
 
 export function KompetanseTabellRadEndre({
@@ -47,10 +48,11 @@ export function KompetanseTabellRadEndre({
     toggleForm,
     slettKompetanse,
     erAnnenForelderOmfattetAvNorskLovgivning,
+    inneholderSkjermetBarn,
 }: Props) {
     const { vurderErLesevisning } = useBehandlingContext();
     const toggles = useFeatureToggles();
-    const lesevisning = vurderErLesevisning(true);
+    const lesevisning = vurderErLesevisning(true) || !!inneholderSkjermetBarn;
 
     const visSubmitFeilmelding = () => {
         if (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -38,7 +38,7 @@ interface Props {
     toggleForm: (visAlert: boolean) => void;
     slettKompetanse: () => void;
     erAnnenForelderOmfattetAvNorskLovgivning?: boolean;
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }
 
 export function KompetanseTabellRadEndre({
@@ -48,11 +48,11 @@ export function KompetanseTabellRadEndre({
     toggleForm,
     slettKompetanse,
     erAnnenForelderOmfattetAvNorskLovgivning,
-    inneholderSkjermetBarn,
+    inneholderBarnSomSkalSkjermes,
 }: Props) {
     const { vurderErLesevisning } = useBehandlingContext();
     const toggles = useFeatureToggles();
-    const lesevisning = vurderErLesevisning(true) || !!inneholderSkjermetBarn;
+    const lesevisning = vurderErLesevisning(true) || !!inneholderBarnSomSkalSkjermes;
 
     const visSubmitFeilmelding = () => {
         if (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
@@ -84,6 +84,7 @@ const UtenlandskPeriodeBeløpRad: React.FC<IProps> = ({ utenlandskPeriodeBeløp,
                         toggleForm={toggleForm}
                         slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
                         status={utenlandskPeriodeBeløp.status}
+                        inneholderSkjermetBarn={utenlandskPeriodeBeløp.inneholderSkjermetBarn}
                     />
                 )
             }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
@@ -84,7 +84,7 @@ const UtenlandskPeriodeBeløpRad: React.FC<IProps> = ({ utenlandskPeriodeBeløp,
                         toggleForm={toggleForm}
                         slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
                         status={utenlandskPeriodeBeløp.status}
-                        inneholderSkjermetBarn={utenlandskPeriodeBeløp.inneholderSkjermetBarn}
+                        inneholderBarnSomSkalSkjermes={utenlandskPeriodeBeløp.inneholderBarnSomSkalSkjermes}
                     />
                 )
             }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -59,7 +59,7 @@ interface IProps {
     sendInnSkjema: () => void;
     toggleForm: (visAlert: boolean) => void;
     slettUtenlandskPeriodeBeløp: () => void;
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }
 
 const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
@@ -69,12 +69,12 @@ const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
     sendInnSkjema,
     toggleForm,
     slettUtenlandskPeriodeBeløp,
-    inneholderSkjermetBarn,
+    inneholderBarnSomSkalSkjermes,
 }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const toggles = useFeatureToggles();
 
-    const lesevisning = vurderErLesevisning(true) || !!inneholderSkjermetBarn;
+    const lesevisning = vurderErLesevisning(true) || !!inneholderBarnSomSkalSkjermes;
 
     const visUtbetaltBeløpGruppeFeilmelding = (): React.ReactNode => {
         if (skjema.felter.beløp?.valideringsstatus === Valideringsstatus.FEIL) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -59,6 +59,7 @@ interface IProps {
     sendInnSkjema: () => void;
     toggleForm: (visAlert: boolean) => void;
     slettUtenlandskPeriodeBeløp: () => void;
+    inneholderSkjermetBarn?: boolean;
 }
 
 const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
@@ -68,11 +69,12 @@ const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
     sendInnSkjema,
     toggleForm,
     slettUtenlandskPeriodeBeløp,
+    inneholderSkjermetBarn,
 }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const toggles = useFeatureToggles();
 
-    const lesevisning = vurderErLesevisning(true);
+    const lesevisning = vurderErLesevisning(true) || !!inneholderSkjermetBarn;
 
     const visUtbetaltBeløpGruppeFeilmelding = (): React.ReactNode => {
         if (skjema.felter.beløp?.valideringsstatus === Valideringsstatus.FEIL) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -83,7 +83,7 @@ const ValutakursTabellRad: React.FC<IProps> = ({ valutakurs, åpenBehandling, vi
                         key={`${valutakurs.id}-${erValutakursEkspandert ? 'ekspandert' : 'lukket'}`}
                         vurderingsform={valutakurs.vurderingsform}
                         åpenBehandling={åpenBehandling}
-                        inneholderSkjermetBarn={valutakurs.inneholderSkjermetBarn}
+                        inneholderBarnSomSkalSkjermes={valutakurs.inneholderBarnSomSkalSkjermes}
                     />
                 ) : null
             }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -83,6 +83,7 @@ const ValutakursTabellRad: React.FC<IProps> = ({ valutakurs, åpenBehandling, vi
                         key={`${valutakurs.id}-${erValutakursEkspandert ? 'ekspandert' : 'lukket'}`}
                         vurderingsform={valutakurs.vurderingsform}
                         åpenBehandling={åpenBehandling}
+                        inneholderSkjermetBarn={valutakurs.inneholderSkjermetBarn}
                     />
                 ) : null
             }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -60,6 +60,7 @@ interface IProps {
     erManuellInputAvKurs: boolean;
     vurderingsform: Vurderingsform | undefined;
     åpenBehandling: IBehandling;
+    inneholderSkjermetBarn?: boolean;
 }
 
 const ValutakursTabellRadEndre: React.FC<IProps> = ({
@@ -73,6 +74,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
     sletterValutakurs,
     erManuellInputAvKurs,
     åpenBehandling,
+    inneholderSkjermetBarn,
 }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const toggles = useFeatureToggles();
@@ -82,7 +84,9 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
         åpenBehandling.vurderingsstrategiForValutakurser === VurderingsstrategiForValutakurser.MANUELL;
 
     const erLesevisning =
-        vurderErLesevisning(true) || (erValutakursVurdertAutomatisk && !skaAutomatiskeValutakurserKunneRedigeres);
+        vurderErLesevisning(true) ||
+        !!inneholderSkjermetBarn ||
+        (erValutakursVurdertAutomatisk && !skaAutomatiskeValutakurserKunneRedigeres);
 
     const visKursGruppeFeilmelding = (): React.ReactNode => {
         if (skjema.felter.valutakode?.valideringsstatus === Valideringsstatus.FEIL) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -60,7 +60,7 @@ interface IProps {
     erManuellInputAvKurs: boolean;
     vurderingsform: Vurderingsform | undefined;
     åpenBehandling: IBehandling;
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }
 
 const ValutakursTabellRadEndre: React.FC<IProps> = ({
@@ -74,7 +74,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
     sletterValutakurs,
     erManuellInputAvKurs,
     åpenBehandling,
-    inneholderSkjermetBarn,
+    inneholderBarnSomSkalSkjermes,
 }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const toggles = useFeatureToggles();
@@ -85,7 +85,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
 
     const erLesevisning =
         vurderErLesevisning(true) ||
-        !!inneholderSkjermetBarn ||
+        !!inneholderBarnSomSkalSkjermes ||
         (erValutakursVurdertAutomatisk && !skaAutomatiskeValutakurserKunneRedigeres);
 
     const visKursGruppeFeilmelding = (): React.ReactNode => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -215,10 +215,11 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                             <BodyShort align="end">Beløp</BodyShort>
                         </UtbetalingsbeløpRad>
                         {utbetalingsperiode.utbetalingsperiodeDetaljer.sort(sorterUtbetaling).map(detalj => {
-                            const anonymisert = detalj.person.skjermet;
+                            const personSkalSkjermesForBruker = detalj.person.skjermesForBruker;
+
                             return (
                                 <UtbetalingsbeløpRad key={detalj.person.navn + detalj.ytelseType}>
-                                    {anonymisert ? (
+                                    {personSkalSkjermesForBruker ? (
                                         <BodyShort>{detalj.person.navn}</BodyShort>
                                     ) : (
                                         <HStack gap={'space-4'}>
@@ -231,7 +232,8 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                         </HStack>
                                     )}
                                     <BodyShort>{ytelsetype[detalj.ytelseType].navn}</BodyShort>
-                                    {!anonymisert && !utbetalingsBeløpStatusMap.get(detalj.person.personIdent) ? (
+                                    {!personSkalSkjermesForBruker &&
+                                    !utbetalingsBeløpStatusMap.get(detalj.person.personIdent) ? (
                                         <Alert variant="warning" children={'Må beregnes'} size={'small'} inline />
                                     ) : (
                                         <BodyShort align="end">{formaterBeløp(detalj.utbetaltPerMnd)}</BodyShort>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -214,24 +214,31 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                             <BodyShort>Sats</BodyShort>
                             <BodyShort align="end">Beløp</BodyShort>
                         </UtbetalingsbeløpRad>
-                        {utbetalingsperiode.utbetalingsperiodeDetaljer.sort(sorterUtbetaling).map(detalj => (
-                            <UtbetalingsbeløpRad key={detalj.person.navn + detalj.ytelseType}>
-                                <HStack gap={'space-4'}>
-                                    <BodyShort>
-                                        {`${detalj.person.navn} (${hentAlderSomString(detalj.person.fødselsdato)})`}
-                                    </BodyShort>
-                                    <Skillelinje />
-                                    <FalskIdentitet harFalskIdentitet={detalj.person.harFalskIdentitet} />
-                                    <BodyShort>{formaterIdent(detalj.person.personIdent)}</BodyShort>
-                                </HStack>
-                                <BodyShort>{ytelsetype[detalj.ytelseType].navn}</BodyShort>
-                                {utbetalingsBeløpStatusMap.get(detalj.person.personIdent) ? (
-                                    <BodyShort align="end">{formaterBeløp(detalj.utbetaltPerMnd)}</BodyShort>
-                                ) : (
-                                    <Alert variant="warning" children={'Må beregnes'} size={'small'} inline />
-                                )}
-                            </UtbetalingsbeløpRad>
-                        ))}
+                        {utbetalingsperiode.utbetalingsperiodeDetaljer.sort(sorterUtbetaling).map(detalj => {
+                            const anonymisert = detalj.person.skjermet;
+                            return (
+                                <UtbetalingsbeløpRad key={detalj.person.navn + detalj.ytelseType}>
+                                    {anonymisert ? (
+                                        <BodyShort>{detalj.person.navn}</BodyShort>
+                                    ) : (
+                                        <HStack gap={'space-4'}>
+                                            <BodyShort>
+                                                {`${detalj.person.navn} (${hentAlderSomString(detalj.person.fødselsdato)})`}
+                                            </BodyShort>
+                                            <Skillelinje />
+                                            <FalskIdentitet harFalskIdentitet={detalj.person.harFalskIdentitet} />
+                                            <BodyShort>{formaterIdent(detalj.person.personIdent)}</BodyShort>
+                                        </HStack>
+                                    )}
+                                    <BodyShort>{ytelsetype[detalj.ytelseType].navn}</BodyShort>
+                                    {!anonymisert && !utbetalingsBeløpStatusMap.get(detalj.person.personIdent) ? (
+                                        <Alert variant="warning" children={'Må beregnes'} size={'small'} inline />
+                                    ) : (
+                                        <BodyShort align="end">{formaterBeløp(detalj.utbetaltPerMnd)}</BodyShort>
+                                    )}
+                                </UtbetalingsbeløpRad>
+                            );
+                        })}
                         <TotaltUtbetaltRad columns="1fr 5rem">
                             <BodyShort weight="semibold">Totalt utbetalt per mnd</BodyShort>
                             <BodyShort weight="semibold" align="end">

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/TilkjentYtelseTidslinje.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/TilkjentYtelseTidslinje.tsx
@@ -23,6 +23,10 @@ const TidslinjeHeader = styled.div`
     margin-bottom: 1rem;
 `;
 
+const StyledBodyShort = styled(BodyShort)`
+    padding-right: 0.5rem;
+`;
+
 const TidslinjeControls = styled.div`
     display: flex;
     flex-direction: column;
@@ -84,9 +88,9 @@ const TilkjentYtelseTidslinje: React.FC<IProps> = ({ grunnlagPersoner, tidslinje
                 <TidslinjeLabels>
                     {grunnlagPersoner.map((person, index) => {
                         return (
-                            <BodyShort key={index} title={person.navn}>
+                            <StyledBodyShort key={index} title={person.navn}>
                                 {formaterIdent(person.personIdent)}
-                            </BodyShort>
+                            </StyledBodyShort>
                         );
                     })}
                 </TidslinjeLabels>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -1,11 +1,11 @@
 import React, { Activity, useEffect, useState } from 'react';
 
-import { ChevronDownIcon, ChevronUpIcon, PlusCircleIcon } from '@navikt/aksel-icons';
-import { Alert, BodyShort, Box, Button, HStack, List } from '@navikt/ds-react';
-import type { FeltState } from '@navikt/familie-skjema';
+import { ChevronDownIcon, ChevronUpIcon, PlusCircleIcon, ShieldLockFillIcon } from '@navikt/aksel-icons';
+import { Alert, BodyShort, Box, Button, Heading, HStack, List } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import styles from './VilkårsvurderingSkjema.module.css';
 import { useFeatureToggles } from '../../../../../../hooks/useFeatureToggles';
 import PersonInformasjon from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
 import { BehandlingSteg, BehandlingÅrsak, type IBehandling } from '../../../../../../typer/behandling';
@@ -14,8 +14,6 @@ import { PersonType } from '../../../../../../typer/person';
 import {
     annenVurderingConfig,
     type IPersonResultat,
-    type IVilkårConfig,
-    type IVilkårResultat,
     Resultat,
     vilkårConfig,
     VilkårType,
@@ -26,7 +24,6 @@ import GeneriskVilkår from '../GeneriskVilkår/GeneriskVilkår';
 import Registeropplysninger from '../Registeropplysninger/Registeropplysninger';
 import { utledVilkårSomMåKontrolleresPerPerson } from '../utils';
 import { useVilkårsvurderingContext, VilkårSubmit } from '../VilkårsvurderingContext';
-import styles from './VilkårsvurderingSkjema.module.css';
 
 interface IVilkårsvurderingSkjemaNormal {
     visFeilmeldinger: boolean;
@@ -118,115 +115,129 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
                 const harUtvidet = personResultat.vilkårResultater.find(
                     vilkårResultat => vilkårResultat.verdi.vilkårType === VilkårType.UTVIDET_BARNETRYGD
                 );
+                const personErSkjermet = personResultat.person.skjermet;
 
                 return (
                     <div
                         key={`${index}_${personResultat.person.fødselsdato}`}
                         id={`${index}_${personResultat.person.fødselsdato}`}
                     >
-                        <HStack wrap={false} justify={'space-between'} className={styles.personLinje}>
-                            <PersonInformasjon
-                                person={personResultat.person}
-                                somOverskrift
-                                erLesevisning={erLesevisning}
-                            />
-                            {!erLesevisning &&
-                                personErEkspandert[personResultat.personIdent] &&
-                                personResultat.person.type === PersonType.SØKER &&
-                                !harUtvidet &&
-                                kanLeggeTilUtvidetVilkår && (
+                        {personErSkjermet ? (
+                            <HStack gap="space-24" wrap={false} align="center">
+                                <ShieldLockFillIcon
+                                    fontSize="2.5rem"
+                                    color="var(--ax-warning-500)"
+                                    style={{ margin: '-0.25rem' }}
+                                />{' '}
+                                <Heading level="2" size="medium">
+                                    {personResultat.person.navn}
+                                </Heading>
+                            </HStack>
+                        ) : (
+                            <>
+                                <HStack wrap={false} justify={'space-between'} className={styles.personLinje}>
+                                    <PersonInformasjon
+                                        person={personResultat.person}
+                                        somOverskrift
+                                        erLesevisning={erLesevisning}
+                                    />
+                                    {!erLesevisning &&
+                                        personErEkspandert[personResultat.personIdent] &&
+                                        personResultat.person.type === PersonType.SØKER &&
+                                        !harUtvidet &&
+                                        kanLeggeTilUtvidetVilkår && (
+                                            <Button
+                                                variant={'tertiary'}
+                                                id={`${index}_${personResultat.person.fødselsdato}__legg-til-vilkår-utvidet`}
+                                                onClick={() => leggTilVilkårUtvidet(personResultat.personIdent)}
+                                                size={'small'}
+                                                icon={<PlusCircleIcon title="Legg til vilkår utvidet barnetrygd" />}
+                                            >
+                                                {`Legg til vilkår utvidet barnetrygd`}
+                                            </Button>
+                                        )}
                                     <Button
-                                        variant={'tertiary'}
-                                        id={`${index}_${personResultat.person.fødselsdato}__legg-til-vilkår-utvidet`}
-                                        onClick={() => leggTilVilkårUtvidet(personResultat.personIdent)}
-                                        size={'small'}
-                                        icon={<PlusCircleIcon title="Legg til vilkår utvidet barnetrygd" />}
-                                    >
-                                        {`Legg til vilkår utvidet barnetrygd`}
-                                    </Button>
-                                )}
-                            <Button
-                                id={`vis-skjul-vilkårsvurdering-${index}_${personResultat.person.fødselsdato}}`}
-                                variant="tertiary"
-                                onClick={() =>
-                                    settPersonErEkspandert({
-                                        ...personErEkspandert,
-                                        [personResultat.personIdent]: !personErEkspandert[personResultat.personIdent],
-                                    })
-                                }
-                                icon={
-                                    personErEkspandert[personResultat.personIdent] ? (
-                                        <ChevronUpIcon aria-hidden />
-                                    ) : (
-                                        <ChevronDownIcon aria-hidden />
-                                    )
-                                }
-                                iconPosition="right"
-                            >
-                                {personErEkspandert[personResultat.personIdent]
-                                    ? 'Skjul vilkårsvurdering'
-                                    : 'Vis vilkårsvurdering'}
-                            </Button>
-                        </HStack>
-                        <Activity mode={personErEkspandert[personResultat.personIdent] ? 'visible' : 'hidden'}>
-                            <Box paddingInline={'space-56 space-0'}>
-                                <>
-                                    {personResultat.person.registerhistorikk ? (
-                                        <Registeropplysninger
-                                            registerHistorikk={personResultat.person.registerhistorikk}
-                                            fødselsdato={personResultat.person.fødselsdato}
-                                        />
-                                    ) : (
-                                        <Alert variant="warning" children={'Klarte ikke hente registeropplysninger'} />
-                                    )}
-                                </>
-                                {Object.values(vilkårConfig)
-                                    .filter((vc: IVilkårConfig) =>
-                                        vc.parterDetteGjelderFor.includes(personResultat.person.type)
-                                    )
-                                    .map((vc: IVilkårConfig) => {
-                                        const vilkårResultater: FeltState<IVilkårResultat>[] =
-                                            personResultat.vilkårResultater.filter(
-                                                (vilkårResultat: FeltState<IVilkårResultat>) =>
-                                                    vilkårResultat.verdi.vilkårType === vc.key
-                                            );
-
-                                        if (
-                                            vilkårResultater.length === 0 &&
-                                            personResultat.person.type === PersonType.SØKER
-                                        )
-                                            return undefined;
-                                        // For barn ønsker vi alltid å rendre alle vilkår slik at man evt kan legge til tom periode
-                                        else
-                                            return (
-                                                <GeneriskVilkår
-                                                    key={`${index}_${personResultat.person.fødselsdato}_${vc.key}`}
-                                                    generiskVilkårKey={`${index}_${personResultat.person.fødselsdato}_${vc.key}`}
-                                                    person={personResultat.person}
-                                                    vilkårResultater={vilkårResultater}
-                                                    vilkårFraConfig={vc}
-                                                    visFeilmeldinger={visFeilmeldinger}
-                                                />
-                                            );
-                                    })}
-                                {andreVurderinger.length > 0 &&
-                                    Object.values(annenVurderingConfig)
-                                        .filter(annenVurderingConfig =>
-                                            annenVurderingConfig.parterDetteGjelderFor.includes(
-                                                personResultat.person.type
+                                        id={`vis-skjul-vilkårsvurdering-${index}_${personResultat.person.fødselsdato}}`}
+                                        variant="tertiary"
+                                        onClick={() =>
+                                            settPersonErEkspandert({
+                                                ...personErEkspandert,
+                                                [personResultat.personIdent]:
+                                                    !personErEkspandert[personResultat.personIdent],
+                                            })
+                                        }
+                                        icon={
+                                            personErEkspandert[personResultat.personIdent] ? (
+                                                <ChevronUpIcon aria-hidden />
+                                            ) : (
+                                                <ChevronDownIcon aria-hidden />
                                             )
-                                        )
-                                        .map(annenVurderingConfig => (
-                                            <GeneriskAnnenVurdering
-                                                key={`${index}_${personResultat.person.fødselsdato}_${annenVurderingConfig.key}`}
-                                                person={personResultat.person}
-                                                andreVurderinger={personResultat.andreVurderinger}
-                                                annenVurderingConfig={annenVurderingConfig}
-                                                visFeilmeldinger={visFeilmeldinger}
+                                        }
+                                        iconPosition="right"
+                                    >
+                                        {personErEkspandert[personResultat.personIdent]
+                                            ? 'Skjul vilkårsvurdering'
+                                            : 'Vis vilkårsvurdering'}
+                                    </Button>
+                                </HStack>
+                                <Activity mode={personErEkspandert[personResultat.personIdent] ? 'visible' : 'hidden'}>
+                                    <Box paddingInline={'space-56 space-0'}>
+                                        {personResultat.person.registerhistorikk ? (
+                                            <Registeropplysninger
+                                                registerHistorikk={personResultat.person.registerhistorikk}
+                                                fødselsdato={personResultat.person.fødselsdato}
                                             />
-                                        ))}
-                            </Box>
-                        </Activity>
+                                        ) : (
+                                            <Alert
+                                                variant="warning"
+                                                children={'Klarte ikke hente registeropplysninger'}
+                                            />
+                                        )}
+                                        {Object.values(vilkårConfig)
+                                            .filter(vc => vc.parterDetteGjelderFor.includes(personResultat.person.type))
+                                            .map(vc => {
+                                                const vilkårResultater = personResultat.vilkårResultater.filter(
+                                                    vilkårResultat => vilkårResultat.verdi.vilkårType === vc.key
+                                                );
+
+                                                if (
+                                                    vilkårResultater.length === 0 &&
+                                                    personResultat.person.type === PersonType.SØKER
+                                                )
+                                                    return undefined;
+                                                // For barn ønsker vi alltid å rendre alle vilkår slik at man evt kan legge til tom periode
+                                                else
+                                                    return (
+                                                        <GeneriskVilkår
+                                                            key={`${index}_${personResultat.person.fødselsdato}_${vc.key}`}
+                                                            generiskVilkårKey={`${index}_${personResultat.person.fødselsdato}_${vc.key}`}
+                                                            person={personResultat.person}
+                                                            vilkårResultater={vilkårResultater}
+                                                            vilkårFraConfig={vc}
+                                                            visFeilmeldinger={visFeilmeldinger}
+                                                        />
+                                                    );
+                                            })}
+                                        {andreVurderinger.length > 0 &&
+                                            Object.values(annenVurderingConfig)
+                                                .filter(annenVurderingConfig =>
+                                                    annenVurderingConfig.parterDetteGjelderFor.includes(
+                                                        personResultat.person.type
+                                                    )
+                                                )
+                                                .map(annenVurderingConfig => (
+                                                    <GeneriskAnnenVurdering
+                                                        key={`${index}_${personResultat.person.fødselsdato}_${annenVurderingConfig.key}`}
+                                                        person={personResultat.person}
+                                                        andreVurderinger={personResultat.andreVurderinger}
+                                                        annenVurderingConfig={annenVurderingConfig}
+                                                        visFeilmeldinger={visFeilmeldinger}
+                                                    />
+                                                ))}
+                                    </Box>
+                                </Activity>
+                            </>
+                        )}
                     </div>
                 );
             })}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -115,14 +115,14 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
                 const harUtvidet = personResultat.vilkårResultater.find(
                     vilkårResultat => vilkårResultat.verdi.vilkårType === VilkårType.UTVIDET_BARNETRYGD
                 );
-                const personErSkjermet = personResultat.person.skjermet;
+                const personSkalSkjermesForBruker = personResultat.person.skjermesForBruker;
 
                 return (
                     <div
                         key={`${index}_${personResultat.person.fødselsdato}`}
                         id={`${index}_${personResultat.person.fødselsdato}`}
                     >
-                        {personErSkjermet ? (
+                        {personSkalSkjermesForBruker ? (
                             <HStack gap="space-24" wrap={false} align="center">
                                 <ShieldLockFillIcon
                                     fontSize="2.5rem"

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
@@ -71,8 +71,8 @@ export const mapFraRestPersonResultatTilPersonResultat = (
 ): IPersonResultat[] => {
     const mappedPersonIdenter = new Set(personResultater.map(pr => pr.personIdent));
 
-    const skjermedePersoner: IPersonResultat[] = personer
-        .filter(person => person.skjermet && !mappedPersonIdenter.has(person.personIdent))
+    const personerSomSkalSkjermesForBruker: IPersonResultat[] = personer
+        .filter(person => person.skjermesForBruker && !mappedPersonIdenter.has(person.personIdent))
         .sort((a, b) => a.navn.localeCompare(b.navn))
         .map(person => ({
             person,
@@ -164,7 +164,7 @@ export const mapFraRestPersonResultatTilPersonResultat = (
                 isoStringTilDate(a.person.fødselsdato)
             );
         })
-        .concat(skjermedePersoner);
+        .concat(personerSomSkalSkjermesForBruker);
 };
 
 export const utledVilkårSomMåKontrolleresPerPerson = (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/utils.ts
@@ -69,6 +69,18 @@ export const mapFraRestPersonResultatTilPersonResultat = (
     personResultater: IRestPersonResultat[],
     personer: IGrunnlagPerson[]
 ): IPersonResultat[] => {
+    const mappedPersonIdenter = new Set(personResultater.map(pr => pr.personIdent));
+
+    const skjermedePersoner: IPersonResultat[] = personer
+        .filter(person => person.skjermet && !mappedPersonIdenter.has(person.personIdent))
+        .sort((a, b) => a.navn.localeCompare(b.navn))
+        .map(person => ({
+            person,
+            personIdent: person.personIdent,
+            vilkårResultater: [],
+            andreVurderinger: [],
+        }));
+
     return personResultater
         .map((personResultat: IRestPersonResultat) => {
             const person: IGrunnlagPerson | undefined = personer.find(
@@ -151,7 +163,8 @@ export const mapFraRestPersonResultatTilPersonResultat = (
                 isoStringTilDate(b.person.fødselsdato),
                 isoStringTilDate(a.person.fødselsdato)
             );
-        });
+        })
+        .concat(skjermedePersoner);
 };
 
 export const utledVilkårSomMåKontrolleresPerPerson = (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
@@ -19,6 +19,7 @@ export interface IUnderside {
     ident: string;
     antallAksjonspunkter: () => number;
     hash: string;
+    skjermet?: boolean;
 }
 
 export interface ITrinn extends ISide {
@@ -85,6 +86,7 @@ export const sider: Record<SideId, ISide> = {
                     navn: personResultat.person.navn,
                     ident: personResultat.person.personIdent,
                     hash: `${index}_${personResultat.person.fødselsdato}`,
+                    skjermet: personResultat.person.skjermet,
                     antallAksjonspunkter: () =>
                         personResultat.vilkårResultater.filter((vilkårResultat: FeltState<IVilkårResultat>) => {
                             return vilkårResultat.verdi.resultat.verdi === Resultat.IKKE_VURDERT;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
@@ -19,7 +19,7 @@ export interface IUnderside {
     ident: string;
     antallAksjonspunkter: () => number;
     hash: string;
-    skjermet?: boolean;
+    skjermesForBruker?: boolean;
 }
 
 export interface ITrinn extends ISide {
@@ -86,7 +86,7 @@ export const sider: Record<SideId, ISide> = {
                     navn: personResultat.person.navn,
                     ident: personResultat.person.personIdent,
                     hash: `${index}_${personResultat.person.fødselsdato}`,
-                    skjermet: personResultat.person.skjermet,
+                    skjermesForBruker: personResultat.person.skjermesForBruker,
                     antallAksjonspunkter: () =>
                         personResultat.vilkårResultater.filter((vilkårResultat: FeltState<IVilkårResultat>) => {
                             return vilkårResultat.verdi.resultat.verdi === Resultat.IKKE_VURDERT;

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -94,7 +94,7 @@ export function Venstremeny() {
                                                 )}
                                                 <VStack>
                                                     <BodyShort size={'small'}>{underside.navn}</BodyShort>
-                                                    {underside.ident && !underside.skjermet && (
+                                                    {underside.ident && !underside.skjermesForBruker && (
                                                         <HStack align={'center'}>
                                                             <BodyShort size={'small'} className={Styles.ident}>
                                                                 {formaterIdent(underside.ident)}

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -93,13 +93,15 @@ export function Venstremeny() {
                                                     <Box padding={'space-12'} />
                                                 )}
                                                 <VStack>
-                                                    <BodyShort>{underside.navn}</BodyShort>
-                                                    <HStack align={'center'}>
-                                                        <BodyShort size={'small'} className={Styles.ident}>
-                                                            {formaterIdent(underside.ident)}
-                                                        </BodyShort>
-                                                        <CopyButton copyText={underside.ident} size={'xsmall'} />
-                                                    </HStack>
+                                                    <BodyShort size={'small'}>{underside.navn}</BodyShort>
+                                                    {underside.ident && !underside.skjermet && (
+                                                        <HStack align={'center'}>
+                                                            <BodyShort size={'small'} className={Styles.ident}>
+                                                                {formaterIdent(underside.ident)}
+                                                            </BodyShort>
+                                                            <CopyButton copyText={underside.ident} size={'xsmall'} />
+                                                        </HStack>
+                                                    )}
                                                 </VStack>
                                             </HStack>
                                         </NavLink>

--- a/src/frontend/typer/beregning.ts
+++ b/src/frontend/typer/beregning.ts
@@ -7,7 +7,6 @@ export interface IPersonMedAndelerTilkjentYtelse {
     beløp: number;
     stønadFom: IsoMånedString;
     stønadTom: IsoMånedString;
-    skjermet?: boolean;
 }
 
 export interface IYtelsePeriode {

--- a/src/frontend/typer/beregning.ts
+++ b/src/frontend/typer/beregning.ts
@@ -7,6 +7,7 @@ export interface IPersonMedAndelerTilkjentYtelse {
     beløp: number;
     stønadFom: IsoMånedString;
     stønadTom: IsoMånedString;
+    skjermet?: boolean;
 }
 
 export interface IYtelsePeriode {

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -81,6 +81,7 @@ export interface IRestEøsPeriode extends IEøsPeriodeStatus {
     fom: IsoMånedString;
     tom?: IsoMånedString;
     barnIdenter: string[];
+    inneholderSkjermetBarn?: boolean;
 }
 
 export interface IRestKompetanse extends IRestEøsPeriode {
@@ -105,6 +106,7 @@ export interface IKompetanse extends IEøsPeriodeStatus {
     annenForeldersAktivitetsland: string | undefined;
     barnetsBostedsland: string | undefined;
     resultat: KompetanseResultat | undefined;
+    inneholderSkjermetBarn?: boolean;
 }
 
 export enum UtenlandskPeriodeBeløpIntervall {
@@ -140,6 +142,7 @@ export interface IUtenlandskPeriodeBeløp {
     valutakode?: string | undefined;
     intervall?: UtenlandskPeriodeBeløpIntervall | undefined;
     utbetalingsland: string | undefined;
+    inneholderSkjermetBarn?: boolean;
 }
 
 export enum Vurderingsform {
@@ -165,4 +168,5 @@ export interface IValutakurs {
     valutakode: string | undefined;
     valutakursdato: Date | undefined;
     kurs: string | undefined;
+    inneholderSkjermetBarn?: boolean;
 }

--- a/src/frontend/typer/eøsPerioder.ts
+++ b/src/frontend/typer/eøsPerioder.ts
@@ -81,7 +81,7 @@ export interface IRestEøsPeriode extends IEøsPeriodeStatus {
     fom: IsoMånedString;
     tom?: IsoMånedString;
     barnIdenter: string[];
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }
 
 export interface IRestKompetanse extends IRestEøsPeriode {
@@ -106,7 +106,7 @@ export interface IKompetanse extends IEøsPeriodeStatus {
     annenForeldersAktivitetsland: string | undefined;
     barnetsBostedsland: string | undefined;
     resultat: KompetanseResultat | undefined;
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }
 
 export enum UtenlandskPeriodeBeløpIntervall {
@@ -142,7 +142,7 @@ export interface IUtenlandskPeriodeBeløp {
     valutakode?: string | undefined;
     intervall?: UtenlandskPeriodeBeløpIntervall | undefined;
     utbetalingsland: string | undefined;
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }
 
 export enum Vurderingsform {
@@ -168,5 +168,5 @@ export interface IValutakurs {
     valutakode: string | undefined;
     valutakursdato: Date | undefined;
     kurs: string | undefined;
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -50,6 +50,7 @@ export interface IGrunnlagPerson {
     dødsfallDato?: string;
     erManueltLagtTilISøknad?: boolean;
     harFalskIdentitet: boolean;
+    skjermet?: boolean;
 }
 
 export interface IPersonInfo {

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -50,7 +50,7 @@ export interface IGrunnlagPerson {
     dødsfallDato?: string;
     erManueltLagtTilISøknad?: boolean;
     harFalskIdentitet: boolean;
-    skjermet?: boolean;
+    skjermesForBruker?: boolean;
 }
 
 export interface IPersonInfo {

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -26,6 +26,7 @@ export interface IBarnMedOpplysningerBackend {
     manueltRegistrert: boolean;
     navn?: string;
     erFolkeregistrert: boolean;
+    skjermet?: boolean;
 }
 
 export interface IBarnMedOpplysninger {
@@ -35,6 +36,7 @@ export interface IBarnMedOpplysninger {
     manueltRegistrert: boolean;
     navn?: string;
     erFolkeregistrert: boolean;
+    skjermet?: boolean;
 }
 
 export enum Målform {

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -26,7 +26,7 @@ export interface IBarnMedOpplysningerBackend {
     manueltRegistrert: boolean;
     navn?: string;
     erFolkeregistrert: boolean;
-    skjermet?: boolean;
+    skjermesForBruker?: boolean;
 }
 
 export interface IBarnMedOpplysninger {
@@ -36,7 +36,7 @@ export interface IBarnMedOpplysninger {
     manueltRegistrert: boolean;
     navn?: string;
     erFolkeregistrert: boolean;
-    skjermet?: boolean;
+    skjermesForBruker?: boolean;
 }
 
 export enum Målform {

--- a/src/frontend/typer/utbetalingAndel.ts
+++ b/src/frontend/typer/utbetalingAndel.ts
@@ -11,7 +11,7 @@ export interface IRestEndretUtbetalingAndel {
     avtaletidspunktDeltBosted?: IsoDatoString;
     årsak?: IEndretUtbetalingAndelÅrsak;
     erTilknyttetAndeler?: boolean;
-    inneholderSkjermetBarn?: boolean;
+    inneholderBarnSomSkalSkjermes?: boolean;
 }
 
 export enum IEndretUtbetalingAndelÅrsak {

--- a/src/frontend/typer/utbetalingAndel.ts
+++ b/src/frontend/typer/utbetalingAndel.ts
@@ -11,6 +11,7 @@ export interface IRestEndretUtbetalingAndel {
     avtaletidspunktDeltBosted?: IsoDatoString;
     årsak?: IEndretUtbetalingAndelÅrsak;
     erTilknyttetAndeler?: boolean;
+    inneholderSkjermetBarn?: boolean;
 }
 
 export enum IEndretUtbetalingAndelÅrsak {

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -32,6 +32,8 @@ const erPersonId = (personIdent: string) => {
     return /^[+-]?\d+(\.\d+)?$/.test(id) && id.length === 11;
 };
 
+const erSkjermetBarn = (personIdent: string) => personIdent.toLowerCase().includes('skjermet barn');
+
 export const erOrgNr = (orgNr: string) => {
     // Sjekker kun etter ni siffer, validerer ikke kontrollsifferet (det 9. sifferet)
     return kunSiffer(orgNr) && orgNr.length === 9;
@@ -40,6 +42,10 @@ export const erOrgNr = (orgNr: string) => {
 export const formaterIdent = (personIdent: string, ukjentTekst = 'Ukjent id') => {
     if (personIdent === '') {
         return ukjentTekst;
+    }
+
+    if (erSkjermetBarn(personIdent)) {
+        return personIdent;
     }
 
     return erPersonId(personIdent)
@@ -58,20 +64,17 @@ export const formaterNavnAlderOgIdent = (person: {
 };
 
 export const lagPersonLabel = (ident: string, personer: IGrunnlagPerson[]): string => {
-    const person = personer.find(person => person.personIdent === ident);
-    if (person) {
-        return formaterNavnAlderOgIdent({ ...person });
-    } else {
-        return ident;
-    }
+    const person = personer.find(p => p.personIdent === ident);
+    if (!person) return ident;
+    if (person.skjermet) return person.navn;
+    return formaterNavnAlderOgIdent(person);
 };
 
 export const lagBrukerLabel = (bruker: IPersonInfo): string =>
     `${bruker.navn} (${hentAlder(bruker.fødselsdato)} år) ${formaterIdent(bruker.personIdent)}`;
 
-export const lagBarnLabel = (barn: IBarnMedOpplysninger): string => {
-    return `${barn.navn ?? 'Navn ukjent'} (${hentAlderSomString(barn.fødselsdato)}) | ${formaterIdent(barn.ident)}`;
-};
+export const lagBarnLabel = (barn: IBarnMedOpplysninger): string =>
+    `${barn.navn ?? 'Navn ukjent'} (${hentAlderSomString(barn.fødselsdato)}) | ${formaterIdent(barn.ident)}`;
 
 export const sorterPåDato = (personA: IGrunnlagPerson, personB: IGrunnlagPerson) => {
     if (personA.fødselsdato === personB.fødselsdato) {
@@ -87,7 +90,19 @@ export const sorterPåDato = (personA: IGrunnlagPerson, personB: IGrunnlagPerson
 export const sorterPåFødselsnummer = (personA: IGrunnlagPerson, personB: IGrunnlagPerson) =>
     Number(personA.personIdent) - Number(personB.personIdent);
 
+const sorterSkjermetBarnSist = (
+    a: { navn: string; skjermet?: boolean },
+    b: { navn: string; skjermet?: boolean }
+): number | null => {
+    if (a.skjermet && !b.skjermet) return 1;
+    if (!a.skjermet && b.skjermet) return -1;
+    if (a.skjermet && b.skjermet) return a.navn.localeCompare(b.navn);
+    return null;
+};
+
 export const sorterPersonTypeOgFødselsdato = (personA: IGrunnlagPerson, personB: IGrunnlagPerson) => {
+    const anonymisertResultat = sorterSkjermetBarnSist(personA, personB);
+    if (anonymisertResultat !== null) return anonymisertResultat;
     if (personA.type === PersonType.SØKER) return -1;
     else if (personB.type === PersonType.SØKER) return 1;
     else return sorterPåDato(personA, personB);
@@ -97,6 +112,11 @@ export const sorterUtbetaling = (
     utbetalingsperiodeDetaljA: IUtbetalingsperiodeDetalj,
     utbetalingsperiodeDetaljB: IUtbetalingsperiodeDetalj
 ) => {
+    const anonymisertResultat = sorterSkjermetBarnSist(
+        utbetalingsperiodeDetaljA.person,
+        utbetalingsperiodeDetaljB.person
+    );
+    if (anonymisertResultat !== null) return anonymisertResultat;
     if (utbetalingsperiodeDetaljA.ytelseType === YtelseType.UTVIDET_BARNETRYGD) return -1;
     else if (utbetalingsperiodeDetaljB.ytelseType === YtelseType.UTVIDET_BARNETRYGD) return 1;
     else if (utbetalingsperiodeDetaljA.ytelseType === YtelseType.SMÅBARNSTILLEGG) return -1;

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -66,7 +66,7 @@ export const formaterNavnAlderOgIdent = (person: {
 export const lagPersonLabel = (ident: string, personer: IGrunnlagPerson[]): string => {
     const person = personer.find(p => p.personIdent === ident);
     if (!person) return ident;
-    if (person.skjermet) return person.navn;
+    if (person.skjermesForBruker) return person.navn;
     return formaterNavnAlderOgIdent(person);
 };
 
@@ -91,18 +91,18 @@ export const sorterPåFødselsnummer = (personA: IGrunnlagPerson, personB: IGrun
     Number(personA.personIdent) - Number(personB.personIdent);
 
 const sorterSkjermetBarnSist = (
-    a: { navn: string; skjermet?: boolean },
-    b: { navn: string; skjermet?: boolean }
+    a: { navn: string; skjermesForBruker?: boolean },
+    b: { navn: string; skjermesForBruker?: boolean }
 ): number | null => {
-    if (a.skjermet && !b.skjermet) return 1;
-    if (!a.skjermet && b.skjermet) return -1;
-    if (a.skjermet && b.skjermet) return a.navn.localeCompare(b.navn);
+    if (a.skjermesForBruker && !b.skjermesForBruker) return 1;
+    if (!a.skjermesForBruker && b.skjermesForBruker) return -1;
+    if (a.skjermesForBruker && b.skjermesForBruker) return a.navn.localeCompare(b.navn);
     return null;
 };
 
 export const sorterPersonTypeOgFødselsdato = (personA: IGrunnlagPerson, personB: IGrunnlagPerson) => {
-    const anonymisertResultat = sorterSkjermetBarnSist(personA, personB);
-    if (anonymisertResultat !== null) return anonymisertResultat;
+    const sorterBarnSomSkalSkjermesAvBrukerSist = sorterSkjermetBarnSist(personA, personB);
+    if (sorterBarnSomSkalSkjermesAvBrukerSist !== null) return sorterBarnSomSkalSkjermesAvBrukerSist;
     if (personA.type === PersonType.SØKER) return -1;
     else if (personB.type === PersonType.SØKER) return 1;
     else return sorterPåDato(personA, personB);
@@ -112,11 +112,11 @@ export const sorterUtbetaling = (
     utbetalingsperiodeDetaljA: IUtbetalingsperiodeDetalj,
     utbetalingsperiodeDetaljB: IUtbetalingsperiodeDetalj
 ) => {
-    const anonymisertResultat = sorterSkjermetBarnSist(
+    const sorterBarnSomSkalSkjermesAvBrukerSist = sorterSkjermetBarnSist(
         utbetalingsperiodeDetaljA.person,
         utbetalingsperiodeDetaljB.person
     );
-    if (anonymisertResultat !== null) return anonymisertResultat;
+    if (sorterBarnSomSkalSkjermesAvBrukerSist !== null) return sorterBarnSomSkalSkjermesAvBrukerSist;
     if (utbetalingsperiodeDetaljA.ytelseType === YtelseType.UTVIDET_BARNETRYGD) return -1;
     else if (utbetalingsperiodeDetaljB.ytelseType === YtelseType.UTVIDET_BARNETRYGD) return 1;
     else if (utbetalingsperiodeDetaljA.ytelseType === YtelseType.SMÅBARNSTILLEGG) return -1;


### PR DESCRIPTION
### 📮 Favro: Nav-28486

### 💰 Hva skal gjøres, og hvorfor?

For å hente ut en behandling med barn med diskresjonskode 6/7 i dag, så må en av disse kravene være på plass:

- Man har tilgang til vikafossen
- Man har ikke tilgang til vikafossen, men skjermet barn i behandlingen har ikke lenger løpende andel.

Vi ønsker nå også å anonymisere  informasjonen om barn for saksbehandlere uten rettigheter.
- Når et skjermet barn vises i frontend så ønsker vi at dette skjer i de forskjellige stedene:
- registrer søknad steget 
- Gjenomgånde i hele behandlingen: i personoversikten i høyre side
- I vilkårsvurdering: Vilkårsvurdering for barnet skal ikke være ekspanderbart, registeropplysninger og alle vilkår skal være skjult. 
- På behandlingsresultat steget, inkludert alle skjema på behandlingsresultat steget: Tidslinje + utbetalingsboks. Endret utbetaling, kompetanse, utbetalt i annet land og valuta skal være skjult.

Dette gjør vi i frontend ved å:

- Basert på hva som kommer fra backend, bruke flaggene skjermesForBruker / inneholderBarnSomSkalSkjermes til å låse ned dropdowns, vise forskjellige ikoner og sette til lesevisning.

Slik ser det ut når man er en saksbehandler med vikafossen tilgang (ingen endring fra prod):

https://github.com/user-attachments/assets/05b6ec69-27c5-4509-8392-4c740840f4f0



Slik ser det ut når man er en saksbehandler uten vikafossen tilgang:


https://github.com/user-attachments/assets/f7aea87c-7ee8-4239-a348-2828cb21fcaf

BACKEND PR: https://github.com/navikt/familie-ba-sak/pull/6213

