### PR TITLE
NAV-28401: Refaktorer logikk rundt saksbehandler

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 
 import '@navikt/ds-css';
 import './index.css';
@@ -6,17 +6,15 @@ import './index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
-import { hentInnloggetBruker } from './api/saksbehandler';
 import { Container } from './Container';
 import { AppProvider } from './context/AppContext';
 import { AuthContextProvider } from './context/AuthContext';
 import { HttpContextProvider } from './context/HttpContext';
 import { ModalProvider } from './context/ModalContext';
+import { SaksbehandlerProvider } from './context/SaksbehandlerContext';
 import { FeatureTogglesProvider } from './context/TogglesContext';
 import { useStartUmami } from './hooks/useStartUmami';
-import { ErrorBoundary } from './komponenter/ErrorBoundary/ErrorBoundary';
+import { ErrorBoundary, ErrorBoundaryMedSaksbehandler } from './komponenter/ErrorBoundary/ErrorBoundary';
 import { initGrafanaFaro } from './utils/grafanaFaro';
 import { erProd } from './utils/miljø';
 
@@ -29,34 +27,32 @@ const queryClient = new QueryClient({
 });
 
 const App: React.FC = () => {
-    const [autentisertSaksbehandler, settInnloggetSaksbehandler] = React.useState<ISaksbehandler | undefined>(
-        undefined
-    );
     useStartUmami();
 
-    React.useEffect(() => {
+    useEffect(() => {
         initGrafanaFaro();
-        hentInnloggetBruker().then((innhentetInnloggetSaksbehandler: ISaksbehandler) => {
-            settInnloggetSaksbehandler(innhentetInnloggetSaksbehandler);
-        });
     }, []);
 
     return (
-        <ErrorBoundary autentisertSaksbehandler={autentisertSaksbehandler}>
-            <AuthContextProvider autentisertSaksbehandler={autentisertSaksbehandler}>
-                <HttpContextProvider>
-                    <QueryClientProvider client={queryClient}>
-                        {!erProd() && <ReactQueryDevtools position={'right'} initialIsOpen={false} />}
-                        <FeatureTogglesProvider>
-                            <AppProvider>
-                                <ModalProvider>
-                                    <Container />
-                                </ModalProvider>
-                            </AppProvider>
-                        </FeatureTogglesProvider>
-                    </QueryClientProvider>
-                </HttpContextProvider>
-            </AuthContextProvider>
+        <ErrorBoundary>
+            <QueryClientProvider client={queryClient}>
+                {!erProd() && <ReactQueryDevtools position={'right'} initialIsOpen={false} />}
+                <SaksbehandlerProvider>
+                    <ErrorBoundaryMedSaksbehandler>
+                        <AuthContextProvider>
+                            <HttpContextProvider>
+                                <FeatureTogglesProvider>
+                                    <AppProvider>
+                                        <ModalProvider>
+                                            <Container />
+                                        </ModalProvider>
+                                    </AppProvider>
+                                </FeatureTogglesProvider>
+                            </HttpContextProvider>
+                        </AuthContextProvider>
+                    </ErrorBoundaryMedSaksbehandler>
+                </SaksbehandlerProvider>
+            </QueryClientProvider>
         </ErrorBoundary>
     );
 };

--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -22,7 +22,7 @@ import { Oppgavebenk } from './sider/Oppgavebenk/Oppgavebenk';
 import { Samhandler } from './sider/Samhandler/Samhandler';
 
 export function Container() {
-    const { autentisert, innloggetSaksbehandler, appInfoModal } = useAppContext();
+    const { autentisert, appInfoModal } = useAppContext();
     const { systemetLaster } = useHttp();
 
     return (
@@ -36,10 +36,7 @@ export function Container() {
                         <OpprettFagsakModal />
                         <FeilmeldingModal />
                         <ForhåndsvisOpprettingAvPdfModal />
-                        <HeaderMedSøk
-                            brukerNavn={innloggetSaksbehandler?.displayName}
-                            brukerEnhet={innloggetSaksbehandler?.enhet}
-                        />
+                        <HeaderMedSøk />
                         <Routes>
                             <Route path="/fagsak/:fagsakId/*" element={<FagsakContainer />} />
                             <Route path="/oppgaver/journalfor/:oppgaveId" element={<ManuellJournalføring />} />

--- a/src/frontend/api/hentSaksbehandler.test.ts
+++ b/src/frontend/api/hentSaksbehandler.test.ts
@@ -1,0 +1,56 @@
+import { http, HttpResponse } from 'msw';
+import { describe, it, expect } from 'vitest';
+
+import { hentSaksbehandler } from './hentSaksbehandler';
+import { server } from '../testutils/mocks/node';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+
+describe('hentSaksbehandler', () => {
+    it('skal hente saksbehandler', async () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+
+        server.use(
+            http.get('/user/profile', () => {
+                return HttpResponse.json(saksbehandler);
+            })
+        );
+
+        // Act
+        const result = await hentSaksbehandler();
+
+        // Assert
+        expect(result).toEqual(saksbehandler);
+    });
+
+    it('skal returnere en tom liste for groups hvis ingen gruppe er definert', async () => {
+        // Arrange
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { groups, ...saksbehandlerUtenGrupper } = lagSaksbehandler();
+
+        server.use(
+            http.get('/user/profile', () => {
+                return HttpResponse.json(saksbehandlerUtenGrupper);
+            })
+        );
+
+        // Act
+        const result = await hentSaksbehandler();
+
+        // Assert
+        expect(result.groups).toEqual([]);
+        expect(result.displayName).toBe('Sak Behandler');
+    });
+
+    it('skal kaste en feil hvis API-kallet feiler', async () => {
+        // Arrange
+        server.use(
+            http.get('/user/profile', () => {
+                return new HttpResponse(null, { status: 401, statusText: 'Unauthorized' });
+            })
+        );
+
+        // Act & assert
+        expect(hentSaksbehandler()).rejects.toThrow();
+    });
+});

--- a/src/frontend/api/hentSaksbehandler.test.ts
+++ b/src/frontend/api/hentSaksbehandler.test.ts
@@ -3,16 +3,16 @@ import { describe, it, expect } from 'vitest';
 
 import { hentSaksbehandler } from './hentSaksbehandler';
 import { server } from '../testutils/mocks/node';
-import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { lagISaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 
 describe('hentSaksbehandler', () => {
     it('skal hente saksbehandler', async () => {
         // Arrange
-        const saksbehandler = lagSaksbehandler();
+        const iSaksbehandler = lagISaksbehandler();
 
         server.use(
             http.get('/user/profile', () => {
-                return HttpResponse.json(saksbehandler);
+                return HttpResponse.json(iSaksbehandler);
             })
         );
 
@@ -20,26 +20,7 @@ describe('hentSaksbehandler', () => {
         const result = await hentSaksbehandler();
 
         // Assert
-        expect(result).toEqual(saksbehandler);
-    });
-
-    it('skal returnere en tom liste for groups hvis ingen gruppe er definert', async () => {
-        // Arrange
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { groups, ...saksbehandlerUtenGrupper } = lagSaksbehandler();
-
-        server.use(
-            http.get('/user/profile', () => {
-                return HttpResponse.json(saksbehandlerUtenGrupper);
-            })
-        );
-
-        // Act
-        const result = await hentSaksbehandler();
-
-        // Assert
-        expect(result.groups).toEqual([]);
-        expect(result.displayName).toBe('Sak Behandler');
+        expect(result).toEqual(iSaksbehandler);
     });
 
     it('skal kaste en feil hvis API-kallet feiler', async () => {

--- a/src/frontend/api/hentSaksbehandler.ts
+++ b/src/frontend/api/hentSaksbehandler.ts
@@ -1,0 +1,12 @@
+import { preferredAxios } from '@navikt/familie-http';
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+export async function hentSaksbehandler(): Promise<Saksbehandler> {
+    const response = await preferredAxios.get<ISaksbehandler>(`/user/profile`);
+    return {
+        ...response.data,
+        groups: response.data.groups ?? [],
+    };
+}

--- a/src/frontend/api/hentSaksbehandler.ts
+++ b/src/frontend/api/hentSaksbehandler.ts
@@ -1,12 +1,7 @@
 import { preferredAxios } from '@navikt/familie-http';
 import type { ISaksbehandler } from '@navikt/familie-typer';
 
-import type { Saksbehandler } from '../typer/saksbehandler';
-
-export async function hentSaksbehandler(): Promise<Saksbehandler> {
+export async function hentSaksbehandler(): Promise<ISaksbehandler> {
     const response = await preferredAxios.get<ISaksbehandler>(`/user/profile`);
-    return {
-        ...response.data,
-        groups: response.data.groups ?? [],
-    };
+    return response.data;
 }

--- a/src/frontend/api/saksbehandler.ts
+++ b/src/frontend/api/saksbehandler.ts
@@ -1,7 +1,0 @@
-import { preferredAxios } from '@navikt/familie-http';
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
-export const hentInnloggetBruker = async (): Promise<ISaksbehandler> => {
-    const svar = await preferredAxios.get<ISaksbehandler>(`/user/profile`);
-    return svar.data;
-};

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -4,18 +4,17 @@ import type { AxiosRequestConfig } from 'axios';
 
 import { BodyShort, Button, HStack } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
-import type { ISaksbehandler, Ressurs } from '@navikt/familie-typer';
+import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useAuthContext } from './AuthContext';
 import { useFeatureToggles } from '../hooks/useFeatureToggles';
+import { useSaksbehandler } from '../hooks/useSaksbehandler';
 import StatusIkon, { Status } from '../ikoner/StatusIkon';
 import type { IToast, ToastTyper } from '../komponenter/Toast/typer';
-import { BehandlerRolle } from '../typer/behandling';
 import { FeatureToggle } from '../typer/featureToggles';
 import type { IPersonInfo, IRestTilgang } from '../typer/person';
 import { adressebeskyttelsestyper } from '../typer/person';
-import { gruppeIdTilRolle, gruppeIdTilSuperbrukerRolle } from '../utils/behandling';
 
 export type FamilieAxiosRequestConfig<D> = AxiosRequestConfig & {
     data?: D;
@@ -54,10 +53,6 @@ const tilgangModal = (data: IRestTilgang, lukkModal: () => void) => ({
 
 interface AppContextValue {
     autentisert: boolean;
-    hentSaksbehandlerRolle: () => BehandlerRolle;
-    innloggetSaksbehandler: ISaksbehandler | undefined;
-    harInnloggetSaksbehandlerSkrivetilgang: () => boolean;
-    harInnloggetSaksbehandlerSuperbrukerTilgang: () => boolean | undefined;
     appInfoModal: IModal;
     settToast: (toastId: ToastTyper, toast: IToast) => void;
     settToasts: React.Dispatch<React.SetStateAction<{ [toastId: string]: IToast }>>;
@@ -70,12 +65,14 @@ interface AppContextValue {
 const AppContext = createContext<AppContextValue | undefined>(undefined);
 
 const AppProvider = (props: PropsWithChildren) => {
-    const { autentisert, innloggetSaksbehandler } = useAuthContext();
+    const { autentisert } = useAuthContext();
     const { request } = useHttp();
     const toggles = useFeatureToggles();
 
     const [appInfoModal, settAppInfoModal] = React.useState<IModal>(initalState);
     const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
+
+    const saksbehandler = useSaksbehandler();
 
     const lukkModal = () => {
         settAppInfoModal(initalState);
@@ -120,40 +117,12 @@ const AppProvider = (props: PropsWithChildren) => {
         });
     };
 
-    const hentSaksbehandlerRolle = (): BehandlerRolle => {
-        let rolle = BehandlerRolle.UKJENT;
-        if (innloggetSaksbehandler && innloggetSaksbehandler.groups) {
-            innloggetSaksbehandler.groups.forEach((id: string) => {
-                rolle = rolle < gruppeIdTilRolle(id) ? gruppeIdTilRolle(id) : rolle;
-            });
-        }
-
-        if (innloggetSaksbehandler && rolle === BehandlerRolle.UKJENT) {
-            throw new Error('Finner ikke rolle til saksbehandler.');
-        }
-
-        return rolle;
-    };
-
-    const harInnloggetSaksbehandlerSkrivetilgang = () => {
-        const rolle = hentSaksbehandlerRolle();
-
-        return rolle >= BehandlerRolle.SAKSBEHANDLER;
-    };
-
-    const harInnloggetSaksbehandlerSuperbrukerTilgang = () =>
-        innloggetSaksbehandler?.groups?.includes(gruppeIdTilSuperbrukerRolle);
-
-    const skalObfuskereData = toggles[FeatureToggle.skalObfuskereData] && !harInnloggetSaksbehandlerSkrivetilgang();
+    const skalObfuskereData = toggles[FeatureToggle.skalObfuskereData] && !saksbehandler.harSkrivetilgang;
 
     return (
         <AppContext.Provider
             value={{
                 autentisert,
-                hentSaksbehandlerRolle,
-                innloggetSaksbehandler,
-                harInnloggetSaksbehandlerSkrivetilgang,
-                harInnloggetSaksbehandlerSuperbrukerTilgang,
                 appInfoModal,
                 settToast: (toastId: ToastTyper, toast: IToast) =>
                     settToasts({

--- a/src/frontend/context/AuthContext.tsx
+++ b/src/frontend/context/AuthContext.tsx
@@ -1,34 +1,16 @@
-import React, { createContext, useEffect, type PropsWithChildren, useState } from 'react';
-
-import type { ISaksbehandler } from '@navikt/familie-typer';
+import React, { createContext, type PropsWithChildren, useState } from 'react';
 
 interface Context {
     autentisert: boolean;
     settAutentisert: (autentisert: boolean) => void;
-    innloggetSaksbehandler: ISaksbehandler | undefined;
 }
 
 const AuthContext = createContext<Context | undefined>(undefined);
 
-interface Props extends PropsWithChildren {
-    autentisertSaksbehandler: ISaksbehandler | undefined;
-}
-
-export function AuthContextProvider({ autentisertSaksbehandler, children }: Props) {
+export function AuthContextProvider({ children }: PropsWithChildren) {
     const [autentisert, settAutentisert] = useState(true);
-    const [innloggetSaksbehandler, settInnloggetSaksbehandler] = React.useState(autentisertSaksbehandler);
 
-    useEffect(() => {
-        if (autentisertSaksbehandler) {
-            settInnloggetSaksbehandler(autentisertSaksbehandler);
-        }
-    }, [autentisertSaksbehandler]);
-
-    return (
-        <AuthContext.Provider value={{ autentisert, settAutentisert, innloggetSaksbehandler }}>
-            {children}
-        </AuthContext.Provider>
-    );
+    return <AuthContext.Provider value={{ autentisert, settAutentisert }}>{children}</AuthContext.Provider>;
 }
 
 export function useAuthContext() {

--- a/src/frontend/context/HttpContext.tsx
+++ b/src/frontend/context/HttpContext.tsx
@@ -3,17 +3,20 @@ import React, { type PropsWithChildren } from 'react';
 import { HttpProvider } from '@navikt/familie-http';
 
 import { useAuthContext } from './AuthContext';
+import { useSaksbehandler } from '../hooks/useSaksbehandler';
 
 interface Props extends PropsWithChildren {
     fjernRessursSomLasterTimeout?: number;
 }
 
 export function HttpContextProvider({ fjernRessursSomLasterTimeout = 300, children }: Props) {
-    const { innloggetSaksbehandler, settAutentisert } = useAuthContext();
+    const { settAutentisert } = useAuthContext();
+
+    const saksbehandler = useSaksbehandler();
 
     return (
         <HttpProvider
-            innloggetSaksbehandler={innloggetSaksbehandler}
+            innloggetSaksbehandler={saksbehandler}
             settAutentisert={settAutentisert}
             fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}
         >

--- a/src/frontend/context/SaksbehandlerContext.test.tsx
+++ b/src/frontend/context/SaksbehandlerContext.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import type { UseQueryResult } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { SaksbehandlerProvider, useSaksbehandlerContext } from './SaksbehandlerContext';
+import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+vi.mock('../hooks/useHentSaksbehandler', () => ({
+    useHentSaksbehandler: vi.fn(),
+}));
+
+function TestConsumer() {
+    const { saksbehandler } = useSaksbehandlerContext();
+    return <div>Logget inn som: {saksbehandler.displayName}</div>;
+}
+
+describe('SaksbehandlerContext', () => {
+    beforeEach(() => {
+        vi.mocked(useHentSaksbehandler).mockReset();
+    });
+
+    it('skal vise systemet laster ved innlasting', () => {
+        // Arrange
+        const resultat = {
+            data: undefined,
+            isPending: true,
+            error: null,
+        } as UseQueryResult<Saksbehandler, Error>;
+
+        vi.mocked(useHentSaksbehandler).mockReturnValue(resultat);
+
+        // Act
+        render(
+            <SaksbehandlerProvider>
+                <div>Should not be visible yet</div>
+            </SaksbehandlerProvider>
+        );
+
+        // Assert
+        expect(screen.queryByText('Should not be visible yet')).not.toBeInTheDocument();
+        expect(screen.queryByText('Systemet laster')).toBeInTheDocument();
+    });
+
+    it('skal vise feilmelding hvis feil oppstår ved API-kallet', () => {
+        // Arrange
+        const resultat = {
+            data: undefined,
+            isPending: false,
+            error: new Error('Nettverksfeil'),
+        } as UseQueryResult<Saksbehandler, Error>;
+
+        vi.mocked(useHentSaksbehandler).mockReturnValue(resultat);
+
+        // Act
+        render(
+            <SaksbehandlerProvider>
+                <div>Burde være usynlig</div>
+            </SaksbehandlerProvider>
+        );
+
+        // Assert
+        expect(screen.getByText('Feil oppstod ved innlasting av saksbehandler')).toBeInTheDocument();
+        expect(screen.getByText('Nettverksfeil')).toBeInTheDocument();
+        expect(screen.queryByText('Burde være usynlig')).not.toBeInTheDocument();
+    });
+
+    it('skal eksponere saksbehandler til children', () => {
+        // Arrange
+        const resultat = {
+            data: lagSaksbehandler(),
+            isPending: false,
+            error: null,
+        } as UseQueryResult<Saksbehandler, Error>;
+
+        vi.mocked(useHentSaksbehandler).mockReturnValue(resultat);
+
+        // Act
+        render(
+            <SaksbehandlerProvider>
+                <TestConsumer />
+            </SaksbehandlerProvider>
+        );
+
+        // Assert
+        expect(screen.getByText('Logget inn som: Sak Behandler')).toBeInTheDocument();
+    });
+
+    it('skal kaste feil hvis useSaksbehandlerContext brukes utenfor SaksbehandlerProvider', () => {
+        // Arrange
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        // Act & assert
+        expect(() => render(<TestConsumer />)).toThrow(
+            'useSaksbehandlerContext må brukes innenfor en SaksbehandlerProvider'
+        );
+
+        // Cleanup
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/frontend/context/SaksbehandlerContext.tsx
+++ b/src/frontend/context/SaksbehandlerContext.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, type PropsWithChildren, useContext } from 'react';
+
+import { Box, LocalAlert } from '@navikt/ds-react';
+
+import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
+import SystemetLaster from '../komponenter/SystemetLaster/SystemetLaster';
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+interface Context {
+    saksbehandler: Saksbehandler;
+}
+
+const Context = createContext<Context | undefined>(undefined);
+
+interface Props extends PropsWithChildren {
+    saksbehandler?: Saksbehandler;
+}
+
+export function SaksbehandlerProvider({ saksbehandler, children }: Props) {
+    const { data, isPending, error } = useHentSaksbehandler({ initialData: saksbehandler });
+
+    if (isPending) {
+        return <SystemetLaster />;
+    }
+
+    if (error) {
+        return (
+            <Box padding={'space-8'}>
+                <LocalAlert status={'error'}>
+                    <LocalAlert.Header>
+                        <LocalAlert.Title>Feil oppstod ved innlasting av saksbehandler</LocalAlert.Title>
+                    </LocalAlert.Header>
+                    <LocalAlert.Content>{error.message ?? 'En ukjent feil oppstod.'}</LocalAlert.Content>
+                </LocalAlert>
+            </Box>
+        );
+    }
+
+    return <Context.Provider value={{ saksbehandler: data }}>{children}</Context.Provider>;
+}
+
+export function useSaksbehandlerContext() {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useSaksbehandlerContext må brukes innenfor en SaksbehandlerProvider');
+    }
+    return context;
+}

--- a/src/frontend/context/SaksbehandlerContext.tsx
+++ b/src/frontend/context/SaksbehandlerContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, type PropsWithChildren, useContext } from 'react';
 
-import { Box, LocalAlert } from '@navikt/ds-react';
+import { Box, GlobalAlert } from '@navikt/ds-react';
 
 import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
 import SystemetLaster from '../komponenter/SystemetLaster/SystemetLaster';
@@ -26,12 +26,12 @@ export function SaksbehandlerProvider({ saksbehandler, children }: Props) {
     if (error) {
         return (
             <Box padding={'space-8'}>
-                <LocalAlert status={'error'}>
-                    <LocalAlert.Header>
-                        <LocalAlert.Title>Feil oppstod ved innlasting av saksbehandler</LocalAlert.Title>
-                    </LocalAlert.Header>
-                    <LocalAlert.Content>{error.message ?? 'En ukjent feil oppstod.'}</LocalAlert.Content>
-                </LocalAlert>
+                <GlobalAlert status={'error'}>
+                    <GlobalAlert.Header>
+                        <GlobalAlert.Title>Feil oppstod ved innlasting av saksbehandler</GlobalAlert.Title>
+                    </GlobalAlert.Header>
+                    <GlobalAlert.Content>{error.message ?? 'En ukjent feil oppstod.'}</GlobalAlert.Content>
+                </GlobalAlert>
             </Box>
         );
     }

--- a/src/frontend/hooks/useHentSaksbehandler.test.tsx
+++ b/src/frontend/hooks/useHentSaksbehandler.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useHentSaksbehandler } from './useHentSaksbehandler';
+import { hentSaksbehandler } from '../api/hentSaksbehandler';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+
+vi.mock('../api/hentSaksbehandler', () => ({
+    hentSaksbehandler: vi.fn(),
+}));
+
+const createTestQueryClient = () =>
+    new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+describe('useHentSaksbehandler', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('skal hente saksbehandler', async () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+        vi.mocked(hentSaksbehandler).mockResolvedValueOnce(saksbehandler);
+
+        const queryClient = createTestQueryClient();
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+
+        // Act
+        const { result } = renderHook(() => useHentSaksbehandler(), { wrapper });
+
+        // Assert
+        expect(result.current.isPending).toBe(true);
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.error).toBe(null);
+        expect(hentSaksbehandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('skal håndtere feil ved API-kallet', async () => {
+        // Arrange
+        const networkError = new Error('Nettverksfeil');
+        vi.mocked(hentSaksbehandler).mockRejectedValueOnce(networkError);
+
+        const queryClient = createTestQueryClient();
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+
+        // Suppress console.error for clean test output (React Query logs errors to console)
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        // Act
+        const { result } = renderHook(() => useHentSaksbehandler(), { wrapper });
+
+        // Assert
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.data).toBe(undefined);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.error).toBe(networkError);
+
+        // Cleanup
+        consoleSpy.mockRestore();
+    });
+
+    it('skal kunne sette initialData', () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+        const queryClient = createTestQueryClient();
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+
+        // Act
+        const { result } = renderHook(() => useHentSaksbehandler({ initialData: saksbehandler }), { wrapper });
+
+        // Assert
+        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.isPending).toBe(false);
+        expect(result.current.error).toBe(null);
+    });
+});

--- a/src/frontend/hooks/useHentSaksbehandler.test.tsx
+++ b/src/frontend/hooks/useHentSaksbehandler.test.tsx
@@ -6,7 +6,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { useHentSaksbehandler } from './useHentSaksbehandler';
 import { hentSaksbehandler } from '../api/hentSaksbehandler';
-import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { lagISaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { BehandlerRolle } from '../typer/behandling';
 
 vi.mock('../api/hentSaksbehandler', () => ({
     hentSaksbehandler: vi.fn(),
@@ -28,8 +29,8 @@ describe('useHentSaksbehandler', () => {
 
     it('skal hente saksbehandler', async () => {
         // Arrange
-        const saksbehandler = lagSaksbehandler();
-        vi.mocked(hentSaksbehandler).mockResolvedValueOnce(saksbehandler);
+        const iSaksbehandler = lagISaksbehandler();
+        vi.mocked(hentSaksbehandler).mockResolvedValueOnce(iSaksbehandler);
 
         const queryClient = createTestQueryClient();
         const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -42,7 +43,12 @@ describe('useHentSaksbehandler', () => {
         // Assert
         expect(result.current.isPending).toBe(true);
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
-        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.data).toEqual({
+            ...iSaksbehandler,
+            rolle: BehandlerRolle.SAKSBEHANDLER,
+            harSkrivetilgang: true,
+            harSuperbrukertilgang: false,
+        });
         expect(result.current.isPending).toBe(false);
         expect(result.current.error).toBe(null);
         expect(hentSaksbehandler).toHaveBeenCalledTimes(1);
@@ -76,17 +82,22 @@ describe('useHentSaksbehandler', () => {
 
     it('skal kunne sette initialData', () => {
         // Arrange
-        const saksbehandler = lagSaksbehandler();
+        const iSaksbehandler = lagISaksbehandler();
         const queryClient = createTestQueryClient();
         const wrapper = ({ children }: { children: React.ReactNode }) => (
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
         );
 
         // Act
-        const { result } = renderHook(() => useHentSaksbehandler({ initialData: saksbehandler }), { wrapper });
+        const { result } = renderHook(() => useHentSaksbehandler({ initialData: iSaksbehandler }), { wrapper });
 
         // Assert
-        expect(result.current.data).toBe(saksbehandler);
+        expect(result.current.data).toEqual({
+            ...iSaksbehandler,
+            rolle: BehandlerRolle.SAKSBEHANDLER,
+            harSkrivetilgang: true,
+            harSuperbrukertilgang: false,
+        });
         expect(result.current.isPending).toBe(false);
         expect(result.current.error).toBe(null);
     });

--- a/src/frontend/hooks/useHentSaksbehandler.ts
+++ b/src/frontend/hooks/useHentSaksbehandler.ts
@@ -1,17 +1,20 @@
 import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
 import { hentSaksbehandler } from '../api/hentSaksbehandler';
-import type { Saksbehandler } from '../typer/saksbehandler';
+import { mapISaksbehandlerTilSaksbehandler, type Saksbehandler } from '../typer/saksbehandler';
 
 type Options = Omit<
-    UseQueryOptions<Saksbehandler, DefaultError, Saksbehandler>,
-    'queryKey' | 'queryFn' | 'gcTime' | 'staleTime'
+    UseQueryOptions<ISaksbehandler, DefaultError, Saksbehandler>,
+    'queryKey' | 'queryFn' | 'gcTime' | 'staleTime' | 'select'
 >;
 
 export function useHentSaksbehandler(options?: Options) {
     return useQuery({
         queryKey: ['saksbehandler'],
-        queryFn: () => hentSaksbehandler(),
+        queryFn: hentSaksbehandler,
+        select: mapISaksbehandlerTilSaksbehandler,
         gcTime: 0,
         staleTime: 0,
         ...options,

--- a/src/frontend/hooks/useHentSaksbehandler.ts
+++ b/src/frontend/hooks/useHentSaksbehandler.ts
@@ -1,0 +1,19 @@
+import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { hentSaksbehandler } from '../api/hentSaksbehandler';
+import type { Saksbehandler } from '../typer/saksbehandler';
+
+type Options = Omit<
+    UseQueryOptions<Saksbehandler, DefaultError, Saksbehandler>,
+    'queryKey' | 'queryFn' | 'gcTime' | 'staleTime'
+>;
+
+export function useHentSaksbehandler(options?: Options) {
+    return useQuery({
+        queryKey: ['saksbehandler'],
+        queryFn: () => hentSaksbehandler(),
+        gcTime: 0,
+        staleTime: 0,
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useSaksbehandler.test.ts
+++ b/src/frontend/hooks/useSaksbehandler.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useSaksbehandler } from './useSaksbehandler';
+import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { BehandlerRolle } from '../typer/behandling';
+
+vi.mock('../context/SaksbehandlerContext', () => ({
+    useSaksbehandlerContext: vi.fn(),
+}));
+
+describe('useSaksbehandler', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('skal hente saksbehandler med skrivetilgang', () => {
+        // Arrange
+        const saksbehandler = lagSaksbehandler();
+
+        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
+
+        // Act
+        const { result } = renderHook(() => useSaksbehandler());
+
+        // Assert
+        expect(result.current.displayName).toBe('Sak Behandler');
+        expect(result.current.email).toBe('saksbehandler@nav.no');
+        expect(result.current.firstName).toBe('Sak');
+        expect(result.current.groups).toStrictEqual(['d21e00a4-969d-4b28-8782-dc818abfae65']);
+        expect(result.current.identifier).toBe('30987654321');
+        expect(result.current.lastName).toBe('Behandler');
+        expect(result.current.enhet).toBe('0001');
+        expect(result.current.navIdent).toBe('A1');
+        expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
+        expect(result.current.harSkrivetilgang).toBe(true);
+        expect(result.current.harSuperbrukertilgang).toBe(false);
+    });
+
+    it('skal hente saksbehandler med skrivetilgang og superbrukertilgang', () => {
+        // Arrange
+        const grupper = ['d21e00a4-969d-4b28-8782-dc818abfae65', '314fa714-f13c-4cdc-ac5c-e13ce08e241c'];
+        const saksbehandler = lagSaksbehandler({ groups: grupper });
+
+        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
+
+        // Act
+        const { result } = renderHook(() => useSaksbehandler());
+
+        // Assert
+        expect(result.current.displayName).toBe('Sak Behandler');
+        expect(result.current.email).toBe('saksbehandler@nav.no');
+        expect(result.current.firstName).toBe('Sak');
+        expect(result.current.groups).toStrictEqual(grupper);
+        expect(result.current.identifier).toBe('30987654321');
+        expect(result.current.lastName).toBe('Behandler');
+        expect(result.current.enhet).toBe('0001');
+        expect(result.current.navIdent).toBe('A1');
+        expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
+        expect(result.current.harSkrivetilgang).toBe(true);
+        expect(result.current.harSuperbrukertilgang).toBe(true);
+    });
+
+    it('skal hente saksbehandler uten skrivetilgang eller superbrukertilgang', () => {
+        // Arrange
+        const grupper = ['93a26831-9866-4410-927b-74ff51a9107c'];
+        const saksbehandler = lagSaksbehandler({ groups: grupper });
+
+        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
+
+        // Act
+        const { result } = renderHook(() => useSaksbehandler());
+
+        // Assert
+        expect(result.current.displayName).toBe('Sak Behandler');
+        expect(result.current.email).toBe('saksbehandler@nav.no');
+        expect(result.current.firstName).toBe('Sak');
+        expect(result.current.groups).toStrictEqual(grupper);
+        expect(result.current.identifier).toBe('30987654321');
+        expect(result.current.lastName).toBe('Behandler');
+        expect(result.current.enhet).toBe('0001');
+        expect(result.current.navIdent).toBe('A1');
+        expect(result.current.rolle).toBe(BehandlerRolle.VEILEDER);
+        expect(result.current.harSkrivetilgang).toBe(false);
+        expect(result.current.harSuperbrukertilgang).toBe(false);
+    });
+});

--- a/src/frontend/hooks/useSaksbehandler.test.ts
+++ b/src/frontend/hooks/useSaksbehandler.test.ts
@@ -15,7 +15,7 @@ describe('useSaksbehandler', () => {
         vi.clearAllMocks();
     });
 
-    it('skal hente saksbehandler med skrivetilgang', () => {
+    it('skal hente saksbehandler', () => {
         // Arrange
         const saksbehandler = lagSaksbehandler();
 
@@ -35,54 +35,6 @@ describe('useSaksbehandler', () => {
         expect(result.current.navIdent).toBe('A1');
         expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
         expect(result.current.harSkrivetilgang).toBe(true);
-        expect(result.current.harSuperbrukertilgang).toBe(false);
-    });
-
-    it('skal hente saksbehandler med skrivetilgang og superbrukertilgang', () => {
-        // Arrange
-        const grupper = ['d21e00a4-969d-4b28-8782-dc818abfae65', '314fa714-f13c-4cdc-ac5c-e13ce08e241c'];
-        const saksbehandler = lagSaksbehandler({ groups: grupper });
-
-        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
-
-        // Act
-        const { result } = renderHook(() => useSaksbehandler());
-
-        // Assert
-        expect(result.current.displayName).toBe('Sak Behandler');
-        expect(result.current.email).toBe('saksbehandler@nav.no');
-        expect(result.current.firstName).toBe('Sak');
-        expect(result.current.groups).toStrictEqual(grupper);
-        expect(result.current.identifier).toBe('30987654321');
-        expect(result.current.lastName).toBe('Behandler');
-        expect(result.current.enhet).toBe('0001');
-        expect(result.current.navIdent).toBe('A1');
-        expect(result.current.rolle).toBe(BehandlerRolle.SAKSBEHANDLER);
-        expect(result.current.harSkrivetilgang).toBe(true);
-        expect(result.current.harSuperbrukertilgang).toBe(true);
-    });
-
-    it('skal hente saksbehandler uten skrivetilgang eller superbrukertilgang', () => {
-        // Arrange
-        const grupper = ['93a26831-9866-4410-927b-74ff51a9107c'];
-        const saksbehandler = lagSaksbehandler({ groups: grupper });
-
-        vi.mocked(useSaksbehandlerContext).mockReturnValue({ saksbehandler });
-
-        // Act
-        const { result } = renderHook(() => useSaksbehandler());
-
-        // Assert
-        expect(result.current.displayName).toBe('Sak Behandler');
-        expect(result.current.email).toBe('saksbehandler@nav.no');
-        expect(result.current.firstName).toBe('Sak');
-        expect(result.current.groups).toStrictEqual(grupper);
-        expect(result.current.identifier).toBe('30987654321');
-        expect(result.current.lastName).toBe('Behandler');
-        expect(result.current.enhet).toBe('0001');
-        expect(result.current.navIdent).toBe('A1');
-        expect(result.current.rolle).toBe(BehandlerRolle.VEILEDER);
-        expect(result.current.harSkrivetilgang).toBe(false);
         expect(result.current.harSuperbrukertilgang).toBe(false);
     });
 });

--- a/src/frontend/hooks/useSaksbehandler.ts
+++ b/src/frontend/hooks/useSaksbehandler.ts
@@ -1,17 +1,6 @@
-import { useMemo } from 'react';
-
 import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
-import { harSkrivetilgang, harSuperbrukertilgang, utledBehandlerRolle } from '../typer/saksbehandler';
 
 export function useSaksbehandler() {
     const { saksbehandler } = useSaksbehandlerContext();
-
-    return useMemo(() => {
-        return {
-            ...saksbehandler,
-            rolle: utledBehandlerRolle(saksbehandler),
-            harSuperbrukertilgang: harSuperbrukertilgang(saksbehandler),
-            harSkrivetilgang: harSkrivetilgang(saksbehandler),
-        };
-    }, [saksbehandler]);
+    return saksbehandler;
 }

--- a/src/frontend/hooks/useSaksbehandler.ts
+++ b/src/frontend/hooks/useSaksbehandler.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
-import { harSkrivetilgang, harSuperbrukerTilgang, utledBehandlerRolle } from '../typer/saksbehandler';
+import { harSkrivetilgang, harSuperbrukertilgang, utledBehandlerRolle } from '../typer/saksbehandler';
 
 export function useSaksbehandler() {
     const { saksbehandler } = useSaksbehandlerContext();
@@ -10,7 +10,7 @@ export function useSaksbehandler() {
         return {
             ...saksbehandler,
             rolle: utledBehandlerRolle(saksbehandler),
-            harSuperbrukertilgang: harSuperbrukerTilgang(saksbehandler),
+            harSuperbrukertilgang: harSuperbrukertilgang(saksbehandler),
             harSkrivetilgang: harSkrivetilgang(saksbehandler),
         };
     }, [saksbehandler]);

--- a/src/frontend/hooks/useSaksbehandler.ts
+++ b/src/frontend/hooks/useSaksbehandler.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+
+import { useSaksbehandlerContext } from '../context/SaksbehandlerContext';
+import { harSkrivetilgang, harSuperbrukerTilgang, utledBehandlerRolle } from '../typer/saksbehandler';
+
+export function useSaksbehandler() {
+    const { saksbehandler } = useSaksbehandlerContext();
+
+    return useMemo(() => {
+        return {
+            ...saksbehandler,
+            rolle: utledBehandlerRolle(saksbehandler),
+            harSuperbrukertilgang: harSuperbrukerTilgang(saksbehandler),
+            harSkrivetilgang: harSkrivetilgang(saksbehandler),
+        };
+    }, [saksbehandler]);
+}

--- a/src/frontend/hooks/useTrackTidsbrukPåSide.ts
+++ b/src/frontend/hooks/useTrackTidsbrukPåSide.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { useAppContext } from '../context/AppContext';
+import { useSaksbehandler } from './useSaksbehandler';
 import { hentSideFraUrl } from '../sider/Fagsak/Behandling/Sider/sider';
 import type { IBehandling } from '../typer/behandling';
 import type { IMinimalFagsak } from '../typer/fagsak';
@@ -8,9 +8,10 @@ import { hentSideHref } from '../utils/miljø';
 import { sendTilUmami } from '../utils/umami';
 
 export const useTrackTidsbrukPåSide = (fagsak: IMinimalFagsak, behandling: IBehandling) => {
+    const saksbehandler = useSaksbehandler();
+
     const sidevisning = hentSideHref(location.pathname);
     const sideId = hentSideFraUrl(sidevisning);
-    const { hentSaksbehandlerRolle } = useAppContext();
 
     useEffect(() => {
         const startTid = new Date();
@@ -37,7 +38,7 @@ export const useTrackTidsbrukPåSide = (fagsak: IMinimalFagsak, behandling: IBeh
                 behandlingStatus: behandling.status,
                 resultat: behandling.resultat,
                 stegTilstand: behandling.stegTilstand,
-                behandlerRolle: hentSaksbehandlerRolle(),
+                behandlerRolle: saksbehandler.rolle,
                 startTid: startTid,
                 sluttTid: sluttTid,
                 intervallISekunder: intervallISekunder,

--- a/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
@@ -1,14 +1,16 @@
-import type { PropsWithChildren } from 'react';
-import * as React from 'react';
+import { Component, type PropsWithChildren, type ReactNode } from 'react';
+import React from 'react';
 
 import * as Sentry from '@sentry/browser';
 
 import { XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button, ErrorMessage, Heading, HStack, VStack } from '@navikt/ds-react';
-import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 interface Props extends PropsWithChildren {
-    autentisertSaksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
 }
 
 interface State {
@@ -16,7 +18,7 @@ interface State {
     error?: Error;
 }
 
-export class ErrorBoundary extends React.Component<Props, State> {
+export class ErrorBoundary extends Component<Props, State> {
     public constructor(props: Props) {
         super(props);
         this.state = { hasError: false };
@@ -32,10 +34,8 @@ export class ErrorBoundary extends React.Component<Props, State> {
         console.error(error, info);
         if (Sentry.isEnabled()) {
             Sentry.setUser({
-                username: this.props.autentisertSaksbehandler
-                    ? this.props.autentisertSaksbehandler.displayName
-                    : 'Ukjent bruker',
-                email: this.props.autentisertSaksbehandler ? this.props.autentisertSaksbehandler.email : 'Ukjent email',
+                username: this.props.saksbehandler?.displayName ?? 'Ukjent navn',
+                email: this.props.saksbehandler?.email ?? 'Ukjent e-post',
             });
             Sentry.withScope(scope => {
                 Object.keys(info).forEach(key => {
@@ -43,11 +43,29 @@ export class ErrorBoundary extends React.Component<Props, State> {
                     Sentry.captureException(error);
                 });
             });
-            this.visSentryDialog();
         }
     }
 
-    render(): React.ReactNode {
+    private visSentryDialog() {
+        if (Sentry.isEnabled()) {
+            Sentry.showReportDialog({
+                title: 'En feil har oppstått i vedtaksløsningen',
+                subtitle: '',
+                subtitle2: 'Teamet har fått beskjed. Dersom du ønsker å hjelpe oss, si litt om hva som skjedde.',
+                user: {
+                    name: this.props.saksbehandler?.displayName ?? 'Ukjent navn',
+                    email: this.props.saksbehandler?.email ?? 'Ukjent e-post',
+                },
+                labelName: 'NAVN',
+                labelComments: 'HVA SKJEDDE?',
+                labelClose: 'Lukk',
+                labelSubmit: 'Send inn rapport',
+                successMessage: 'Rapport er innsendt',
+            });
+        }
+    }
+
+    render(): ReactNode {
         if (this.state.hasError) {
             return (
                 <VStack height={'100vh'} align={'center'} justify={'center'}>
@@ -82,23 +100,9 @@ export class ErrorBoundary extends React.Component<Props, State> {
         }
         return this.props.children;
     }
+}
 
-    private visSentryDialog() {
-        if (Sentry.isEnabled()) {
-            Sentry.showReportDialog({
-                title: 'En feil har oppstått i vedtaksløsningen',
-                subtitle: '',
-                subtitle2: 'Teamet har fått beskjed. Dersom du ønsker å hjelpe oss, si litt om hva som skjedde.',
-                user: {
-                    name: this.props.autentisertSaksbehandler?.displayName,
-                    email: this.props.autentisertSaksbehandler?.email,
-                },
-                labelName: 'NAVN',
-                labelComments: 'HVA SKJEDDE?',
-                labelClose: 'Lukk',
-                labelSubmit: 'Send inn rapport',
-                successMessage: 'Rapport er innsendt',
-            });
-        }
-    }
+export function ErrorBoundaryMedSaksbehandler({ children }: PropsWithChildren) {
+    const saksbehandler = useSaksbehandler();
+    return <ErrorBoundary saksbehandler={saksbehandler}>{children}</ErrorBoundary>;
 }

--- a/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
@@ -3,17 +3,15 @@ import React from 'react';
 import { Header } from '@navikt/familie-header';
 
 import FagsakDeltagerSøk from './FagsakDeltagerSøk';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 
-interface IHeaderMedSøkProps {
-    brukerNavn?: string;
-    brukerEnhet?: string;
-}
+export function HeaderMedSøk() {
+    const saksbehandler = useSaksbehandler();
 
-export const HeaderMedSøk: React.FunctionComponent<IHeaderMedSøkProps> = ({ brukerNavn, brukerEnhet }) => {
     return (
         <Header
-            tittel="Nav Barnetrygd"
-            brukerinfo={{ navn: brukerNavn ?? 'Ukjent', enhet: brukerEnhet ?? 'Ukjent' }}
+            tittel={'Nav Barnetrygd'}
+            brukerinfo={{ navn: saksbehandler.displayName, enhet: saksbehandler.enhet }}
             brukerPopoverItems={[{ name: 'Logg ut', href: `${window.origin}/auth/logout` }]}
             eksterneLenker={[
                 {
@@ -31,4 +29,4 @@ export const HeaderMedSøk: React.FunctionComponent<IHeaderMedSøkProps> = ({ br
             <FagsakDeltagerSøk />
         </Header>
     );
-};
+}

--- a/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
@@ -4,8 +4,8 @@ import { useController, useFormContext } from 'react-hook-form';
 
 import { Select } from '@navikt/ds-react';
 
-import { useAuthContext } from '../../../../context/AuthContext';
 import { useFeatureToggles } from '../../../../hooks/useFeatureToggles';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { FagsakType } from '../../../../typer/fagsak';
 import { FeatureToggle } from '../../../../typer/featureToggles';
 import { erProd } from '../../../../utils/miljø';
@@ -41,7 +41,7 @@ interface Props {
 }
 
 export function FagsaktypeFelt({ readOnly }: Props) {
-    const { innloggetSaksbehandler } = useAuthContext();
+    const saksbehandler = useSaksbehandler();
     const toggles = useFeatureToggles();
     const { harNormalFagsak, harBarnEnsligMindreårigFagsak } = useFagsakerContext();
 
@@ -56,9 +56,8 @@ export function FagsaktypeFelt({ readOnly }: Props) {
     const options = fagsakTypeOptions
         .filter(option => {
             if (option.value === FagsakType.SKJERMET_BARN) {
-                const groups = innloggetSaksbehandler?.groups ?? [];
                 const aktuellGruppe = erProd() ? SKJERMET_BARN_GRUPPE.PROD : SKJERMET_BARN_GRUPPE.DEV;
-                const harTilgang = groups.some(group => group === aktuellGruppe);
+                const harTilgang = saksbehandler.groups.some(group => group === aktuellGruppe);
                 return harTilgang && toggles[FeatureToggle.tillattBehandlingAvSkjermetBarn];
             }
             return true;

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
@@ -3,8 +3,6 @@ import React, { type PropsWithChildren } from 'react';
 import { Route, Routes } from 'react-router';
 import { describe, expect, test } from 'vitest';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import { Behandlingslinje } from './Behandlingslinje';
 import { BehandlingProvider } from '../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { HentOgSettBehandlingProvider } from '../../sider/Fagsak/Behandling/context/HentOgSettBehandlingContext';
@@ -19,9 +17,10 @@ import { render, TestProviders } from '../../testutils/testrender';
 import type { IBehandling } from '../../typer/behandling';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import type { IPersonInfo } from '../../typer/person';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 interface WrapperProps extends PropsWithChildren {
-    saksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
     fagsak?: IMinimalFagsak;
     bruker?: IPersonInfo;
     behandling?: IBehandling;

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
@@ -6,7 +6,7 @@ import { FileTextIcon, HouseIcon, MagnifyingGlassIcon } from '@navikt/aksel-icon
 import { Box, Button, HStack } from '@navikt/ds-react';
 
 import { Behandlingsmeny } from './Meny/Behandlingsmeny';
-import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
@@ -16,9 +16,9 @@ function lagAktivFaneStyle(fanenavn: string, pathname: string) {
 }
 
 export function Behandlingslinje() {
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
     const { fagsak } = useFagsakContext();
     const { pathname } = useLocation();
+    const saksbehandler = useSaksbehandler();
 
     return (
         <Box borderWidth={'0 0 1 0'} borderColor={'neutral-subtle'}>
@@ -55,7 +55,7 @@ export function Behandlingslinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {harInnloggetSaksbehandlerSkrivetilgang() && <Behandlingsmeny />}
+                {saksbehandler.harSkrivetilgang && <Behandlingsmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
@@ -3,8 +3,6 @@ import React, { type PropsWithChildren } from 'react';
 import { Route, Routes } from 'react-router';
 import { describe, expect, test } from 'vitest';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import { Fagsaklinje } from './Fagsaklinje';
 import { BrukerProvider } from '../../sider/Fagsak/BrukerContext';
 import { FagsakProvider } from '../../sider/Fagsak/FagsakContext';
@@ -15,9 +13,10 @@ import { lagSaksbehandler } from '../../testutils/testdata/saksbehandlerTestdata
 import { render, TestProviders } from '../../testutils/testrender';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import type { IPersonInfo } from '../../typer/person';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 interface WrapperProps extends PropsWithChildren {
-    saksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
     fagsak?: IMinimalFagsak;
     bruker?: IPersonInfo;
 }

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
@@ -6,7 +6,7 @@ import { FileTextIcon, HouseIcon, MagnifyingGlassIcon } from '@navikt/aksel-icon
 import { Box, Button, HStack } from '@navikt/ds-react';
 
 import { Fagsakmeny } from './Meny/Fagsakmeny';
-import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
@@ -16,9 +16,9 @@ function lagAktivFaneStyle(fanenavn: string, pathname: string) {
 }
 
 export function Fagsaklinje() {
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
     const { fagsak } = useFagsakContext();
     const { pathname } = useLocation();
+    const saksbehandler = useSaksbehandler();
 
     return (
         <Box borderWidth={'0 0 1 0'} borderColor={'neutral-subtle'}>
@@ -55,7 +55,7 @@ export function Fagsaklinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {harInnloggetSaksbehandlerSkrivetilgang() && <Fagsakmeny />}
+                {saksbehandler.harSkrivetilgang && <Fagsakmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
@@ -7,7 +7,7 @@ import { Button, Fieldset, Modal, VStack } from '@navikt/ds-react';
 import { BegrunnelseField } from './BegrunnelseField';
 import { useEndreBehandlendeEnhetForm } from './useEndreBehandlendeEnhetForm';
 import { VelgNyEnhetField } from './VelgNyEnhetField';
-import { useAppContext } from '../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { BehandlingSteg, hentStegNummer } from '../../../../typer/behandling';
 
@@ -17,7 +17,7 @@ interface Props {
 
 export function EndreBehandlendeEnhetModal({ lukkModal }: Props) {
     const { behandling, vurderErLesevisning } = useBehandlingContext();
-    const { innloggetSaksbehandler } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const { form, onSubmit } = useEndreBehandlendeEnhetForm({ lukkModal });
 
@@ -31,7 +31,7 @@ export function EndreBehandlendeEnhetModal({ lukkModal }: Props) {
         if (
             steg &&
             hentStegNummer(steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK) &&
-            innloggetSaksbehandler?.navIdent !== behandling.totrinnskontroll?.saksbehandlerId
+            saksbehandler.navIdent !== behandling.totrinnskontroll?.saksbehandlerId
         ) {
             return false;
         } else {

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.test.tsx
@@ -1,6 +1,7 @@
 import React, { type PropsWithChildren } from 'react';
 
-import { describe, expect, vi, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { describe, expect } from 'vitest';
 
 import { ActionMenu } from '@navikt/ds-react';
 
@@ -11,34 +12,14 @@ import { useModal } from '../../../../hooks/useModal';
 import { BehandlingProvider } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { HentOgSettBehandlingProvider } from '../../../../sider/Fagsak/Behandling/context/HentOgSettBehandlingContext';
 import { FagsakProvider } from '../../../../sider/Fagsak/FagsakContext';
+import { server } from '../../../../testutils/mocks/node';
 import { lagBehandling } from '../../../../testutils/testdata/behandlingTestdata';
 import { lagFagsak } from '../../../../testutils/testdata/fagsakTestdata';
+import { lagSaksbehandler } from '../../../../testutils/testdata/saksbehandlerTestdata';
 import { render, TestProviders } from '../../../../testutils/testrender';
 import { BehandlingStatus, BehandlingSteg, type IBehandling } from '../../../../typer/behandling';
 import type { IMinimalFagsak } from '../../../../typer/fagsak';
-
-const { mockState } = vi.hoisted(() => ({
-    mockState: {
-        superbruker: false,
-    },
-}));
-
-vi.mock('../../../../context/AppContext', async () => {
-    const actual = await vi.importActual('../../../../context/AppContext');
-    const originalUseAppContext = (actual as { useAppContext: () => object }).useAppContext;
-
-    return {
-        ...actual,
-        useAppContext: () => ({
-            ...originalUseAppContext(),
-            harInnloggetSaksbehandlerSuperbrukerTilgang: () => mockState.superbruker,
-        }),
-    };
-});
-
-afterEach(() => {
-    mockState.superbruker = false;
-});
+import type { Saksbehandler } from '../../../../typer/saksbehandler';
 
 function ModalWrapper() {
     const { erModalÅpen } = useModal(ModalType.HENLEGG_BEHANDLING);
@@ -51,11 +32,17 @@ function ModalWrapper() {
 interface WrapperProps extends PropsWithChildren {
     fagsak?: IMinimalFagsak;
     behandling?: IBehandling;
+    saksbehandler?: Saksbehandler;
 }
 
-function Wrapper({ fagsak = lagFagsak(), behandling = lagBehandling(), children }: WrapperProps) {
+function Wrapper({
+    fagsak = lagFagsak(),
+    behandling = lagBehandling(),
+    saksbehandler = lagSaksbehandler(),
+    children,
+}: WrapperProps) {
     return (
-        <TestProviders>
+        <TestProviders saksbehandler={saksbehandler}>
             <FagsakProvider fagsak={fagsak}>
                 <HentOgSettBehandlingProvider>
                     <BehandlingProvider behandling={behandling}>
@@ -107,18 +94,29 @@ describe('HenleggBehandling', () => {
     });
 
     test('skal vise knapp selv om det er lesevisning og på et steg som ikke er henlegtbart hvis man er superbruker', async () => {
-        mockState.superbruker = true;
+        const saksbehandler = lagSaksbehandler({
+            groups: ['d21e00a4-969d-4b28-8782-dc818abfae65', '314fa714-f13c-4cdc-ac5c-e13ce08e241c'],
+        });
+
+        server.use(
+            http.get('/user/profile', () => {
+                return HttpResponse.json(saksbehandler);
+            })
+        );
 
         const { screen } = render(<HenleggBehandling />, {
-            wrapper: props => (
-                <Wrapper
-                    {...props}
-                    behandling={lagBehandling({
-                        status: BehandlingStatus.UTREDES,
-                        steg: BehandlingSteg.BESLUTTE_VEDTAK,
-                    })}
-                />
-            ),
+            wrapper: props => {
+                return (
+                    <Wrapper
+                        {...props}
+                        behandling={lagBehandling({
+                            status: BehandlingStatus.UTREDES,
+                            steg: BehandlingSteg.BESLUTTE_VEDTAK,
+                        })}
+                        saksbehandler={saksbehandler}
+                    />
+                );
+            },
         });
 
         const knapp = await screen.findByRole('menuitem', { name: 'Henlegg behandling' });

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.tsx
@@ -2,19 +2,20 @@ import React from 'react';
 
 import { ActionMenu } from '@navikt/ds-react';
 
-import { useAppContext } from '../../../../context/AppContext';
 import { ModalType } from '../../../../context/ModalContext';
 import { useModal } from '../../../../hooks/useModal';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { erPåHenleggbartSteg } from '../../../../typer/behandling';
 
 export function HenleggBehandling() {
-    const { harInnloggetSaksbehandlerSuperbrukerTilgang } = useAppContext();
     const { behandling, vurderErLesevisning } = useBehandlingContext();
     const { åpneModal } = useModal(ModalType.HENLEGG_BEHANDLING);
 
+    const saksbehandler = useSaksbehandler();
+
     const erLesevisning = vurderErLesevisning();
-    const harTilgangTilTekniskVedlikeholdHenleggelse = harInnloggetSaksbehandlerSuperbrukerTilgang();
+    const harTilgangTilTekniskVedlikeholdHenleggelse = saksbehandler.harSuperbrukertilgang;
 
     const kanHenlegge =
         harTilgangTilTekniskVedlikeholdHenleggelse || (!erLesevisning && erPåHenleggbartSteg(behandling.steg));

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/ÅrsakFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/ÅrsakFelt.tsx
@@ -5,14 +5,12 @@ import { useController, useFormContext } from 'react-hook-form';
 import { Select } from '@navikt/ds-react';
 
 import { HenleggBehandlingFormFields, type HenleggBehandlingFormValues } from './useHenleggBehandlingForm';
-import { useAppContext } from '../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { erPåHenleggbartSteg, henleggÅrsak, HenleggÅrsak } from '../../../../typer/behandling';
 
 export function ÅrsakFelt() {
     const { behandling } = useBehandlingContext();
-
-    const { harInnloggetSaksbehandlerSuperbrukerTilgang } = useAppContext();
 
     const { control } = useFormContext<HenleggBehandlingFormValues>();
 
@@ -22,7 +20,9 @@ export function ÅrsakFelt() {
         rules: { required: 'Årsak er påkrevd.' },
     });
 
-    const harTilgangTilTekniskVedlikeholdHenleggelse = harInnloggetSaksbehandlerSuperbrukerTilgang();
+    const saksbehandler = useSaksbehandler();
+
+    const harTilgangTilTekniskVedlikeholdHenleggelse = saksbehandler.harSuperbrukertilgang;
 
     const valgmuligheter = Object.values(HenleggÅrsak)
         .filter(årsak => årsak !== HenleggÅrsak.FØDSELSHENDELSE_UGYLDIG_UTFALL)

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -5,8 +5,8 @@ import type { ISkjema } from '@navikt/familie-skjema';
 
 import { OpprettBehandlingBehandlingstemaSelect } from './OpprettBehandlingBehandlingstemaSelect';
 import type { IOpprettBehandlingSkjemaFelter } from './useOpprettBehandling';
-import { useAppContext } from '../../../../context/AppContext';
 import { useFeatureToggles } from '../../../../hooks/useFeatureToggles';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import type { VisningBehandling } from '../../../../sider/Fagsak/Saksoversikt/visningBehandling';
 import type { ManuellJournalføringSkjemaFelter } from '../../../../sider/ManuellJournalføring/ManuellJournalføringContext';
 import type { IBehandling } from '../../../../typer/behandling';
@@ -100,7 +100,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
     manuellJournalfør = false,
     bruker = undefined,
 }) => {
-    const { harInnloggetSaksbehandlerSuperbrukerTilgang } = useAppContext();
+    const saksbehandler = useSaksbehandler();
     const toggles = useFeatureToggles();
     const aktivBehandling: VisningBehandling | undefined = minimalFagsak
         ? hentAktivBehandlingPåMinimalFagsak(minimalFagsak)
@@ -114,8 +114,8 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
         ? false
         : minimalFagsak.behandlinger.filter(behandling => !erBehandlingHenlagt(behandling.resultat)).length > 0 &&
           kanOppretteBehandling;
-    const kanOppretteTekniskEndring = kanOppretteBehandling && harInnloggetSaksbehandlerSuperbrukerTilgang();
-    const kanManueltKorrigereMedVedtaksbrev = harInnloggetSaksbehandlerSuperbrukerTilgang() ?? false;
+    const kanOppretteTekniskEndring = kanOppretteBehandling && saksbehandler.harSuperbrukertilgang;
+    const kanManueltKorrigereMedVedtaksbrev = saksbehandler.harSuperbrukertilgang ?? false;
     const kanOppretteTilbakekreving = !manuellJournalfør;
     const kanOppretteMigreringFraInfotrygd = !manuellJournalfør && kanOppretteBehandling;
     const erMigreringFraInfotrygd =

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling.ts
@@ -7,11 +7,11 @@ import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../context/AppContext';
 import { HentBarnetrygdbehandlingerQueryKeyFactory } from '../../../../hooks/useHentBarnetrygdbehandlinger';
 import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
 import { HentKlagebehandlingerQueryKeyFactory } from '../../../../hooks/useHentKlagebehandlinger';
 import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '../../../../hooks/useHentTilbakekrevingsbehandlinger';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { useBrukerContext } from '../../../../sider/Fagsak/BrukerContext';
 import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
 import type { IBehandling, IRestNyBehandling } from '../../../../typer/behandling';
@@ -42,7 +42,8 @@ export interface IOpprettBehandlingSkjemaFelter extends IOpprettBehandlingSkjema
 const useOpprettBehandling = (fagsakId: number, lukkModal: () => void, onOpprettTilbakekrevingSuccess: () => void) => {
     const { fagsak } = useFagsakContext();
     const { bruker } = useBrukerContext();
-    const { innloggetSaksbehandler } = useAppContext();
+
+    const saksbehandler = useSaksbehandler();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
 
@@ -235,7 +236,7 @@ const useOpprettBehandling = (fagsakId: number, lukkModal: () => void, onOpprett
                     underkategori: behandlingstema.verdi?.underkategori ?? null,
                     behandlingType: behandlingstype.verdi as Behandlingstype,
                     behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
-                    navIdent: innloggetSaksbehandler?.navIdent,
+                    navIdent: saksbehandler.navIdent,
                     nyMigreringsdato: erMigreringFraInfoTrygd
                         ? dateTilIsoDatoStringEllerUndefined(migreringsdato.verdi)
                         : undefined,

--- a/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.test.tsx
@@ -3,17 +3,17 @@ import React, { type PropsWithChildren } from 'react';
 import { describe, expect } from 'vitest';
 
 import { ActionMenu } from '@navikt/ds-react';
-import type { ISaksbehandler } from '@navikt/familie-typer';
 
 import { SendInformasjonsbrev } from './SendInformasjonsbrev';
 import { FagsakProvider } from '../../../../sider/Fagsak/FagsakContext';
 import { lagFagsak } from '../../../../testutils/testdata/fagsakTestdata';
 import { lagSaksbehandler } from '../../../../testutils/testdata/saksbehandlerTestdata';
 import { render, TestProviders } from '../../../../testutils/testrender';
+import type { Saksbehandler } from '../../../../typer/saksbehandler';
 
 interface WrapperProps extends PropsWithChildren {
     initialEntries?: [{ pathname: string }];
-    saksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
 }
 
 function Wrapper({

--- a/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
@@ -4,19 +4,19 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { ActionMenu } from '@navikt/ds-react';
 
-import { useAppContext } from '../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
 import { BehandlerRolle } from '../../../../typer/behandling';
 
 export function SendInformasjonsbrev() {
     const { fagsak } = useFagsakContext();
-    const { hentSaksbehandlerRolle } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const navigate = useNavigate();
     const location = useLocation();
 
     const erPåDokumentutsending = location.pathname.includes('dokumentutsending');
-    const erSaksbehandlerEllerHøyere = hentSaksbehandlerRolle() >= BehandlerRolle.SAKSBEHANDLER;
+    const erSaksbehandlerEllerHøyere = saksbehandler.rolle >= BehandlerRolle.SAKSBEHANDLER;
 
     if (erPåDokumentutsending || !erSaksbehandlerEllerHøyere) {
         return null;

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/LeggTilBarnKnapp.tsx
@@ -3,14 +3,14 @@ import * as React from 'react';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
-import { useAppContext } from '../../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
 import { useLeggTilBarnModalContext } from '../../../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 
 export function LeggTilBarnKnapp() {
     const { åpneModal } = useLeggTilBarnModalContext();
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
-    if (!harInnloggetSaksbehandlerSkrivetilgang()) {
+    if (!saksbehandler.harSkrivetilgang) {
         return null;
     }
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -18,7 +18,7 @@ import {
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
 import ØyeGrå from '../../../../../ikoner/ØyeGrå';
 import ØyeGrønn from '../../../../../ikoner/ØyeGrønn';
 import ØyeRød from '../../../../../ikoner/ØyeRød';
@@ -36,7 +36,7 @@ interface Props {
 
 export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props) {
     const { behandling, trinnPåBehandling } = useBehandlingContext();
-    const { innloggetSaksbehandler } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const [beslutning, settBeslutning] = React.useState<TotrinnskontrollBeslutning>(
         TotrinnskontrollBeslutning.IKKE_VURDERT
@@ -47,10 +47,10 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
 
     const totrinnskontroll = behandling.totrinnskontroll;
 
-    const saksbehandler = totrinnskontroll?.saksbehandler ?? 'UKJENT SAKSBEHANDLER';
+    const totrinnskontrollSaksbehandler = totrinnskontroll?.saksbehandler ?? 'UKJENT SAKSBEHANDLER';
     const opprettetTidspunkt = totrinnskontroll?.opprettetTidspunkt ?? undefined;
 
-    const egetVedtak = totrinnskontroll?.saksbehandlerId === innloggetSaksbehandler?.navIdent;
+    const egetVedtak = totrinnskontroll?.saksbehandlerId === saksbehandler.navIdent;
 
     return (
         <Fieldset
@@ -77,7 +77,7 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
                                         defaultString: 'UKJENT OPPRETTELSESTIDSPUNKT',
                                     })}
                                 </BodyShort>
-                                <BodyShort>{saksbehandler}</BodyShort>
+                                <BodyShort>{totrinnskontrollSaksbehandler}</BodyShort>
                             </div>
                             <Detail>Vedtaket er sendt til godkjenning</Detail>
                         </VStack>

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/useSkalViseTotrinnskontroll.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/useSkalViseTotrinnskontroll.ts
@@ -1,16 +1,14 @@
-import { useAppContext } from '../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { BehandlerRolle, BehandlingStatus } from '../../../../typer/behandling';
 import { useBehandlingContext } from '../context/BehandlingContext';
 
 export function useSkalViseTotrinnskontroll() {
     const { behandling } = useBehandlingContext();
-    const { hentSaksbehandlerRolle, innloggetSaksbehandler } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
-    const saksbehandlerrolle = hentSaksbehandlerRolle();
-    const egetVedtak = behandling.totrinnskontroll?.saksbehandlerId === innloggetSaksbehandler?.navIdent;
+    const erBeslutter = BehandlerRolle.BESLUTTER === saksbehandler.rolle;
+    const erEgetVedtak = behandling.totrinnskontroll?.saksbehandlerId === saksbehandler.navIdent;
+    const erPåFatterVedtak = behandling.status === BehandlingStatus.FATTER_VEDTAK;
 
-    return (
-        (BehandlerRolle.BESLUTTER === saksbehandlerrolle || egetVedtak) &&
-        behandling.status === BehandlingStatus.FATTER_VEDTAK
-    );
+    return (erBeslutter || erEgetVedtak) && erPåFatterVedtak;
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
@@ -8,7 +8,7 @@ import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import ValutakursTabellRad from './ValutakursTabellRad';
-import { useAppContext } from '../../../../../../../context/AppContext';
+import { useSaksbehandler } from '../../../../../../../hooks/useSaksbehandler';
 import {
     Behandlingstype,
     type IBehandling,
@@ -59,13 +59,15 @@ interface IProps {
 }
 
 const Valutakurser: React.FC<IProps> = ({ valutakurser, erValutakurserGyldige, åpenBehandling, visFeilmeldinger }) => {
-    const { harInnloggetSaksbehandlerSuperbrukerTilgang } = useAppContext();
     const { settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
     const { request } = useHttp();
     const [erGjenopprettAutomatiskeValutakurserModalÅpen, settErGjenopprettAutomatiskeValutakurserModalÅpen] =
         useState(false);
+
+    const saksbehandler = useSaksbehandler();
+
     const kanOverstyreAutomatiskeValutakurser =
-        åpenBehandling.type == Behandlingstype.TEKNISK_ENDRING && harInnloggetSaksbehandlerSuperbrukerTilgang();
+        åpenBehandling.type == Behandlingstype.TEKNISK_ENDRING && saksbehandler.harSuperbrukertilgang;
 
     const erLesevisning = vurderErLesevisning();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -13,8 +13,8 @@ import { useSammensattKontrollsakContext } from './SammensattKontrollsak/Sammens
 import { TilbakekrevingsvedtakMotregning } from './UlovfestetMotregning/TilbakekrevingsvedtakMotregning';
 import { BehandlingKorrigertAlert } from './Vedtak';
 import Vedtaksperioder from './Vedtaksperioder/Vedtaksperioder';
-import { useAppContext } from '../../../../../context/AppContext';
 import useDokument from '../../../../../hooks/useDokument';
+import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '../../../../../komponenter/Brevmottaker/BrevmottakereAlert';
 import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
 import {
@@ -36,7 +36,6 @@ interface Props {
 }
 
 export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandling, bruker }) => {
-    const { hentSaksbehandlerRolle } = useAppContext();
     const { vurderErLesevisning } = useBehandlingContext();
     const { hentForhåndsvisning, nullstillDokument, visDokumentModal, hentetDokument, settVisDokumentModal } =
         useDokument();
@@ -47,6 +46,8 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
     const { erSammensattKontrollsak } = useSammensattKontrollsakContext();
 
     const { oppdaterTilbakekrevingsvedtakMotregning } = useTilbakekrevingsvedtakMotregning(åpenBehandling);
+
+    const saksbehandler = useSaksbehandler();
 
     const erLesevisning = vurderErLesevisning();
 
@@ -71,15 +72,12 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
 
     const hentVedtaksbrev = () => {
         const vedtak = åpenBehandling.vedtak;
-        const rolle = hentSaksbehandlerRolle();
         const genererBrevUnderBehandling =
-            rolle &&
-            rolle > BehandlerRolle.VEILEDER &&
+            saksbehandler.rolle > BehandlerRolle.VEILEDER &&
             hentStegNummer(åpenBehandling.steg) < hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
 
         const genererBrevUnderBeslutning =
-            rolle &&
-            rolle === BehandlerRolle.BESLUTTER &&
+            saksbehandler.rolle === BehandlerRolle.BESLUTTER &&
             hentStegNummer(åpenBehandling.steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
 
         const httpMethod = genererBrevUnderBehandling || genererBrevUnderBeslutning ? 'POST' : 'GET';
@@ -92,15 +90,12 @@ export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandl
 
     const hentBrevForTilbakekrevingsvedtakMotregning = () => {
         const behandlingId = åpenBehandling.behandlingId;
-        const rolle = hentSaksbehandlerRolle();
         const genererBrevUnderBehandling =
-            rolle !== undefined &&
-            rolle > BehandlerRolle.VEILEDER &&
+            saksbehandler.rolle > BehandlerRolle.VEILEDER &&
             hentStegNummer(åpenBehandling.steg) < hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
 
         const genererBrevUnderBeslutning =
-            rolle !== undefined &&
-            rolle === BehandlerRolle.BESLUTTER &&
+            saksbehandler.rolle === BehandlerRolle.BESLUTTER &&
             hentStegNummer(åpenBehandling.steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
 
         const httpMethod = genererBrevUnderBehandling || genererBrevUnderBeslutning ? 'POST' : 'GET';

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -7,8 +7,8 @@ import { type Ressurs } from '@navikt/familie-typer';
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
 import useBehandlingssteg from './useBehandlingssteg';
 import { saksbehandlerHarKunLesevisning } from './utils';
-import { useAppContext } from '../../../../context/AppContext';
 import { useNavigerAutomatiskTilSideForBehandlingssteg } from '../../../../hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import type { BehandlingSteg, IBehandling, ISettPåVent } from '../../../../typer/behandling';
 import { BehandlerRolle, BehandlingStatus, Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
 import { harTilgangTilEnhet } from '../../../../typer/enhet';
@@ -67,12 +67,7 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         sendTilBeslutterNesteOnClick,
     } = useBehandlingssteg(settBehandlingRessurs, behandling);
 
-    const {
-        harInnloggetSaksbehandlerSkrivetilgang,
-        harInnloggetSaksbehandlerSuperbrukerTilgang,
-        innloggetSaksbehandler,
-        hentSaksbehandlerRolle,
-    } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const location = useLocation();
     const [trinnPåBehandling, settTrinnPåBehandling] = React.useState<{ [sideId: string]: ITrinn }>({});
@@ -139,8 +134,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
             return true;
         }
 
-        const innloggetSaksbehandlerSkrivetilgang = harInnloggetSaksbehandlerSkrivetilgang();
-        const saksbehandlerHarSuperbrukerRolle = harInnloggetSaksbehandlerSuperbrukerTilgang();
         const behandlingsårsak = åpenBehandlingData?.årsak;
         const behandlingsårsakErÅpenForAlleMedTilgangTilÅOppretteÅrsak =
             behandlingsårsak === BehandlingÅrsak.TEKNISK_ENDRING ||
@@ -148,16 +141,16 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
 
         const saksbehandlerHarTilgangTilEnhet =
             behandlingsårsakErÅpenForAlleMedTilgangTilÅOppretteÅrsak ||
-            saksbehandlerHarSuperbrukerRolle ||
+            saksbehandler.harSuperbrukertilgang ||
             harTilgangTilEnhet(
                 åpenBehandlingData?.arbeidsfordelingPåBehandling.behandlendeEnhetId ?? '',
-                innloggetSaksbehandler?.groups ?? []
+                saksbehandler.groups
             );
 
         const steg = hentStegPåÅpenBehandling();
 
         return saksbehandlerHarKunLesevisning(
-            innloggetSaksbehandlerSkrivetilgang,
+            saksbehandler.harSkrivetilgang,
             saksbehandlerHarTilgangTilEnhet,
             steg,
             sjekkTilgangTilEnhet
@@ -169,8 +162,8 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
 
     const kanBeslutteVedtak =
         behandling.status === BehandlingStatus.FATTER_VEDTAK &&
-        BehandlerRolle.BESLUTTER === hentSaksbehandlerRolle() &&
-        innloggetSaksbehandler?.email !== behandling.endretAv;
+        BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
+        saksbehandler.email !== behandling.endretAv;
 
     const erMigreringsbehandling = behandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
 

--- a/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
@@ -12,6 +12,7 @@ import { useBehandlingIdParam } from '../../../../hooks/useBehandlingIdParam';
 import { useFagsak } from '../../../../hooks/useFagsak';
 import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
 import { HentHistorikkinnslagQueryKeyFactory } from '../../../../hooks/useHentHistorikkinnslag';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { BehandlerRolle, type IBehandling } from '../../../../typer/behandling';
 import { obfuskerBehandling } from '../../../../utils/obfuskerData';
 
@@ -23,9 +24,10 @@ interface HentOgSettBehandlingContextValue {
 const HentOgSettBehandlingContext = createContext<HentOgSettBehandlingContextValue | undefined>(undefined);
 
 export function HentOgSettBehandlingProvider({ children }: PropsWithChildren) {
-    const { skalObfuskereData, hentSaksbehandlerRolle } = useAppContext();
+    const { skalObfuskereData } = useAppContext();
     const { request } = useHttp();
 
+    const saksbehandler = useSaksbehandler();
     const fagsak = useFagsak();
     const behandlingIdParam = useBehandlingIdParam();
 
@@ -62,7 +64,7 @@ export function HentOgSettBehandlingProvider({ children }: PropsWithChildren) {
         privatSettBehandlingRessurs(byggTomRessurs());
 
         const requestBasertPåBehandlerRolle = () => {
-            if (hentSaksbehandlerRolle() === BehandlerRolle.BESLUTTER) {
+            if (saksbehandler.rolle === BehandlerRolle.BESLUTTER) {
                 return request<void, IBehandling>({
                     method: 'PUT',
                     url: `/familie-ba-sak/api/behandlinger/${behandlingIdParam}/oppdatert-valutakurs`,

--- a/src/frontend/sider/Fagsak/Behandling/context/useBehandlingssteg.ts
+++ b/src/frontend/sider/Fagsak/Behandling/context/useBehandlingssteg.ts
@@ -6,8 +6,8 @@ import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../context/AppContext';
 import { useFagsakId } from '../../../../hooks/useFagsakId';
+import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import { BehandlingResultat, Behandlingstype, BehandlingÅrsak, type IBehandling } from '../../../../typer/behandling';
 import { defaultFunksjonellFeil } from '../../../../typer/feilmeldinger';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../typer/vedtaksperiode';
@@ -17,7 +17,7 @@ const useBehandlingssteg = (
     behandling: IBehandling
 ) => {
     const { request } = useHttp();
-    const { innloggetSaksbehandler } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const fagsakId = useFagsakId();
     const navigate = useNavigate();
@@ -126,7 +126,7 @@ const useBehandlingssteg = (
                 method: 'POST',
                 url: `/familie-ba-sak/api/behandlinger/${
                     behandling?.behandlingId
-                }/steg/send-til-beslutter?behandlendeEnhet=${innloggetSaksbehandler?.enhet ?? '9999'}`,
+                }/steg/send-til-beslutter?behandlendeEnhet=${saksbehandler.enhet ?? '9999'}`,
             }).then((response: Ressurs<IBehandling>) => {
                 settSubmitRessurs(response);
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -17,8 +17,8 @@ import {
 import FritekstAvsnitt from './FritekstAvsnitt/FritekstAvsnitt';
 import KanSøkeSkjema from './KanSøke/KanSøkeSkjema';
 import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
-import { useAppContext } from '../../../context/AppContext';
 import { useFeatureToggles } from '../../../hooks/useFeatureToggles';
+import { useSaksbehandler } from '../../../hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '../../../komponenter/Brevmottaker/BrevmottakereAlert';
 import { LeggTilBarnModal } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
 import { LeggTilBarnModalContextProvider } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
@@ -86,7 +86,8 @@ export function DokumentutsendingSkjema() {
         brukerHarUtenlandskAdresse,
         dokumentÅrsaker,
     } = useDokumentutsendingContext();
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
+
+    const saksbehandler = useSaksbehandler();
     const toggles = useFeatureToggles();
 
     const { manuelleBrevmottakerePåFagsak } = useManuelleBrevmottakerePåFagsakContext();
@@ -152,7 +153,7 @@ export function DokumentutsendingSkjema() {
         }
     };
 
-    const erLesevisning = !harInnloggetSaksbehandlerSkrivetilgang();
+    const erLesevisning = !saksbehandler.harSkrivetilgang;
 
     function onLeggTilBarn(barn: IBarnMedOpplysninger) {
         if (skjema.felter.årsak.verdi === DokumentÅrsakPerson.DELT_BOSTED) {
@@ -241,7 +242,7 @@ export function DokumentutsendingSkjema() {
                                     visFeilmeldinger={skjema.visFeilmeldinger}
                                     settVisFeilmeldinger={settVisfeilmeldinger}
                                     manuelleBrevmottakere={manuelleBrevmottakerePåFagsak}
-                                    vurderErLesevisning={() => !harInnloggetSaksbehandlerSkrivetilgang()}
+                                    vurderErLesevisning={() => !saksbehandler.harSkrivetilgang}
                                 />
                                 {!erLesevisning && <LeggTilBarnKnapp />}
                             </>

--- a/src/frontend/sider/Fagsak/Dokumentutsending/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/LeggTilBarnKnapp.tsx
@@ -3,14 +3,14 @@ import * as React from 'react';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
-import { useAppContext } from '../../../context/AppContext';
+import { useSaksbehandler } from '../../../hooks/useSaksbehandler';
 import { useLeggTilBarnModalContext } from '../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
 
 export function LeggTilBarnKnapp() {
     const { åpneModal } = useLeggTilBarnModalContext();
-    const { harInnloggetSaksbehandlerSkrivetilgang } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
-    if (!harInnloggetSaksbehandlerSkrivetilgang()) {
+    if (!saksbehandler.harSkrivetilgang) {
         return null;
     }
 

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -11,7 +11,7 @@ import { FagsakLenkepanel, SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import { GjennomførValutajusteringKnapp } from './GjennomførValutajusteringKnapp';
 import Utbetalinger from './Utbetalinger';
 import type { VisningBehandling } from './visningBehandling';
-import { useAppContext } from '../../../context/AppContext';
+import { useSaksbehandler } from '../../../hooks/useSaksbehandler';
 import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingStatus, erBehandlingHenlagt } from '../../../typer/behandling';
 import { behandlingKategori, BehandlingKategori, behandlingUnderkategori } from '../../../typer/behandlingstema';
@@ -27,7 +27,7 @@ const StyledAlert = styled(Alert)`
 
 export function Saksoversikt() {
     const { fagsak } = useFagsakContext();
-    const { harInnloggetSaksbehandlerSuperbrukerTilgang } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const iverksatteBehandlinger = fagsak.behandlinger.filter(
         (behandling: VisningBehandling) =>
@@ -118,7 +118,7 @@ export function Saksoversikt() {
         <Box maxWidth="70rem" marginBlock="space-40" marginInline="space-64">
             <Heading size="large" level="1" children="Saksoversikt" />
 
-            {harInnloggetSaksbehandlerSuperbrukerTilgang() && fagsak.løpendeKategori === BehandlingKategori.EØS && (
+            {saksbehandler.harSuperbrukertilgang && fagsak.løpendeKategori === BehandlingKategori.EØS && (
                 <GjennomførValutajusteringKnapp fagsakId={fagsak.id} />
             )}
 

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -11,8 +11,8 @@ import { hentDataFraRessurs, type IDokumentInfo, Journalstatus, type Ressurs } f
 import { byggFeiletRessurs, byggHenterRessurs, byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useKlageApi } from '../../api/useKlageApi';
-import { useAppContext } from '../../context/AppContext';
 import useDokument from '../../hooks/useDokument';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import type { IOpprettBehandlingSkjemaBase } from '../../komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling';
 import { Behandlingstype, BehandlingÅrsak } from '../../typer/behandling';
 import type { IBehandlingstema } from '../../typer/behandlingstema';
@@ -85,7 +85,7 @@ interface ManuellJournalføringContextValue {
 const ManuellJournalføringContext = createContext<ManuellJournalføringContextValue | undefined>(undefined);
 
 export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
-    const { innloggetSaksbehandler } = useAppContext();
+    const saksbehandler = useSaksbehandler();
 
     const navigate = useNavigate();
     const { request } = useHttp();
@@ -405,7 +405,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
                     method: 'POST',
                     url: `/familie-ba-sak/api/journalpost/${
                         dataForManuellJournalføring.data.journalpost.journalpostId
-                    }/journalfør/${oppgaveId}?journalfoerendeEnhet=${innloggetSaksbehandler?.enhet ?? '9999'}`,
+                    }/journalfør/${oppgaveId}?journalfoerendeEnhet=${saksbehandler.enhet ?? '9999'}`,
                     data: {
                         journalpostTittel: skjema.felter.journalpostTittel.verdi,
                         kategori: behandlingstema?.kategori ?? null,
@@ -448,7 +448,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
                                   ? BehandlingÅrsak.SØKNAD
                                   : nyBehandlingsårsak,
 
-                        navIdent: innloggetSaksbehandler?.navIdent ?? '',
+                        navIdent: saksbehandler.navIdent,
                         fagsakType: skjema.felter.fagsakType.verdi,
                         institusjon:
                             skjema.felter.samhandler && skjema.felter.samhandler.verdi?.orgNummer
@@ -515,7 +515,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
                                     : nyBehandlingsårsak === ''
                                       ? BehandlingÅrsak.SØKNAD
                                       : nyBehandlingsårsak,
-                            navIdent: innloggetSaksbehandler?.navIdent ?? '',
+                            navIdent: saksbehandler.navIdent,
                         },
                     },
                     (fagsakId: Ressurs<string>) => {
@@ -532,8 +532,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
 
     const erTilordnetInnloggetSaksbehandler = () =>
         dataForManuellJournalføring.status === RessursStatus.SUKSESS &&
-        innloggetSaksbehandler !== undefined &&
-        dataForManuellJournalføring.data.oppgave.tilordnetRessurs === innloggetSaksbehandler.navIdent;
+        dataForManuellJournalføring.data.oppgave.tilordnetRessurs === saksbehandler.navIdent;
 
     const erLesevisning = () => {
         return (

--- a/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
+++ b/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
@@ -6,15 +6,16 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useOppgavebenkContext } from './OppgavebenkContext';
 import type { IOppgaveFelt } from './oppgavefelter';
-import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import DatovelgerForGammelSkjemaløsning from '../../komponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
 import type { IPar } from '../../typer/common';
 import type { IsoDatoString } from '../../utils/dato';
 
 const FilterSkjema: React.FunctionComponent = () => {
-    const { innloggetSaksbehandler } = useAppContext();
     const { hentOppgaver, oppgaver, oppgaveFelter, settVerdiPåOppgaveFelt, tilbakestillOppgaveFelter, validerSkjema } =
         useOppgavebenkContext();
+
+    const saksbehandler = useSaksbehandler();
 
     function tilOppgaveFeltKomponent(oppgaveFelt: IOppgaveFelt) {
         switch (oppgaveFelt.filter?.type) {
@@ -49,7 +50,7 @@ const FilterSkjema: React.FunctionComponent = () => {
                             {oppgaveFelt.filter.nøkkelPar &&
                                 Object.values(oppgaveFelt.filter.nøkkelPar)
                                     .filter((par: IPar) =>
-                                        oppgaveFelt.erSynlig ? oppgaveFelt.erSynlig(par, innloggetSaksbehandler) : true
+                                        oppgaveFelt.erSynlig ? oppgaveFelt.erSynlig(par, saksbehandler) : true
                                     )
                                     .map((par: IPar) => {
                                         return (

--- a/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
@@ -144,7 +144,7 @@ const OppgaveList: React.FunctionComponent = () => {
                             <Table.DataCell>
                                 <OppgavelisteSaksbehandler
                                     oppgave={rad.tilordnetRessurs.oppg}
-                                    innloggetSaksbehandler={rad.tilordnetRessurs.innloggetSaksbehandler}
+                                    saksbehandler={rad.tilordnetRessurs.saksbehandler}
                                 />
                             </Table.DataCell>
                             <Table.DataCell>

--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -15,6 +15,7 @@ import { type IOppgaveRad, Sorteringsnøkkel, sorterEtterNøkkel } from './utils
 import { mapIOppgaverTilOppgaveRad } from './utils';
 import { useFagsakApi } from '../../api/useFagsakApi';
 import { useAppContext } from '../../context/AppContext';
+import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { AlertType, ToastTyper } from '../../komponenter/Toast/typer';
 import type { IMinimalFagsak } from '../../typer/fagsak';
 import { FagsakStatus } from '../../typer/fagsak';
@@ -51,8 +52,9 @@ interface OppgavebenkContextValue {
 const OppgavebenkContext = createContext<OppgavebenkContextValue | undefined>(undefined);
 
 export const OppgavebenkProvider = (props: PropsWithChildren) => {
+    const { settToast } = useAppContext();
+    const saksbehandler = useSaksbehandler();
     const navigate = useNavigate();
-    const { innloggetSaksbehandler, settToast } = useAppContext();
     const { request } = useHttp();
 
     const [hentOppgaverVedSidelast, settHentOppgaverVedSidelast] = useState(true);
@@ -60,11 +62,11 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
 
     const [oppgaver, settOppgaver] = React.useState<Ressurs<IHentOppgaveDto>>(byggTomRessurs<IHentOppgaveDto>());
 
-    const [oppgaveFelter, settOppgaveFelter] = useState<IOppgaveFelter>(initialOppgaveFelter(innloggetSaksbehandler));
+    const [oppgaveFelter, settOppgaveFelter] = useState<IOppgaveFelter>(initialOppgaveFelter(saksbehandler));
 
     const oppgaverader: IOppgaveRad[] = useMemo(() => {
         return oppgaver.status === RessursStatus.SUKSESS && oppgaver.data.oppgaver.length > 0
-            ? mapIOppgaverTilOppgaveRad(oppgaver.data.oppgaver, innloggetSaksbehandler)
+            ? mapIOppgaverTilOppgaveRad(oppgaver.data.oppgaver, saksbehandler)
             : [];
     }, [oppgaver]);
 
@@ -100,11 +102,11 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
     };
 
     useEffect(() => {
-        settOppgaveFelter(initialOppgaveFelter(innloggetSaksbehandler));
-    }, [innloggetSaksbehandler]);
+        settOppgaveFelter(initialOppgaveFelter(saksbehandler));
+    }, [saksbehandler]);
 
     useEffect(() => {
-        if (hentOppgaverVedSidelast && innloggetSaksbehandler) {
+        if (hentOppgaverVedSidelast) {
             if (
                 Object.values(oppgaveFelter).filter(
                     (oppgaveFelt: IOppgaveFelt) =>
@@ -182,7 +184,7 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
 
     const tilbakestillOppgaveFelter = () => {
         tilbakestillOppgaveFeltILocalStorage();
-        settOppgaveFelter(initialOppgaveFelter(innloggetSaksbehandler));
+        settOppgaveFelter(initialOppgaveFelter(saksbehandler));
     };
 
     const { hentFagsakerForPerson } = useFagsakApi();
@@ -347,7 +349,7 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
             hentOppgaveFelt('tildeltEnhetsnr').filter?.selectedValue,
             hentOppgaveFelt('fristFerdigstillelse').filter?.selectedValue,
             hentOppgaveFelt('opprettetTidspunkt').filter?.selectedValue,
-            saksbehandlerFilter === SaksbehandlerFilter.INNLOGGET ? innloggetSaksbehandler?.navIdent : undefined,
+            saksbehandlerFilter === SaksbehandlerFilter.INNLOGGET ? saksbehandler.navIdent : undefined,
             tildeltRessurs
         ).then((oppgaverRessurs: Ressurs<IHentOppgaveDto>) => {
             settOppgaver(oppgaverRessurs);

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
@@ -66,7 +66,7 @@ const OppgavelisteSaksbehandler: React.FunctionComponent<IOppgavelisteSaksbehand
                         const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
 
                         if (!brukerident || (brukerident && (await sjekkTilgang(brukerident)))) {
-                            fordelOppgave(oppgave, saksbehandler?.navIdent);
+                            fordelOppgave(oppgave, saksbehandler.navIdent);
                         }
                     }}
                     children={'Tildel meg'}

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
@@ -1,23 +1,20 @@
 import React, { useEffect, useRef } from 'react';
 
-import { Alert, BodyShort, Button, HGrid } from '@navikt/ds-react';
-import type { ISaksbehandler } from '@navikt/familie-typer';
+import { BodyShort, Button, HGrid } from '@navikt/ds-react';
 
 import { useOppgavebenkContext } from './OppgavebenkContext';
 import { useAppContext } from '../../context/AppContext';
 import type { IOppgave } from '../../typer/oppgave';
 import { OppgavetypeFilter } from '../../typer/oppgave';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 import { hentFnrFraOppgaveIdenter } from '../../utils/oppgave';
 
 interface IOppgavelisteSaksbehandler {
     oppgave: IOppgave;
-    innloggetSaksbehandler?: ISaksbehandler;
+    saksbehandler: Saksbehandler;
 }
 
-const OppgavelisteSaksbehandler: React.FunctionComponent<IOppgavelisteSaksbehandler> = ({
-    oppgave,
-    innloggetSaksbehandler,
-}) => {
+const OppgavelisteSaksbehandler: React.FunctionComponent<IOppgavelisteSaksbehandler> = ({ oppgave, saksbehandler }) => {
     const { fordelOppgave, tilbakestillFordelingPåOppgave } = useOppgavebenkContext();
     const { sjekkTilgang } = useAppContext();
     const oppgaveRef = useRef<IOppgave | null>(null);
@@ -28,10 +25,6 @@ const OppgavelisteSaksbehandler: React.FunctionComponent<IOppgavelisteSaksbehand
         }
         oppgaveRef.current = oppgave;
     }, [oppgave]);
-
-    if (innloggetSaksbehandler == null) {
-        return <Alert variant="error">Klarte ikke hente innlogget saksbehandler</Alert>;
-    }
 
     const oppgaveTypeErStøttet =
         [
@@ -73,7 +66,7 @@ const OppgavelisteSaksbehandler: React.FunctionComponent<IOppgavelisteSaksbehand
                         const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
 
                         if (!brukerident || (brukerident && (await sjekkTilgang(brukerident)))) {
-                            fordelOppgave(oppgave, innloggetSaksbehandler?.navIdent);
+                            fordelOppgave(oppgave, saksbehandler?.navIdent);
                         }
                     }}
                     children={'Tildel meg'}

--- a/src/frontend/sider/Oppgavebenk/oppgavefelter.ts
+++ b/src/frontend/sider/Oppgavebenk/oppgavefelter.ts
@@ -1,5 +1,4 @@
 import { Valideringsstatus } from '@navikt/familie-skjema';
-import type { ISaksbehandler } from '@navikt/familie-typer';
 
 import type { INøkkelPar, IPar } from '../../typer/common';
 import { hentPar } from '../../typer/common';
@@ -16,6 +15,7 @@ import {
     SaksbehandlerFilter,
     saksbehandlerFilter,
 } from '../../typer/oppgave';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
 enum FeltSortOrder {
     NONE = 'NONE',
@@ -38,7 +38,7 @@ export interface IOppgaveFelt {
     // TODO: midlertidig - ønsker å bruke FeltState og Skjema-hook
     valideringsstatus?: Valideringsstatus;
     feilmelding?: string;
-    erSynlig?: (par: IPar, innloggetSaksbehandler?: ISaksbehandler) => boolean;
+    erSynlig?: (par: IPar, saksbehandler: Saksbehandler) => boolean;
 }
 
 export interface IOppgaveFelter {
@@ -56,7 +56,7 @@ export interface IOppgaveFelter {
     tilordnetRessurs: IOppgaveFelt;
 }
 
-export const initialOppgaveFelter = (innloggetSaksbehandler?: ISaksbehandler): IOppgaveFelter => {
+export const initialOppgaveFelter = (saksbehandler: Saksbehandler): IOppgaveFelter => {
     const searchParams = JSON.parse(localStorage.getItem('oppgaveFeltVerdier') || '{}');
 
     return {
@@ -146,8 +146,8 @@ export const initialOppgaveFelter = (innloggetSaksbehandler?: ISaksbehandler): I
                 nøkkelPar: enhetFilter,
             },
             order: FeltSortOrder.NONE,
-            erSynlig: (par: IPar, innloggetSaksbehandler?: ISaksbehandler) => {
-                return harTilgangTilEnhet(par.id.replace('E', ''), innloggetSaksbehandler?.groups ?? []);
+            erSynlig: (par: IPar, saksbehandler: Saksbehandler) => {
+                return harTilgangTilEnhet(par.id.replace('E', ''), saksbehandler.groups);
             },
         },
         tilordnetRessurs: {
@@ -157,11 +157,11 @@ export const initialOppgaveFelter = (innloggetSaksbehandler?: ISaksbehandler): I
                 type: 'select',
                 selectedValue: hentPar(
                     searchParams['tilordnetRessurs']?.toString(),
-                    saksbehandlerFilter(innloggetSaksbehandler),
+                    saksbehandlerFilter(saksbehandler),
                     SaksbehandlerFilter.ALLE
                 ),
                 initialValue: SaksbehandlerFilter.ALLE,
-                nøkkelPar: saksbehandlerFilter(innloggetSaksbehandler),
+                nøkkelPar: saksbehandlerFilter(saksbehandler),
             },
             order: FeltSortOrder.NONE,
         },

--- a/src/frontend/sider/Oppgavebenk/utils.ts
+++ b/src/frontend/sider/Oppgavebenk/utils.ts
@@ -1,8 +1,7 @@
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import type { IPar } from '../../typer/common';
 import type { BehandlingstypeFilter, EnhetFilter, IOppgave, IOppgaveIdent } from '../../typer/oppgave';
 import { behandlingstypeFilter, enhetFilter } from '../../typer/oppgave';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 import { hentFnrFraOppgaveIdenter } from '../../utils/oppgave';
 
 export enum Sorteringsnøkkel {
@@ -21,7 +20,7 @@ export enum Sorteringsnøkkel {
 
 export interface IOppgaveRad extends Omit<IOppgave, 'tilordnetRessurs' | 'identer'> {
     ident: IOppgaveIdent[] | undefined;
-    tilordnetRessurs: { oppg: IOppgave; innloggetSaksbehandler?: ISaksbehandler };
+    tilordnetRessurs: { oppg: IOppgave; saksbehandler: Saksbehandler };
     handlinger: IOppgave;
 }
 
@@ -48,10 +47,7 @@ export const sorterEtterNøkkel = (a: IOppgaveRad, b: IOppgaveRad, sorteringsnø
     return 0;
 };
 
-export const mapIOppgaverTilOppgaveRad = (
-    oppgaver: IOppgave[],
-    innloggetSaksbehandler?: ISaksbehandler
-): IOppgaveRad[] =>
+export const mapIOppgaverTilOppgaveRad = (oppgaver: IOppgave[], saksbehandler: Saksbehandler): IOppgaveRad[] =>
     oppgaver.map((oppg: IOppgave) => {
         const enhet: IPar | undefined = enhetFilter[`E${oppg.tildeltEnhetsnr}` as EnhetFilter];
         return {
@@ -66,7 +62,7 @@ export const mapIOppgaverTilOppgaveRad = (
             beskrivelse: oppg.beskrivelse,
             opprettetTidspunkt: oppg.opprettetTidspunkt,
             prioritet: oppg.prioritet,
-            tilordnetRessurs: { oppg, innloggetSaksbehandler },
+            tilordnetRessurs: { oppg, saksbehandler },
             tildeltEnhetsnr: enhet ? enhet.navn : oppg.tildeltEnhetsnr,
             handlinger: oppg,
         };

--- a/src/frontend/testutils/mocks/handlers/handlers.ts
+++ b/src/frontend/testutils/mocks/handlers/handlers.ts
@@ -4,6 +4,7 @@ import { fagsakHandlers } from './fagsakHandlers';
 import { featureToggleHandlers } from './featureToggleHandlers';
 import { klageHandlers } from './klageHandlers';
 import { personHandlers } from './personHandlers';
+import { saksbehandlerHandlers } from './saksbehandlerHandlers';
 import { tilbakekrevingHandlers } from './tilbakekrevingHandlers';
 import { versionHandlers } from './versionHandlers';
 
@@ -16,4 +17,5 @@ export const handlers = [
     ...personHandlers,
     ...fagsakHandlers,
     ...ainntektHandlers,
+    ...saksbehandlerHandlers,
 ];

--- a/src/frontend/testutils/mocks/handlers/saksbehandlerHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/saksbehandlerHandlers.ts
@@ -1,0 +1,9 @@
+import { http, HttpResponse } from 'msw';
+
+import { lagSaksbehandler } from '../../testdata/saksbehandlerTestdata';
+
+export const saksbehandlerHandlers = [
+    http.get('/user/profile', () => {
+        return HttpResponse.json(lagSaksbehandler());
+    }),
+];

--- a/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
+++ b/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
@@ -1,8 +1,8 @@
-import { type ISaksbehandler } from '@navikt/familie-typer';
+import type { Saksbehandler } from '../../typer/saksbehandler';
 
-export function lagSaksbehandler(saksbehandler: Partial<ISaksbehandler> = {}): ISaksbehandler {
+export function lagSaksbehandler(saksbehandler: Partial<Saksbehandler> = {}): Saksbehandler {
     return {
-        displayName: 'Saksbehandler',
+        displayName: 'Sak Behandler',
         email: 'saksbehandler@nav.no',
         firstName: 'Sak',
         groups: ['d21e00a4-969d-4b28-8782-dc818abfae65'],

--- a/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
+++ b/src/frontend/testutils/testdata/saksbehandlerTestdata.ts
@@ -1,3 +1,6 @@
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import { BehandlerRolle } from '../../typer/behandling';
 import type { Saksbehandler } from '../../typer/saksbehandler';
 
 export function lagSaksbehandler(saksbehandler: Partial<Saksbehandler> = {}): Saksbehandler {
@@ -10,7 +13,24 @@ export function lagSaksbehandler(saksbehandler: Partial<Saksbehandler> = {}): Sa
         lastName: 'Behandler',
         enhet: '0001',
         navIdent: 'A1',
+        rolle: BehandlerRolle.SAKSBEHANDLER,
+        harSkrivetilgang: true,
+        harSuperbrukertilgang: false,
         ...saksbehandler,
+    };
+}
+
+export function lagISaksbehandler(iSaksbehandler: Partial<ISaksbehandler> = {}): ISaksbehandler {
+    return {
+        displayName: 'Sak Behandler',
+        email: 'saksbehandler@nav.no',
+        firstName: 'Sak',
+        groups: ['d21e00a4-969d-4b28-8782-dc818abfae65'],
+        identifier: '30987654321',
+        lastName: 'Behandler',
+        enhet: '0001',
+        navIdent: 'A1',
+        ...iSaksbehandler,
     };
 }
 

--- a/src/frontend/testutils/testrender.tsx
+++ b/src/frontend/testutils/testrender.tsx
@@ -1,20 +1,19 @@
-import React from 'react';
-import type { PropsWithChildren } from 'react';
+import React, { type PropsWithChildren } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, type RenderOptions, screen as rtlScreen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import { AppProvider } from '../context/AppContext';
 import { AuthContextProvider } from '../context/AuthContext';
 import { ModalProvider } from '../context/ModalContext';
-import { SaksbehandlerTestdata } from './testdata/saksbehandlerTestdata';
+import { lagSaksbehandler } from './testdata/saksbehandlerTestdata';
 import { HttpContextProvider } from '../context/HttpContext';
+import { SaksbehandlerProvider } from '../context/SaksbehandlerContext';
 import { FeatureTogglesProvider } from '../context/TogglesContext';
 import type { FeatureToggles } from '../typer/featureToggles';
+import type { Saksbehandler } from '../typer/saksbehandler';
 import { skruPåAlleToggles } from './mocks/handlers/featureToggleHandlers';
 
 function lagQueryClient() {
@@ -30,7 +29,7 @@ function lagQueryClient() {
 interface Props extends PropsWithChildren {
     queryClient?: QueryClient;
     initialEntries?: [{ pathname: string }];
-    saksbehandler?: ISaksbehandler;
+    saksbehandler?: Saksbehandler;
     fjernRessursSomLasterTimeout?: number;
     featureToggles?: FeatureToggles;
 }
@@ -38,25 +37,27 @@ interface Props extends PropsWithChildren {
 export function TestProviders({
     queryClient = lagQueryClient(), // Ny instans for hver test
     initialEntries = [{ pathname: '/' }],
-    saksbehandler = SaksbehandlerTestdata.lagSaksbehandler(),
+    saksbehandler = lagSaksbehandler(),
     fjernRessursSomLasterTimeout = 0,
     featureToggles = skruPåAlleToggles(),
     children,
 }: Props) {
     return (
-        <AuthContextProvider autentisertSaksbehandler={saksbehandler}>
-            <HttpContextProvider fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}>
-                <QueryClientProvider client={queryClient}>
-                    <FeatureTogglesProvider featureToggles={featureToggles}>
-                        <AppProvider>
-                            <ModalProvider>
-                                <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-                            </ModalProvider>
-                        </AppProvider>
-                    </FeatureTogglesProvider>
-                </QueryClientProvider>
-            </HttpContextProvider>
-        </AuthContextProvider>
+        <QueryClientProvider client={queryClient}>
+            <SaksbehandlerProvider saksbehandler={saksbehandler}>
+                <AuthContextProvider>
+                    <HttpContextProvider fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}>
+                        <FeatureTogglesProvider featureToggles={featureToggles}>
+                            <AppProvider>
+                                <ModalProvider>
+                                    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+                                </ModalProvider>
+                            </AppProvider>
+                        </FeatureTogglesProvider>
+                    </HttpContextProvider>
+                </AuthContextProvider>
+            </SaksbehandlerProvider>
+        </QueryClientProvider>
     );
 }
 

--- a/src/frontend/typer/oppgave.ts
+++ b/src/frontend/typer/oppgave.ts
@@ -1,5 +1,3 @@
-import type { ISaksbehandler } from '@navikt/familie-typer';
-
 import {
     type BehandlingKategori,
     type BehandlingUnderkategori,
@@ -10,6 +8,7 @@ import {
 } from './behandlingstema';
 import type { IPar } from './common';
 import type { INavnOgIdent, TilknyttetBehandling } from './manuell-journalføring';
+import type { Saksbehandler } from './saksbehandler';
 
 export interface IFinnOppgaveRequest {
     behandlingstema?: string;
@@ -92,10 +91,8 @@ export enum SaksbehandlerFilter {
     UFORDELTE = 'UFORDELTE',
 }
 
-export const saksbehandlerFilter = (
-    innloggetSaksbehandler: ISaksbehandler | undefined
-): Record<SaksbehandlerFilter, IPar> => ({
-    INNLOGGET: { id: 'INNLOGGET', navn: innloggetSaksbehandler?.displayName ?? 'INNLOGGET' },
+export const saksbehandlerFilter = (saksbehandler: Saksbehandler): Record<SaksbehandlerFilter, IPar> => ({
+    INNLOGGET: { id: 'INNLOGGET', navn: saksbehandler.displayName },
     ALLE: { id: 'ALLE', navn: 'Alle' },
     FORDELTE: { id: 'FORDELTE', navn: 'Fordelte' },
     UFORDELTE: { id: 'UFORDELTE', navn: 'Ufordelte' },

--- a/src/frontend/typer/saksbehandler.test.ts
+++ b/src/frontend/typer/saksbehandler.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { BehandlerRolle } from './behandling';
-import { utledBehandlerRolle, harSuperbrukerTilgang, harSkrivetilgang } from './saksbehandler';
+import { utledBehandlerRolle, harSuperbrukertilgang, harSkrivetilgang } from './saksbehandler';
 import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 import { erProd } from '../utils/miljø';
 
@@ -42,7 +42,7 @@ describe('Saksbehandler', () => {
         describe('harSuperbrukerTilgang', () => {
             it('skal returnere true hvis bruker har superbruker-gruppe', () => {
                 const saksbehandler = lagSaksbehandler({ groups: [devGrupper.superbruker] });
-                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
             });
         });
 
@@ -87,7 +87,7 @@ describe('Saksbehandler', () => {
         describe('harSuperbrukerTilgang', () => {
             it('skal returnere true for prod-superbruker', () => {
                 const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.superbruker] });
-                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
             });
         });
     });

--- a/src/frontend/typer/saksbehandler.test.ts
+++ b/src/frontend/typer/saksbehandler.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { BehandlerRolle } from './behandling';
-import { utledBehandlerRolle, harSuperbrukertilgang, harSkrivetilgang } from './saksbehandler';
-import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import {
+    utledBehandlerRolle,
+    harSuperbrukertilgang,
+    harSkrivetilgang,
+    mapISaksbehandlerTilSaksbehandler,
+} from './saksbehandler';
+import { lagISaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 import { erProd } from '../utils/miljø';
 
 vi.mock('../utils/miljø', () => ({
@@ -14,80 +19,132 @@ describe('Saksbehandler', () => {
         vi.resetAllMocks();
     });
 
-    describe('Når miljø ikke er prod (Dev/Preprod)', () => {
+    const devGrupper = {
+        veileder: '93a26831-9866-4410-927b-74ff51a9107c',
+        saksbehandler: 'd21e00a4-969d-4b28-8782-dc818abfae65',
+        beslutter: '9449c153-5a1e-44a7-84c6-7cc7a8867233',
+        superbruker: '314fa714-f13c-4cdc-ac5c-e13ce08e241c',
+        ukjent: 'en-tilfeldig-gruppe-id',
+    };
+
+    const prodGrupper = {
+        veileder: '199c2b39-e535-4ae8-ac59-8ccbee7991ae',
+        saksbehandler: '847e3d72-9dc1-41c3-80ff-f5d4acdd5d46',
+        beslutter: '7a271f87-39fb-468b-a9ee-6cf3c070f548',
+        superbruker: '9b8239c4-cca7-440b-b359-51a64e3f0f00',
+    };
+
+    describe('utledBehandlerRolle - ikke prod', () => {
         beforeEach(() => {
             vi.mocked(erProd).mockReturnValue(false);
         });
 
-        const devGrupper = {
-            veileder: '93a26831-9866-4410-927b-74ff51a9107c',
-            saksbehandler: 'd21e00a4-969d-4b28-8782-dc818abfae65',
-            beslutter: '9449c153-5a1e-44a7-84c6-7cc7a8867233',
-            superbruker: '314fa714-f13c-4cdc-ac5c-e13ce08e241c',
-            ukjent: 'en-tilfeldig-gruppe-id',
-        };
-
-        describe('utledBehandlerRolle', () => {
-            it('skal returnere høyeste rolle (BESLUTTER) ved flere grupper', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder, devGrupper.beslutter] });
-                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.BESLUTTER);
-            });
-
-            it('skal kaste feil hvis ingen gyldige grupper finnes', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.ukjent] });
-                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
-            });
+        it('skal returnere høyeste rolle (BESLUTTER) ved flere grupper', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.veileder, devGrupper.beslutter] });
+            expect(utledBehandlerRolle(iSaksbehandler)).toBe(BehandlerRolle.BESLUTTER);
         });
 
-        describe('harSuperbrukerTilgang', () => {
-            it('skal returnere true hvis bruker har superbruker-gruppe', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.superbruker] });
-                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
-            });
-        });
-
-        describe('harSkrivetilgang', () => {
-            it('skal returnere true for SAKSBEHANDLER', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.saksbehandler] });
-                expect(harSkrivetilgang(saksbehandler)).toBe(true);
-            });
-
-            it('skal returnere false for kun VEILEDER', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder] });
-                expect(harSkrivetilgang(saksbehandler)).toBe(false);
-            });
+        it('skal kaste feil hvis ingen gyldige grupper finnes', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.ukjent] });
+            expect(() => utledBehandlerRolle(iSaksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
         });
     });
 
-    describe('Når miljø ER prod', () => {
+    describe('utledBehandlerRolle - prod', () => {
         beforeEach(() => {
             vi.mocked(erProd).mockReturnValue(true);
         });
 
-        const prodGrupper = {
-            veileder: '199c2b39-e535-4ae8-ac59-8ccbee7991ae',
-            saksbehandler: '847e3d72-9dc1-41c3-80ff-f5d4acdd5d46',
-            beslutter: '7a271f87-39fb-468b-a9ee-6cf3c070f548',
-            superbruker: '9b8239c4-cca7-440b-b359-51a64e3f0f00',
-        };
-
-        describe('utledBehandlerRolle', () => {
-            it('skal returnere riktig rolle basert på prod-grupper', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.saksbehandler] });
-                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.SAKSBEHANDLER);
-            });
-
-            it('skal kaste feil hvis en bruker i prod kun har dev-grupper', () => {
-                const devVeilederGruppe = '93a26831-9866-4410-927b-74ff51a9107c';
-                const saksbehandler = lagSaksbehandler({ groups: [devVeilederGruppe] });
-                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
-            });
+        it('skal returnere riktig rolle basert på prod-grupper', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.saksbehandler] });
+            expect(utledBehandlerRolle(iSaksbehandler)).toBe(BehandlerRolle.SAKSBEHANDLER);
         });
 
-        describe('harSuperbrukerTilgang', () => {
-            it('skal returnere true for prod-superbruker', () => {
-                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.superbruker] });
-                expect(harSuperbrukertilgang(saksbehandler)).toBe(true);
+        it('skal kaste feil hvis en bruker i prod kun har dev-grupper', () => {
+            const devVeilederGruppe = '93a26831-9866-4410-927b-74ff51a9107c';
+            const iSaksbehandler = lagISaksbehandler({ groups: [devVeilederGruppe] });
+            expect(() => utledBehandlerRolle(iSaksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
+        });
+    });
+
+    describe('harSuperbrukerTilgang - ikke prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(false);
+        });
+
+        it('skal returnere true hvis bruker har superbruker-gruppe', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.superbruker] });
+            expect(harSuperbrukertilgang(iSaksbehandler)).toBe(true);
+        });
+    });
+
+    describe('harSuperbrukerTilgang - prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(true);
+        });
+
+        it('skal returnere true for prod-superbruker', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.superbruker] });
+            expect(harSuperbrukertilgang(iSaksbehandler)).toBe(true);
+        });
+    });
+
+    describe('harSkrivetilgang - ikke prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(false);
+        });
+
+        it('skal returnere true for SAKSBEHANDLER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.saksbehandler] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(true);
+        });
+
+        it('skal returnere false for kun VEILEDER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [devGrupper.veileder] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(false);
+        });
+    });
+
+    describe('harSkrivetilgang - prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(true);
+        });
+
+        it('skal returnere true for SAKSBEHANDLER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.saksbehandler] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(true);
+        });
+
+        it('skal returnere false for kun VEILEDER', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: [prodGrupper.veileder] });
+            expect(harSkrivetilgang(iSaksbehandler)).toBe(false);
+        });
+    });
+
+    describe('mapISaksbehandlerTilSaksbehandler', () => {
+        it('skal kaste feil hvis groups er undefined for ISaksbehandler', () => {
+            // Arrange
+            const iSaksbehandler = lagISaksbehandler({ groups: undefined });
+
+            // Act & assert
+            expect(() => mapISaksbehandlerTilSaksbehandler(iSaksbehandler)).toThrow(
+                'Finner ikke rolle til saksbehandler.'
+            );
+        });
+
+        it('skal bevare gruppene fra ISaksbehandler', () => {
+            const iSaksbehandler = lagISaksbehandler({ groups: ['93a26831-9866-4410-927b-74ff51a9107c'] });
+
+            // Act
+            const result = mapISaksbehandlerTilSaksbehandler(iSaksbehandler);
+
+            // Assert
+            expect(result).toEqual({
+                ...iSaksbehandler,
+                groups: ['93a26831-9866-4410-927b-74ff51a9107c'],
+                rolle: BehandlerRolle.VEILEDER,
+                harSkrivetilgang: false,
+                harSuperbrukertilgang: false,
             });
         });
     });

--- a/src/frontend/typer/saksbehandler.test.ts
+++ b/src/frontend/typer/saksbehandler.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { BehandlerRolle } from './behandling';
+import { utledBehandlerRolle, harSuperbrukerTilgang, harSkrivetilgang } from './saksbehandler';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { erProd } from '../utils/miljø';
+
+vi.mock('../utils/miljø', () => ({
+    erProd: vi.fn(),
+}));
+
+describe('Saksbehandler', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    describe('Når miljø ikke er prod (Dev/Preprod)', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(false);
+        });
+
+        const devGrupper = {
+            veileder: '93a26831-9866-4410-927b-74ff51a9107c',
+            saksbehandler: 'd21e00a4-969d-4b28-8782-dc818abfae65',
+            beslutter: '9449c153-5a1e-44a7-84c6-7cc7a8867233',
+            superbruker: '314fa714-f13c-4cdc-ac5c-e13ce08e241c',
+            ukjent: 'en-tilfeldig-gruppe-id',
+        };
+
+        describe('utledBehandlerRolle', () => {
+            it('skal returnere høyeste rolle (BESLUTTER) ved flere grupper', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder, devGrupper.beslutter] });
+                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.BESLUTTER);
+            });
+
+            it('skal kaste feil hvis ingen gyldige grupper finnes', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.ukjent] });
+                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
+            });
+        });
+
+        describe('harSuperbrukerTilgang', () => {
+            it('skal returnere true hvis bruker har superbruker-gruppe', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.superbruker] });
+                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+            });
+        });
+
+        describe('harSkrivetilgang', () => {
+            it('skal returnere true for SAKSBEHANDLER', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.saksbehandler] });
+                expect(harSkrivetilgang(saksbehandler)).toBe(true);
+            });
+
+            it('skal returnere false for kun VEILEDER', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [devGrupper.veileder] });
+                expect(harSkrivetilgang(saksbehandler)).toBe(false);
+            });
+        });
+    });
+
+    describe('Når miljø ER prod', () => {
+        beforeEach(() => {
+            vi.mocked(erProd).mockReturnValue(true);
+        });
+
+        const prodGrupper = {
+            veileder: '199c2b39-e535-4ae8-ac59-8ccbee7991ae',
+            saksbehandler: '847e3d72-9dc1-41c3-80ff-f5d4acdd5d46',
+            beslutter: '7a271f87-39fb-468b-a9ee-6cf3c070f548',
+            superbruker: '9b8239c4-cca7-440b-b359-51a64e3f0f00',
+        };
+
+        describe('utledBehandlerRolle', () => {
+            it('skal returnere riktig rolle basert på prod-grupper', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.saksbehandler] });
+                expect(utledBehandlerRolle(saksbehandler)).toBe(BehandlerRolle.SAKSBEHANDLER);
+            });
+
+            it('skal kaste feil hvis en bruker i prod kun har dev-grupper', () => {
+                const devVeilederGruppe = '93a26831-9866-4410-927b-74ff51a9107c';
+                const saksbehandler = lagSaksbehandler({ groups: [devVeilederGruppe] });
+                expect(() => utledBehandlerRolle(saksbehandler)).toThrow('Finner ikke rolle til saksbehandler.');
+            });
+        });
+
+        describe('harSuperbrukerTilgang', () => {
+            it('skal returnere true for prod-superbruker', () => {
+                const saksbehandler = lagSaksbehandler({ groups: [prodGrupper.superbruker] });
+                expect(harSuperbrukerTilgang(saksbehandler)).toBe(true);
+            });
+        });
+    });
+});

--- a/src/frontend/typer/saksbehandler.ts
+++ b/src/frontend/typer/saksbehandler.ts
@@ -24,11 +24,15 @@ function hentGruppeIdTilSuperbrukerRolle() {
 
 export interface Saksbehandler extends ISaksbehandler {
     groups: string[];
+    rolle: BehandlerRolle;
+    harSkrivetilgang: boolean;
+    harSuperbrukertilgang: boolean;
 }
 
-export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRolle {
+export function utledBehandlerRolle(iSaksbehandler: ISaksbehandler): BehandlerRolle {
     let rolle = BehandlerRolle.UKJENT;
-    saksbehandler.groups.forEach(id => {
+    const groups = iSaksbehandler.groups ?? [];
+    groups.forEach(id => {
         rolle = rolle < gruppeIdTilRolle(id) ? gruppeIdTilRolle(id) : rolle;
     });
     if (rolle === BehandlerRolle.UKJENT) {
@@ -37,11 +41,22 @@ export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRoll
     return rolle;
 }
 
-export function harSuperbrukertilgang(saksbehandler: Saksbehandler) {
-    return saksbehandler.groups.includes(hentGruppeIdTilSuperbrukerRolle());
+export function harSuperbrukertilgang(iSaksbehandler: ISaksbehandler) {
+    const groups = iSaksbehandler.groups ?? [];
+    return groups.includes(hentGruppeIdTilSuperbrukerRolle());
 }
 
-export function harSkrivetilgang(saksbehandler: Saksbehandler) {
-    const rolle = utledBehandlerRolle(saksbehandler);
+export function harSkrivetilgang(iSaksbehandler: ISaksbehandler) {
+    const rolle = utledBehandlerRolle(iSaksbehandler);
     return rolle >= BehandlerRolle.SAKSBEHANDLER;
+}
+
+export function mapISaksbehandlerTilSaksbehandler(iSaksbehandler: ISaksbehandler): Saksbehandler {
+    return {
+        ...iSaksbehandler,
+        groups: iSaksbehandler.groups ?? [],
+        rolle: utledBehandlerRolle(iSaksbehandler),
+        harSkrivetilgang: harSkrivetilgang(iSaksbehandler),
+        harSuperbrukertilgang: harSuperbrukertilgang(iSaksbehandler),
+    };
 }

--- a/src/frontend/typer/saksbehandler.ts
+++ b/src/frontend/typer/saksbehandler.ts
@@ -37,7 +37,7 @@ export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRoll
     return rolle;
 }
 
-export function harSuperbrukerTilgang(saksbehandler: Saksbehandler) {
+export function harSuperbrukertilgang(saksbehandler: Saksbehandler) {
     return saksbehandler.groups.includes(hentGruppeIdTilSuperbrukerRolle());
 }
 

--- a/src/frontend/typer/saksbehandler.ts
+++ b/src/frontend/typer/saksbehandler.ts
@@ -1,0 +1,47 @@
+import type { ISaksbehandler } from '@navikt/familie-typer';
+
+import { BehandlerRolle } from './behandling';
+import { erProd } from '../utils/miljø';
+
+function gruppeIdTilRolle(gruppeId: string) {
+    const rolleConfig = erProd()
+        ? new Map([
+              ['199c2b39-e535-4ae8-ac59-8ccbee7991ae', BehandlerRolle.VEILEDER],
+              ['847e3d72-9dc1-41c3-80ff-f5d4acdd5d46', BehandlerRolle.SAKSBEHANDLER],
+              ['7a271f87-39fb-468b-a9ee-6cf3c070f548', BehandlerRolle.BESLUTTER],
+          ])
+        : new Map([
+              ['93a26831-9866-4410-927b-74ff51a9107c', BehandlerRolle.VEILEDER],
+              ['d21e00a4-969d-4b28-8782-dc818abfae65', BehandlerRolle.SAKSBEHANDLER],
+              ['9449c153-5a1e-44a7-84c6-7cc7a8867233', BehandlerRolle.BESLUTTER],
+          ]);
+    return rolleConfig.get(gruppeId) ?? BehandlerRolle.UKJENT;
+}
+
+function hentGruppeIdTilSuperbrukerRolle() {
+    return erProd() ? '9b8239c4-cca7-440b-b359-51a64e3f0f00' : '314fa714-f13c-4cdc-ac5c-e13ce08e241c';
+}
+
+export interface Saksbehandler extends ISaksbehandler {
+    groups: string[];
+}
+
+export function utledBehandlerRolle(saksbehandler: Saksbehandler): BehandlerRolle {
+    let rolle = BehandlerRolle.UKJENT;
+    saksbehandler.groups.forEach(id => {
+        rolle = rolle < gruppeIdTilRolle(id) ? gruppeIdTilRolle(id) : rolle;
+    });
+    if (rolle === BehandlerRolle.UKJENT) {
+        throw new Error('Finner ikke rolle til saksbehandler.');
+    }
+    return rolle;
+}
+
+export function harSuperbrukerTilgang(saksbehandler: Saksbehandler) {
+    return saksbehandler.groups.includes(hentGruppeIdTilSuperbrukerRolle());
+}
+
+export function harSkrivetilgang(saksbehandler: Saksbehandler) {
+    const rolle = utledBehandlerRolle(saksbehandler);
+    return rolle >= BehandlerRolle.SAKSBEHANDLER;
+}

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -1,28 +1,7 @@
-import { erProd } from './miljø';
 import { Behandlingstype, BehandlingÅrsak, type IBehandling } from '../typer/behandling';
-import { BehandlerRolle } from '../typer/behandling';
 import type { IGrunnlagPerson } from '../typer/person';
 import { PersonType } from '../typer/person';
 import { Målform } from '../typer/søknad';
-
-export const gruppeIdTilRolle = (gruppeId: string) => {
-    const rolleConfig = erProd()
-        ? new Map([
-              ['199c2b39-e535-4ae8-ac59-8ccbee7991ae', BehandlerRolle.VEILEDER],
-              ['847e3d72-9dc1-41c3-80ff-f5d4acdd5d46', BehandlerRolle.SAKSBEHANDLER],
-              ['7a271f87-39fb-468b-a9ee-6cf3c070f548', BehandlerRolle.BESLUTTER],
-          ])
-        : new Map([
-              ['93a26831-9866-4410-927b-74ff51a9107c', BehandlerRolle.VEILEDER],
-              ['d21e00a4-969d-4b28-8782-dc818abfae65', BehandlerRolle.SAKSBEHANDLER],
-              ['9449c153-5a1e-44a7-84c6-7cc7a8867233', BehandlerRolle.BESLUTTER],
-          ]);
-    return rolleConfig.get(gruppeId) ?? BehandlerRolle.UKJENT;
-};
-
-export const gruppeIdTilSuperbrukerRolle = erProd()
-    ? '9b8239c4-cca7-440b-b359-51a64e3f0f00'
-    : '314fa714-f13c-4cdc-ac5c-e13ce08e241c';
 
 export const hentSøkersMålform = (behandling: IBehandling) =>
     behandling.personer.find((person: IGrunnlagPerson) => {


### PR DESCRIPTION
### 📮 Favro
NAV-28401

### 💰 Hva skal gjøres, og hvorfor?
Flytter saksbehandler tilstanden til react-query. Introdusere en "composite" `useSaksbehandler` hook for å hente ut saksbehandler, samt legger til ekstra informasjon som som `rolle`, `harSkrivetilgang`, og `harSuperbrukertilgang`. Dette vil også gjøre slik at vi ikke trenger å sjekke saksbehandler for `undefined` da man alltid vil ha en `saksbehandler` i minne hvis man har lastet inn applikasjonen. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Feil ved innlasting av saksbehandler:
<img width="3099" height="113" alt="image" src="https://github.com/user-attachments/assets/a9eb78ef-801e-43e2-a4a5-f916deb4d9d1" />