### PR TITLE
NAV-28790: Innfører en useErLesevisning hook

### DIFF
--- a/src/frontend/hooks/useErLesevisning.test.ts
+++ b/src/frontend/hooks/useErLesevisning.test.ts
@@ -1,0 +1,148 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useBehandling } from './useBehandling';
+import { useErLesevisning } from './useErLesevisning';
+import { useSaksbehandler } from './useSaksbehandler';
+import { lagBehandling } from '../testutils/testdata/behandlingTestdata';
+import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
+import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak } from '../typer/behandling';
+import { harTilgangTilEnhet } from '../typer/enhet';
+import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
+
+vi.mock('./useBehandling');
+vi.mock('./useSaksbehandler');
+vi.mock('../typer/enhet');
+
+const mockUseBehandling = vi.mocked(useBehandling);
+const mockUseSaksbehandler = vi.mocked(useSaksbehandler);
+const mockHarTilgangTilEnhet = vi.mocked(harTilgangTilEnhet);
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    mockUseBehandling.mockReturnValue(lagBehandling());
+    mockUseSaksbehandler.mockReturnValue(lagSaksbehandler());
+    mockHarTilgangTilEnhet.mockReturnValue(true);
+});
+
+describe('useErLesevisning', () => {
+    it('returnerer true når behandlingen er avsluttet', () => {
+        mockUseBehandling.mockReturnValue(lagBehandling({ status: BehandlingStatus.AVSLUTTET }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returnerer true når behandlingen er på vent', () => {
+        mockUseBehandling.mockReturnValue(lagBehandling({ status: BehandlingStatus.SATT_PÅ_VENT }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returnerer true når behandlingen er satt på maskinell vent', () => {
+        mockUseBehandling.mockReturnValue(lagBehandling({ status: BehandlingStatus.SATT_PÅ_MASKINELL_VENT }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returnerer true når behandling er på midlertidig enhet', () => {
+        mockUseBehandling.mockReturnValue(
+            lagBehandling({
+                arbeidsfordelingPåBehandling: {
+                    behandlendeEnhetNavn: 'midlertidig enhet',
+                    behandlendeEnhetId: MIDLERTIDIG_BEHANDLENDE_ENHET_ID,
+                    manueltOverstyrt: false,
+                },
+            })
+        );
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returnerer false når behandling er på midlertidig enhet men skalIgnorereOmEnhetErMidlertidig er true', () => {
+        mockUseBehandling.mockReturnValue(
+            lagBehandling({
+                arbeidsfordelingPåBehandling: {
+                    behandlendeEnhetNavn: 'midlertidig enhet',
+                    behandlendeEnhetId: MIDLERTIDIG_BEHANDLENDE_ENHET_ID,
+                    manueltOverstyrt: false,
+                },
+            })
+        );
+
+        const { result } = renderHook(() => useErLesevisning({ skalIgnorereOmEnhetErMidlertidig: true }));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returnerer true når saksbehandler mangler skrivetilgang', () => {
+        mockUseSaksbehandler.mockReturnValue(lagSaksbehandler({ harSkrivetilgang: false }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returnerer true når saksbehandler mangler tilgang til enhet', () => {
+        mockHarTilgangTilEnhet.mockReturnValue(false);
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returnerer false når saksbehandler mangler enhetstilgang men er superbruker', () => {
+        mockHarTilgangTilEnhet.mockReturnValue(false);
+        mockUseSaksbehandler.mockReturnValue(lagSaksbehandler({ harSuperbrukertilgang: true }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returnerer false når saksbehandler mangler enhetstilgang men årsak er KORREKSJON_VEDTAKSBREV', () => {
+        mockHarTilgangTilEnhet.mockReturnValue(false);
+        mockUseBehandling.mockReturnValue(lagBehandling({ årsak: BehandlingÅrsak.KORREKSJON_VEDTAKSBREV }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(false);
+    });
+
+    it('hopper over enhetstilgangssjekk når sjekkTilgangTilEnhet er false', () => {
+        mockHarTilgangTilEnhet.mockReturnValue(false);
+
+        const { result } = renderHook(() => useErLesevisning({ sjekkTilgangTilEnhet: false }));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returnerer true når behandlingen er etter BESLUTTE_VEDTAK', () => {
+        mockUseBehandling.mockReturnValue(lagBehandling({ steg: BehandlingSteg.BEHANDLING_AVSLUTTET }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returnerer false når behandlingen er før BESLUTTE_VEDTAK og alle andre vilkår er oppfylt', () => {
+        mockUseBehandling.mockReturnValue(lagBehandling({ steg: BehandlingSteg.REGISTRERE_SØKNAD }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(false);
+    });
+
+    it('bruker standardverdier når ingen parametere sendes inn', () => {
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(false);
+    });
+});

--- a/src/frontend/hooks/useErLesevisning.ts
+++ b/src/frontend/hooks/useErLesevisning.ts
@@ -1,0 +1,56 @@
+import { useBehandling } from './useBehandling';
+import { useSaksbehandler } from './useSaksbehandler';
+import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak, hentStegNummer } from '../typer/behandling';
+import { harTilgangTilEnhet } from '../typer/enhet';
+import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
+
+const ÅRSAKER_ÅPEN_FOR_ALLE = new Set([BehandlingÅrsak.TEKNISK_ENDRING, BehandlingÅrsak.KORREKSJON_VEDTAKSBREV]);
+
+interface Parameters {
+    sjekkTilgangTilEnhet?: boolean;
+    skalIgnorereOmEnhetErMidlertidig?: boolean;
+}
+
+export function useErLesevisning({
+    sjekkTilgangTilEnhet = true,
+    skalIgnorereOmEnhetErMidlertidig = false,
+}: Parameters = {}) {
+    const saksbehandler = useSaksbehandler();
+    const behandling = useBehandling();
+
+    const behandlendeEnhetId = behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId;
+    const erBehandlingenAvsluttet = behandling.status === BehandlingStatus.AVSLUTTET;
+    const erBehandlingenPåVent = behandling.status === BehandlingStatus.SATT_PÅ_VENT;
+    const erBehandlingenPåMaskinellVent = behandling.status === BehandlingStatus.SATT_PÅ_MASKINELL_VENT;
+    const erBehandleneEnhetMidlertidig = behandlendeEnhetId === MIDLERTIDIG_BEHANDLENDE_ENHET_ID;
+    const harAlleTilgangTilBehandlingen = ÅRSAKER_ÅPEN_FOR_ALLE.has(behandling.årsak);
+    const harSaksbehandlerTilgangTilEnhet = harTilgangTilEnhet(behandlendeEnhetId, saksbehandler.groups);
+    const erEtterBeslutteVedtak = hentStegNummer(behandling.steg) >= hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
+
+    if (erBehandlingenAvsluttet) {
+        return true;
+    }
+
+    if (erBehandlingenPåVent || erBehandlingenPåMaskinellVent) {
+        return true;
+    }
+
+    if (erBehandleneEnhetMidlertidig && !skalIgnorereOmEnhetErMidlertidig) {
+        return true;
+    }
+
+    if (!saksbehandler.harSkrivetilgang) {
+        return true;
+    }
+
+    if (
+        sjekkTilgangTilEnhet &&
+        !saksbehandler.harSuperbrukertilgang &&
+        !harAlleTilgangTilBehandlingen &&
+        !harSaksbehandlerTilgangTilEnhet
+    ) {
+        return true;
+    }
+
+    return erEtterBeslutteVedtak;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
@@ -8,14 +8,15 @@ import IkonTotrinnskontroll from './Ikoner/IkonTotrinnskontroll';
 import { Tab } from './TabContextProvider';
 import styles from './Tabvelger.module.css';
 import { useSkalViseTotrinnskontroll } from './useSkalViseTotrinnskontroll';
+import { useBehandling } from '../../../../hooks/useBehandling';
+import { useErLesevisning } from '../../../../hooks/useErLesevisning';
 import { Behandlingstype } from '../../../../typer/behandling';
-import { useBehandlingContext } from '../context/BehandlingContext';
 
 export function Tabvelger() {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
     const skalViseTotrinnskontroll = useSkalViseTotrinnskontroll();
 
-    const erLesevisning = vurderErLesevisning();
     const erMigreringFraInfotrygd = behandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -27,6 +27,9 @@ interface Props extends React.PropsWithChildren {
 }
 
 interface BehandlingContextValue {
+    /**
+     * @Deprecated - Erstattes av {@link useErLesevisning}.
+     */
     vurderErLesevisning: (sjekkTilgangTilEnhet?: boolean, skalIgnorereOmEnhetErMidlertidig?: boolean) => boolean;
     leggTilBesøktSide: (besøktSide: SideId) => void;
     settIkkeKontrollerteSiderTilManglerKontroll: () => void;
@@ -122,6 +125,9 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         return behandling?.steg;
     };
 
+    /**
+     * @Deprecated - Erstattes av {@link useErLesevisning}.
+     */
     const vurderErLesevisning = (sjekkTilgangTilEnhet = true, skalIgnorereOmEnhetErMidlertidig = false): boolean => {
         const åpenBehandlingData = behandling;
         if (


### PR DESCRIPTION
### 📮 Favro
NAV-28790

### 💰 Hva skal gjøres, og hvorfor?
Innfører en "useErLesevisning" hook som skal erstatte metode eksponert fra "BehandlingContext".

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer.