### PR TITLE
NAV-28202: samsvarer farger mellom ikon og border fra Aksel

### DIFF
--- a/src/frontend/ikoner/StatusIkon.tsx
+++ b/src/frontend/ikoner/StatusIkon.tsx
@@ -22,25 +22,25 @@ export enum Status {
 }
 
 const OkIkon = styled(CheckmarkCircleFillIcon)`
-    color: var(--ax-border-success);
+    color: var(--ax-text-success-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;
 
 const FeilIkon = styled(XMarkOctagonFillIcon)`
-    color: var(--ax-border-danger);
+    color: var(--ax-text-danger-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;
 
 const AdvarselIkon = styled(ExclamationmarkTriangleFillIcon)`
-    color: var(--ax-border-warning);
+    color: var(--ax-text-warning-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;
 
 const InfoIkon = styled(InformationSquareFillIcon)`
-    color: var(--ax-border-info);
+    color: var(--ax-text-info-subtle);
     font-size: 1.5rem;
     min-width: 1.5rem;
 `;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Fieldset, Label, Radio, RadioGroup, Select, Textarea, VStack } from '@navikt/ds-react';
-import { BorderAccent, BorderNeutral, BorderWarning } from '@navikt/ds-tokens/dist/tokens';
+import { BorderNeutral, TextInfoSubtle, TextWarningSubtle } from '@navikt/ds-tokens/dist/tokens';
 import type { FeltState } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
@@ -19,8 +19,15 @@ import type { IBehandling } from '../../../../../../typer/behandling';
 import { BehandlingÅrsak } from '../../../../../../typer/behandling';
 import type { IGrunnlagPerson } from '../../../../../../typer/person';
 import { PersonType } from '../../../../../../typer/person';
-import type { IPersonResultat, IVilkårConfig, IVilkårResultat } from '../../../../../../typer/vilkår';
-import { Regelverk, Resultat, ResultatBegrunnelse, VilkårType } from '../../../../../../typer/vilkår';
+import {
+    type IPersonResultat,
+    type IVilkårConfig,
+    type IVilkårResultat,
+    Regelverk,
+    Resultat,
+    ResultatBegrunnelse,
+    VilkårType,
+} from '../../../../../../typer/vilkår';
 import { alleRegelverk } from '../../../../../../utils/vilkår';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { validerVilkår } from '../validering';
@@ -47,9 +54,9 @@ export const StyledVStack = styled(VStack)<{ $lesevisning: boolean; $vilkårResu
                 return BorderNeutral;
             }
             if (props.$vilkårResultat === Resultat.IKKE_VURDERT) {
-                return BorderWarning;
+                return TextWarningSubtle;
             }
-            return BorderAccent;
+            return TextInfoSubtle;
         }};
     padding-left: 2rem;
     margin-left: -3rem;


### PR DESCRIPTION
### 📮 Favro: NAV-28202

### 💰 Hva skal gjøres, og hvorfor?
Farger var ulik de som ble brukt i Aksel ettersom de var selvvalgt etter Aksel V.8 oppdatering. Denne fiksen vil bruke samme farge som er brukt i InlineMessage komponenten.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Oppdatering av accent fargen for border-left er veldig mørk for å samsvare med info-ikon. Men da blir den mørk og ser ganske lik ut lesevisning border neutral. Tanker? Behold lysere accent farge?

Bemerk at bildene ikke er reelle eksempler, det er nok ikke mange InlineMessage på disse sidene, men det fins ihvertfall EN warning et sted, men uansett så vil fargene nå samsvare.


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant


### 👀 Screen shots
Suksess
før
<img width="334" height="299" alt="image" src="https://github.com/user-attachments/assets/ad931f54-a0e9-4469-a28d-a481e70abbe8" />

etter
<img width="588" height="443" alt="image" src="https://github.com/user-attachments/assets/aa8f2e17-a29b-462b-a30a-00c531018207" />

warning
før
<img width="436" height="299" alt="image" src="https://github.com/user-attachments/assets/e414c4ef-f6bc-466c-830a-1ca3c40393d8" />

etter
<img width="359" height="326" alt="image" src="https://github.com/user-attachments/assets/bc9094d0-6f5a-48ca-96c9-b404244cc2d5" />

error
før
<img width="473" height="350" alt="image" src="https://github.com/user-attachments/assets/49ef1c2e-0905-4de3-83a4-795f081b767b" />

etter
<img width="496" height="329" alt="image" src="https://github.com/user-attachments/assets/0fbe09c1-171f-4814-a9f7-4206cca81168" />

lesevisning
før
<img width="454" height="444" alt="image" src="https://github.com/user-attachments/assets/546d7e8d-ed58-464f-bd0c-bc5ba0aef992" />

etter
<img width="542" height="369" alt="image" src="https://github.com/user-attachments/assets/720130dd-59d4-4c76-a62d-85cc54799a01" />
