### PR TITLE
Nav 28688 skjermet barn det ma settes inn riktig symbol for søker

### DIFF
--- a/src/frontend/komponenter/PersonIkon.test.tsx
+++ b/src/frontend/komponenter/PersonIkon.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { describe, test, expect } from 'vitest';
+
+import { kjønnType } from '@navikt/familie-typer';
+
+import { PersonIkon } from './PersonIkon';
+import { render } from '../testutils/testrender';
+import { FagsakType } from '../typer/fagsak';
+
+describe('PersonIkon', () => {
+    test('Voksen kvinne skal få kvinne-ikon, ikke jente-ikon', () => {
+        const { screen } = render(
+            <PersonIkon
+                fagsakType={FagsakType.SKJERMET_BARN}
+                kjønn={kjønnType.KVINNE}
+                erBarn={false}
+                erAdresseBeskyttet={false}
+            />
+        );
+
+        expect(screen.getByTitle('Kvinne')).toBeInTheDocument();
+        expect(screen.queryByTitle('Jente')).not.toBeInTheDocument();
+    });
+
+    test('Voksen mann skal få mann-ikon, ikke gutt-ikon', () => {
+        const { screen } = render(
+            <PersonIkon
+                fagsakType={FagsakType.SKJERMET_BARN}
+                kjønn={kjønnType.MANN}
+                erBarn={false}
+                erAdresseBeskyttet={false}
+            />
+        );
+
+        expect(screen.getByTitle('Mann')).toBeInTheDocument();
+        expect(screen.queryByTitle('Gutt')).not.toBeInTheDocument();
+    });
+
+    test('Gutt skal få gutt ikon', () => {
+        const { screen } = render(
+            <PersonIkon
+                fagsakType={FagsakType.SKJERMET_BARN}
+                kjønn={kjønnType.MANN}
+                erBarn={true}
+                erAdresseBeskyttet={true}
+            />
+        );
+
+        expect(screen.getByTitle('Gutt')).toBeInTheDocument();
+    });
+
+    test('Jente skal få jente ikon', () => {
+        const { screen } = render(
+            <PersonIkon
+                fagsakType={FagsakType.SKJERMET_BARN}
+                kjønn={kjønnType.KVINNE}
+                erBarn={true}
+                erAdresseBeskyttet={true}
+            />
+        );
+
+        expect(screen.getByTitle('Jente')).toBeInTheDocument();
+    });
+});

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -216,10 +216,18 @@ export const PersonIkon = ({
     let ikonProps = størrelse === 's' ? { height: 28, width: 28 } : { height: 36, width: 36 };
     if (fagsakType === FagsakType.SKJERMET_BARN) {
         if (kjønn === kjønnType.KVINNE) {
-            return <StyledJenteIkon $adresseBeskyttet={true} {...ikonProps} />;
+            return erBarn ? (
+                <StyledJenteIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+            ) : (
+                <StyledKvinneIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+            );
         }
         if (kjønn === kjønnType.MANN) {
-            return <StyledGuttIkon $adresseBeskyttet={true} {...ikonProps} />;
+            return erBarn ? (
+                <StyledGuttIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+            ) : (
+                <StyledMannIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
+            );
         }
     }
 

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -213,29 +213,20 @@ export const PersonIkon = ({
         }
         return <KontorIkonGrønn height="24" width="24" color={erAdresseBeskyttet ? Warning500 : Success500} />;
     }
-    let ikonProps = størrelse === 's' ? { height: 28, width: 28 } : { height: 36, width: 36 };
-    if (fagsakType === FagsakType.SKJERMET_BARN) {
-        if (kjønn === kjønnType.KVINNE) {
-            return erBarn ? (
-                <StyledJenteIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
-            ) : (
-                <StyledKvinneIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
-            );
-        }
-        if (kjønn === kjønnType.MANN) {
-            return erBarn ? (
-                <StyledGuttIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
-            ) : (
-                <StyledMannIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />
-            );
-        }
-    }
+    const brukStørreIkon = fagsakType === FagsakType.SKJERMET_BARN || fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG;
+
+    const ikonProps = brukStørreIkon
+        ? størrelse === 's'
+            ? { height: 28, width: 28 }
+            : { height: 36, width: 36 }
+        : størrelse === 's'
+          ? { height: 24, width: 24 }
+          : { height: 32, width: 32 };
 
     if (fagsakType === FagsakType.BARN_ENSLIG_MINDREÅRIG) {
         return <StyledEnsligMindreårigIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />;
     }
 
-    ikonProps = størrelse === 's' ? { height: 24, width: 24 } : { height: 32, width: 32 };
     if (kjønn === kjønnType.KVINNE) {
         return erBarn ? (
             <StyledJenteIkon $adresseBeskyttet={erAdresseBeskyttet} {...ikonProps} />


### PR DESCRIPTION
### 📮 Favro: Nav-28688

### 💰 Hva skal gjøres, og hvorfor?

Vi har en eksisterende bug der det blir brukt barn ikon for søker i skjermet barn saker:
<img width="722" height="291" alt="før" src="https://github.com/user-attachments/assets/3f67ebd3-ac34-4a3d-b800-cfc5b0a73c47" />

Dette stemmer jo ikke helt. Det skal følge samme regler.
Endrer derfor på dette til at det blir slik:
<img width="728" height="321" alt="etter" src="https://github.com/user-attachments/assets/6a0378f1-f4cd-4b5d-b715-87e2fd32526b" />

