### PR TITLE
NAV-28170: Tilpasser venstre- og høyremeny

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.module.css
@@ -5,7 +5,6 @@
 
 .venstreKolonne {
     min-width: 1rem;
-    max-width: 22rem;
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
@@ -20,7 +19,6 @@
 
 .høyreKolonne {
     min-width: 1rem;
-    max-width: 25rem;
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Behandlingskort.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Behandlingskort.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
-
-import { BodyShort, Box, Heading, VStack } from '@navikt/ds-react';
+import { BodyShort, Box, Heading, HStack, VStack } from '@navikt/ds-react';
 import { TextDangerSubtle, TextInfoSubtle, TextNeutral, TextSuccessSubtle } from '@navikt/ds-tokens/dist/tokens';
 import type { AkselColoredBorderToken } from '@navikt/ds-tokens/types';
 
-import Informasjonsbolk from './Informasjonsbolk';
+import { Informasjonsbolk } from './Informasjonsbolk';
+import { useBehandling } from '../../../../../hooks/useBehandling';
+import { useFagsak } from '../../../../../hooks/useFagsak';
 import {
     BehandlingResultat,
     behandlingsresultater,
@@ -14,68 +14,68 @@ import {
     behandlingstyper,
     behandlingÅrsak,
     erBehandlingHenlagt,
+    type IBehandling,
 } from '../../../../../typer/behandling';
+import { behandlingKategori, behandlingUnderkategori } from '../../../../../typer/behandlingstema';
 import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
-import { useFagsakContext } from '../../../FagsakContext';
-import { sakstype } from '../../../Saksoversikt/Saksoversikt';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
-const hentResultatfarge = (behandlingResultat: BehandlingResultat): AkselColoredBorderToken => {
+function hentResultatfarge(behandlingResultat: BehandlingResultat): AkselColoredBorderToken {
     if (erBehandlingHenlagt(behandlingResultat)) {
         return 'neutral-subtle';
     }
-
     switch (behandlingResultat) {
         case BehandlingResultat.INNVILGET:
         case BehandlingResultat.DELVIS_INNVILGET:
         case BehandlingResultat.FORTSATT_INNVILGET:
             return 'success';
-        case (BehandlingResultat.ENDRET_UTBETALING, BehandlingResultat.ENDRET_UTEN_UTBETALING):
+        case BehandlingResultat.ENDRET_UTBETALING:
+        case BehandlingResultat.ENDRET_UTEN_UTBETALING:
             return 'accent';
         case BehandlingResultat.AVSLÅTT:
-        case (BehandlingResultat.OPPHØRT, BehandlingResultat.FORTSATT_OPPHØRT):
+        case BehandlingResultat.OPPHØRT:
+        case BehandlingResultat.FORTSATT_OPPHØRT:
             return 'danger';
         case BehandlingResultat.IKKE_VURDERT:
             return 'neutral-subtle';
         default:
             return 'neutral';
     }
-};
+}
 
-const hentResultatfargeTekst = (behandlingResultat: BehandlingResultat) => {
+function hentResultatfargeTekst(behandlingResultat: BehandlingResultat) {
     if (erBehandlingHenlagt(behandlingResultat)) {
         return TextNeutral;
     }
-
     switch (behandlingResultat) {
         case BehandlingResultat.INNVILGET:
         case BehandlingResultat.DELVIS_INNVILGET:
         case BehandlingResultat.FORTSATT_INNVILGET:
             return TextSuccessSubtle;
-        case (BehandlingResultat.ENDRET_UTBETALING, BehandlingResultat.ENDRET_UTEN_UTBETALING):
+        case BehandlingResultat.ENDRET_UTBETALING:
+        case BehandlingResultat.ENDRET_UTEN_UTBETALING:
             return TextInfoSubtle;
         case BehandlingResultat.AVSLÅTT:
-        case (BehandlingResultat.OPPHØRT, BehandlingResultat.FORTSATT_OPPHØRT):
+        case BehandlingResultat.OPPHØRT:
+        case BehandlingResultat.FORTSATT_OPPHØRT:
             return TextDangerSubtle;
         default:
             return TextNeutral;
     }
-};
+}
 
-const StyledHeading = styled(Heading)`
-    font-size: var(--ax-space-16);
-`;
+function utledSakstype(behandling: IBehandling) {
+    const kategori = behandling?.kategori && behandlingKategori[behandling.kategori];
+    const underkategori = behandling?.underkategori && behandlingUnderkategori[behandling.underkategori].toLowerCase();
+    return [kategori, underkategori].filter(Boolean).join(', ');
+}
 
 export function Behandlingskort() {
-    const { fagsak } = useFagsakContext();
-    const { behandling } = useBehandlingContext();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
 
     const behandlinger = fagsak.behandlinger;
-
     const antallBehandlinger = behandlinger.length;
     const behandlingIndex = behandlinger.findIndex(b => b.behandlingId === behandling.behandlingId) + 1;
-
-    const tittel = `${behandlingstyper[behandling.type].navn} (${behandlingIndex}/${antallBehandlinger}) - ${sakstype(behandling).toLowerCase()}`;
 
     return (
         <Box
@@ -87,20 +87,23 @@ export function Behandlingskort() {
         >
             <Box borderWidth="0 0 1 0" borderColor="neutral-subtle">
                 <VStack gap="space-4" marginBlock="space-0 space-8">
-                    <StyledHeading size={'xsmall'} level={'2'}>
-                        {tittel}
-                    </StyledHeading>
+                    <HStack gap={'space-4'}>
+                        <Heading size={'xsmall'} level={'2'}>
+                            {`${behandlingstyper[behandling.type].navn} (${behandlingIndex}/${antallBehandlinger})`}
+                        </Heading>
+                        <BodyShort>{utledSakstype(behandling)}</BodyShort>
+                    </HStack>
                     <BodyShort>{behandlingÅrsak[behandling.årsak]}</BodyShort>
                 </VStack>
             </Box>
-            <VStack gap="space-16" marginBlock="space-16">
+            <VStack gap="space-16" marginBlock="space-12 space-0">
                 <Informasjonsbolk label="Behandlingsstatus" tekst={behandlingsstatuser[behandling.status]} />
                 <Informasjonsbolk
                     label="Resultat"
                     tekst={behandlingsresultater[behandling.resultat]}
                     tekstFarge={hentResultatfargeTekst(behandling.resultat)}
                 />
-                <div>
+                <Box>
                     {behandling.søknadMottattDato && (
                         <Informasjonsbolk
                             label="Søknad mottatt"
@@ -125,7 +128,7 @@ export function Behandlingskort() {
                             defaultString: 'Ikke satt',
                         })}
                     />
-                </div>
+                </Box>
                 <Informasjonsbolk
                     label="Enhet"
                     tekst={behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Informasjonsbolk.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Informasjonsbolk.tsx
@@ -3,22 +3,20 @@ import * as React from 'react';
 import { BodyShort, HGrid } from '@navikt/ds-react';
 import { TextNeutral } from '@navikt/ds-tokens/dist/tokens';
 
-interface IProps {
+interface Props {
     label: string;
     tekst: string;
     tekstHover?: string;
     tekstFarge?: string;
 }
 
-const Informasjonsbolk: React.FC<IProps> = ({ label, tekst, tekstHover, tekstFarge }) => {
+export function Informasjonsbolk({ label, tekst, tekstHover, tekstFarge }: Props) {
     return (
-        <HGrid columns={2}>
+        <HGrid columns={'1.25fr 1fr'} gap={'space-8'} align={'center'}>
             <BodyShort>{label}</BodyShort>
-            <BodyShort weight="semibold" style={{ color: tekstFarge ?? TextNeutral }} title={tekstHover}>
+            <BodyShort weight={'semibold'} style={{ color: tekstFarge ?? TextNeutral }} title={tekstHover}>
                 {tekst}
             </BodyShort>
         </HGrid>
     );
-};
-
-export default Informasjonsbolk;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
@@ -411,7 +411,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                     <Button
                         variant={'secondary'}
                         id={'forhandsvis-vedtaksbrev'}
-                        size={'medium'}
+                        size={'small'}
                         disabled={skjemaErLåst}
                         onClick={() => {
                             if (kanSendeSkjema()) {
@@ -428,7 +428,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                 )}
                 <Button
                     variant={'primary'}
-                    size={'medium'}
+                    size={'small'}
                     loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                     disabled={skjemaErLåst}
                     onClick={() => {

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
@@ -48,7 +48,7 @@ export function Høyremeny() {
                     onClick={() => settErÅpen(prev => !prev)}
                 />
                 <Activity mode={erÅpen ? 'visible' : 'hidden'}>
-                    <VStack width={'25rem'}>
+                    <VStack width={'clamp(20rem, 20vw, 25rem)'}>
                         <Behandlingskort />
                         <Tabs value={tab} onChange={tab => settTab(tab as Tab)} iconPosition={'top'}>
                             <Tabvelger />

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { Tabs } from '@navikt/ds-react';
 
-import IkonDokumenter from './Ikoner/IkonDokumenter';
 import IkonHistorikk from './Ikoner/IkonHistorikk';
 import IkonMeldinger from './Ikoner/IkonMeldinger';
 import IkonTotrinnskontroll from './Ikoner/IkonTotrinnskontroll';
@@ -25,7 +24,6 @@ export function Tabvelger() {
                 <Tabs.Tab value={Tab.Totrinnskontroll} label={Tab.Totrinnskontroll} icon={<IkonTotrinnskontroll />} />
             )}
             <Tabs.Tab value={Tab.Historikk} label={Tab.Historikk} icon={<IkonHistorikk />} />
-            <Tabs.Tab value={Tab.Dokumenter} label={Tab.Dokumenter} icon={<IkonDokumenter />} />
             {!erLesevisning && !erMigreringFraInfotrygd && (
                 <Tabs.Tab value={Tab.Meldinger} label={'Send brev'} icon={<IkonMeldinger />} />
             )}

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
@@ -1,7 +1,3 @@
-.container {
-    min-width: 18rem;
-}
-
 .knapp {
     position: absolute;
     margin-right: -20px;
@@ -17,7 +13,7 @@
 
 .menylenke {
     text-decoration: none;
-    padding: var(--ax-space-8) var(--ax-space-20);
+    padding: var(--ax-space-6) var(--ax-space-8);
     border-left: 5px solid transparent;
     user-select: text;
 }
@@ -34,7 +30,7 @@
 
 .undersidelenke {
     text-decoration: none;
-    padding: var(--ax-space-8) var(--ax-space-16);
+    padding: var(--ax-space-6) var(--ax-space-12);
     border-left: 5px solid transparent;
     user-select: text;
 }
@@ -66,10 +62,12 @@
     border: 1px solid var(--ax-border-warning);
     border-radius: 50%;
     background-color: var(--ax-bg-warning-moderate);
-    display: inline-grid;
-    place-items: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--ax-space-24);
     height: var(--ax-space-24);
-    width: var(--ax-space-24);
+    padding: 0 0.4em;
 }
 
 .ident {

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -45,7 +45,7 @@ export function Venstremeny() {
                 onClick={() => settErÅpen(prev => !prev)}
             />
             <Activity mode={erÅpen ? 'visible' : 'hidden'}>
-                <Box as={'nav'} className={Styles.container}>
+                <Box as={'nav'} width={'clamp(14rem, 15vw, 25rem)'}>
                     {Object.entries(trinnPåBehandling).map(([sideId, side], index) => {
                         const tilPath = `/fagsak/${fagsakId}/${behandling.behandlingId}/${side.href}`;
                         const undersider = side.undersider ? side.undersider(behandling) : [];

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -12,9 +12,8 @@ import { GjennomførValutajusteringKnapp } from './GjennomførValutajusteringKna
 import Utbetalinger from './Utbetalinger';
 import type { VisningBehandling } from './visningBehandling';
 import { useSaksbehandler } from '../../../hooks/useSaksbehandler';
-import type { IBehandling } from '../../../typer/behandling';
 import { BehandlingStatus, erBehandlingHenlagt } from '../../../typer/behandling';
-import { behandlingKategori, BehandlingKategori, behandlingUnderkategori } from '../../../typer/behandlingstema';
+import { BehandlingKategori } from '../../../typer/behandlingstema';
 import { FagsakStatus } from '../../../typer/fagsak';
 import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
 import { Datoformat, isoStringTilDate, periodeOverlapperMedValgtDato } from '../../../utils/dato';
@@ -137,13 +136,3 @@ export function Saksoversikt() {
         </Box>
     );
 }
-
-export const sakstype = (behandling?: IBehandling) => {
-    if (!behandling) {
-        return 'Ikke satt';
-    }
-
-    return `${behandling?.kategori ? behandlingKategori[behandling?.kategori] : behandling?.kategori}, ${
-        behandling?.underkategori ? behandlingUnderkategori[behandling?.underkategori] : behandling?.underkategori
-    }`;
-};


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
Tilpasser venstre- og høyremeny for forskjellige skjermstørrelser. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
1280x720 ny:
<img width="969" height="544" alt="image" src="https://github.com/user-attachments/assets/b8be2128-f2c9-4ed0-bc62-46d2cd344d53" />

1280x720 gammel:
<img width="1045" height="594" alt="image" src="https://github.com/user-attachments/assets/bd9c2f54-72e9-4982-aad5-db0febaf2cca" />

--- 

1920x1080 ny:
<img width="969" height="544" alt="image" src="https://github.com/user-attachments/assets/5cc6f8cc-3f33-4daf-9191-4d0321c69064" />

1920x1080 gammel:
<img width="971" height="544" alt="image" src="https://github.com/user-attachments/assets/80def8b4-3a7f-4fb6-9ef8-371e6f0540d9" />

---

2560x1080 ny:
<img width="1293" height="544" alt="image" src="https://github.com/user-attachments/assets/0a4c8540-6816-4683-9245-eeccdafbfeb3" />

2560x1080 gammel:
<img width="1293" height="544" alt="image" src="https://github.com/user-attachments/assets/7fd0feb3-ee0d-4c50-bec7-f85e51e9d50b" />
