### PR TITLE
Forhindre oppretting av klage fagsak dersom det finnes strengt fortrolig personer i fagsaken

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -131,6 +131,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
 
     const kanOppretteKlagebehandling =
         minimalFagsak !== undefined &&
+        !minimalFagsak.finnesStrengtFortroligPersonIFagsak &&
         (minimalFagsak.fagsakType !== FagsakType.INSTITUSJON ||
             toggles[FeatureToggle.skalKunneBehandleBaInstitusjonFagsaker]);
 

--- a/src/frontend/testutils/testdata/fagsakTestdata.ts
+++ b/src/frontend/testutils/testdata/fagsakTestdata.ts
@@ -15,6 +15,7 @@ export function lagFagsak(fagsak?: Partial<IMinimalFagsak>): IMinimalFagsak {
         løpendeUnderkategori: BehandlingUnderkategori.ORDINÆR,
         fagsakType: FagsakType.NORMAL,
         institusjon: undefined,
+        finnesStrengtFortroligPersonIFagsak: false,
         migreringsdato: '',
         behandlinger: [BehandlingTestdata.lagVisningBehandling()],
         gjeldendeUtbetalingsperioder: [],

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -72,7 +72,7 @@ export const mapMinimalFagsakTilBaseFagsak = (it: IMinimalFagsak): IBaseFagsak =
     løpendeUnderkategori: it.løpendeUnderkategori,
     fagsakType: it.fagsakType,
     institusjon: it.institusjon,
-    harStrengtFortroligPersonIFagsak: it.harStrengtFortroligPersonIFagsak,
+    finnesStrengtFortroligPersonIFagsak: it.finnesStrengtFortroligPersonIFagsak,
 });
 
 export const fagsakStatus: INøkkelPar = {

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -31,6 +31,7 @@ export interface IBaseFagsak {
     løpendeUnderkategori?: BehandlingUnderkategori;
     fagsakType: FagsakType;
     institusjon?: IInstitusjon;
+    finnesStrengtFortroligPersonIFagsak: boolean;
 }
 
 export function sjekkHarNormalFagsak(fagsaker: IBaseFagsak[] | undefined): boolean {
@@ -71,6 +72,7 @@ export const mapMinimalFagsakTilBaseFagsak = (it: IMinimalFagsak): IBaseFagsak =
     løpendeUnderkategori: it.løpendeUnderkategori,
     fagsakType: it.fagsakType,
     institusjon: it.institusjon,
+    harStrengtFortroligPersonIFagsak: it.harStrengtFortroligPersonIFagsak,
 });
 
 export const fagsakStatus: INøkkelPar = {


### PR DESCRIPTION
### 📮 Favro: Nav-28618

### 💰 Hva skal gjøres, og hvorfor?

- Vi må kaste funksjonellfeil dersom det forsøkes å opprettes en klagebehandling på en fagsak der det finnes personer som er strengt fortrolig
- Sende med flagg i fagsak dto som sier om personene i fagsaken er strengt fortrolige for å skjule klage som årsak/type hvis det er tilfellet.