### PR TITLE
NAV-28170: Refaktorerer PersonInformasjon

### DIFF
--- a/src/frontend/hooks/useBruker.ts
+++ b/src/frontend/hooks/useBruker.ts
@@ -1,0 +1,6 @@
+import { useBrukerContext } from '../sider/Fagsak/BrukerContext';
+
+export function useBruker() {
+    const { bruker } = useBrukerContext();
+    return bruker;
+}

--- a/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.test.tsx
+++ b/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.test.tsx
@@ -6,36 +6,25 @@ import { FalskIdentitet } from './FalskIdentitet';
 import { render } from '../../testutils/testrender';
 
 describe('FalskIdentitet', () => {
-    test('skal rendre komponent som forventet når harFalskIdentitet er true', () => {
-        const { screen } = render(<FalskIdentitet harFalskIdentitet={true} />);
+    test('skal rendre komponent som forventet når erHeading er false', () => {
+        const { screen } = render(<FalskIdentitet erHeading={false} />);
         const mark = screen.getByRole('mark');
         const span = mark?.parentElement;
-        const skillelinjeParagraf = screen.getByText('|');
 
         expect(mark).toBeInTheDocument();
         expect(mark).toHaveTextContent('Falsk identitet');
         expect(span).toBeInTheDocument();
         expect(span).toHaveClass('aksel-body-short');
-        expect(skillelinjeParagraf).toBeInTheDocument();
-        expect(skillelinjeParagraf).toHaveClass('aksel-body-short');
     });
 
-    test('skal rendre komponent som heading når erHeading er true', () => {
-        const { screen } = render(<FalskIdentitet harFalskIdentitet={true} erHeading />);
+    test('skal rendre komponent som forventet når erHeading er true', () => {
+        const { screen } = render(<FalskIdentitet erHeading />);
         const mark = screen.getByRole('mark');
         const span = mark?.parentElement;
-        const skillelinjeSpan = screen.getByText('|');
 
         expect(mark).toBeInTheDocument();
         expect(mark).toHaveTextContent('Falsk identitet');
         expect(span).toBeInTheDocument();
         expect(span).toHaveClass('aksel-heading');
-        expect(skillelinjeSpan).toBeInTheDocument();
-        expect(skillelinjeSpan).toHaveClass('aksel-heading');
-    });
-
-    test('skal ikke rendre komponent når harFalskIdentitet er false', async () => {
-        const { screen } = render(<FalskIdentitet harFalskIdentitet={false} />);
-        expect(screen.queryByRole('mark')).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.tsx
+++ b/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.tsx
@@ -3,33 +3,22 @@ import React from 'react';
 import { BodyShort, Heading } from '@navikt/ds-react';
 
 import styles from './FalskIdentitet.module.css';
-import { Skillelinje } from '../PersonInformasjon/PersonInformasjon';
 
 interface Props {
-    harFalskIdentitet: boolean;
     erHeading?: boolean;
 }
 
-export function FalskIdentitet({ harFalskIdentitet, erHeading }: Props) {
-    if (!harFalskIdentitet) {
-        return null;
-    }
+export function FalskIdentitet({ erHeading }: Props) {
     if (erHeading) {
         return (
-            <>
-                <Heading level="2" size="medium" as="span">
-                    <mark className={styles.falskIdentitet}>Falsk identitet</mark>
-                </Heading>
-                <Skillelinje erHeading />
-            </>
+            <Heading level={'2'} size={'medium'} as={'span'}>
+                <mark className={styles.falskIdentitet}>Falsk identitet</mark>
+            </Heading>
         );
     }
     return (
-        <>
-            <BodyShort as={'span'} weight={'semibold'}>
-                <mark className={styles.falskIdentitet}>Falsk identitet</mark>
-            </BodyShort>
-            <Skillelinje />
-        </>
+        <BodyShort as={'span'} weight={'semibold'}>
+            <mark className={styles.falskIdentitet}>Falsk identitet</mark>
+        </BodyShort>
     );
 }

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -3,33 +3,27 @@ import * as React from 'react';
 import { BodyShort, CopyButton, Heading, HStack } from '@navikt/ds-react';
 
 import RegistrerDødsfallDatoMeny from './RegistrerDødsfallDatoMeny';
-import { useBrukerContext } from '../../sider/Fagsak/BrukerContext';
-import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
+import { useBruker } from '../../hooks/useBruker';
+import { useFagsak } from '../../hooks/useFagsak';
+import { useBehandlingContext } from '../../sider/Fagsak/Behandling/context/BehandlingContext';
 import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '../../typer/person';
 import { formaterIdent, hentAlder } from '../../utils/formatter';
-import { erAdresseBeskyttet } from '../../utils/validators';
 import DødsfallTag from '../DødsfallTag';
 import { PersonIkon } from '../PersonIkon';
 import styles from './PersonInformasjon.module.css';
+import { erAdresseBeskyttet } from '../../utils/validators';
 import { FalskIdentitet } from '../FalskIdentitet/FalskIdentitet';
 
-interface IProps {
-    person: IGrunnlagPerson;
-    somOverskrift?: boolean;
-    width?: string;
-    erLesevisning: boolean;
-}
-
-const hentAdresseBeskyttelseGradering = (bruker: IPersonInfo, personIdent: string): boolean | undefined => {
+function hentAdresseBeskyttelseGradering(bruker: IPersonInfo, personIdent: string): boolean | undefined {
     const forelderBarnRelasjon = bruker.forelderBarnRelasjon.find(rel => rel.personIdent === personIdent);
     if (bruker.personIdent === personIdent) {
         return erAdresseBeskyttet(bruker.adressebeskyttelseGradering);
     } else if (forelderBarnRelasjon?.personIdent === personIdent) {
         return erAdresseBeskyttet(forelderBarnRelasjon.adressebeskyttelseGradering);
     }
-};
+}
 
-export const Skillelinje: React.FC<{ erHeading?: boolean }> = ({ erHeading = false }) => {
+export function Skillelinje({ erHeading = false }: { erHeading?: boolean }) {
     if (erHeading) {
         return (
             <Heading level="2" size="medium" as="span">
@@ -38,71 +32,58 @@ export const Skillelinje: React.FC<{ erHeading?: boolean }> = ({ erHeading = fal
         );
     }
     return <BodyShort>|</BodyShort>;
-};
+}
 
-const PersonInformasjon: React.FunctionComponent<IProps> = ({ person, somOverskrift = false, erLesevisning }) => {
+interface Props {
+    person: IGrunnlagPerson;
+}
+
+export function PersonInformasjon({ person }: Props) {
+    const fagsak = useFagsak();
+    const bruker = useBruker();
+    const { vurderErLesevisning } = useBehandlingContext();
+
     const alder = hentAlder(person.fødselsdato);
     const navnOgAlder = `${person.navn} (${alder} år)`;
     const formattertIdent = formaterIdent(person.personIdent);
-    const { fagsak } = useFagsakContext();
-    const { bruker } = useBrukerContext();
 
     const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(bruker, person.personIdent);
     const erEgenAnsatt = bruker.erEgenAnsatt;
 
-    if (somOverskrift) {
-        return (
-            <HStack gap="space-24" wrap={false} align="center">
-                <PersonIkon
-                    fagsakType={fagsak.fagsakType}
-                    kjønn={person.kjønn}
-                    erBarn={alder < 18}
-                    størrelse={'m'}
-                    erAdresseBeskyttet={erAdresseBeskyttet}
-                    erEgenAnsatt={erEgenAnsatt}
-                />
-                <HStack gap="space-16" align="center" wrap={false}>
-                    <Heading className={styles.headingUtenOverflow} level="2" size="medium" title={navnOgAlder}>
-                        {navnOgAlder}
-                    </Heading>
-                    <Skillelinje erHeading />
-                    <FalskIdentitet harFalskIdentitet={person.harFalskIdentitet} erHeading />
-                    <HStack gap="space-4" wrap={false} align="center">
-                        <Heading level="2" size="medium" as="span">
-                            {formattertIdent}
-                        </Heading>
-                        <CopyButton size="small" copyText={person.personIdent} />
-                    </HStack>
-                    <Skillelinje erHeading />
-                    <Heading level="2" size="medium" as="span">{`${personTypeMap[person.type]} `}</Heading>
-                    {person.dødsfallDato?.length && <DødsfallTag dødsfallDato={person.dødsfallDato} />}
-                    {!person.dødsfallDato?.length && !erLesevisning && <RegistrerDødsfallDatoMeny person={person} />}
-                </HStack>
-            </HStack>
-        );
-    }
+    const erLesevisning = vurderErLesevisning();
 
     return (
-        <HStack gap="space-8" align="center" wrap={false}>
+        <HStack gap={'space-24'} wrap={false} align={'center'}>
             <PersonIkon
                 fagsakType={fagsak.fagsakType}
                 kjønn={person.kjønn}
                 erBarn={alder < 18}
                 størrelse={'m'}
                 erAdresseBeskyttet={erAdresseBeskyttet}
+                erEgenAnsatt={erEgenAnsatt}
             />
-            <BodyShort className={'navn'} title={navnOgAlder}>
-                {navnOgAlder}
-            </BodyShort>
-            <Skillelinje />
-            <HStack gap="space-4" wrap={false} align="center">
-                <BodyShort>{formattertIdent}</BodyShort>
-                <CopyButton size="small" copyText={person.personIdent} />
+            <HStack gap={'space-16'} align={'center'} wrap={false}>
+                <Heading level={'2'} size={'medium'} title={navnOgAlder} className={styles.headingUtenOverflow}>
+                    {navnOgAlder}
+                </Heading>
+                <Skillelinje erHeading={true} />
+                {person.harFalskIdentitet && (
+                    <HStack gap={'space-16'} align={'center'}>
+                        <FalskIdentitet erHeading={true} />
+                        <Skillelinje erHeading={true} />
+                    </HStack>
+                )}
+                <HStack gap={'space-4'} align={'center'} wrap={false}>
+                    <Heading level={'2'} size={'medium'} as={'span'}>
+                        {formattertIdent}
+                    </Heading>
+                    <CopyButton size={'small'} copyText={person.personIdent} />
+                </HStack>
+                <Skillelinje erHeading={true} />
+                <Heading level={'2'} size={'medium'} as={'span'}>{`${personTypeMap[person.type]} `}</Heading>
+                {person.dødsfallDato?.length && <DødsfallTag dødsfallDato={person.dødsfallDato} />}
+                {!person.dødsfallDato?.length && !erLesevisning && <RegistrerDødsfallDatoMeny person={person} />}
             </HStack>
-            <Skillelinje />
-            <BodyShort>{`${personTypeMap[person.type]} `}</BodyShort>
         </HStack>
     );
-};
-
-export default PersonInformasjon;
+}

--- a/src/frontend/komponenter/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Personlinje/Personlinje.tsx
@@ -86,7 +86,12 @@ export function Personlinje({ bruker, fagsak }: Props) {
                             {fagsakeier.navn} ({fagsakeier.alder} år)
                         </BodyShort>
                         <Divider />
-                        <FalskIdentitet harFalskIdentitet={fagsakeier.harFalskIdentitet} />
+                        {fagsakeier.harFalskIdentitet && (
+                            <HStack align={'center'} gap={'space-12 space-16'}>
+                                <FalskIdentitet erHeading={false} />
+                                <Divider />
+                            </HStack>
+                        )}
                         <HStack align={'center'} gap={'space-4'}>
                             {fagsakeier.ident}
                             <CopyButton copyText={fagsakeier.ident.replaceAll(' ', '')} size={'small'} />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -227,7 +227,12 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
                                                 {`${detalj.person.navn} (${hentAlderSomString(detalj.person.fødselsdato)})`}
                                             </BodyShort>
                                             <Skillelinje />
-                                            <FalskIdentitet harFalskIdentitet={detalj.person.harFalskIdentitet} />
+                                            {detalj.person.harFalskIdentitet && (
+                                                <HStack gap={'space-4'}>
+                                                    <FalskIdentitet />
+                                                    <Skillelinje />
+                                                </HStack>
+                                            )}
                                             <BodyShort>{formaterIdent(detalj.person.personIdent)}</BodyShort>
                                         </HStack>
                                     )}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Alert, Box, HStack } from '@navikt/ds-react';
 
-import PersonInformasjon from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
+import { PersonInformasjon } from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
 import { PersonType } from '../../../../../../typer/person';
 import type { IPersonResultat } from '../../../../../../typer/vilkår';
 import {
@@ -11,7 +11,6 @@ import {
     vilkårConfigEnsligMindreårig,
     VilkårType,
 } from '../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import GeneriskAnnenVurdering from '../GeneriskAnnenVurdering/GeneriskAnnenVurdering';
 import GeneriskVilkår from '../GeneriskVilkår/GeneriskVilkår';
 import Registeropplysninger from '../Registeropplysninger/Registeropplysninger';
@@ -23,7 +22,6 @@ interface IProps {
 }
 
 const VilkårsvurderingSkjemaEnsligMindreårig: React.FC<IProps> = ({ visFeilmeldinger }) => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { vilkårsvurdering } = useVilkårsvurderingContext();
 
     const personResultat = vilkårsvurdering.find((value: IPersonResultat) => value.person.type === PersonType.BARN);
@@ -39,7 +37,7 @@ const VilkårsvurderingSkjemaEnsligMindreårig: React.FC<IProps> = ({ visFeilmel
                 paddingBlock={'space-32 space-0'}
                 className={styles.personLinje}
             >
-                <PersonInformasjon person={personResultat.person} somOverskrift erLesevisning={vurderErLesevisning()} />
+                <PersonInformasjon person={personResultat.person} />
             </HStack>
 
             <Box paddingInline={'space-56 space-0'}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Alert, Bleed, Box, HStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import PersonInformasjon from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
+import { PersonInformasjon } from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
 import SamhandlerInformasjon from '../../../../../../komponenter/Samhandler/SamhandlerInformasjon';
 import { useSamhandlerRequest } from '../../../../../../komponenter/Samhandler/useSamhandler';
 import { PersonType } from '../../../../../../typer/person';
@@ -21,7 +21,7 @@ interface IProps {
 }
 
 const VilkårsvurderingSkjemaInstitusjon: React.FunctionComponent<IProps> = ({ visFeilmeldinger }) => {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling } = useBehandlingContext();
     const { vilkårsvurdering } = useVilkårsvurderingContext();
     const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);
 
@@ -58,7 +58,7 @@ const VilkårsvurderingSkjemaInstitusjon: React.FunctionComponent<IProps> = ({ v
                 </>
             )}
             <HStack paddingBlock={'space-56 space-32'} justify={'space-between'} className={styles.personLinje}>
-                <PersonInformasjon person={personResultat.person} somOverskrift erLesevisning={vurderErLesevisning()} />
+                <PersonInformasjon person={personResultat.person} />
             </HStack>
             <Box paddingInline={'space-56 space-0'}>
                 {personResultat.person.registerhistorikk ? (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -7,7 +7,7 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import styles from './VilkårsvurderingSkjema.module.css';
 import { useFeatureToggles } from '../../../../../../hooks/useFeatureToggles';
-import PersonInformasjon from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
+import { PersonInformasjon } from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
 import { BehandlingSteg, BehandlingÅrsak, type IBehandling } from '../../../../../../typer/behandling';
 import { FeatureToggle } from '../../../../../../typer/featureToggles';
 import { PersonType } from '../../../../../../typer/person';
@@ -136,11 +136,7 @@ const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingS
                         ) : (
                             <>
                                 <HStack wrap={false} justify={'space-between'} className={styles.personLinje}>
-                                    <PersonInformasjon
-                                        person={personResultat.person}
-                                        somOverskrift
-                                        erLesevisning={erLesevisning}
-                                    />
+                                    <PersonInformasjon person={personResultat.person} />
                                     {!erLesevisning &&
                                         personErEkspandert[personResultat.personIdent] &&
                                         personResultat.person.type === PersonType.SØKER &&

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import { BodyShort, CopyButton, HStack } from '@navikt/ds-react';
+
+import { useBruker } from '../../../hooks/useBruker';
+import { useFagsak } from '../../../hooks/useFagsak';
+import { PersonIkon } from '../../../komponenter/PersonIkon';
+import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '../../../typer/person';
+import { formaterIdent, hentAlder } from '../../../utils/formatter';
+import { erAdresseBeskyttet } from '../../../utils/validators';
+
+function hentAdresseBeskyttelseGradering(bruker: IPersonInfo, personIdent: string): boolean | undefined {
+    const forelderBarnRelasjon = bruker.forelderBarnRelasjon.find(rel => rel.personIdent === personIdent);
+    if (bruker.personIdent === personIdent) {
+        return erAdresseBeskyttet(bruker.adressebeskyttelseGradering);
+    } else if (forelderBarnRelasjon?.personIdent === personIdent) {
+        return erAdresseBeskyttet(forelderBarnRelasjon.adressebeskyttelseGradering);
+    }
+}
+
+interface Props {
+    person: IGrunnlagPerson;
+}
+
+export function PersonInformasjonUtbetaling({ person }: Props) {
+    const fagsak = useFagsak();
+    const bruker = useBruker();
+
+    const alder = hentAlder(person.fødselsdato);
+    const navnOgAlder = `${person.navn} (${alder} år)`;
+    const formattertIdent = formaterIdent(person.personIdent);
+
+    const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(bruker, person.personIdent);
+
+    return (
+        <HStack gap={'space-8'} align={'center'} wrap={false}>
+            <PersonIkon
+                fagsakType={fagsak.fagsakType}
+                kjønn={person.kjønn}
+                erBarn={alder < 18}
+                størrelse={'m'}
+                erAdresseBeskyttet={erAdresseBeskyttet}
+            />
+            <BodyShort className={'navn'} title={navnOgAlder}>
+                {navnOgAlder}
+            </BodyShort>
+            <BodyShort>|</BodyShort>
+            <HStack gap={'space-4'} wrap={false} align={'center'}>
+                <BodyShort>{formattertIdent}</BodyShort>
+                <CopyButton size={'small'} copyText={person.personIdent} />
+            </HStack>
+            <BodyShort>|</BodyShort>
+            <BodyShort>{`${personTypeMap[person.type]}`}</BodyShort>
+        </HStack>
+    );
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { BodyShort, HStack } from '@navikt/ds-react';
 import { Space16, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
 
-import PersonInformasjon from '../../../komponenter/PersonInformasjon/PersonInformasjon';
+import { PersonInformasjonUtbetaling } from './PersonInformasjonUtbetaling';
 import { YtelseType, ytelsetype } from '../../../typer/beregning';
 import type { IUtbetalingsperiodeDetalj } from '../../../typer/vedtaksperiode';
 import { formaterBeløp, hentAlder } from '../../../utils/formatter';
@@ -29,7 +29,7 @@ const PersonUtbetaling: React.FC<IPersonUtbetalingProps> = ({ utbetalingsperiode
 
     return (
         <section>
-            <PersonInformasjon person={utbetalingsperiodeDetaljer[0].person} erLesevisning={false} />
+            <PersonInformasjonUtbetaling person={utbetalingsperiodeDetaljer[0].person} />
             <Ytelser>
                 {utbetalingsperiodeDetaljer.map(utbetalingsperiodeDetalj => {
                     return (


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
Refaktorerer PersonInformasjon slik at det blir lettere å skrive om senere. Skiller ut en egen komponent for personinformasjon knyttet til utbetaling.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Endrer ikke logikken stort. 

### 👀 Screen shots
Ingen visuelle endringer.