### PR TITLE
NAV-28039: Tilpasser stylingen i FlaggCombobox

### DIFF
--- a/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.module.css
+++ b/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.module.css
@@ -83,6 +83,7 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
     max-height: 250px;
     overflow-y: auto;
+    overflow-x: hidden;
     z-index: 50;
     padding: 4px 0;
     margin: 0;
@@ -105,19 +106,20 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 8px 12px;
+    padding: 0.75rem;
+    margin-inline: var(--ax-space-8);
+    margin-block: var(--ax-space-2);
+    border-radius: var(--ax-radius-8);
     cursor: pointer;
-    border-left: 4px solid transparent;
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
+    right: 0;
 }
 
 .option:hover,
 .optionFocused {
-    background-color: var(--ax-bg-neutral-moderate-hover);
-    border-left: 4px solid var(--ax-border-neutral-strong);
+    outline: 2px solid var(--ax-border-focus);
 }
 
 .optionText {
@@ -214,7 +216,7 @@
     border: 1px solid var(--ax-border-neutral-subtle);
     color: var(--ax-text-neutral);
     padding: 0 6px;
-    border-radius: var(--ax-radius-4);
+    border-radius: var(--ax-radius-full);
     font-size: var(--ax-font-size-large);
     white-space: nowrap;
 }


### PR DESCRIPTION
### 📮 Favro
NAV-28039

### 💰 Hva skal gjøres, og hvorfor?
Tilpasser stylingen i FlaggCombobox slik at det bedre samsvarer med hvordan en combobox ser ut i Aksel V8. Tidligere ble V7 stylingen brukt.

Basert på tilbakemeldinger fra Tove: 
- Chips skal være runde.
- Ikke vis grå bakgrunn ved hover, vis heller en sort outline. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ny:
<img width="584" height="427" alt="image" src="https://github.com/user-attachments/assets/7b085c3e-e0dc-47b1-84bb-3560f3d8b2f2" />

Gammel:
<img width="584" height="427" alt="image" src="https://github.com/user-attachments/assets/66a33358-65c9-45e6-9d6b-ae41892bf3bb" />
