### PR TITLE
Bruk react-jsx i TSConfig, bruker nyere "JSX Transform"

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,6 +92,38 @@ export default [
                 },
             ],
 
+            '@typescript-eslint/no-restricted-types': [
+                'error',
+                {
+                    types: {
+                        'React.FC':
+                            'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
+                        'React.FunctionComponent':
+                            'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
+                        'React.VFC':
+                            'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
+                    },
+                },
+            ],
+            'no-restricted-syntax': [
+                'error',
+                {
+                    // Ban default import: import React from 'react';
+                    selector: 'ImportDeclaration[source.value="react"] > ImportDefaultSpecifier[local.name="React"]',
+                    message: 'Do not default-import React; use named imports.',
+                },
+                {
+                    // Ban namespace import: import * as React from 'react';
+                    selector: 'ImportDeclaration[source.value="react"] > ImportNamespaceSpecifier',
+                    message: 'Do not namespace-import React; use named imports.',
+                },
+                {
+                    // Ban React.<member>
+                    selector: 'MemberExpression[object.name="React"]',
+                    message: 'Import this from react instead of using React.XYZ.',
+                },
+            ],
+
             'import/named': 'error',
             'import/namespace': 'error',
             'import/default': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,10 +98,14 @@ export default [
                     types: {
                         'React.FC':
                             'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
+                        FC: 'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
                         'React.FunctionComponent':
+                            'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
+                        FunctionComponent:
                             'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
                         'React.VFC':
                             'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
+                        VFC: 'Annotate the props on the parameter instead: (const X = ({ X, Y }: Props) => ...).',
                     },
                 },
             ],

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect } from 'react';
 
 import '@navikt/ds-css';
@@ -27,7 +26,7 @@ const queryClient = new QueryClient({
     },
 });
 
-const App: FC = () => {
+const App = () => {
     useStartUmami();
 
     useEffect(() => {

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 
 import '@navikt/ds-css';
 import './index.css';
@@ -26,7 +27,7 @@ const queryClient = new QueryClient({
     },
 });
 
-const App: React.FC = () => {
+const App: FC = () => {
     useStartUmami();
 
     useEffect(() => {

--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classNames from 'classnames';
 import { BrowserRouter as Router, Navigate, Route, Routes } from 'react-router';
 

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -1,6 +1,12 @@
-import type { JSX, PropsWithChildren } from 'react';
+import {
+    type Dispatch,
+    type JSX,
+    type PropsWithChildren,
+    type ReactNode,
+    type SetStateAction,
+    useContext,
+} from 'react';
 import { createContext, useState } from 'react';
-import * as React from 'react';
 
 import type { AxiosRequestConfig } from 'axios';
 
@@ -24,7 +30,7 @@ export type FamilieAxiosRequestConfig<D> = AxiosRequestConfig & {
 
 export interface IModal {
     actions?: JSX.Element[] | JSX.Element;
-    innhold?: () => React.ReactNode;
+    innhold?: () => ReactNode;
     onClose?: () => void;
     tittel: string;
     visModal: boolean;
@@ -55,7 +61,7 @@ const tilgangModal = (data: IRestTilgang, lukkModal: () => void) => ({
 interface AppContextValue {
     appInfoModal: IModal;
     settToast: (toastId: ToastTyper, toast: IToast) => void;
-    settToasts: React.Dispatch<React.SetStateAction<{ [toastId: string]: IToast }>>;
+    settToasts: Dispatch<SetStateAction<{ [toastId: string]: IToast }>>;
     sjekkTilgang: (brukerIdent: string, visSystemetLaster?: boolean) => Promise<boolean>;
     toasts: { [toastId: string]: IToast };
     hentPerson: (brukerIdent: string) => Promise<Ressurs<IPersonInfo>>;
@@ -68,7 +74,7 @@ const AppProvider = (props: PropsWithChildren) => {
     const { request } = useHttp();
     const toggles = useFeatureToggles();
 
-    const [appInfoModal, settAppInfoModal] = React.useState<IModal>(initalState);
+    const [appInfoModal, settAppInfoModal] = useState<IModal>(initalState);
     const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
 
     const saksbehandler = useSaksbehandler();
@@ -140,7 +146,7 @@ const AppProvider = (props: PropsWithChildren) => {
 };
 
 const useAppContext = () => {
-    const context = React.useContext(AppContext);
+    const context = useContext(AppContext);
     if (!context) {
         throw new Error('useAppContext må brukes innenfor AppProvider');
     }

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, type JSX, type PropsWithChildren, useState } from 'react';
+import type { JSX, PropsWithChildren } from 'react';
+import { createContext, useState } from 'react';
+import * as React from 'react';
 
 import type { AxiosRequestConfig } from 'axios';
 

--- a/src/frontend/context/AuthContext.tsx
+++ b/src/frontend/context/AuthContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { useContext, createContext, useState } from 'react';
 
 interface Context {
     autentisert: boolean;
@@ -14,7 +15,7 @@ export function AuthContextProvider({ children }: PropsWithChildren) {
 }
 
 export function useAuthContext() {
-    const context = React.useContext(AuthContext);
+    const context = useContext(AuthContext);
     if (!context) {
         throw new Error('useAuthContext må brukes innenfor AuthContextProvider');
     }

--- a/src/frontend/context/HttpContext.tsx
+++ b/src/frontend/context/HttpContext.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { HttpProvider } from '@navikt/familie-http';
 

--- a/src/frontend/context/ModalContext.tsx
+++ b/src/frontend/context/ModalContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useCallback, useContext, useReducer } from 'react';
+import type { ReactNode, PropsWithChildren } from 'react';
+import { createContext, useCallback, useContext, useReducer } from 'react';
 
 import type { MutationKey } from '@tanstack/react-query';
 
@@ -27,7 +28,7 @@ export enum ModalType {
 export interface Args {
     [ModalType.HENLEGG_BEHANDLING_VEIVALG]: { årsak: HenleggÅrsak };
     [ModalType.OPPRETT_FAGSAK]: { ident: string };
-    [ModalType.FEILMELDING]: { feilmelding: string | React.ReactNode };
+    [ModalType.FEILMELDING]: { feilmelding: string | ReactNode };
     [ModalType.FORHÅNDSVIS_OPPRETTING_AV_PDF]: { mutationKey: MutationKey };
 }
 

--- a/src/frontend/context/SaksbehandlerContext.test.tsx
+++ b/src/frontend/context/SaksbehandlerContext.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { UseQueryResult } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/src/frontend/context/SaksbehandlerContext.tsx
+++ b/src/frontend/context/SaksbehandlerContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import { Box, GlobalAlert } from '@navikt/ds-react';
 

--- a/src/frontend/context/TogglesContext.tsx
+++ b/src/frontend/context/TogglesContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import { Alert, BodyShort, ErrorMessage } from '@navikt/ds-react';
 

--- a/src/frontend/hooks/useBehandlingIdParam.test.tsx
+++ b/src/frontend/hooks/useBehandlingIdParam.test.tsx
@@ -1,5 +1,4 @@
 import type { PropsWithChildren } from 'react';
-import React from 'react';
 
 import { renderHook } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';

--- a/src/frontend/hooks/useDokument.ts
+++ b/src/frontend/hooks/useDokument.ts
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import * as React from 'react';
 
 import type { AxiosError } from 'axios';
 

--- a/src/frontend/hooks/useDokument.ts
+++ b/src/frontend/hooks/useDokument.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import * as React from 'react';
 
 import type { AxiosError } from 'axios';
 
@@ -21,9 +20,9 @@ const useDokument = () => {
 
     const [visDokumentModal, settVisDokumentModal] = useState<boolean>(false);
 
-    const [hentetDokument, settHentetDokument] = React.useState<Ressurs<string>>(byggTomRessurs());
+    const [hentetDokument, settHentetDokument] = useState<Ressurs<string>>(byggTomRessurs());
 
-    const [distribusjonskanal, settDistribusjonskanal] = React.useState<Ressurs<Distribusjonskanal>>(byggTomRessurs());
+    const [distribusjonskanal, settDistribusjonskanal] = useState<Ressurs<Distribusjonskanal>>(byggTomRessurs());
 
     const nullstillDokument = () => {
         settHentetDokument(byggTomRessurs);

--- a/src/frontend/hooks/useFagsakIdParam.test.tsx
+++ b/src/frontend/hooks/useFagsakIdParam.test.tsx
@@ -1,5 +1,4 @@
 import type { PropsWithChildren } from 'react';
-import React from 'react';
 
 import { renderHook } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';

--- a/src/frontend/hooks/useHentSaksbehandler.test.tsx
+++ b/src/frontend/hooks/useHentSaksbehandler.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -33,7 +33,7 @@ describe('useHentSaksbehandler', () => {
         vi.mocked(hentSaksbehandler).mockResolvedValueOnce(iSaksbehandler);
 
         const queryClient = createTestQueryClient();
-        const wrapper = ({ children }: { children: React.ReactNode }) => (
+        const wrapper = ({ children }: { children: ReactNode }) => (
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
         );
 
@@ -60,7 +60,7 @@ describe('useHentSaksbehandler', () => {
         vi.mocked(hentSaksbehandler).mockRejectedValueOnce(networkError);
 
         const queryClient = createTestQueryClient();
-        const wrapper = ({ children }: { children: React.ReactNode }) => (
+        const wrapper = ({ children }: { children: ReactNode }) => (
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
         );
 
@@ -84,7 +84,7 @@ describe('useHentSaksbehandler', () => {
         // Arrange
         const iSaksbehandler = lagISaksbehandler();
         const queryClient = createTestQueryClient();
-        const wrapper = ({ children }: { children: React.ReactNode }) => (
+        const wrapper = ({ children }: { children: ReactNode }) => (
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
         );
 

--- a/src/frontend/ikoner/DokumentIkon.tsx
+++ b/src/frontend/ikoner/DokumentIkon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 interface IDokumentIkon {
     filled?: boolean;
@@ -7,7 +7,7 @@ interface IDokumentIkon {
     width?: number;
 }
 
-export const DokumentIkon: React.FC<IDokumentIkon> = ({ className, filled = false, width = 48, height = 48 }) => {
+export const DokumentIkon: FC<IDokumentIkon> = ({ className, filled = false, width = 48, height = 48 }) => {
     return filled ? (
         <svg
             aria-labelledby={'dokument'}

--- a/src/frontend/ikoner/DokumentIkon.tsx
+++ b/src/frontend/ikoner/DokumentIkon.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 interface IDokumentIkon {
     filled?: boolean;
     className?: string;
@@ -7,7 +5,7 @@ interface IDokumentIkon {
     width?: number;
 }
 
-export const DokumentIkon: FC<IDokumentIkon> = ({ className, filled = false, width = 48, height = 48 }) => {
+export const DokumentIkon = ({ className, filled = false, width = 48, height = 48 }: IDokumentIkon) => {
     return filled ? (
         <svg
             aria-labelledby={'dokument'}

--- a/src/frontend/ikoner/EksternLenke.tsx
+++ b/src/frontend/ikoner/EksternLenke.tsx
@@ -1,12 +1,10 @@
-import type { FC } from 'react';
-
 interface IEksternLenke {
     className?: string;
     height?: number;
     width?: number;
 }
 
-export const EksternLenke: FC<IEksternLenke> = ({ className, width = 16, height = 16 }) => {
+export const EksternLenke = ({ className, width = 16, height = 16 }: IEksternLenke) => {
     //<!-- Created with Method Draw - http://github.com/duopixel/Method-Draw/ -->
     return (
         <svg

--- a/src/frontend/ikoner/EksternLenke.tsx
+++ b/src/frontend/ikoner/EksternLenke.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 interface IEksternLenke {
     className?: string;
@@ -6,7 +6,7 @@ interface IEksternLenke {
     width?: number;
 }
 
-export const EksternLenke: React.FC<IEksternLenke> = ({ className, width = 16, height = 16 }) => {
+export const EksternLenke: FC<IEksternLenke> = ({ className, width = 16, height = 16 }) => {
     //<!-- Created with Method Draw - http://github.com/duopixel/Method-Draw/ -->
     return (
         <svg

--- a/src/frontend/ikoner/EmailIkon.tsx
+++ b/src/frontend/ikoner/EmailIkon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 interface IEmailIkon {
     filled?: boolean;
@@ -7,7 +7,7 @@ interface IEmailIkon {
     width?: number;
 }
 
-export const EmailIkon: React.FC<IEmailIkon> = ({ className, filled = false, width = 48, height = 48 }) => {
+export const EmailIkon: FC<IEmailIkon> = ({ className, filled = false, width = 48, height = 48 }) => {
     return filled ? (
         <svg
             aria-labelledby={'email'}

--- a/src/frontend/ikoner/EmailIkon.tsx
+++ b/src/frontend/ikoner/EmailIkon.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 interface IEmailIkon {
     filled?: boolean;
     className?: string;
@@ -7,7 +5,7 @@ interface IEmailIkon {
     width?: number;
 }
 
-export const EmailIkon: FC<IEmailIkon> = ({ className, filled = false, width = 48, height = 48 }) => {
+export const EmailIkon = ({ className, filled = false, width = 48, height = 48 }: IEmailIkon) => {
     return filled ? (
         <svg
             aria-labelledby={'email'}

--- a/src/frontend/ikoner/KontoSirkel.tsx
+++ b/src/frontend/ikoner/KontoSirkel.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 interface IKontoSirkel {
@@ -9,7 +7,7 @@ interface IKontoSirkel {
     width?: number;
 }
 
-export const KontoSirkel: FC<IKontoSirkel> = ({ className, filled = false, width = 48, height = 48 }) => {
+export const KontoSirkel = ({ className, filled = false, width = 48, height = 48 }: IKontoSirkel) => {
     return filled ? (
         <StyledSvg
             aria-labelledby={'kontosirkel'}

--- a/src/frontend/ikoner/KontoSirkel.tsx
+++ b/src/frontend/ikoner/KontoSirkel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -9,7 +9,7 @@ interface IKontoSirkel {
     width?: number;
 }
 
-export const KontoSirkel: React.FC<IKontoSirkel> = ({ className, filled = false, width = 48, height = 48 }) => {
+export const KontoSirkel: FC<IKontoSirkel> = ({ className, filled = false, width = 48, height = 48 }) => {
     return filled ? (
         <StyledSvg
             aria-labelledby={'kontosirkel'}

--- a/src/frontend/ikoner/KontorIkonGrønn.tsx
+++ b/src/frontend/ikoner/KontorIkonGrønn.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,7 +27,7 @@ const IkonSirkel = styled.span<{
     color: white;
 `;
 
-const KontorIkonGrønn: React.FunctionComponent<IKontorIkonGrønn> = ({
+const KontorIkonGrønn: FunctionComponent<IKontorIkonGrønn> = ({
     className,
     height = '24',
     width = '24',

--- a/src/frontend/ikoner/KontorIkonGrønn.tsx
+++ b/src/frontend/ikoner/KontorIkonGrønn.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import styled from 'styled-components';
 
 import { Buildings3Icon } from '@navikt/aksel-icons';
@@ -27,12 +25,7 @@ const IkonSirkel = styled.span<{
     color: white;
 `;
 
-const KontorIkonGrønn: FunctionComponent<IKontorIkonGrønn> = ({
-    className,
-    height = '24',
-    width = '24',
-    color = Success500,
-}) => {
+const KontorIkonGrønn = ({ className, height = '24', width = '24', color = Success500 }: IKontorIkonGrønn) => {
     return (
         <IkonSirkel $height={height} $width={width} $color={color}>
             <Buildings3Icon height={height === '24' ? 20 : 28} width={width === '24' ? 20 : 28} className={className} />

--- a/src/frontend/ikoner/NavLogo.tsx
+++ b/src/frontend/ikoner/NavLogo.tsx
@@ -1,12 +1,10 @@
-import type { FunctionComponent } from 'react';
-
 interface INavLogo {
     className?: string;
     height?: number;
     width?: number;
 }
 
-const NavLogo: FunctionComponent<INavLogo> = ({ className, height = 20, width = 65 }) => {
+const NavLogo = ({ className, height = 20, width = 65 }: INavLogo) => {
     return (
         <svg
             width={width}

--- a/src/frontend/ikoner/NavLogo.tsx
+++ b/src/frontend/ikoner/NavLogo.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 interface INavLogo {
     className?: string;
@@ -6,7 +6,7 @@ interface INavLogo {
     width?: number;
 }
 
-const NavLogo: React.FunctionComponent<INavLogo> = ({ className, height = 20, width = 65 }) => {
+const NavLogo: FunctionComponent<INavLogo> = ({ className, height = 20, width = 65 }) => {
     return (
         <svg
             width={width}

--- a/src/frontend/ikoner/Slett.tsx
+++ b/src/frontend/ikoner/Slett.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 interface ISlett {
     className?: string;
@@ -6,7 +6,7 @@ interface ISlett {
     width?: number;
 }
 
-const Slett: React.FunctionComponent<ISlett> = ({ className, height = 24, width = 24 }) => {
+const Slett: FunctionComponent<ISlett> = ({ className, height = 24, width = 24 }) => {
     return (
         <svg
             aria-labelledby={'Slett'}

--- a/src/frontend/ikoner/Slett.tsx
+++ b/src/frontend/ikoner/Slett.tsx
@@ -1,12 +1,10 @@
-import type { FunctionComponent } from 'react';
-
 interface ISlett {
     className?: string;
     height?: number;
     width?: number;
 }
 
-const Slett: FunctionComponent<ISlett> = ({ className, height = 24, width = 24 }) => {
+const Slett = ({ className, height = 24, width = 24 }: ISlett) => {
     return (
         <svg
             aria-labelledby={'Slett'}

--- a/src/frontend/ikoner/StatusIkon.tsx
+++ b/src/frontend/ikoner/StatusIkon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -45,7 +45,7 @@ const InfoIkon = styled(InformationSquareFillIcon)`
     min-width: 1.5rem;
 `;
 
-const StatusIkon: React.FC<IProps> = ({ status, title }) => {
+const StatusIkon: FC<IProps> = ({ status, title }) => {
     switch (status) {
         case Status.OK:
             return <OkIkon title={title} />;

--- a/src/frontend/ikoner/StatusIkon.tsx
+++ b/src/frontend/ikoner/StatusIkon.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import {
@@ -45,7 +43,7 @@ const InfoIkon = styled(InformationSquareFillIcon)`
     min-width: 1.5rem;
 `;
 
-const StatusIkon: FC<IProps> = ({ status, title }) => {
+const StatusIkon = ({ status, title }: IProps) => {
     switch (status) {
         case Status.OK:
             return <OkIkon title={title} />;

--- a/src/frontend/ikoner/VilkårResultatIkon.tsx
+++ b/src/frontend/ikoner/VilkårResultatIkon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import StatusIkon, { Status } from './StatusIkon';
 import type { ResultatBegrunnelse } from '../typer/vilkår';
@@ -11,7 +11,7 @@ interface IVilkårResultatIkon {
     resultatBegrunnelse?: ResultatBegrunnelse | null;
 }
 
-const VilkårResultatIkon: React.FC<IVilkårResultatIkon> = ({ resultat, resultatBegrunnelse }) => {
+const VilkårResultatIkon: FC<IVilkårResultatIkon> = ({ resultat, resultatBegrunnelse }) => {
     if (resultatBegrunnelse && resultat === Resultat.OPPFYLT) {
         return <StatusIkon status={Status.INFO} />;
     }

--- a/src/frontend/ikoner/VilkårResultatIkon.tsx
+++ b/src/frontend/ikoner/VilkårResultatIkon.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import StatusIkon, { Status } from './StatusIkon';
 import type { ResultatBegrunnelse } from '../typer/vilkår';
 import { Resultat } from '../typer/vilkår';
@@ -11,7 +9,7 @@ interface IVilkårResultatIkon {
     resultatBegrunnelse?: ResultatBegrunnelse | null;
 }
 
-const VilkårResultatIkon: FC<IVilkårResultatIkon> = ({ resultat, resultatBegrunnelse }) => {
+const VilkårResultatIkon = ({ resultat, resultatBegrunnelse }: IVilkårResultatIkon) => {
     if (resultatBegrunnelse && resultat === Resultat.OPPFYLT) {
         return <StatusIkon status={Status.INFO} />;
     }

--- a/src/frontend/ikoner/ØyeGrå.tsx
+++ b/src/frontend/ikoner/ØyeGrå.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 interface IØyeGrå {
     className?: string;
@@ -6,7 +6,7 @@ interface IØyeGrå {
     width?: number;
 }
 
-const ØyeGrå: React.FunctionComponent<IØyeGrå> = ({ className, height, width }) => {
+const ØyeGrå: FunctionComponent<IØyeGrå> = ({ className, height, width }) => {
     return (
         <svg
             aria-labelledby={'Øye grå'}

--- a/src/frontend/ikoner/ØyeGrå.tsx
+++ b/src/frontend/ikoner/ØyeGrå.tsx
@@ -1,12 +1,10 @@
-import type { FunctionComponent } from 'react';
-
 interface IØyeGrå {
     className?: string;
     height?: number;
     width?: number;
 }
 
-const ØyeGrå: FunctionComponent<IØyeGrå> = ({ className, height, width }) => {
+const ØyeGrå = ({ className, height, width }: IØyeGrå) => {
     return (
         <svg
             aria-labelledby={'Øye grå'}

--- a/src/frontend/ikoner/ØyeGrønn.tsx
+++ b/src/frontend/ikoner/ØyeGrønn.tsx
@@ -1,12 +1,10 @@
-import type { FunctionComponent } from 'react';
-
 interface IØyeGrønn {
     className?: string;
     height?: number;
     width?: number;
 }
 
-const ØyeGrønn: FunctionComponent<IØyeGrønn> = ({ className, height, width }) => {
+const ØyeGrønn = ({ className, height, width }: IØyeGrønn) => {
     return (
         <svg
             aria-labelledby={'Øye grønn'}

--- a/src/frontend/ikoner/ØyeGrønn.tsx
+++ b/src/frontend/ikoner/ØyeGrønn.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 interface IØyeGrønn {
     className?: string;
@@ -6,7 +6,7 @@ interface IØyeGrønn {
     width?: number;
 }
 
-const ØyeGrønn: React.FunctionComponent<IØyeGrønn> = ({ className, height, width }) => {
+const ØyeGrønn: FunctionComponent<IØyeGrønn> = ({ className, height, width }) => {
     return (
         <svg
             aria-labelledby={'Øye grønn'}

--- a/src/frontend/ikoner/ØyeRød.tsx
+++ b/src/frontend/ikoner/ØyeRød.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 interface IØyeRød {
     className?: string;
@@ -6,7 +6,7 @@ interface IØyeRød {
     width?: number;
 }
 
-const ØyeRød: React.FunctionComponent<IØyeRød> = ({ className, height, width }) => {
+const ØyeRød: FunctionComponent<IØyeRød> = ({ className, height, width }) => {
     return (
         <svg
             aria-labelledby={'Øye rød'}

--- a/src/frontend/ikoner/ØyeRød.tsx
+++ b/src/frontend/ikoner/ØyeRød.tsx
@@ -1,12 +1,10 @@
-import type { FunctionComponent } from 'react';
-
 interface IØyeRød {
     className?: string;
     height?: number;
     width?: number;
 }
 
-const ØyeRød: FunctionComponent<IØyeRød> = ({ className, height, width }) => {
+const ØyeRød = ({ className, height, width }: IØyeRød) => {
     return (
         <svg
             aria-labelledby={'Øye rød'}

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -1,4 +1,5 @@
-import axe from '@axe-core/react';
+import { StrictMode } from 'react';
+
 import * as Sentry from '@sentry/browser';
 import { setDefaultOptions } from 'date-fns';
 import { nb } from 'date-fns/locale';
@@ -23,13 +24,16 @@ if (!erLokal()) {
 }
 
 if (erLokal()) {
-    axe(React, ReactDOM, 1000);
+    (async () => {
+        const [{ default: axe }, { default: React }] = await Promise.all([import('@axe-core/react'), import('react')]);
+        axe(React, ReactDOM, 1000);
+    })();
 }
 
 const container = document.getElementById('app');
 const root = createRoot(container!);
 root.render(
-    <React.StrictMode>
+    <StrictMode>
         <App />
-    </React.StrictMode>
+    </StrictMode>
 );

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import axe from '@axe-core/react';
 import * as Sentry from '@sentry/browser';

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import axe from '@axe-core/react';
 import * as Sentry from '@sentry/browser';
 import { setDefaultOptions } from 'date-fns';

--- a/src/frontend/komponenter/Alert/BehandlingPåVentAlert.tsx
+++ b/src/frontend/komponenter/Alert/BehandlingPåVentAlert.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Alert } from '@navikt/ds-react';
 
 import { useBehandlingContext } from '../../sider/Fagsak/Behandling/context/BehandlingContext';

--- a/src/frontend/komponenter/Alert/MidlertidigEnhetAlert.tsx
+++ b/src/frontend/komponenter/Alert/MidlertidigEnhetAlert.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Alert } from '@navikt/ds-react';
 
 import { useBehandlingContext } from '../../sider/Fagsak/Behandling/context/BehandlingContext';

--- a/src/frontend/komponenter/Brevmottaker/BrevmottakerListe.tsx
+++ b/src/frontend/komponenter/Brevmottaker/BrevmottakerListe.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
 import { FagsakType } from '../../typer/fagsak';
 import type { IPersonInfo } from '../../typer/person';
@@ -12,7 +10,7 @@ interface IProps {
     brevmottakere: SkjemaBrevmottaker[];
 }
 
-const BrevmottakerListe: FC<IProps> = ({ bruker, brevmottakere }) => {
+const BrevmottakerListe = ({ bruker, brevmottakere }: IProps) => {
     const { fagsak } = useFagsakContext();
     const institusjon = fagsak.institusjon;
     const fagsakType = fagsak.fagsakType;

--- a/src/frontend/komponenter/Brevmottaker/BrevmottakerListe.tsx
+++ b/src/frontend/komponenter/Brevmottaker/BrevmottakerListe.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
 import { FagsakType } from '../../typer/fagsak';
@@ -12,7 +12,7 @@ interface IProps {
     brevmottakere: SkjemaBrevmottaker[];
 }
 
-const BrevmottakerListe: React.FC<IProps> = ({ bruker, brevmottakere }) => {
+const BrevmottakerListe: FC<IProps> = ({ bruker, brevmottakere }) => {
     const { fagsak } = useFagsakContext();
     const institusjon = fagsak.institusjon;
     const fagsakType = fagsak.fagsakType;

--- a/src/frontend/komponenter/Brevmottaker/BrevmottakereAlert.tsx
+++ b/src/frontend/komponenter/Brevmottaker/BrevmottakereAlert.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import { useLocation } from 'react-router';
@@ -35,7 +34,7 @@ interface BrevmottakereAlertFagsakProps extends Props {
     brevmottakere: SkjemaBrevmottaker[];
 }
 
-export const BrevmottakereAlert: FC<BrevmottakereAlertBehandlingProps | BrevmottakereAlertFagsakProps> = props => {
+export const BrevmottakereAlert = (props: BrevmottakereAlertBehandlingProps | BrevmottakereAlertFagsakProps) => {
     const { brevmottakere, className, bruker } = props;
 
     const location = useLocation();

--- a/src/frontend/komponenter/Brevmottaker/BrevmottakereAlert.tsx
+++ b/src/frontend/komponenter/Brevmottaker/BrevmottakereAlert.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { useState } from 'react';
 
 import { useLocation } from 'react-router';
@@ -35,9 +35,7 @@ interface BrevmottakereAlertFagsakProps extends Props {
     brevmottakere: SkjemaBrevmottaker[];
 }
 
-export const BrevmottakereAlert: React.FC<
-    BrevmottakereAlertBehandlingProps | BrevmottakereAlertFagsakProps
-> = props => {
+export const BrevmottakereAlert: FC<BrevmottakereAlertBehandlingProps | BrevmottakereAlertFagsakProps> = props => {
     const { brevmottakere, className, bruker } = props;
 
     const location = useLocation();

--- a/src/frontend/komponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Datovelger/Datovelger.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 
 import { addDays, format, subDays } from 'date-fns';
@@ -87,7 +86,7 @@ const Datovelger = ({
         },
     });
 
-    const [forrigeFeltVerdi, settForrigeFeltVerdi] = React.useState<Date | undefined>();
+    const [forrigeFeltVerdi, settForrigeFeltVerdi] = useState<Date | undefined>();
 
     // Oppdaterer verdien til datovelgeren hvis feltet har endret seg uten at det er datovelgeren som har trigget endringen
     if (felt.verdi != forrigeFeltVerdi) {

--- a/src/frontend/komponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
+++ b/src/frontend/komponenter/Datovelger/DatovelgerForGammelSkjemaløsning.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useEffect } from 'react';
 
 import { isValid, parseISO } from 'date-fns';

--- a/src/frontend/komponenter/Datovelger/Månedvelger.tsx
+++ b/src/frontend/komponenter/Datovelger/Månedvelger.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 
 import { endOfMonth, isBefore, isSameDay, startOfMonth } from 'date-fns';

--- a/src/frontend/komponenter/DødsfallTag.tsx
+++ b/src/frontend/komponenter/DødsfallTag.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { Tag } from '@navikt/ds-react';
 
@@ -8,7 +8,7 @@ interface IDødsfallTagProps {
     dødsfallDato: string;
 }
 
-const DødsfallTag: React.FC<IDødsfallTagProps> = ({ dødsfallDato }) => {
+const DødsfallTag: FC<IDødsfallTagProps> = ({ dødsfallDato }) => {
     const formatertDato = isoStringTilFormatertString({
         isoString: dødsfallDato,
         tilFormat: Datoformat.DATO,

--- a/src/frontend/komponenter/DødsfallTag.tsx
+++ b/src/frontend/komponenter/DødsfallTag.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { Tag } from '@navikt/ds-react';
 
 import { Datoformat, isoStringTilFormatertString } from '../utils/dato';
@@ -8,7 +6,7 @@ interface IDødsfallTagProps {
     dødsfallDato: string;
 }
 
-const DødsfallTag: FC<IDødsfallTagProps> = ({ dødsfallDato }) => {
+const DødsfallTag = ({ dødsfallDato }: IDødsfallTagProps) => {
     const formatertDato = isoStringTilFormatertString({
         isoString: dødsfallDato,
         tilFormat: Datoformat.DATO,

--- a/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,4 @@
 import { Component, type PropsWithChildren, type ReactNode } from 'react';
-import React from 'react';
 
 import * as Sentry from '@sentry/browser';
 

--- a/src/frontend/komponenter/ExternalLink.test.tsx
+++ b/src/frontend/komponenter/ExternalLink.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { describe, test, expect } from 'vitest';
 
 import { ExternalLink } from './ExternalLink';

--- a/src/frontend/komponenter/ExternalLink.tsx
+++ b/src/frontend/komponenter/ExternalLink.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import type { UIEvent } from 'react';
 
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { HStack, Link } from '@navikt/ds-react';
 
 interface Props {
     label: string;
-    onClick: (event: React.UIEvent) => void;
+    onClick: (event: UIEvent) => void;
 }
 
 export function ExternalLink({ label, onClick }: Props) {

--- a/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.test.tsx
+++ b/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { expect } from 'vitest';
 
 import { FalskIdentitet } from './FalskIdentitet';

--- a/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.tsx
+++ b/src/frontend/komponenter/FalskIdentitet/FalskIdentitet.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { BodyShort, Heading } from '@navikt/ds-react';
 
 import styles from './FalskIdentitet.module.css';

--- a/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.test.tsx
+++ b/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { fireEvent } from '@testing-library/dom';
 import { vi, beforeAll, afterAll } from 'vitest';

--- a/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.tsx
+++ b/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.tsx
@@ -1,6 +1,4 @@
-import type { KeyboardEvent } from 'react';
-import { useState, useRef, useEffect, useId, useLayoutEffect, useMemo } from 'react';
-import * as React from 'react';
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
@@ -256,7 +254,7 @@ export function FlaggCombobox<T extends string>(props: FlaggComboboxProps<T>) {
         }
     }
 
-    function handleOnKeyDownPressed(event: KeyboardEvent<HTMLInputElement>) {
+    function handleOnKeyDownPressed(event: React.KeyboardEvent<HTMLInputElement>) {
         if (readOnly) {
             return;
         }
@@ -317,7 +315,7 @@ export function FlaggCombobox<T extends string>(props: FlaggComboboxProps<T>) {
         }
     }
 
-    function handleOnChipRemoved(event: React.MouseEvent<HTMLButtonElement>, valToRemove: T) {
+    function handleOnChipRemoved(event: React.MouseEvent, valToRemove: T) {
         if (!props.isMulti || readOnly) {
             return;
         }

--- a/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.tsx
+++ b/src/frontend/komponenter/FlaggCombobox/FlaggCombobox.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useRef, useEffect, useId, type KeyboardEvent, useLayoutEffect, useMemo } from 'react';
+import type { KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, useId, useLayoutEffect, useMemo } from 'react';
+import * as React from 'react';
 
 import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';

--- a/src/frontend/komponenter/FlaggCombobox/RegionCombobox/RegionCombobox.tsx
+++ b/src/frontend/komponenter/FlaggCombobox/RegionCombobox/RegionCombobox.tsx
@@ -1,4 +1,5 @@
-import React, { type Ref, useMemo } from 'react';
+import type { Ref } from 'react';
+import { useMemo } from 'react';
 
 import { FlaggCombobox } from '../FlaggCombobox';
 import { REGIONKODE_TIL_LABEL, type Regionkode } from './region';

--- a/src/frontend/komponenter/FlaggCombobox/ValutaCombobox/ValutaCombobox.tsx
+++ b/src/frontend/komponenter/FlaggCombobox/ValutaCombobox/ValutaCombobox.tsx
@@ -1,4 +1,5 @@
-import React, { type Ref, useMemo } from 'react';
+import type { Ref } from 'react';
+import { useMemo } from 'react';
 
 import { VALUTAKODE_TIL_LABEL, VALUTAKODE_TIL_REGIONKODE, type Valutakode } from './valuta';
 import { FlaggCombobox } from '../FlaggCombobox';

--- a/src/frontend/komponenter/FormDebugger.tsx
+++ b/src/frontend/komponenter/FormDebugger.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useFormContext } from 'react-hook-form';
 
 const style = {

--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, FC } from 'react';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
@@ -40,7 +40,7 @@ function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): ReactNode {
     );
 }
 
-const FagsakDeltagerSøk: FC = () => {
+const FagsakDeltagerSøk = () => {
     const { request } = useHttp();
     const navigate = useNavigate();
     const { skalObfuskereData } = useAppContext();

--- a/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/FagsakDeltagerSøk.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactNode, FC } from 'react';
+import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
 
@@ -25,7 +26,7 @@ import { obfuskerFagsakDeltager } from '../../utils/obfuskerData';
 import { erAdresseBeskyttet } from '../../utils/validators';
 import { PersonIkon } from '../PersonIkon';
 
-function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactNode {
+function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): ReactNode {
     return (
         <PersonIkon
             fagsakType={fagsakDeltager.fagsakType}
@@ -39,12 +40,12 @@ function mapFagsakDeltagerTilIkon(fagsakDeltager: IFagsakDeltager): React.ReactN
     );
 }
 
-const FagsakDeltagerSøk: React.FC = () => {
+const FagsakDeltagerSøk: FC = () => {
     const { request } = useHttp();
     const navigate = useNavigate();
     const { skalObfuskereData } = useAppContext();
 
-    const [fagsakDeltagere, settFagsakDeltagere] = React.useState<Ressurs<IFagsakDeltager[]>>(byggTomRessurs());
+    const [fagsakDeltagere, settFagsakDeltagere] = useState<Ressurs<IFagsakDeltager[]>>(byggTomRessurs());
 
     const { åpneModal } = useModal(ModalType.OPPRETT_FAGSAK);
 

--- a/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Header } from '@navikt/familie-header';
 
 import FagsakDeltagerSøk from './FagsakDeltagerSøk';

--- a/src/frontend/komponenter/Knapperekke.tsx
+++ b/src/frontend/komponenter/Knapperekke.tsx
@@ -1,9 +1,8 @@
-import type { PropsWithChildren } from 'react';
-import React from 'react';
+import type { FC, PropsWithChildren } from 'react';
 
 import { HStack } from '@navikt/ds-react';
 
-const Knapperekke: React.FC<PropsWithChildren> = ({ children }) => {
+const Knapperekke: FC<PropsWithChildren> = ({ children }) => {
     return (
         <HStack marginBlock="space-16 space-0" justify="space-between">
             {children}

--- a/src/frontend/komponenter/Knapperekke.tsx
+++ b/src/frontend/komponenter/Knapperekke.tsx
@@ -1,8 +1,8 @@
-import type { FC, PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { HStack } from '@navikt/ds-react';
 
-const Knapperekke: FC<PropsWithChildren> = ({ children }) => {
+const Knapperekke = ({ children }: PropsWithChildren) => {
     return (
         <HStack marginBlock="space-16 space-0" justify="space-between">
             {children}

--- a/src/frontend/komponenter/Modal/AppInfoModal.tsx
+++ b/src/frontend/komponenter/Modal/AppInfoModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Modal } from '@navikt/ds-react';
 
 import type { IModal } from '../../context/AppContext';

--- a/src/frontend/komponenter/Modal/LeggTilBarn/ErFolkeregistrertField.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/ErFolkeregistrertField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { HStack, Radio, RadioGroup } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Modal/LeggTilBarn/FødselsdatoField.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/FødselsdatoField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { startOfDay } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';
 

--- a/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/FødselsnummerField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Modal/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/LeggTilBarnModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { UIEvent } from 'react';
 
 import { FormProvider } from 'react-hook-form';
 
@@ -22,7 +22,7 @@ export function LeggTilBarnModal() {
         form.reset();
     }
 
-    function åpneDrek(event: React.UIEvent) {
+    function åpneDrek(event: UIEvent) {
         event.preventDefault();
         window.open('/redirect/drek', '_new');
     }

--- a/src/frontend/komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createContext, type PropsWithChildren, useContext, useState } from 'react';
 
 import type { IBarnMedOpplysninger } from '../../../typer/søknad';

--- a/src/frontend/komponenter/Modal/LeggTilBarn/NavnField.tsx
+++ b/src/frontend/komponenter/Modal/LeggTilBarn/NavnField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Modal/SesjonUtløpt.tsx
+++ b/src/frontend/komponenter/Modal/SesjonUtløpt.tsx
@@ -1,8 +1,6 @@
-import type { FC } from 'react';
-
 import { BodyShort, Modal } from '@navikt/ds-react';
 
-const UgyldigSesjon: FC = () => {
+const UgyldigSesjon = () => {
     return (
         <Modal header={{ heading: 'Ugyldig sesjon', size: 'small', closeButton: false }} width={'small'}>
             <Modal.Body>

--- a/src/frontend/komponenter/Modal/SesjonUtløpt.tsx
+++ b/src/frontend/komponenter/Modal/SesjonUtløpt.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { BodyShort, Modal } from '@navikt/ds-react';
 
-const UgyldigSesjon: React.FC = () => {
+const UgyldigSesjon: FC = () => {
     return (
         <Modal header={{ heading: 'Ugyldig sesjon', size: 'small', closeButton: false }} width={'small'}>
             <Modal.Body>

--- a/src/frontend/komponenter/Modal/fagsak/FeilmeldingModal.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/FeilmeldingModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert, Modal } from '@navikt/ds-react';
 
 import { ModalType } from '../../../context/ModalContext';

--- a/src/frontend/komponenter/Modal/fagsak/OpprettFagsakModal.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/OpprettFagsakModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert, Button, Modal } from '@navikt/ds-react';
 
 import { OpprettFagsakModalInnhold } from './OpprettFagsakModalInnhold';

--- a/src/frontend/komponenter/Modal/fagsak/OpprettFagsakModalInnhold.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/OpprettFagsakModalInnhold.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert, Button, Modal, Skeleton, VStack } from '@navikt/ds-react';
 
 import { FagsakerProvider } from './context/FagsakerContext';

--- a/src/frontend/komponenter/Modal/fagsak/PersonDetaljer.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/PersonDetaljer.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { BodyShort } from '@navikt/ds-react';
 
 import type { IPersonInfo } from '../../../typer/person';

--- a/src/frontend/komponenter/Modal/fagsak/SamhandlerTabell.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/SamhandlerTabell.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { TrashFillIcon } from '@navikt/aksel-icons';
 import { Button, HStack, Table } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Modal/fagsak/Undertittel.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/Undertittel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { BodyShort } from '@navikt/ds-react';
 
 import type { IBaseFagsak } from '../../../typer/fagsak';

--- a/src/frontend/komponenter/Modal/fagsak/context/FagsakerContext.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/context/FagsakerContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import { type IBaseFagsak, sjekkHarBarnEnsligMindreårigFagsak, sjekkHarNormalFagsak } from '../../../../typer/fagsak';
 

--- a/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Select } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Modal/fagsak/felt/OrganisasjonsnummerFelt.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/felt/OrganisasjonsnummerFelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Modal/fagsak/felt/SkjermetBarnSøkerFelt.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/felt/SkjermetBarnSøkerFelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Box, TextField } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Modal/fagsak/form/OpprettFagsakForm.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/form/OpprettFagsakForm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { type FieldErrors, FormProvider, type SubmitHandler, type UseFormReturn } from 'react-hook-form';
 
 import { VStack } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Modal/fagsak/form/SamhandlerForm.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/form/SamhandlerForm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { type FieldErrors, FormProvider, type SubmitHandler, type UseFormReturn } from 'react-hook-form';
 
 import { Alert, Box, Button, HGrid } from '@navikt/ds-react';

--- a/src/frontend/komponenter/MålformVelger.tsx
+++ b/src/frontend/komponenter/MålformVelger.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, FC } from 'react';
+import type { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
@@ -22,12 +22,12 @@ interface IProps {
     Legend?: ReactNode;
 }
 
-const MålformVelger: FC<IProps> = ({
+const MålformVelger = ({
     målformFelt,
     visFeilmeldinger,
     erLesevisning,
     Legend = <Heading size={'medium'} level={'2'} children={'Målform'} />,
-}) => {
+}: IProps) => {
     const radioOnChange = (målform: Målform) => {
         målformFelt.validerOgSettFelt(målform);
     };

--- a/src/frontend/komponenter/MålformVelger.tsx
+++ b/src/frontend/komponenter/MålformVelger.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ReactNode, FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -19,10 +19,10 @@ interface IProps {
     målformFelt: Felt<Målform | undefined>;
     visFeilmeldinger: boolean;
     erLesevisning: boolean;
-    Legend?: React.ReactNode;
+    Legend?: ReactNode;
 }
 
-const MålformVelger: React.FC<IProps> = ({
+const MålformVelger: FC<IProps> = ({
     målformFelt,
     visFeilmeldinger,
     erLesevisning,

--- a/src/frontend/komponenter/MånedÅrInput/MånedVelger.tsx
+++ b/src/frontend/komponenter/MånedÅrInput/MånedVelger.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { Select } from '@navikt/ds-react';
 
 interface MånedProps {
@@ -26,7 +24,7 @@ const månedValg = [
     { mndNr: '12', verdi: 'Desember' },
 ];
 
-const MånedVelger: FC<MånedProps> = ({ måned, settMåned, lesevisning = false, className, feil = false, label }) => {
+const MånedVelger = ({ måned, settMåned, lesevisning = false, className, feil = false, label }: MånedProps) => {
     return (
         <Select
             readOnly={lesevisning}

--- a/src/frontend/komponenter/MånedÅrInput/MånedVelger.tsx
+++ b/src/frontend/komponenter/MånedÅrInput/MånedVelger.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { Select } from '@navikt/ds-react';
 
@@ -26,14 +26,7 @@ const månedValg = [
     { mndNr: '12', verdi: 'Desember' },
 ];
 
-const MånedVelger: React.FC<MånedProps> = ({
-    måned,
-    settMåned,
-    lesevisning = false,
-    className,
-    feil = false,
-    label,
-}) => {
+const MånedVelger: FC<MånedProps> = ({ måned, settMåned, lesevisning = false, className, feil = false, label }) => {
     return (
         <Select
             readOnly={lesevisning}

--- a/src/frontend/komponenter/MånedÅrInput/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/MånedÅrInput/MånedÅrVelger.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
@@ -33,7 +33,7 @@ const StyledErrorMessage = styled(ErrorMessage)`
     margin-bottom: 0.5rem;
 `;
 
-const MånedÅrVelger: FC<Props> = ({
+const MånedÅrVelger = ({
     feil,
     value,
     label,
@@ -41,7 +41,7 @@ const MånedÅrVelger: FC<Props> = ({
     antallÅrTilbake = 10,
     antallÅrFrem = 4,
     lesevisning = false,
-}) => {
+}: Props) => {
     const årFraVerdi = () => (value ? parseInt(value.split('-')[0], 10) : undefined);
     const månedFraVerdi = () => (value ? value.split('-')[1] : undefined);
 

--- a/src/frontend/komponenter/MånedÅrInput/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/MånedÅrInput/MånedÅrVelger.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import React, { useEffect, useState } from 'react';
+import type { FC, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -33,7 +33,7 @@ const StyledErrorMessage = styled(ErrorMessage)`
     margin-bottom: 0.5rem;
 `;
 
-const MånedÅrVelger: React.FC<Props> = ({
+const MånedÅrVelger: FC<Props> = ({
     feil,
     value,
     label,

--- a/src/frontend/komponenter/MånedÅrInput/ÅrVelger.tsx
+++ b/src/frontend/komponenter/MånedÅrInput/ÅrVelger.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { Select } from '@navikt/ds-react';
 
@@ -26,14 +26,7 @@ const lagÅrOptions = (år: number | undefined, antallÅrFrem: number, antallÅr
     });
 };
 
-const Årvelger: React.FC<ÅrProps> = ({
-    år,
-    settÅr,
-    antallÅrFrem,
-    antallÅrTilbake,
-    lesevisning = false,
-    feil = false,
-}) => {
+const Årvelger: FC<ÅrProps> = ({ år, settÅr, antallÅrFrem, antallÅrTilbake, lesevisning = false, feil = false }) => {
     const årOptions = lagÅrOptions(år, antallÅrFrem, antallÅrTilbake);
     return (
         <Select

--- a/src/frontend/komponenter/MånedÅrInput/ÅrVelger.tsx
+++ b/src/frontend/komponenter/MånedÅrInput/ÅrVelger.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { Select } from '@navikt/ds-react';
 
 interface ÅrProps {
@@ -26,7 +24,7 @@ const lagÅrOptions = (år: number | undefined, antallÅrFrem: number, antallÅr
     });
 };
 
-const Årvelger: FC<ÅrProps> = ({ år, settÅr, antallÅrFrem, antallÅrTilbake, lesevisning = false, feil = false }) => {
+const Årvelger = ({ år, settÅr, antallÅrFrem, antallÅrTilbake, lesevisning = false, feil = false }: ÅrProps) => {
     const årOptions = lagÅrOptions(år, antallÅrFrem, antallÅrTilbake);
     return (
         <Select

--- a/src/frontend/komponenter/PdfVisningModal/ForhåndsvisOpprettingAvPdfModal.tsx
+++ b/src/frontend/komponenter/PdfVisningModal/ForhåndsvisOpprettingAvPdfModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { type MutationKey, useMutationState } from '@tanstack/react-query';
 import styled from 'styled-components';
 

--- a/src/frontend/komponenter/PdfVisningModal/PdfVisningModal.tsx
+++ b/src/frontend/komponenter/PdfVisningModal/PdfVisningModal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 
 import styled from 'styled-components';
 
@@ -26,7 +27,7 @@ const StyledModal = styled(Modal)`
 /**
  * @Deprecated - Erstattes av {@link ForhåndsvisPdfModal}.
  */
-const PdfVisningModal: React.FC<IPdfVisningModalProps> = ({ onRequestClose, onRequestOpen, pdfdata }) => {
+const PdfVisningModal: FC<IPdfVisningModalProps> = ({ onRequestClose, onRequestOpen, pdfdata }) => {
     useEffect(() => {
         if (onRequestOpen) {
             onRequestOpen();
@@ -54,7 +55,7 @@ const IframePdfVisning = styled.iframe`
     width: 100%;
 `;
 
-const Dokument: React.FC<{ pdfdata: Ressurs<string> }> = ({ pdfdata }) => {
+const Dokument: FC<{ pdfdata: Ressurs<string> }> = ({ pdfdata }) => {
     switch (pdfdata.status) {
         case RessursStatus.HENTER:
             return (

--- a/src/frontend/komponenter/PdfVisningModal/PdfVisningModal.tsx
+++ b/src/frontend/komponenter/PdfVisningModal/PdfVisningModal.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect } from 'react';
 
 import styled from 'styled-components';
@@ -27,7 +26,7 @@ const StyledModal = styled(Modal)`
 /**
  * @Deprecated - Erstattes av {@link ForhåndsvisPdfModal}.
  */
-const PdfVisningModal: FC<IPdfVisningModalProps> = ({ onRequestClose, onRequestOpen, pdfdata }) => {
+const PdfVisningModal = ({ onRequestClose, onRequestOpen, pdfdata }: IPdfVisningModalProps) => {
     useEffect(() => {
         if (onRequestOpen) {
             onRequestOpen();
@@ -55,7 +54,7 @@ const IframePdfVisning = styled.iframe`
     width: 100%;
 `;
 
-const Dokument: FC<{ pdfdata: Ressurs<string> }> = ({ pdfdata }) => {
+const Dokument = ({ pdfdata }: { pdfdata: Ressurs<string> }) => {
     switch (pdfdata.status) {
         case RessursStatus.HENTER:
             return (

--- a/src/frontend/komponenter/PersonIkon.test.tsx
+++ b/src/frontend/komponenter/PersonIkon.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { describe, test, expect } from 'vitest';
 
 import { kjønnType } from '@navikt/familie-typer';

--- a/src/frontend/komponenter/PersonIkon.tsx
+++ b/src/frontend/komponenter/PersonIkon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { PersonCircleFillIcon } from '@navikt/aksel-icons';

--- a/src/frontend/komponenter/PersonInformasjon/BegrunnelseFelt.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/BegrunnelseFelt.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { useFormContext } from 'react-hook-form';
 
 import { Textarea } from '@navikt/ds-react';

--- a/src/frontend/komponenter/PersonInformasjon/DødsfallDatoFelt.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/DødsfallDatoFelt.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { startOfDay } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';
 

--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { BodyShort, CopyButton, Heading, HStack } from '@navikt/ds-react';
 
 import RegistrerDødsfallDatoMeny from './RegistrerDødsfallDatoMeny';

--- a/src/frontend/komponenter/PersonInformasjon/RegistrerDødsfallDatoMeny.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/RegistrerDødsfallDatoMeny.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import { MenuElipsisHorizontalCircleIcon } from '@navikt/aksel-icons';
@@ -11,7 +10,7 @@ interface IRegistrerDødsfallDato {
     person: IGrunnlagPerson;
 }
 
-const RegistrerDødsfallDatoMeny: FC<IRegistrerDødsfallDato> = ({ person }) => {
+const RegistrerDødsfallDatoMeny = ({ person }: IRegistrerDødsfallDato) => {
     const [visModal, settVisModal] = useState<boolean>(false);
 
     return (

--- a/src/frontend/komponenter/PersonInformasjon/RegistrerDødsfallDatoMeny.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/RegistrerDødsfallDatoMeny.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import { MenuElipsisHorizontalCircleIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button } from '@navikt/ds-react';
@@ -10,8 +11,8 @@ interface IRegistrerDødsfallDato {
     person: IGrunnlagPerson;
 }
 
-const RegistrerDødsfallDatoMeny: React.FC<IRegistrerDødsfallDato> = ({ person }) => {
-    const [visModal, settVisModal] = React.useState<boolean>(false);
+const RegistrerDødsfallDatoMeny: FC<IRegistrerDødsfallDato> = ({ person }) => {
+    const [visModal, settVisModal] = useState<boolean>(false);
 
     return (
         <>

--- a/src/frontend/komponenter/PersonInformasjon/RegistrerDødsfallDatoModal.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/RegistrerDødsfallDatoModal.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { FormProvider } from 'react-hook-form';
 
 import { Button, Fieldset, Modal } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Personlinje/Personlinje.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { BodyShort, Box, CopyButton, HStack, Tag } from '@navikt/ds-react';
 import { kjønnType } from '@navikt/familie-typer';
 

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { Route, Routes } from 'react-router';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link as ReactRouterLink, useLocation } from 'react-router';
 
 import { FileTextIcon, HouseIcon, MagnifyingGlassIcon } from '@navikt/aksel-icons';

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { Route, Routes } from 'react-router';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link as ReactRouterLink, useLocation } from 'react-router';
 
 import { FileTextIcon, HouseIcon, MagnifyingGlassIcon } from '@navikt/aksel-icons';

--- a/src/frontend/komponenter/Saklinje/Meny/AInntekt/AInntekt.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/AInntekt/AInntekt.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { delay, http, HttpResponse } from 'msw';
 import { afterEach, beforeEach, describe, expect, type MockInstance, vi } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Meny/AInntekt/AInntekt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/AInntekt/AInntekt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu, BodyShort, Loader } from '@navikt/ds-react';
 
 import { useHentAInntektUrl } from './useHentAInntektUrl';

--- a/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { Route, Routes } from 'react-router';
 import { describe, expect, type MockInstance } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/BegrunnelseField.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/BegrunnelseField.tsx
@@ -1,4 +1,4 @@
-import React, { type ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 
 import { useController, useFormContext } from 'react-hook-form';
 

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe, expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 interface Props {

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/EndreBehandlendeEnhetModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormProvider } from 'react-hook-form';
 
 import { Button, Fieldset, Modal, VStack } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/VelgNyEnhetField.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandlendeEnhet/VelgNyEnhetField.tsx
@@ -1,4 +1,4 @@
-import React, { type ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 
 import { useController, useFormContext } from 'react-hook-form';
 

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/BehandlingstemaSelect.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/BehandlingstemaSelect.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Select } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstema.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstema.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe, expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstema.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstema.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstemaModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstemaModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormProvider } from 'react-hook-form';
 
 import { Button, Fieldset, Modal } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { Route, Routes } from 'react-router';
 import { describe, expect } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/BegrunnelseFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/BegrunnelseFelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Textarea } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/ForhåndsvisBrevLenke.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/ForhåndsvisBrevLenke.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link } from '@navikt/ds-react';
 
 import { ModalType } from '../../../../context/ModalContext';

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { http, HttpResponse } from 'msw';
 import { describe, expect } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 import { ModalType } from '../../../../context/ModalContext';

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormProvider } from 'react-hook-form';
 
 import { Alert, BodyLong, Button, Fieldset, Modal, VStack } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingVeivalgModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingVeivalgModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useNavigate } from 'react-router';
 
 import { Alert, BodyShort, Button, Modal } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/ÅrsakFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/ÅrsakFelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Select } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort, Button, Fieldset, Modal, Select } from '@navikt/ds-react';
@@ -27,7 +25,7 @@ interface IProps {
     lukkModal: () => void;
 }
 
-export const SettBehandlingPåVentModal: FC<IProps> = ({ lukkModal }) => {
+export const SettBehandlingPåVentModal = ({ lukkModal }: IProps) => {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const årsaker = hentVelgbareÅrsaker();
     const { skjema, kanSendeSkjema, onSubmit } = useSettPåVentSkjema(behandling.aktivSettPåVent);

--- a/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettBehandlingPåVentModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,7 +27,7 @@ interface IProps {
     lukkModal: () => void;
 }
 
-export const SettBehandlingPåVentModal: React.FC<IProps> = ({ lukkModal }) => {
+export const SettBehandlingPåVentModal: FC<IProps> = ({ lukkModal }) => {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const årsaker = hentVelgbareÅrsaker();
     const { skjema, kanSendeSkjema, onSubmit } = useSettPåVentSkjema(behandling.aktivSettPåVent);

--- a/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettEllerOppdaterVenting.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettEllerOppdaterVenting.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettEllerOppdaterVenting.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/SettEllerOppdaterVenting.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/TaBehandlingAvVent.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/TaBehandlingAvVent.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe, expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/TaBehandlingAvVent.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/TaBehandlingAvVent.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/TaBehandlingAvVentModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggBehandlingPåVent/TaBehandlingAvVentModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnFelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe, expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandlingModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormProvider } from 'react-hook-form';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 
 import { useLocation } from 'react-router';
 import styled from 'styled-components';
@@ -71,7 +71,7 @@ const BrevmottakerSkjema = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
                     {...skjema.felter.mottaker.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                     readOnly={erLesevisning}
                     label="Mottaker"
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>): void => {
+                    onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
                         skjema.felter.mottaker.validerOgSettFelt(event.target.value as Mottaker);
                     }}
                 >

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useLocation } from 'react-router';
 import styled from 'styled-components';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
 import { useLagreEllerFjernMottakerPåBehandling } from './useLagreOgFjernMottakerPåBehandling';
 import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
@@ -8,7 +6,7 @@ interface IBehandlingModalProps {
     lukkModal: () => void;
 }
 
-export const LeggTilBrevmottakerModalBehandling: FC<IBehandlingModalProps> = ({ lukkModal }) => {
+export const LeggTilBrevmottakerModalBehandling = ({ lukkModal }: IBehandlingModalProps) => {
     const { behandling, vurderErLesevisning } = useBehandlingContext();
 
     const { lagreMottaker, fjernMottaker } = useLagreEllerFjernMottakerPåBehandling({

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
 import { useLagreEllerFjernMottakerPåBehandling } from './useLagreOgFjernMottakerPåBehandling';
@@ -8,7 +8,7 @@ interface IBehandlingModalProps {
     lukkModal: () => void;
 }
 
-export const LeggTilBrevmottakerModalBehandling: React.FC<IBehandlingModalProps> = ({ lukkModal }) => {
+export const LeggTilBrevmottakerModalBehandling: FC<IBehandlingModalProps> = ({ lukkModal }) => {
     const { behandling, vurderErLesevisning } = useBehandlingContext();
 
     const { lagreMottaker, fjernMottaker } = useLagreEllerFjernMottakerPåBehandling({

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
 import type { BrevmottakerUseSkjema, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import { felterTilSkjemaBrevmottaker } from './useBrevmottakerSkjema';
@@ -9,7 +7,7 @@ interface IFagsakModalProps {
     lukkModal: () => void;
 }
 
-export const LeggTilBrevmottakerModalFagsak: FC<IFagsakModalProps> = ({ lukkModal }) => {
+export const LeggTilBrevmottakerModalFagsak = ({ lukkModal }: IFagsakModalProps) => {
     const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
         useManuelleBrevmottakerePåFagsakContext();
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
 import type { BrevmottakerUseSkjema, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
@@ -9,7 +9,7 @@ interface IFagsakModalProps {
     lukkModal: () => void;
 }
 
-export const LeggTilBrevmottakerModalFagsak: React.FC<IFagsakModalProps> = ({ lukkModal }) => {
+export const LeggTilBrevmottakerModalFagsak: FC<IFagsakModalProps> = ({ lukkModal }) => {
     const { manuelleBrevmottakerePåFagsak, settManuelleBrevmottakerePåFagsak } =
         useManuelleBrevmottakerePåFagsakContext();
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe, expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { Route, Routes } from 'react-router';
 import { describe, expect } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useLocation } from 'react-router';
 
 import { ActionMenu } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandling.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 interface Props {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingBehandlingstemaSelect.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingBehandlingstemaSelect.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Select } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
 

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { isBefore, subDays } from 'date-fns';
 import styled from 'styled-components';
 

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -1,4 +1,4 @@
-import type { FC, ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 
 import { Select, UNSAFE_Combobox } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
@@ -93,13 +93,13 @@ interface BehandlingÅrsakSelect extends HTMLSelectElement {
     value: BehandlingÅrsak | '';
 }
 
-const OpprettBehandlingValg: FC<IProps> = ({
+const OpprettBehandlingValg = ({
     skjema,
     minimalFagsak,
     erLesevisning = false,
     manuellJournalfør = false,
     bruker = undefined,
-}) => {
+}: IProps) => {
     const saksbehandler = useSaksbehandler();
     const toggles = useFeatureToggles();
     const aktivBehandling: VisningBehandling | undefined = minimalFagsak

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC, ChangeEvent } from 'react';
 
 import { Select, UNSAFE_Combobox } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
@@ -93,7 +93,7 @@ interface BehandlingÅrsakSelect extends HTMLSelectElement {
     value: BehandlingÅrsak | '';
 }
 
-const OpprettBehandlingValg: React.FC<IProps> = ({
+const OpprettBehandlingValg: FC<IProps> = ({
     skjema,
     minimalFagsak,
     erLesevisning = false,
@@ -152,7 +152,7 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                 readOnly={erLesevisning}
                 name={'Behandling'}
                 label={'Velg type behandling'}
-                onChange={(event: React.ChangeEvent<BehandlingstypeSelect>): void => {
+                onChange={(event: ChangeEvent<BehandlingstypeSelect>): void => {
                     behandlingstype.onChange(event.target.value);
                 }}
             >
@@ -210,14 +210,13 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                     </option>
                 )}
             </Select>
-
             {behandlingsårsak.erSynlig && (
                 <Select
                     {...behandlingsårsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                     readOnly={erLesevisning}
                     name={'Behandlingsårsak'}
                     label={'Velg årsak'}
-                    onChange={(event: React.ChangeEvent<BehandlingÅrsakSelect>): void => {
+                    onChange={(event: ChangeEvent<BehandlingÅrsakSelect>): void => {
                         behandlingsårsak.onChange(event.target.value);
                     }}
                 >
@@ -238,7 +237,6 @@ const OpprettBehandlingValg: React.FC<IProps> = ({
                     })}
                 </Select>
             )}
-
             {erHelmanuellMigrering && erOpprettBehandlingSkjema(skjema) && skjema.felter.valgteBarn?.erSynlig && (
                 <UNSAFE_Combobox
                     label={'Legg til juridiske barn for migrering'}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { describe, expect } from 'vitest';

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useNavigate } from 'react-router';
 
 import { BodyLong, Button, Modal } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettFagsak/OpprettFagsak.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettFagsak/OpprettFagsak.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe, expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettFagsak/OpprettFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettFagsak/OpprettFagsak.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ActionMenu } from '@navikt/ds-react';
 
 import { ModalType } from '../../../../context/ModalContext';

--- a/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { describe, expect } from 'vitest';
 

--- a/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/SendInformasjonsbrev/SendInformasjonsbrev.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useLocation, useNavigate } from 'react-router';
 
 import { ActionMenu } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Samhandler/SamhandlerInformasjon.tsx
+++ b/src/frontend/komponenter/Samhandler/SamhandlerInformasjon.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort, CopyButton, Heading } from '@navikt/ds-react';
@@ -39,7 +37,7 @@ const FlexBox = styled.div`
     gap: 0.25rem;
 `;
 
-const SamhandlerInformasjon: FunctionComponent<IProps> = ({ samhandler, somOverskrift = false }) => {
+const SamhandlerInformasjon = ({ samhandler, somOverskrift = false }: IProps) => {
     const navn = samhandler.navn;
     const formattertOrgNummer = formaterIdent(samhandler.orgNummer);
     return (

--- a/src/frontend/komponenter/Samhandler/SamhandlerInformasjon.tsx
+++ b/src/frontend/komponenter/Samhandler/SamhandlerInformasjon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import styled from 'styled-components';
 
@@ -39,7 +39,7 @@ const FlexBox = styled.div`
     gap: 0.25rem;
 `;
 
-const SamhandlerInformasjon: React.FunctionComponent<IProps> = ({ samhandler, somOverskrift = false }) => {
+const SamhandlerInformasjon: FunctionComponent<IProps> = ({ samhandler, somOverskrift = false }) => {
     const navn = samhandler.navn;
     const formattertOrgNummer = formaterIdent(samhandler.orgNummer);
     return (

--- a/src/frontend/komponenter/Samhandler/SamhandlerTabell.tsx
+++ b/src/frontend/komponenter/Samhandler/SamhandlerTabell.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { Table } from '@navikt/ds-react';
 
 import type { ISamhandlerInfo } from '../../typer/samhandler';
 import { formaterIdent, formaterTekstStorForbokstav } from '../../utils/formatter';
 
-export const SamhandlerTabell: React.FC<{ samhandler: ISamhandlerInfo }> = ({ samhandler }) => {
+export const SamhandlerTabell: FC<{ samhandler: ISamhandlerInfo }> = ({ samhandler }) => {
     return (
         <Table size="small">
             <Table.Header>

--- a/src/frontend/komponenter/Samhandler/SamhandlerTabell.tsx
+++ b/src/frontend/komponenter/Samhandler/SamhandlerTabell.tsx
@@ -1,11 +1,9 @@
-import type { FC } from 'react';
-
 import { Table } from '@navikt/ds-react';
 
 import type { ISamhandlerInfo } from '../../typer/samhandler';
 import { formaterIdent, formaterTekstStorForbokstav } from '../../utils/formatter';
 
-export const SamhandlerTabell: FC<{ samhandler: ISamhandlerInfo }> = ({ samhandler }) => {
+export const SamhandlerTabell = ({ samhandler }: { samhandler: ISamhandlerInfo }) => {
     return (
         <Table size="small">
             <Table.Header>

--- a/src/frontend/komponenter/SystemetLaster/SystemetLaster.tsx
+++ b/src/frontend/komponenter/SystemetLaster/SystemetLaster.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import styled from 'styled-components';
 
 import { Heading, Loader, VStack } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useState } from 'react';
 
 import { addMonths, endOfMonth, startOfMonth, subMonths } from 'date-fns';
 

--- a/src/frontend/komponenter/Tidslinje/TidslinjeEtikett.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeEtikett.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import type { FunctionComponent } from 'react';
+import { useEffect } from 'react';
 
 import styled from 'styled-components';
 
@@ -48,7 +49,7 @@ const EtikettKnapp = styled(FamilieBaseKnapp)<{ disabled: boolean; $valgt: boole
     }
 `;
 
-const TidslinjeEtikett: React.FunctionComponent<IEtikettProp> = ({ etikett }) => {
+const TidslinjeEtikett: FunctionComponent<IEtikettProp> = ({ etikett }) => {
     const {
         aktivEtikett,
         settAktivEtikett,

--- a/src/frontend/komponenter/Tidslinje/TidslinjeEtikett.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeEtikett.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useEffect } from 'react';
 
 import styled from 'styled-components';
@@ -49,7 +48,7 @@ const EtikettKnapp = styled(FamilieBaseKnapp)<{ disabled: boolean; $valgt: boole
     }
 `;
 
-const TidslinjeEtikett: FunctionComponent<IEtikettProp> = ({ etikett }) => {
+const TidslinjeEtikett = ({ etikett }: IEtikettProp) => {
     const {
         aktivEtikett,
         settAktivEtikett,

--- a/src/frontend/komponenter/Tidslinje/TidslinjeNavigering.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeNavigering.tsx
@@ -1,5 +1,4 @@
-import type { PropsWithChildren } from 'react';
-import React from 'react';
+import type { FC, PropsWithChildren } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,7 +26,7 @@ const FlexMedSentrering = styled.div`
     align-items: center;
 `;
 
-const TidslinjeNavigering: React.FC<IProps> = ({
+const TidslinjeNavigering: FC<IProps> = ({
     naviger,
     kanNavigereTilHøyre = true,
     kanNavigereTilVenstre = true,

--- a/src/frontend/komponenter/Tidslinje/TidslinjeNavigering.tsx
+++ b/src/frontend/komponenter/Tidslinje/TidslinjeNavigering.tsx
@@ -1,4 +1,4 @@
-import type { FC, PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import styled from 'styled-components';
 
@@ -26,14 +26,14 @@ const FlexMedSentrering = styled.div`
     align-items: center;
 `;
 
-const TidslinjeNavigering: FC<IProps> = ({
+const TidslinjeNavigering = ({
     naviger,
     kanNavigereTilHøyre = true,
     kanNavigereTilVenstre = true,
     navigerTilVenstreTittel = 'Naviger til venstre i tidslinjen',
     navigerTilHøyreTittel = 'Naviger til høyre i tidslinjen',
     children,
-}) => {
+}: IProps) => {
     return (
         <StyledTidslinjenavigering className={'tidslinje-header__navigering'}>
             <Button

--- a/src/frontend/komponenter/Tidslinje/VinduVelger.tsx
+++ b/src/frontend/komponenter/Tidslinje/VinduVelger.tsx
@@ -1,10 +1,8 @@
-import type { FunctionComponent } from 'react';
-
 import { ToggleGroup } from '@navikt/ds-react';
 
 import { useTidslinjeContext } from './TidslinjeContext';
 
-const Vinduvelger: FunctionComponent = () => {
+const Vinduvelger = () => {
     const { tidslinjeVinduer, endreTidslinjeVindu, aktivtTidslinjeVindu } = useTidslinjeContext();
 
     return (

--- a/src/frontend/komponenter/Tidslinje/VinduVelger.tsx
+++ b/src/frontend/komponenter/Tidslinje/VinduVelger.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { ToggleGroup } from '@navikt/ds-react';
 
 import { useTidslinjeContext } from './TidslinjeContext';
 
-const Vinduvelger: React.FunctionComponent = () => {
+const Vinduvelger: FunctionComponent = () => {
     const { tidslinjeVinduer, endreTidslinjeVindu, aktivtTidslinjeVindu } = useTidslinjeContext();
 
     return (

--- a/src/frontend/komponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Toast/Toast.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import type { FC } from 'react';
+import { useEffect, useRef } from 'react';
 
 import styled from 'styled-components';
 
@@ -20,7 +21,7 @@ const Container = styled.div`
     }
 `;
 
-const Toast: React.FC<{ toastId: string; toast: IToast }> = ({ toastId, toast }) => {
+const Toast: FC<{ toastId: string; toast: IToast }> = ({ toastId, toast }) => {
     const { toasts, settToasts } = useAppContext();
     const toastRef = useRef<HTMLDivElement>(null);
 

--- a/src/frontend/komponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Toast/Toast.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect, useRef } from 'react';
 
 import styled from 'styled-components';
@@ -21,7 +20,7 @@ const Container = styled.div`
     }
 `;
 
-const Toast: FC<{ toastId: string; toast: IToast }> = ({ toastId, toast }) => {
+const Toast = ({ toastId, toast }: { toastId: string; toast: IToast }) => {
     const { toasts, settToasts } = useAppContext();
     const toastRef = useRef<HTMLDivElement>(null);
 

--- a/src/frontend/komponenter/Toast/Toasts.tsx
+++ b/src/frontend/komponenter/Toast/Toasts.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import Toast from './Toast';
@@ -13,7 +11,7 @@ const Container = styled.div`
     z-index: 9999;
 `;
 
-const Toasts: FC = () => {
+const Toasts = () => {
     const { toasts } = useAppContext();
 
     return (

--- a/src/frontend/komponenter/Toast/Toasts.tsx
+++ b/src/frontend/komponenter/Toast/Toasts.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -13,7 +13,7 @@ const Container = styled.div`
     z-index: 9999;
 `;
 
-const Toasts: React.FC = () => {
+const Toasts: FC = () => {
     const { toasts } = useAppContext();
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingContainer.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert, Box, HStack, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { Route, Routes, useLocation } from 'react-router';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Behandlingskort.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Behandlingskort.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { BodyShort, Box, Heading, HStack, VStack } from '@navikt/ds-react';
 import { TextDangerSubtle, TextInfoSubtle, TextNeutral, TextSuccessSubtle } from '@navikt/ds-tokens/dist/tokens';
 import type { AkselColoredBorderToken } from '@navikt/ds-tokens/types';

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Informasjonsbolk.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Behandlingskort/Informasjonsbolk.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { BodyShort, HGrid } from '@navikt/ds-react';
 import { TextNeutral } from '@navikt/ds-tokens/dist/tokens';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/BarnBrevetGjelder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/BarnBrevetGjelder.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { differenceInMilliseconds } from 'date-fns';
 
 import { Alert, Checkbox, CheckboxGroup } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brev.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brev.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ChangeEvent } from 'react';
 
 import { FileTextIcon, PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
 import {
@@ -115,7 +115,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
         ? opplysningsdokumenterTilInstitusjon.map(leggTilValuePåOption)
         : opplysningsdokumenter.map(leggTilValuePåOption);
 
-    const onChangeFritekstKulepunkt = (event: React.ChangeEvent<HTMLTextAreaElement>, fritekstKulepunktId: number) =>
+    const onChangeFritekstKulepunkt = (event: ChangeEvent<HTMLTextAreaElement>, fritekstKulepunktId: number) =>
         skjema.felter.fritekstKulepunkter.validerOgSettFelt([
             ...skjema.felter.fritekstKulepunkter.verdi.map(fritekstKulepunkt => {
                 if (fritekstKulepunkt.verdi.id === fritekstKulepunktId) {
@@ -170,7 +170,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                                 </Tag>
                             </HStack>
                         }
-                        onChange={(event: React.ChangeEvent<BrevtypeSelect>): void => {
+                        onChange={(event: ChangeEvent<BrevtypeSelect>): void => {
                             skjema.felter.brevmal.onChange(event.target.value);
                             skjema.felter.dokumenter.nullstill();
                         }}
@@ -230,7 +230,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                                                         value={fritekst.verdi.tekst}
                                                         maxLength={makslengdeFritekstHvertKulepunkt}
                                                         description={hjelpetekst}
-                                                        onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+                                                        onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
                                                             onChangeFritekstKulepunkt(event, fritekstId)
                                                         }
                                                         error={skjema.visFeilmeldinger && fritekst.feilmelding}
@@ -294,7 +294,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                                             className={styles.textarea}
                                             value={skjema.felter.fritekstAvsnitt.verdi}
                                             maxLength={maksLengdeFritekstAvsnitt}
-                                            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+                                            onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
                                                 skjema.felter.fritekstAvsnitt.validerOgSettFelt(event.target.value)
                                             }
                                             error={

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/LeggTilBarnKnapp.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
@@ -29,7 +29,7 @@ export const useBrevModul = () => {
     const makslengdeFritekstHvertKulepunkt = 220;
     const maksLengdeFritekstAvsnitt = 1000;
 
-    const [visFritekstAvsnittTekstboks, settVisFritekstAvsnittTekstboks] = React.useState(false);
+    const [visFritekstAvsnittTekstboks, settVisFritekstAvsnittTekstboks] = useState(false);
 
     const behandlingKategori = behandling?.kategori;
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Historikk/Historikk.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Historikk/Historikk.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { describe, expect, test } from 'vitest';
 
 import { Historikk } from './Historikk';

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Historikk/Historikk.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Historikk/Historikk.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { InformationSquareFillIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
 import { BodyShort, ErrorMessage, HStack, Loader, VStack } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Høyremeny.tsx
@@ -1,4 +1,4 @@
-import React, { Activity } from 'react';
+import { Activity } from 'react';
 
 import { Box, Button, Tabs, VStack } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/HøyremenyKnappikon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/HøyremenyKnappikon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 
 interface Props {

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/Ikon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/Ikon.tsx
@@ -1,4 +1,4 @@
-import type { FunctionComponent, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 export interface IIkonProps {
     color?: string;
@@ -8,7 +8,7 @@ export interface IIkonProps {
     children?: ReactNode | ReactNode[];
 }
 
-const Ikon: FunctionComponent<IIkonProps> = ({ children, width = 16, height = 16, viewBox = 24 }) => {
+const Ikon = ({ children, width = 16, height = 16, viewBox = 24 }: IIkonProps) => {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox={`0 0 ${viewBox} ${viewBox}`}>
             {children}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/Ikon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/Ikon.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react';
-import React from 'react';
+import type { FunctionComponent, ReactNode } from 'react';
 
 export interface IIkonProps {
     color?: string;
@@ -9,7 +8,7 @@ export interface IIkonProps {
     children?: ReactNode | ReactNode[];
 }
 
-const Ikon: React.FunctionComponent<IIkonProps> = ({ children, width = 16, height = 16, viewBox = 24 }) => {
+const Ikon: FunctionComponent<IIkonProps> = ({ children, width = 16, height = 16, viewBox = 24 }) => {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox={`0 0 ${viewBox} ${viewBox}`}>
             {children}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonDokumenter.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonDokumenter.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import type { IIkonProps } from './Ikon';
 import Ikon from './Ikon';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonHistorikk.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonHistorikk.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { IIkonProps } from './Ikon';
 import Ikon from './Ikon';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonMeldinger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonMeldinger.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { IIkonProps } from './Ikon';
 import Ikon from './Ikon';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonTotrinnskontroll.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Ikoner/IkonTotrinnskontroll.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import type { IIkonProps } from './Ikon';
 import Ikon from './Ikon';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/TabContextProvider.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/TabContextProvider.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext, useState, useMemo } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useState, useMemo } from 'react';
 
 import { useSkalViseTotrinnskontroll } from './useSkalViseTotrinnskontroll';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Tabvelger.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Tabs } from '@navikt/ds-react';
 
 import IkonHistorikk from './Ikoner/IkonHistorikk';

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState, useEffect } from 'react';
 
 import type { AxiosError } from 'axios';
 import styled from 'styled-components';
@@ -37,9 +37,9 @@ export function Totrinnskontroll() {
 
     const { request } = useHttp();
 
-    const [innsendtVedtak, settInnsendtVedtak] = React.useState<Ressurs<IBehandling>>(byggTomRessurs());
+    const [innsendtVedtak, settInnsendtVedtak] = useState<Ressurs<IBehandling>>(byggTomRessurs());
 
-    const [forrigeState, settForrigeState] = React.useState(trinnPåBehandling);
+    const [forrigeState, settForrigeState] = useState(trinnPåBehandling);
 
     const nullstillFeilmelding = () => {
         const erFørsteSjekk = Object.entries(forrigeState).some(([sideId, trinn]) => {
@@ -58,7 +58,7 @@ export function Totrinnskontroll() {
         settForrigeState(trinnPåBehandling);
     };
 
-    React.useEffect(() => {
+    useEffect(() => {
         nullstillFeilmelding();
     }, [trinnPåBehandling]);
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/TotrinnskontrollModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/TotrinnskontrollModal.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { useNavigate } from 'react-router';
 
 import { BodyShort, Box, Button, Modal } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/TotrinnskontrollModalContextProvider.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/TotrinnskontrollModalContextProvider.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext, useState, useMemo, useCallback } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useState, useMemo, useCallback } from 'react';
 
 import { TotrinnskontrollBeslutning } from '../../../../../typer/totrinnskontroll';
 

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -167,10 +166,7 @@ const Trinn = styled.div`
     }
 `;
 
-const TrinnStatus: FC<{
-    kontrollertStatus: KontrollertStatus;
-    navn: string;
-}> = ({ kontrollertStatus, navn }) => {
+const TrinnStatus = ({ kontrollertStatus, navn }: { kontrollertStatus: KontrollertStatus; navn: string }) => {
     return (
         <Trinn>
             {kontrollertStatus === KontrollertStatus.IKKE_KONTROLLERT && <ØyeGrå height={24} width={24} />}

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -38,10 +39,8 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
     const { behandling, trinnPåBehandling } = useBehandlingContext();
     const saksbehandler = useSaksbehandler();
 
-    const [beslutning, settBeslutning] = React.useState<TotrinnskontrollBeslutning>(
-        TotrinnskontrollBeslutning.IKKE_VURDERT
-    );
-    const [begrunnelse, settBegrunnelse] = React.useState<string>('');
+    const [beslutning, settBeslutning] = useState<TotrinnskontrollBeslutning>(TotrinnskontrollBeslutning.IKKE_VURDERT);
+    const [begrunnelse, settBegrunnelse] = useState<string>('');
 
     const senderInn = innsendtVedtak.status === RessursStatus.HENTER;
 
@@ -168,7 +167,7 @@ const Trinn = styled.div`
     }
 `;
 
-const TrinnStatus: React.FC<{
+const TrinnStatus: FC<{
     kontrollertStatus: KontrollertStatus;
     navn: string;
 }> = ({ kontrollertStatus, navn }) => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 import { useEffect } from 'react';
 
 import { useNavigate } from 'react-router';
@@ -59,7 +59,7 @@ interface IBehandlingsresultatProps {
     åpenBehandling: IBehandling;
 }
 
-const Behandlingsresultat: React.FunctionComponent<IBehandlingsresultatProps> = ({ åpenBehandling }) => {
+const Behandlingsresultat: FunctionComponent<IBehandlingsresultatProps> = ({ åpenBehandling }) => {
     const { settÅpenBehandling } = useBehandlingContext();
 
     const fagsak = useFagsak();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useEffect } from 'react';
 
 import { useNavigate } from 'react-router';
@@ -59,7 +58,7 @@ interface IBehandlingsresultatProps {
     åpenBehandling: IBehandling;
 }
 
-const Behandlingsresultat: FunctionComponent<IBehandlingsresultatProps> = ({ åpenBehandling }) => {
+const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => {
     const { settÅpenBehandling } = useBehandlingContext();
 
     const fagsak = useFagsak();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import type { IRestEndretUtbetalingAndel } from '../../../../../../typer/utbetalingAndel';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRad.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -27,7 +27,7 @@ const PersonCelle = styled.div`
     }
 `;
 
-const EndretUtbetalingAndelRad: React.FunctionComponent<IEndretUtbetalingAndelRadProps> = ({
+const EndretUtbetalingAndelRad: FunctionComponent<IEndretUtbetalingAndelRadProps> = ({
     lagretEndretUtbetalingAndel,
     åpenBehandling,
 }) => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRad.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -27,10 +26,7 @@ const PersonCelle = styled.div`
     }
 `;
 
-const EndretUtbetalingAndelRad: FunctionComponent<IEndretUtbetalingAndelRadProps> = ({
-    lagretEndretUtbetalingAndel,
-    åpenBehandling,
-}) => {
+const EndretUtbetalingAndelRad = ({ lagretEndretUtbetalingAndel, åpenBehandling }: IEndretUtbetalingAndelRadProps) => {
     const [erSkjemaEkspandert, settErSkjemaEkspandert] = useState<boolean>(
         lagretEndretUtbetalingAndel.personIdenter.length === 0
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRadRHF.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRadRHF.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { describe, expect, test, vi } from 'vitest';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRadRHF.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelRadRHF.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
@@ -1,4 +1,4 @@
-import type { FunctionComponent, ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { useEffect } from 'react';
 
 import styled from 'styled-components';
@@ -58,14 +58,14 @@ interface IEndretUtbetalingAndelSkjemaProps {
     slettEndretUtbetaling: () => void;
 }
 
-const EndretUtbetalingAndelSkjema: FunctionComponent<IEndretUtbetalingAndelSkjemaProps> = ({
+const EndretUtbetalingAndelSkjema = ({
     åpenBehandling,
     lukkSkjema,
     skjema,
     settFelterTilLagredeVerdier,
     oppdaterEndretUtbetaling,
     slettEndretUtbetaling,
-}) => {
+}: IEndretUtbetalingAndelSkjemaProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent, ChangeEvent } from 'react';
 import { useEffect } from 'react';
 
 import styled from 'styled-components';
@@ -58,7 +58,7 @@ interface IEndretUtbetalingAndelSkjemaProps {
     slettEndretUtbetaling: () => void;
 }
 
-const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAndelSkjemaProps> = ({
+const EndretUtbetalingAndelSkjema: FunctionComponent<IEndretUtbetalingAndelSkjemaProps> = ({
     åpenBehandling,
     lukkSkjema,
     skjema,
@@ -245,7 +245,7 @@ const EndretUtbetalingAndelSkjema: React.FunctionComponent<IEndretUtbetalingAnde
                                 ? skjema.felter.begrunnelse.verdi
                                 : ''
                         }
-                        onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                        onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
                             skjema.felter.begrunnelse.validerOgSettFelt(event.target.value);
                         }}
                     />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { type DefaultValues, useForm } from 'react-hook-form';
 import { describe, expect, test, vi } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjemaRHF.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { FormProvider, type SubmitHandler, type UseFormReturn } from 'react-hook-form';
 
 import { Alert, VStack } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelTabell.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import styled from 'styled-components';
 
 import { Heading, Table } from '@navikt/ds-react';
@@ -19,7 +17,7 @@ const EndredePerioderContainer = styled.div`
     margin-top: 6rem;
 `;
 
-const EndretUtbetalingAndelTabell: FunctionComponent<IEndretUtbetalingAndelTabellProps> = ({ åpenBehandling }) => {
+const EndretUtbetalingAndelTabell = ({ åpenBehandling }: IEndretUtbetalingAndelTabellProps) => {
     const toggles = useFeatureToggles();
 
     const endretUtbetalingAndeler = åpenBehandling.endretUtbetalingAndeler;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelTabell.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import styled from 'styled-components';
 
@@ -19,9 +19,7 @@ const EndredePerioderContainer = styled.div`
     margin-top: 6rem;
 `;
 
-const EndretUtbetalingAndelTabell: React.FunctionComponent<IEndretUtbetalingAndelTabellProps> = ({
-    åpenBehandling,
-}) => {
+const EndretUtbetalingAndelTabell: FunctionComponent<IEndretUtbetalingAndelTabellProps> = ({ åpenBehandling }) => {
     const toggles = useFeatureToggles();
 
     const endretUtbetalingAndeler = åpenBehandling.endretUtbetalingAndeler;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/AvtaletidspunktDeltBostedDatovelger.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/AvtaletidspunktDeltBostedDatovelger.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/AvtaletidspunktDeltBostedDatovelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/AvtaletidspunktDeltBostedDatovelger.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useRef } from 'react';
 
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Begrunnelse.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Begrunnelse.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Begrunnelse.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Begrunnelse.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { Textarea } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/FomDato.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/FomDato.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/FomDato.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/FomDato.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { useController, useFormContext } from 'react-hook-form';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Månedperiodevelger.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Månedperiodevelger.test.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Månedperiodevelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Månedperiodevelger.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useMemo } from 'react';
 
 import { useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.test.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, type ReactNode, useContext } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+import { createContext, useContext } from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { afterEach, describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Personvelger.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/SkjemaKnapper.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/SkjemaKnapper.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { useFormContext } from 'react-hook-form';
 
 import { TrashIcon } from '@navikt/aksel-icons';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/SøknadstidspunktDatovelger.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/SøknadstidspunktDatovelger.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/SøknadstidspunktDatovelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/SøknadstidspunktDatovelger.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useRef } from 'react';
 
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/TomDato.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/TomDato.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/TomDato.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/TomDato.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { isBefore, max } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Utbetalingvelger.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Utbetalingvelger.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { describe, expect, test } from 'vitest';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Utbetalingvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Utbetalingvelger.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { Label, Radio, RadioGroup } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Årsakvelger.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Årsakvelger.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { within } from '@testing-library/dom';
 import { type DefaultValues, FormProvider, useForm } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Årsakvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/komponenter/Årsakvelger.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ChangeEvent } from 'react';
 
 import { Controller, useFormContext } from 'react-hook-form';
 
@@ -25,7 +25,7 @@ export const Årsakvelger = ({ erLesevisning }: StandardFeltProps) => {
                 fieldState: { error },
                 formState: { isSubmitting },
             }) => {
-                const håndterEndring = (event: React.ChangeEvent<HTMLSelectElement>) => {
+                const håndterEndring = (event: ChangeEvent<HTMLSelectElement>) => {
                     onChange(event);
                     if (
                         event.target.value === IEndretUtbetalingAndelÅrsak.ENDRE_MOTTAKER ||

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/EøsKomponenter/EøsPeriodeSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/EøsKomponenter/EøsPeriodeSkjema.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Fieldset } from '@navikt/ds-react';
@@ -32,14 +30,14 @@ interface IProps {
     className?: string;
 }
 
-const EøsPeriodeSkjema: FC<IProps> = ({
+const EøsPeriodeSkjema = ({
     periode,
     periodeFeilmeldingId,
     initielFom,
     visFeilmeldinger,
     lesevisning,
     className = '',
-}) => {
+}: IProps) => {
     const finnÅrTilbakeTil = (): number => {
         return new Date().getFullYear() - new Date(initielFom.verdi).getFullYear();
     };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/EøsKomponenter/EøsPeriodeSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/EøsKomponenter/EøsPeriodeSkjema.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -32,7 +32,7 @@ interface IProps {
     className?: string;
 }
 
-const EøsPeriodeSkjema: React.FC<IProps> = ({
+const EøsPeriodeSkjema: FC<IProps> = ({
     periode,
     periodeFeilmeldingId,
     initielFom,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/EøsKomponenter/EøsSkjemaKomponenter.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/EøsKomponenter/EøsSkjemaKomponenter.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { CogRotationIcon } from '@navikt/aksel-icons';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseSkjema.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Alert, Heading, Table } from '@navikt/ds-react';
@@ -37,7 +35,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const KompetanseSkjema: FC<IProps> = ({ kompetanser, åpenBehandling, visFeilmeldinger }) => {
+const KompetanseSkjema = ({ kompetanser, åpenBehandling, visFeilmeldinger }: IProps) => {
     const harUfullstendigeKompetanser =
         åpenBehandling.kompetanser?.filter(kompetanse => kompetanse.status !== EøsPeriodeStatus.OK).length > 0;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseSkjema.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -37,7 +37,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const KompetanseSkjema: React.FC<IProps> = ({ kompetanser, åpenBehandling, visFeilmeldinger }) => {
+const KompetanseSkjema: FC<IProps> = ({ kompetanser, åpenBehandling, visFeilmeldinger }) => {
     const harUfullstendigeKompetanser =
         åpenBehandling.kompetanser?.filter(kompetanse => kompetanse.status !== EøsPeriodeStatus.OK).length > 0;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect } from 'react';
 
 import { BodyShort, Table } from '@navikt/ds-react';
@@ -18,7 +17,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const KompetanseTabellRad: FC<IProps> = ({ kompetanse, åpenBehandling, visFeilmeldinger }) => {
+const KompetanseTabellRad = ({ kompetanse, åpenBehandling, visFeilmeldinger }: IProps) => {
     const barn: OptionType[] = kompetanse.barnIdenter.map(barn => ({
         value: barn,
         label: lagPersonLabel(barn, åpenBehandling.personer),

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRad.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 
 import { BodyShort, Table } from '@navikt/ds-react';
 
@@ -17,7 +18,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const KompetanseTabellRad: React.FC<IProps> = ({ kompetanse, åpenBehandling, visFeilmeldinger }) => {
+const KompetanseTabellRad: FC<IProps> = ({ kompetanse, åpenBehandling, visFeilmeldinger }) => {
     const barn: OptionType[] = kompetanse.barnIdenter.map(barn => ({
         value: barn,
         label: lagPersonLabel(barn, åpenBehandling.personer),
@@ -34,14 +35,14 @@ const KompetanseTabellRad: React.FC<IProps> = ({ kompetanse, åpenBehandling, vi
         erKompetanseSkjemaEndret,
     } = useKompetansePeriodeSkjema({ barnIKompetanse: barn, kompetanse });
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (åpenBehandling) {
             nullstillSkjema();
             settErKompetanseEkspandert(false);
         }
     }, [åpenBehandling]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (visFeilmeldinger && erKompetanseEkspandert) {
             kanSendeSkjema();
         }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/KompetanseTabellRadEndre.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Alert, Box, Button, Fieldset, HStack, Select, UNSAFE_Combobox, VStack } from '@navikt/ds-react';
@@ -105,7 +105,7 @@ export function KompetanseTabellRadEndre({
                     readOnly={lesevisning}
                     label={'Søkers aktivitet'}
                     value={skjema.felter.søkersAktivitet.verdi || ''}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                    onChange={(event: ChangeEvent<HTMLSelectElement>) =>
                         skjema.felter.søkersAktivitet.validerOgSettFelt(event.target.value as KompetanseAktivitet)
                     }
                 >
@@ -126,7 +126,7 @@ export function KompetanseTabellRadEndre({
                     readOnly={lesevisning}
                     label={'Annen forelders aktivitet'}
                     value={skjema.felter.annenForeldersAktivitet.verdi || ''}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                    onChange={(event: ChangeEvent<HTMLSelectElement>) => {
                         skjema.felter.annenForeldersAktivitet.validerOgSettFelt(
                             event.target.value as KompetanseAktivitet
                         );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/useKompetansePeriodeSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Kompetanse/useKompetansePeriodeSkjema.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 
 import { useHttp } from '@navikt/familie-http';
 import { useFelt, useSkjema } from '@navikt/familie-skjema';
@@ -36,7 +36,7 @@ interface IProps {
 }
 
 const useKompetansePeriodeSkjema = ({ barnIKompetanse, kompetanse }: IProps) => {
-    const [erKompetanseEkspandert, settErKompetanseEkspandert] = React.useState<boolean>(false);
+    const [erKompetanseEkspandert, settErKompetanseEkspandert] = useState<boolean>(false);
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { request } = useHttp();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Alert, Heading, Table } from '@navikt/ds-react';
@@ -42,12 +40,12 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const UtbetaltAnnetLand: FC<IProps> = ({
+const UtbetaltAnnetLand = ({
     utbetaltAnnetLandBeløp,
     erUtbetaltAnnetLandBeløpGyldige,
     åpenBehandling,
     visFeilmeldinger,
-}) => {
+}: IProps) => {
     return (
         <UtenlandskPeriodeBeløperContainer>
             <Heading spacing size="medium" level="3">

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtbetaltAnnetLand.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -42,7 +42,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const UtbetaltAnnetLand: React.FC<IProps> = ({
+const UtbetaltAnnetLand: FC<IProps> = ({
     utbetaltAnnetLandBeløp,
     erUtbetaltAnnetLandBeløpGyldige,
     åpenBehandling,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 
 import { Table } from '@navikt/ds-react';
 
@@ -19,7 +20,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const UtenlandskPeriodeBeløpRad: React.FC<IProps> = ({ utenlandskPeriodeBeløp, åpenBehandling, visFeilmeldinger }) => {
+const UtenlandskPeriodeBeløpRad: FC<IProps> = ({ utenlandskPeriodeBeløp, åpenBehandling, visFeilmeldinger }) => {
     const barn: OptionType[] = utenlandskPeriodeBeløp.barnIdenter.map(barn => ({
         value: barn,
         label: lagPersonLabel(barn, åpenBehandling.personer),
@@ -39,14 +40,14 @@ const UtenlandskPeriodeBeløpRad: React.FC<IProps> = ({ utenlandskPeriodeBeløp,
         barnIUtenlandskPeriodeBeløp: barn,
     });
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (åpenBehandling) {
             nullstillSkjema();
             settErUtenlandskPeriodeBeløpEkspandert(false);
         }
     }, [åpenBehandling]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (visFeilmeldinger && erUtenlandskPeriodeBeløpEkspandert) {
             kanSendeSkjema();
         }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect } from 'react';
 
 import { Table } from '@navikt/ds-react';
@@ -20,7 +19,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const UtenlandskPeriodeBeløpRad: FC<IProps> = ({ utenlandskPeriodeBeløp, åpenBehandling, visFeilmeldinger }) => {
+const UtenlandskPeriodeBeløpRad = ({ utenlandskPeriodeBeløp, åpenBehandling, visFeilmeldinger }: IProps) => {
     const barn: OptionType[] = utenlandskPeriodeBeløp.barnIdenter.map(barn => ({
         value: barn,
         label: lagPersonLabel(barn, åpenBehandling.personer),

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode, ChangeEvent } from 'react';
+import type { ReactNode, ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
@@ -57,7 +57,7 @@ interface IProps {
     inneholderBarnSomSkalSkjermes?: boolean;
 }
 
-const UtenlandskPeriodeBeløpTabellRadEndre: FC<IProps> = ({
+const UtenlandskPeriodeBeløpTabellRadEndre = ({
     skjema,
     tilgjengeligeBarn,
     status,
@@ -65,7 +65,7 @@ const UtenlandskPeriodeBeløpTabellRadEndre: FC<IProps> = ({
     toggleForm,
     slettUtenlandskPeriodeBeløp,
     inneholderBarnSomSkalSkjermes,
-}) => {
+}: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
 
     const lesevisning = vurderErLesevisning(true) || !!inneholderBarnSomSkalSkjermes;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC, ReactNode, ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
@@ -57,7 +57,7 @@ interface IProps {
     inneholderBarnSomSkalSkjermes?: boolean;
 }
 
-const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
+const UtenlandskPeriodeBeløpTabellRadEndre: FC<IProps> = ({
     skjema,
     tilgjengeligeBarn,
     status,
@@ -70,7 +70,7 @@ const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
 
     const lesevisning = vurderErLesevisning(true) || !!inneholderBarnSomSkalSkjermes;
 
-    const visUtbetaltBeløpGruppeFeilmelding = (): React.ReactNode => {
+    const visUtbetaltBeløpGruppeFeilmelding = (): ReactNode => {
         if (skjema.felter.beløp?.valideringsstatus === Valideringsstatus.FEIL) {
             return skjema.felter.beløp.feilmelding;
         } else if (skjema.felter.valutakode?.valideringsstatus === Valideringsstatus.FEIL) {
@@ -136,7 +136,7 @@ const UtenlandskPeriodeBeløpTabellRadEndre: React.FC<IProps> = ({
                             label={'Beløp per barn'}
                             readOnly={lesevisning}
                             value={skjema.felter.beløp?.verdi}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                            onChange={(event: ChangeEvent<HTMLInputElement>) =>
                                 skjema.felter.beløp?.validerOgSettFelt(event.target.value)
                             }
                             size={'medium'}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/useUtenlandskPeriodeBeløpSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/useUtenlandskPeriodeBeløpSkjema.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState } from 'react';
 
 import { useHttp } from '@navikt/familie-http';
 import type { FeltState } from '@navikt/familie-skjema';
@@ -55,7 +55,7 @@ interface IProps {
 }
 
 const useUtenlandskPeriodeBeløpSkjema = ({ barnIUtenlandskPeriodeBeløp, utenlandskPeriodeBeløp }: IProps) => {
-    const [erUtenlandskPeriodeBeløpEkspandert, settErUtenlandskPeriodeBeløpEkspandert] = React.useState<boolean>(false);
+    const [erUtenlandskPeriodeBeløpEkspandert, settErUtenlandskPeriodeBeløpEkspandert] = useState<boolean>(false);
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const initelFom = useFelt<string>({ verdi: utenlandskPeriodeBeløp.fom });
     const { request } = useHttp();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/PeriodeValutakurs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/PeriodeValutakurs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { BodyShort } from '@navikt/ds-react';
 
@@ -9,7 +9,7 @@ interface IStatusBarnCelleOgPeriodeCelleProps {
     valutakurs: IRestValutakurs;
 }
 
-export const PeriodeValutakurs: React.FC<IStatusBarnCelleOgPeriodeCelleProps> = ({ valutakurs }) => (
+export const PeriodeValutakurs: FC<IStatusBarnCelleOgPeriodeCelleProps> = ({ valutakurs }) => (
     <BodyShort size="small">
         {isoMånedPeriodeTilFormatertString({
             periode: {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/PeriodeValutakurs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/PeriodeValutakurs.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { BodyShort } from '@navikt/ds-react';
 
 import { type IRestValutakurs } from '../../../../../../../typer/eøsPerioder';
@@ -9,7 +7,7 @@ interface IStatusBarnCelleOgPeriodeCelleProps {
     valutakurs: IRestValutakurs;
 }
 
-export const PeriodeValutakurs: FC<IStatusBarnCelleOgPeriodeCelleProps> = ({ valutakurs }) => (
+export const PeriodeValutakurs = ({ valutakurs }: IStatusBarnCelleOgPeriodeCelleProps) => (
     <BodyShort size="small">
         {isoMånedPeriodeTilFormatertString({
             periode: {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/StatusOgBarnValutakurs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/StatusOgBarnValutakurs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -35,7 +35,7 @@ interface StatusProps {
     vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser | null;
 }
 
-const PeriodeStatus: React.FC<StatusProps> = ({ valutakurs, vurderingsstrategiForValutakurser }) => {
+const PeriodeStatus: FC<StatusProps> = ({ valutakurs, vurderingsstrategiForValutakurser }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
@@ -56,7 +56,7 @@ const PeriodeStatus: React.FC<StatusProps> = ({ valutakurs, vurderingsstrategiFo
     }
 };
 
-export const StatusOgBarnValutakurs: React.FC<Props> = ({ valutakurs, åpenBehandling }) => (
+export const StatusOgBarnValutakurs: FC<Props> = ({ valutakurs, åpenBehandling }) => (
     <HStack wrap={false} align="center" gap="space-16">
         <PeriodeStatus
             valutakurs={valutakurs}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/StatusOgBarnValutakurs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/StatusOgBarnValutakurs.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { CogRotationIcon, PencilWritingIcon } from '@navikt/aksel-icons';
@@ -35,7 +33,7 @@ interface StatusProps {
     vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser | null;
 }
 
-const PeriodeStatus: FC<StatusProps> = ({ valutakurs, vurderingsstrategiForValutakurser }) => {
+const PeriodeStatus = ({ valutakurs, vurderingsstrategiForValutakurser }: StatusProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 
@@ -56,7 +54,7 @@ const PeriodeStatus: FC<StatusProps> = ({ valutakurs, vurderingsstrategiForValut
     }
 };
 
-export const StatusOgBarnValutakurs: FC<Props> = ({ valutakurs, åpenBehandling }) => (
+export const StatusOgBarnValutakurs = ({ valutakurs, åpenBehandling }: Props) => (
     <HStack wrap={false} align="center" gap="space-16">
         <PeriodeStatus
             valutakurs={valutakurs}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState, useEffect } from 'react';
 
 import { Table } from '@navikt/ds-react';
@@ -19,7 +18,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const ValutakursTabellRad: FC<IProps> = ({ valutakurs, åpenBehandling, visFeilmeldinger }) => {
+const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: IProps) => {
     const [skalRendreContentIEkspanderbartPanel, settSkalRendreContentIEkspanderbartPanel] = useState(false);
 
     const barn: OptionType[] = valutakurs.barnIdenter.map(barn => ({

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FC } from 'react';
+import { useState, useEffect } from 'react';
 
 import { Table } from '@navikt/ds-react';
 
@@ -18,8 +19,8 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const ValutakursTabellRad: React.FC<IProps> = ({ valutakurs, åpenBehandling, visFeilmeldinger }) => {
-    const [skalRendreContentIEkspanderbartPanel, settSkalRendreContentIEkspanderbartPanel] = React.useState(false);
+const ValutakursTabellRad: FC<IProps> = ({ valutakurs, åpenBehandling, visFeilmeldinger }) => {
+    const [skalRendreContentIEkspanderbartPanel, settSkalRendreContentIEkspanderbartPanel] = useState(false);
 
     const barn: OptionType[] = valutakurs.barnIdenter.map(barn => ({
         value: barn,
@@ -47,7 +48,7 @@ const ValutakursTabellRad: React.FC<IProps> = ({ valutakurs, åpenBehandling, vi
         settSkalRendreContentIEkspanderbartPanel(true);
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (visFeilmeldinger && erValutakursEkspandert) {
             kanSendeSkjema();
         }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC, ReactNode, ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
@@ -59,7 +59,7 @@ interface IProps {
     inneholderBarnSomSkalSkjermes?: boolean;
 }
 
-const ValutakursTabellRadEndre: React.FC<IProps> = ({
+const ValutakursTabellRadEndre: FC<IProps> = ({
     vurderingsform,
     skjema,
     tilgjengeligeBarn,
@@ -83,7 +83,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
         !!inneholderBarnSomSkalSkjermes ||
         (erValutakursVurdertAutomatisk && !skaAutomatiskeValutakurserKunneRedigeres);
 
-    const visKursGruppeFeilmelding = (): React.ReactNode => {
+    const visKursGruppeFeilmelding = (): ReactNode => {
         if (skjema.felter.valutakode?.valideringsstatus === Valideringsstatus.FEIL) {
             return skjema.felter.valutakode.feilmelding;
         } else if (skjema.felter.valutakursdato?.valideringsstatus === Valideringsstatus.FEIL) {
@@ -167,7 +167,7 @@ const ValutakursTabellRadEndre: React.FC<IProps> = ({
                             label={'Valutakurs'}
                             readOnly={erLesevisning || !erManuellInputAvKurs}
                             value={skjema.felter.kurs?.verdi}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                            onChange={(event: ChangeEvent<HTMLInputElement>) =>
                                 skjema.felter.kurs?.validerOgSettFelt(event.target.value)
                             }
                         />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode, ChangeEvent } from 'react';
+import type { ReactNode, ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
@@ -59,7 +59,7 @@ interface IProps {
     inneholderBarnSomSkalSkjermes?: boolean;
 }
 
-const ValutakursTabellRadEndre: FC<IProps> = ({
+const ValutakursTabellRadEndre = ({
     vurderingsform,
     skjema,
     tilgjengeligeBarn,
@@ -71,7 +71,7 @@ const ValutakursTabellRadEndre: FC<IProps> = ({
     erManuellInputAvKurs,
     åpenBehandling,
     inneholderBarnSomSkalSkjermes,
-}) => {
+}: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
 
     const erValutakursVurdertAutomatisk = vurderingsform === Vurderingsform.AUTOMATISK;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -58,7 +57,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const Valutakurser: FC<IProps> = ({ valutakurser, erValutakurserGyldige, åpenBehandling, visFeilmeldinger }) => {
+const Valutakurser = ({ valutakurser, erValutakurserGyldige, åpenBehandling, visFeilmeldinger }: IProps) => {
     const { settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
     const { request } = useHttp();
     const [erGjenopprettAutomatiskeValutakurserModalÅpen, settErGjenopprettAutomatiskeValutakurserModalÅpen] =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -58,7 +58,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const Valutakurser: React.FC<IProps> = ({ valutakurser, erValutakurserGyldige, åpenBehandling, visFeilmeldinger }) => {
+const Valutakurser: FC<IProps> = ({ valutakurser, erValutakurserGyldige, åpenBehandling, visFeilmeldinger }) => {
     const { settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
     const { request } = useHttp();
     const [erGjenopprettAutomatiskeValutakurserModalÅpen, settErGjenopprettAutomatiskeValutakurserModalÅpen] =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import * as React from 'react';
 
 import { isBefore } from 'date-fns';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import * as React from 'react';
 
 import { isBefore } from 'date-fns';
 
@@ -66,8 +65,8 @@ interface IProps {
 }
 
 const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
-    const [erValutakursEkspandert, settErValutakursEkspandert] = React.useState<boolean>(false);
-    const [sletterValutakurs, settSletterValutakurs] = React.useState<boolean>(false);
+    const [erValutakursEkspandert, settErValutakursEkspandert] = useState<boolean>(false);
+    const [sletterValutakurs, settSletterValutakurs] = useState<boolean>(false);
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const initelFom = useFelt<string>({ verdi: valutakurs.fom });
     const { request } = useHttp();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/MigreringInfoboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/MigreringInfoboks.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -17,7 +18,7 @@ const StyledAlert = styled(Alert)`
     margin: 1rem 0;
 `;
 
-const MigreringInfoboks: React.FC<IProps> = ({ behandlingId }) => {
+const MigreringInfoboks: FC<IProps> = ({ behandlingId }) => {
     const { request } = useHttp();
     const [melding, settMelding] = useState<Ressurs<boolean>>(byggTomRessurs());
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/MigreringInfoboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/MigreringInfoboks.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
@@ -18,7 +17,7 @@ const StyledAlert = styled(Alert)`
     margin: 1rem 0;
 `;
 
-const MigreringInfoboks: FC<IProps> = ({ behandlingId }) => {
+const MigreringInfoboks = ({ behandlingId }: IProps) => {
     const { request } = useHttp();
     const [melding, settMelding] = useState<Ressurs<boolean>>(byggTomRessurs());
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { useState } from 'react';
+import { type FunctionComponent, type PropsWithChildren, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -40,7 +39,7 @@ const UtbetalingsbeløpStack = styled(VStack)`
     padding: var(--ax-space-24) var(--ax-space-40) var(--ax-space-16) 0;
 `;
 
-const UtbetalingsbeløpRad: React.FC<React.PropsWithChildren> = ({ children }) => (
+const UtbetalingsbeløpRad: FunctionComponent<PropsWithChildren> = ({ children }) => (
     <HGrid columns="1fr 8rem 5rem" gap={'space-8'}>
         {children}
     </HGrid>
@@ -105,7 +104,7 @@ const erAllePerioderUtfyltForBarn = (eøsPeriodeStatus: IEøsPeriodeStatus[]) =>
     return eøsPeriodeStatus.every(eøsPeriode => eøsPeriode.status === EøsPeriodeStatus.OK);
 };
 
-const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
+const Oppsummeringsboks: FunctionComponent<IProps> = ({
     utbetalingsperiode,
     aktivEtikett,
     kompetanser,
@@ -118,7 +117,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
     const { settToast } = useAppContext();
     const { settAktivEtikett } = useTidslinjeContext();
 
-    const [utbetalingsBeløpStatusMap, setUtbetalingsBeløpStatusMap] = React.useState(new Map<string, boolean>());
+    const [utbetalingsBeløpStatusMap, setUtbetalingsBeløpStatusMap] = useState(new Map<string, boolean>());
     const [restFeil, settRestFeil] = useState<string | undefined>(undefined);
     const [justererSmåbarnstillegg, setJustererSmåbarnstillegg] = useState<boolean>(false);
 
@@ -179,7 +178,7 @@ const Oppsummeringsboks: React.FunctionComponent<IProps> = ({
         });
     };
 
-    React.useEffect(() => {
+    useEffect(() => {
         setUtbetalingsBeløpStatusMap(
             finnUtbetalingsBeløpStatusMap(utbetalingsperiode, kompetanser, utbetaltAnnetLandBeløp, valutakurser)
         );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -1,4 +1,4 @@
-import { type FunctionComponent, type PropsWithChildren, useEffect, useState } from 'react';
+import { type PropsWithChildren, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -39,7 +39,7 @@ const UtbetalingsbeløpStack = styled(VStack)`
     padding: var(--ax-space-24) var(--ax-space-40) var(--ax-space-16) 0;
 `;
 
-const UtbetalingsbeløpRad: FunctionComponent<PropsWithChildren> = ({ children }) => (
+const UtbetalingsbeløpRad = ({ children }: PropsWithChildren) => (
     <HGrid columns="1fr 8rem 5rem" gap={'space-8'}>
         {children}
     </HGrid>
@@ -104,13 +104,13 @@ const erAllePerioderUtfyltForBarn = (eøsPeriodeStatus: IEøsPeriodeStatus[]) =>
     return eøsPeriodeStatus.every(eøsPeriode => eøsPeriode.status === EøsPeriodeStatus.OK);
 };
 
-const Oppsummeringsboks: FunctionComponent<IProps> = ({
+const Oppsummeringsboks = ({
     utbetalingsperiode,
     aktivEtikett,
     kompetanser,
     utbetaltAnnetLandBeløp,
     valutakurser,
-}) => {
+}: IProps) => {
     const { request } = useHttp();
     const { settÅpenBehandling, behandling, vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/TilkjentYtelseTidslinje.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/TilkjentYtelseTidslinje.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { endOfMonth } from 'date-fns';
 import styled from 'styled-components';
 
@@ -68,7 +66,7 @@ interface IProps {
     fagsakType?: FagsakType;
 }
 
-const TilkjentYtelseTidslinje: FC<IProps> = ({ grunnlagPersoner, tidslinjePersoner, fagsakType }) => {
+const TilkjentYtelseTidslinje = ({ grunnlagPersoner, tidslinjePersoner, fagsakType }: IProps) => {
     const { genererFormatertÅrstall, genererRader, aktivEtikett, aktivtTidslinjeVindu, naviger } =
         useTidslinjeContext();
     const tidslinjeRader = genererRader(fagsakType, tidslinjePersoner);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/TilkjentYtelseTidslinje.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/TilkjentYtelseTidslinje.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { endOfMonth } from 'date-fns';
 import styled from 'styled-components';
@@ -68,7 +68,7 @@ interface IProps {
     fagsakType?: FagsakType;
 }
 
-const TilkjentYtelseTidslinje: React.FC<IProps> = ({ grunnlagPersoner, tidslinjePersoner, fagsakType }) => {
+const TilkjentYtelseTidslinje: FC<IProps> = ({ grunnlagPersoner, tidslinjePersoner, fagsakType }) => {
     const { genererFormatertÅrstall, genererRader, aktivEtikett, aktivtTidslinjeVindu, naviger } =
         useTidslinjeContext();
     const tidslinjeRader = genererRader(fagsakType, tidslinjePersoner);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/FiltreringFødselshendelser/Filtreringsregler.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/FiltreringFødselshendelser/Filtreringsregler.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { useNavigate } from 'react-router';
 
@@ -15,7 +15,7 @@ interface IProps {
     åpenBehandling: IBehandling;
 }
 
-const Filtreringsregler: React.FC<IProps> = ({ åpenBehandling }) => {
+const Filtreringsregler: FC<IProps> = ({ åpenBehandling }) => {
     const fagsakId = useFagsakId();
     const navigate = useNavigate();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/FiltreringFødselshendelser/Filtreringsregler.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/FiltreringFødselshendelser/Filtreringsregler.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { useNavigate } from 'react-router';
 
 import { BodyShort, List } from '@navikt/ds-react';
@@ -15,7 +13,7 @@ interface IProps {
     åpenBehandling: IBehandling;
 }
 
-const Filtreringsregler: FC<IProps> = ({ åpenBehandling }) => {
+const Filtreringsregler = ({ åpenBehandling }: IProps) => {
     const fagsakId = useFagsakId();
     const navigate = useNavigate();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -14,7 +14,7 @@ interface IProps {
     åpenBehandling: IBehandling;
 }
 
-const RegistrerInstitusjon: React.FC<IProps> = ({ åpenBehandling }) => {
+const RegistrerInstitusjon: FC<IProps> = ({ åpenBehandling }) => {
     const { institusjon, onSubmitMottaker, submitFeilmelding } = useInstitusjon(åpenBehandling);
     const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);
     const { behandlingsstegSubmitressurs, vurderErLesevisning } = useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerInstitusjon/RegistrerInstitusjon.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -14,7 +12,7 @@ interface IProps {
     åpenBehandling: IBehandling;
 }
 
-const RegistrerInstitusjon: FC<IProps> = ({ åpenBehandling }) => {
+const RegistrerInstitusjon = ({ åpenBehandling }: IProps) => {
     const { institusjon, onSubmitMottaker, submitFeilmelding } = useInstitusjon(åpenBehandling);
     const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);
     const { behandlingsstegSubmitressurs, vurderErLesevisning } = useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
@@ -1,11 +1,9 @@
-import type { FunctionComponent } from 'react';
-
 import { Heading, Textarea, VStack } from '@navikt/ds-react';
 
 import { useSøknadContext } from './SøknadContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-export const Annet: FunctionComponent = () => {
+export const Annet = () => {
     const { vurderErLesevisning } = useBehandlingContext();
     const { skjema } = useSøknadContext();
     const lesevisning = vurderErLesevisning();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Heading, Textarea, VStack } from '@navikt/ds-react';
 
 import { useSøknadContext } from './SøknadContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-export const Annet: React.FunctionComponent = () => {
+export const Annet: FunctionComponent = () => {
     const { vurderErLesevisning } = useBehandlingContext();
     const { skjema } = useSøknadContext();
     const lesevisning = vurderErLesevisning();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/BarnMedOpplysninger.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import classNames from 'classnames';
 
@@ -15,7 +15,7 @@ interface IProps {
     barn: IBarnMedOpplysninger;
 }
 
-export const BarnMedOpplysninger: React.FunctionComponent<IProps> = ({ barn }) => {
+export const BarnMedOpplysninger: FunctionComponent<IProps> = ({ barn }) => {
     const { skjema, barnMedLøpendeUtbetaling } = useSøknadContext();
     const { vurderErLesevisning, gjelderInstitusjon, gjelderEnsligMindreårig, gjelderSkjermetBarn } =
         useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/BarnMedOpplysninger.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import classNames from 'classnames';
 
 import { BodyShort, Button, Checkbox, HStack } from '@navikt/ds-react';
@@ -15,7 +13,7 @@ interface IProps {
     barn: IBarnMedOpplysninger;
 }
 
-export const BarnMedOpplysninger: FunctionComponent<IProps> = ({ barn }) => {
+export const BarnMedOpplysninger = ({ barn }: IProps) => {
     const { skjema, barnMedLøpendeUtbetaling } = useSøknadContext();
     const { vurderErLesevisning, gjelderInstitusjon, gjelderEnsligMindreårig, gjelderSkjermetBarn } =
         useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Barna.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Barna.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { differenceInMilliseconds } from 'date-fns';
 
 import { Alert, BodyShort, CheckboxGroup, Heading, HStack, Label, VStack } from '@navikt/ds-react';
@@ -14,7 +12,7 @@ import { isoStringTilDate } from '../../../../../utils/dato';
 import { useBrukerContext } from '../../../BrukerContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-export const Barna: FunctionComponent = () => {
+export const Barna = () => {
     const { vurderErLesevisning, gjelderInstitusjon, gjelderEnsligMindreårig, gjelderSkjermetBarn } =
         useBehandlingContext();
     const lesevisning = vurderErLesevisning();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Barna.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Barna.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { differenceInMilliseconds } from 'date-fns';
 
@@ -14,7 +14,7 @@ import { isoStringTilDate } from '../../../../../utils/dato';
 import { useBrukerContext } from '../../../BrukerContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-export const Barna: React.FunctionComponent = () => {
+export const Barna: FunctionComponent = () => {
     const { vurderErLesevisning, gjelderInstitusjon, gjelderEnsligMindreårig, gjelderSkjermetBarn } =
         useBehandlingContext();
     const lesevisning = vurderErLesevisning();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/LeggTilBarnKnapp.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/RegistrerSøknad.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { Alert, BodyShort, Button, ErrorSummary, Modal } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -19,7 +17,7 @@ import { useBehandlingContext } from '../../context/BehandlingContext';
 import Skjemasteg from '../Skjemasteg';
 import styles from './RegistrerSøknad.module.css';
 
-export const RegistrerSøknad: FC = () => {
+export const RegistrerSøknad = () => {
     const { fagsak } = useFagsakContext();
     const { behandling, vurderErLesevisning } = useBehandlingContext();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/RegistrerSøknad.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import { Alert, BodyShort, Button, ErrorSummary, Modal } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -19,7 +19,7 @@ import { useBehandlingContext } from '../../context/BehandlingContext';
 import Skjemasteg from '../Skjemasteg';
 import styles from './RegistrerSøknad.module.css';
 
-export const RegistrerSøknad: React.FC = () => {
+export const RegistrerSøknad: FC = () => {
     const { fagsak } = useFagsakContext();
     const { behandling, vurderErLesevisning } = useBehandlingContext();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { useState, useEffect, createContext, useContext } from 'react';
 
 import { useNavigate } from 'react-router';
 
@@ -22,7 +23,7 @@ import { hentBarnMedLøpendeUtbetaling } from '../../../../../utils/fagsak';
 import { useBrukerContext } from '../../../BrukerContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-interface Props extends React.PropsWithChildren {
+interface Props extends PropsWithChildren {
     åpenBehandling: IBehandling;
 }
 
@@ -59,7 +60,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
     const fagsak = useFagsak();
     const navigate = useNavigate();
 
-    const [visBekreftModal, settVisBekreftModal] = React.useState<boolean>(false);
+    const [visBekreftModal, settVisBekreftModal] = useState<boolean>(false);
 
     const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
 
@@ -93,7 +94,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
         skjemanavn: 'Registrer søknad',
     });
 
-    const [søknadErLastetFraBackend, settSøknadErLastetFraBackend] = React.useState(false);
+    const [søknadErLastetFraBackend, settSøknadErLastetFraBackend] = useState(false);
 
     const tilbakestillSøknad = () => {
         nullstillSkjema();
@@ -127,7 +128,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
         settSøknadErLastetFraBackend(false);
     };
 
-    React.useEffect(() => {
+    useEffect(() => {
         tilbakestillSøknad();
     }, [bruker]);
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadType.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadType.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Heading, Radio, RadioGroup } from '@navikt/ds-react';
 
@@ -7,7 +7,7 @@ import styles from './SøknadType.module.css';
 import { behandlingUnderkategori, BehandlingUnderkategori } from '../../../../../typer/behandlingstema';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-export const SøknadType: React.FunctionComponent = () => {
+export const SøknadType: FunctionComponent = () => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
     const { skjema } = useSøknadContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadType.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadType.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { Heading, Radio, RadioGroup } from '@navikt/ds-react';
 
 import { useSøknadContext } from './SøknadContext';
@@ -7,7 +5,7 @@ import styles from './SøknadType.module.css';
 import { behandlingUnderkategori, BehandlingUnderkategori } from '../../../../../typer/behandlingstema';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-export const SøknadType: FunctionComponent = () => {
+export const SøknadType = () => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
     const { skjema } = useSøknadContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/MigreringAlerts.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/MigreringAlerts.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import styled from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 
@@ -28,7 +26,7 @@ const StyledAlert = styled(Alert)`
     margin-bottom: 2rem;
 `;
 
-const Simulering: FunctionComponent<ISimuleringProps> = ({ åpenBehandling }) => {
+const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
     const {
         hentSkjemadata,
         onSubmit,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
@@ -28,7 +28,7 @@ const StyledAlert = styled(Alert)`
     margin-bottom: 2rem;
 `;
 
-const Simulering: React.FunctionComponent<ISimuleringProps> = ({ åpenBehandling }) => {
+const Simulering: FunctionComponent<ISimuleringProps> = ({ åpenBehandling }) => {
     const {
         hentSkjemadata,
         onSubmit,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 import { isAfter, isBefore } from 'date-fns';
 
@@ -22,7 +23,7 @@ import type {
 import { Tilbakekrevingsvalg } from '../../../../../typer/simulering';
 import { isoStringTilDate, isoStringTilDateMedFallback, tidenesMorgen } from '../../../../../utils/dato';
 
-interface IProps extends React.PropsWithChildren {
+interface IProps extends PropsWithChildren {
     åpenBehandling: IBehandling;
 }
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringPanel.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringPanel.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { isBefore } from 'date-fns';
 import styled from 'styled-components';
 
@@ -31,9 +29,9 @@ interface ISimuleringProps {
     simulering: ISimuleringDTO;
 }
 
-const SimuleringPanel: FunctionComponent<ISimuleringProps> = ({
+const SimuleringPanel = ({
     simulering: { feilutbetaling, fom, etterbetaling, fomDatoNestePeriode, perioder, tomSisteUtbetaling },
-}) => {
+}: ISimuleringProps) => {
     const kapitaliserTekst = (tekst: string): string => {
         return tekst.charAt(0).toUpperCase() + tekst.slice(1).toLowerCase();
     };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringPanel.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { isBefore } from 'date-fns';
 import styled from 'styled-components';
@@ -31,7 +31,7 @@ interface ISimuleringProps {
     simulering: ISimuleringDTO;
 }
 
-const SimuleringPanel: React.FunctionComponent<ISimuleringProps> = ({
+const SimuleringPanel: FunctionComponent<ISimuleringProps> = ({
     simulering: { feilutbetaling, fom, etterbetaling, fomDatoNestePeriode, perioder, tomSisteUtbetaling },
 }) => {
     const kapitaliserTekst = (tekst: string): string => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 import { useState } from 'react';
 
 import { isAfter } from 'date-fns';
@@ -73,7 +73,7 @@ interface ISimuleringProps {
     simulering: ISimuleringDTO;
 }
 
-const SimuleringTabell: React.FunctionComponent<ISimuleringProps> = ({ simulering }) => {
+const SimuleringTabell: FunctionComponent<ISimuleringProps> = ({ simulering }) => {
     const {
         fomDatoNestePeriode,
         fom,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useState } from 'react';
 
 import { isAfter } from 'date-fns';
@@ -73,7 +72,7 @@ interface ISimuleringProps {
     simulering: ISimuleringDTO;
 }
 
-const SimuleringTabell: FunctionComponent<ISimuleringProps> = ({ simulering }) => {
+const SimuleringTabell = ({ simulering }: ISimuleringProps) => {
     const {
         fomDatoNestePeriode,
         fom,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import { ExternalLinkIcon, FileTextIcon } from '@navikt/aksel-icons';
 import {
@@ -40,7 +40,7 @@ import { målform } from '../../../../../typer/søknad';
 import { useBrukerContext } from '../../../BrukerContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-const TilbakekrevingSkjema: React.FC<{
+const TilbakekrevingSkjema: FC<{
     søkerMålform: Målform;
     harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
     åpenBehandling: IBehandling;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { ExternalLinkIcon, FileTextIcon } from '@navikt/aksel-icons';
 import {
     Alert,
@@ -40,11 +38,15 @@ import { målform } from '../../../../../typer/søknad';
 import { useBrukerContext } from '../../../BrukerContext';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-const TilbakekrevingSkjema: FC<{
+const TilbakekrevingSkjema = ({
+    søkerMålform,
+    harÅpenTilbakekrevingRessurs,
+    åpenBehandling,
+}: {
     søkerMålform: Målform;
     harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
     åpenBehandling: IBehandling;
-}> = ({ søkerMålform, harÅpenTilbakekrevingRessurs, åpenBehandling }) => {
+}) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const { tilbakekrevingSkjema, hentFeilTilOppsummering, maksLengdeTekst } = useSimuleringContext();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/BekreftSamtykkeTilMotregning.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Alert, BodyLong, Button, HStack } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import { addDays } from 'date-fns';
@@ -31,7 +30,7 @@ interface IProps {
     behandling: IBehandling;
 }
 
-export const SettBehandlingPåVentModalMotregning: FC<IProps> = ({ lukkModal, behandling }) => {
+export const SettBehandlingPåVentModalMotregning = ({ lukkModal, behandling }: IProps) => {
     const { settÅpenBehandling } = useBehandlingContext();
 
     const { request } = useHttp();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import { addDays } from 'date-fns';
 import styled from 'styled-components';
@@ -30,7 +31,7 @@ interface IProps {
     behandling: IBehandling;
 }
 
-export const SettBehandlingPåVentModalMotregning: React.FC<IProps> = ({ lukkModal, behandling }) => {
+export const SettBehandlingPåVentModalMotregning: FC<IProps> = ({ lukkModal, behandling }) => {
     const { settÅpenBehandling } = useBehandlingContext();
 
     const { request } = useHttp();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ArrowUndoIcon } from '@navikt/aksel-icons';
 import { Alert, BodyShort, Box, Button, ConfirmationPanel, Heading, VStack } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Årsvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Årsvelger.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort } from '@navikt/ds-react';
@@ -20,13 +18,13 @@ interface Props {
     årISimuleringen: number[];
 }
 
-export const Årsvelger: FC<Props> = ({
+export const Årsvelger = ({
     settIndexFramvistÅr,
     indexFramvistÅr,
     erISisteÅrAvPerioden,
     aktueltÅr,
     årISimuleringen,
-}) => (
+}: Props) => (
     <FlexColumn>
         <TidslinjeNavigering
             naviger={retning =>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Årsvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Årsvelger.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -20,7 +20,7 @@ interface Props {
     årISimuleringen: number[];
 }
 
-export const Årsvelger: React.FC<Props> = ({
+export const Årsvelger: FC<Props> = ({
     settIndexFramvistÅr,
     indexFramvistÅr,
     erISisteÅrAvPerioden,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
@@ -1,5 +1,4 @@
-import type { PropsWithChildren } from 'react';
-import * as React from 'react';
+import type { ReactNode, FunctionComponent, PropsWithChildren } from 'react';
 import { useEffect } from 'react';
 
 import styled from 'styled-components';
@@ -19,7 +18,7 @@ interface IProps extends PropsWithChildren {
     nesteKnappTittel?: string;
     nesteOnClick?: () => void;
     senderInn: boolean;
-    tittel: string | React.ReactNode;
+    tittel: string | ReactNode;
     maxWidthStyle?: string;
     skalDisableNesteKnapp?: boolean;
     skalViseNesteKnapp?: boolean;
@@ -43,7 +42,7 @@ const Navigering = styled.div`
     }
 `;
 
-const Skjemasteg: React.FunctionComponent<IProps> = ({
+const Skjemasteg: FunctionComponent<IProps> = ({
     children,
     className,
     forrigeKnappTittel = 'Forrige steg',

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, FunctionComponent, PropsWithChildren } from 'react';
+import type { ReactNode, PropsWithChildren } from 'react';
 import { useEffect } from 'react';
 
 import styled from 'styled-components';
@@ -42,7 +42,7 @@ const Navigering = styled.div`
     }
 `;
 
-const Skjemasteg: FunctionComponent<IProps> = ({
+const Skjemasteg = ({
     children,
     className,
     forrigeKnappTittel = 'Forrige steg',
@@ -56,7 +56,7 @@ const Skjemasteg: FunctionComponent<IProps> = ({
     skalDisableNesteKnapp = false,
     skalViseForrigeKnapp = true,
     feilmelding = '',
-}) => {
+}: IProps) => {
     const { behandling, vurderErLesevisning } = useBehandlingContext();
 
     useEffect(() => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/AlleBegrunnelserContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/AlleBegrunnelserContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/BehandlingSendtTilTotrinnskontrollModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/BehandlingSendtTilTotrinnskontrollModal.tsx
@@ -1,4 +1,4 @@
-import type { SetStateAction, Dispatch, FunctionComponent } from 'react';
+import type { SetStateAction, Dispatch } from 'react';
 
 import { useNavigate } from 'react-router';
 
@@ -10,7 +10,7 @@ interface Props {
     settVisModal: Dispatch<SetStateAction<boolean>>;
 }
 
-export const BehandlingSendtTilTotrinnskontrollModal: FunctionComponent<Props> = ({ settVisModal }) => {
+export const BehandlingSendtTilTotrinnskontrollModal = ({ settVisModal }: Props) => {
     const navigate = useNavigate();
     const fagsakId = useFagsakId();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/BehandlingSendtTilTotrinnskontrollModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/BehandlingSendtTilTotrinnskontrollModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { SetStateAction, Dispatch, FunctionComponent } from 'react';
 
 import { useNavigate } from 'react-router';
 
@@ -7,10 +7,10 @@ import { BodyShort, Button, Modal } from '@navikt/ds-react';
 import { useFagsakId } from '../../../../../hooks/useFagsakId';
 
 interface Props {
-    settVisModal: React.Dispatch<React.SetStateAction<boolean>>;
+    settVisModal: Dispatch<SetStateAction<boolean>>;
 }
 
-export const BehandlingSendtTilTotrinnskontrollModal: React.FunctionComponent<Props> = ({ settVisModal }) => {
+export const BehandlingSendtTilTotrinnskontrollModal: FunctionComponent<Props> = ({ settVisModal }) => {
     const navigate = useNavigate();
     const fagsakId = useFagsakId();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaRad.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Table } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabell.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, CopyButton, Heading, Stack, Table } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabellContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabellContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useCallback, useContext, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useCallback, useContext, useState } from 'react';
 
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValuta.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValuta.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Tooltip } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValutaError.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValutaError.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useMutationState } from '@tanstack/react-query';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/BeløpField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/BeløpField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/FeilutbetaltValutaForm.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/FeilutbetaltValutaForm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormProvider } from 'react-hook-form';
 
 import { XMarkOctagonFillIcon } from '@navikt/aksel-icons';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/FomDatoField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/FomDatoField.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { format, startOfMonth, startOfToday } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/TomDatoField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/form/TomDatoField.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { endOfMonth, format, isBefore, startOfToday } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetaling.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { DocPencilIcon } from '@navikt/aksel-icons';
 import { ActionMenu } from '@navikt/ds-react';
 
@@ -13,7 +11,7 @@ interface IKorrigerEtterbetaling {
     erLesevisning: boolean;
 }
 
-const KorrigerEtterbetaling: FC<IKorrigerEtterbetaling> = ({ korrigertEtterbetaling }) => {
+const KorrigerEtterbetaling = ({ korrigertEtterbetaling }: IKorrigerEtterbetaling) => {
     const { åpneModal } = useModal(ModalType.KORRIGER_ETTERBETALING);
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetaling.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import { DocPencilIcon } from '@navikt/aksel-icons';
 import { ActionMenu } from '@navikt/ds-react';
@@ -13,7 +13,7 @@ interface IKorrigerEtterbetaling {
     erLesevisning: boolean;
 }
 
-const KorrigerEtterbetaling: React.FC<IKorrigerEtterbetaling> = ({ korrigertEtterbetaling }) => {
+const KorrigerEtterbetaling: FC<IKorrigerEtterbetaling> = ({ korrigertEtterbetaling }) => {
     const { åpneModal } = useModal(ModalType.KORRIGER_ETTERBETALING);
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ArrowUndoIcon } from '@navikt/aksel-icons';
 import { Alert, Button, Fieldset, HStack, Modal, Select, Spacer, Textarea, TextField, VStack } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import { ActionMenu } from '@navikt/ds-react';
 
@@ -10,7 +8,7 @@ interface Props {
     korrigertVedtak?: IRestKorrigertVedtak;
 }
 
-const KorrigerVedtak: FC<Props> = ({ åpneModal, korrigertVedtak }) => {
+const KorrigerVedtak = ({ åpneModal, korrigertVedtak }: Props) => {
     return (
         <ActionMenu.Item onSelect={åpneModal}>
             <ExclamationmarkTriangleIcon fontSize={'1.4rem'} />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerVedtakModal/KorrigerVedtak.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import { ActionMenu } from '@navikt/ds-react';
@@ -10,7 +10,7 @@ interface Props {
     korrigertVedtak?: IRestKorrigertVedtak;
 }
 
-const KorrigerVedtak: React.FC<Props> = ({ åpneModal, korrigertVedtak }) => {
+const KorrigerVedtak: FC<Props> = ({ åpneModal, korrigertVedtak }) => {
     return (
         <ActionMenu.Item onSelect={åpneModal}>
             <ExclamationmarkTriangleIcon fontSize={'1.4rem'} />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerVedtakModal/KorrigerVedtakModal.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import styled from 'styled-components';
 
 import { ArrowUndoIcon } from '@navikt/aksel-icons';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsRad.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Table } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsTabell.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, CopyButton, Heading, Stack, Table } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsTabellContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsTabellContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useCallback, useContext, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useCallback, useContext, useState } from 'react';
 
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/SlettRefusjonEøs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/SlettRefusjonEøs.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Tooltip } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/SlettRefusjonEøsError.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/SlettRefusjonEøsError.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useMutationState } from '@tanstack/react-query';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/BeløpField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/BeløpField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/FomDatoField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/FomDatoField.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { format, startOfMonth, startOfToday } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/LandkodeField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/LandkodeField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import Styles from './LandkodeField.module.css';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/RefusjonAvklartField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/RefusjonAvklartField.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Radio, RadioGroup } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/RefusjonEøsForm.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/RefusjonEøsForm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { FormProvider } from 'react-hook-form';
 
 import { XMarkOctagonFillIcon } from '@navikt/aksel-icons';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/TomDatoField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/form/TomDatoField.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 import { endOfMonth, format, isBefore, startOfToday } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -15,7 +16,7 @@ const StyledButton = styled(Button)`
     align-self: start;
 `;
 
-const SammensattKontrollsak: React.FC = () => {
+const SammensattKontrollsak: FC = () => {
     const { vurderErLesevisning } = useBehandlingContext();
     const { sammensattKontrollsak, opprettEllerOppdaterSammensattKontrollsak, feilmelding } =
         useSammensattKontrollsakContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -16,7 +15,7 @@ const StyledButton = styled(Button)`
     align-self: start;
 `;
 
-const SammensattKontrollsak: FC = () => {
+const SammensattKontrollsak = () => {
     const { vurderErLesevisning } = useBehandlingContext();
     const { sammensattKontrollsak, opprettEllerOppdaterSammensattKontrollsak, feilmelding } =
         useSammensattKontrollsakContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { PropsWithChildren, SetStateAction, Dispatch } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
@@ -16,7 +17,7 @@ import type {
     IRestSammensattKontrollsak,
 } from '../../../../../../typer/sammensatt-kontrollsak';
 
-interface ISammensattKontrollsakProps extends React.PropsWithChildren {
+interface ISammensattKontrollsakProps extends PropsWithChildren {
     åpenBehandling: IBehandling;
 }
 
@@ -26,7 +27,7 @@ interface SammensattKontrollsakContextValue {
     feilmelding: string | undefined;
     sammensattKontrollsak: IRestSammensattKontrollsak | undefined;
     erSammensattKontrollsak: boolean;
-    settErSammensattKontrollsak: React.Dispatch<React.SetStateAction<boolean>>;
+    settErSammensattKontrollsak: Dispatch<SetStateAction<boolean>>;
     skalViseSammensattKontrollsakMenyValg: () => boolean;
 }
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Datovelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Datovelger.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { isValid, parseISO } from 'date-fns';
 import { useController } from 'react-hook-form';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Tekstfelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/Tekstfelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController } from 'react-hook-form';
 
 import { Textarea } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { FormProvider, type SubmitHandler, useForm } from 'react-hook-form';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtak.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
@@ -41,7 +40,7 @@ export const BehandlingKorrigertAlert = styled(Alert)`
     margin-bottom: 1.5rem;
 `;
 
-const Vedtak: FunctionComponent<IVedtakProps> = ({ åpenBehandling, bruker }) => {
+const Vedtak = ({ åpenBehandling, bruker }: IVedtakProps) => {
     const { vurderErLesevisning, sendTilBeslutterNesteOnClick, behandlingsstegSubmitressurs } = useBehandlingContext();
 
     const { erLeggTilFeilutbetaltValutaFormÅpen } = useFeilutbetaltValutaTabellContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtak.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
+import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
@@ -40,7 +41,7 @@ export const BehandlingKorrigertAlert = styled(Alert)`
     margin-bottom: 1.5rem;
 `;
 
-const Vedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehandling, bruker }) => {
+const Vedtak: FunctionComponent<IVedtakProps> = ({ åpenBehandling, bruker }) => {
     const { vurderErLesevisning, sendTilBeslutterNesteOnClick, behandlingsstegSubmitressurs } = useBehandlingContext();
 
     const { erLeggTilFeilutbetaltValutaFormÅpen } = useFeilutbetaltValutaTabellContext();
@@ -57,7 +58,7 @@ const Vedtak: React.FunctionComponent<IVedtakProps> = ({ åpenBehandling, bruker
 
     const navigate = useNavigate();
 
-    const [visModal, settVisModal] = React.useState<boolean>(false);
+    const [visModal, settVisModal] = useState<boolean>(false);
 
     const visSubmitKnapp = !erLesevisning && åpenBehandling?.status === BehandlingStatus.UTREDES;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksalert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksalert.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Alert } from '@navikt/ds-react';
 
@@ -8,7 +8,7 @@ interface Props {
     åpenBehandling: IBehandling;
 }
 
-export const Vedtaksalert: React.FunctionComponent<Props> = ({ åpenBehandling }) => {
+export const Vedtaksalert: FunctionComponent<Props> = ({ åpenBehandling }) => {
     if (åpenBehandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD) {
         return <Alert variant="info">Du er inne på en migreringsbehandling og det sendes ingen vedtaksbrev.</Alert>;
     }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksalert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksalert.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { Alert } from '@navikt/ds-react';
 
 import { Behandlingstype, BehandlingÅrsak, type IBehandling } from '../../../../../typer/behandling';
@@ -8,7 +6,7 @@ interface Props {
     åpenBehandling: IBehandling;
 }
 
-export const Vedtaksalert: FunctionComponent<Props> = ({ åpenBehandling }) => {
+export const Vedtaksalert = ({ åpenBehandling }: Props) => {
     if (åpenBehandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD) {
         return <Alert variant="info">Du er inne på en migreringsbehandling og det sendes ingen vedtaksbrev.</Alert>;
     }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { FileTextIcon } from '@navikt/aksel-icons';
 import { Alert, Button } from '@navikt/ds-react';
@@ -35,7 +35,7 @@ interface Props {
     bruker: IPersonInfo;
 }
 
-export const VedtaksbrevBygger: React.FunctionComponent<Props> = ({ åpenBehandling, bruker }) => {
+export const VedtaksbrevBygger: FunctionComponent<Props> = ({ åpenBehandling, bruker }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const { hentForhåndsvisning, nullstillDokument, visDokumentModal, hentetDokument, settVisDokumentModal } =
         useDokument();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { FileTextIcon } from '@navikt/aksel-icons';
 import { Alert, Button } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -35,7 +33,7 @@ interface Props {
     bruker: IPersonInfo;
 }
 
-export const VedtaksbrevBygger: FunctionComponent<Props> = ({ åpenBehandling, bruker }) => {
+export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const { hentForhåndsvisning, nullstillDokument, visDokumentModal, hentetDokument, settVisDokumentModal } =
         useDokument();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 
 import { ArrowUndoIcon, CalculatorIcon, ChevronDownIcon, StarsEuIcon, TasklistStartIcon } from '@navikt/aksel-icons';
@@ -40,7 +39,7 @@ export function Vedtaksmeny() {
 
     const fagsakType = fagsak.fagsakType;
 
-    const [visKorrigerVedtakModal, settVisKorrigerVedtakModal] = React.useState<boolean>(false);
+    const [visKorrigerVedtakModal, settVisKorrigerVedtakModal] = useState<boolean>(false);
     const [visEndreEndringstidspunktModal, settVisEndreEndringstidspunktModal] = useState(false);
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,7 +28,7 @@ const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect: React.FC<IProps> = ({ vedtaksperiodetype }) => {
+const BegrunnelserMultiselect: FC<IProps> = ({ vedtaksperiodetype }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const skalIkkeEditeres = vurderErLesevisning() || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components';
@@ -28,7 +27,7 @@ const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect: FC<IProps> = ({ vedtaksperiodetype }) => {
+const BegrunnelserMultiselect = ({ vedtaksperiodetype }: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const skalIkkeEditeres = vurderErLesevisning() || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
@@ -1,5 +1,4 @@
-import type { PropsWithChildren } from 'react';
-import React from 'react';
+import type { FC, PropsWithChildren } from 'react';
 
 import { endOfMonth, isAfter } from 'date-fns';
 import styled from 'styled-components';
@@ -48,7 +47,7 @@ interface EkspanderbarVedtaksperiodeProps extends PropsWithChildren {
 const slutterSenereEnnInneværendeMåned = (tom?: string) =>
     isAfter(isoStringTilDateMedFallback({ isoString: tom, fallbackDate: tidenesEnde }), endOfMonth(dagensDato));
 
-const EkspanderbarVedtaksperiode: React.FC<EkspanderbarVedtaksperiodeProps> = ({
+const EkspanderbarVedtaksperiode: FC<EkspanderbarVedtaksperiodeProps> = ({
     vedtaksperiodeMedBegrunnelser,
     åpen,
     onClick,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
@@ -1,4 +1,4 @@
-import type { FC, PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { endOfMonth, isAfter } from 'date-fns';
 import styled from 'styled-components';
@@ -47,12 +47,12 @@ interface EkspanderbarVedtaksperiodeProps extends PropsWithChildren {
 const slutterSenereEnnInneværendeMåned = (tom?: string) =>
     isAfter(isoStringTilDateMedFallback({ isoString: tom, fallbackDate: tidenesEnde }), endOfMonth(dagensDato));
 
-const EkspanderbarVedtaksperiode: FC<EkspanderbarVedtaksperiodeProps> = ({
+const EkspanderbarVedtaksperiode = ({
     vedtaksperiodeMedBegrunnelser,
     åpen,
     onClick,
     children,
-}) => {
+}: EkspanderbarVedtaksperiodeProps) => {
     const periode = {
         fom: vedtaksperiodeMedBegrunnelser.fom,
         tom: vedtaksperiodeMedBegrunnelser.tom,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC, ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
@@ -66,7 +66,7 @@ const ItalicText = styled(BodyLong)`
     font-style: italic;
 `;
 
-const FritekstBegrunnelser: React.FC = () => {
+const FritekstBegrunnelser: FC = () => {
     const { vurderErLesevisning, søkersMålform } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
     const {
@@ -81,7 +81,7 @@ const FritekstBegrunnelser: React.FC = () => {
 
     const erMaksAntallKulepunkter = skjema.felter.fritekster.verdi.length >= maksAntallKulepunkter;
 
-    const onChangeFritekst = (event: React.ChangeEvent<HTMLTextAreaElement>, fritekstId: number) =>
+    const onChangeFritekst = (event: ChangeEvent<HTMLTextAreaElement>, fritekstId: number) =>
         skjema.felter.fritekster.validerOgSettFelt([
             ...skjema.felter.fritekster.verdi.map(mapFritekst => {
                 if (mapFritekst.verdi.id === fritekstId) {
@@ -172,7 +172,7 @@ const FritekstBegrunnelser: React.FC = () => {
                                     resize
                                     value={fritekst.verdi.tekst}
                                     maxLength={makslengdeFritekst}
-                                    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+                                    onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
                                         onChangeFritekst(event, fritekstId)
                                     }
                                     error={skjema.visFeilmeldinger && fritekst.feilmelding}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
@@ -1,4 +1,4 @@
-import type { FC, ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
@@ -66,7 +66,7 @@ const ItalicText = styled(BodyLong)`
     font-style: italic;
 `;
 
-const FritekstBegrunnelser: FC = () => {
+const FritekstBegrunnelser = () => {
     const { vurderErLesevisning, søkersMålform } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
     const {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -20,7 +20,7 @@ const UtbetalingsperiodeDetalj = styled.div`
     }
 `;
 
-const Utbetalingsresultat: React.FC<IProps> = ({ utbetalingsperiodeDetaljer }) => {
+const Utbetalingsresultat: FC<IProps> = ({ utbetalingsperiodeDetaljer }) => {
     if (utbetalingsperiodeDetaljer.length === 0) return null;
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort, Label } from '@navikt/ds-react';
@@ -20,7 +18,7 @@ const UtbetalingsperiodeDetalj = styled.div`
     }
 `;
 
-const Utbetalingsresultat: FC<IProps> = ({ utbetalingsperiodeDetaljer }) => {
+const Utbetalingsresultat = ({ utbetalingsperiodeDetaljer }: IProps) => {
     if (utbetalingsperiodeDetaljer.length === 0) return null;
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { BodyShort, ErrorMessage, Label } from '@navikt/ds-react';
 
 import BegrunnelserMultiselect from './BegrunnelserMultiselect';
@@ -16,7 +14,7 @@ interface IProps {
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
 }
 
-const Vedtaksperiode: FC<IProps> = ({ vedtaksperiodeMedBegrunnelser }) => {
+const Vedtaksperiode = ({ vedtaksperiodeMedBegrunnelser }: IProps) => {
     const { erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
 
     const { data: genererteBrevbegrunnelser, error: genererteBrevbegrunnelserError } = useHentGenererteBrevbegrunnelser(

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { BodyShort, ErrorMessage, Label } from '@navikt/ds-react';
 
@@ -16,7 +16,7 @@ interface IProps {
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
 }
 
-const Vedtaksperiode: React.FC<IProps> = ({ vedtaksperiodeMedBegrunnelser }) => {
+const Vedtaksperiode: FC<IProps> = ({ vedtaksperiodeMedBegrunnelser }) => {
     const { erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
 
     const { data: genererteBrevbegrunnelser, error: genererteBrevbegrunnelserError } = useHentGenererteBrevbegrunnelser(

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import deepEqual from 'deep-equal';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { Fragment } from 'react';
 
 import styled from 'styled-components';
@@ -23,7 +22,7 @@ interface VedtaksperioderProps {
     åpenBehandling: IBehandling;
 }
 
-const Vedtaksperioder: FC<VedtaksperioderProps> = ({ åpenBehandling }) => {
+const Vedtaksperioder = ({ åpenBehandling }: VedtaksperioderProps) => {
     const { vedtaksperioder } = useVedtaksperioderContext();
 
     const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
@@ -55,11 +54,15 @@ const Vedtaksperioder: FC<VedtaksperioderProps> = ({ åpenBehandling }) => {
     );
 };
 
-const GrupperteVedtaksperioder: FC<{
+const GrupperteVedtaksperioder = ({
+    vedtaksperioderMedBegrunnelser,
+    overskrift,
+    åpenBehandling,
+}: {
     vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     overskrift: string;
     åpenBehandling: IBehandling;
-}> = ({ vedtaksperioderMedBegrunnelser, overskrift, åpenBehandling }) => {
+}) => {
     if (vedtaksperioderMedBegrunnelser.length === 0) {
         return <></>;
     }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment } from 'react';
+import type { FC } from 'react';
+import { Fragment } from 'react';
 
 import styled from 'styled-components';
 
@@ -22,7 +23,7 @@ interface VedtaksperioderProps {
     åpenBehandling: IBehandling;
 }
 
-const Vedtaksperioder: React.FC<VedtaksperioderProps> = ({ åpenBehandling }) => {
+const Vedtaksperioder: FC<VedtaksperioderProps> = ({ åpenBehandling }) => {
     const { vedtaksperioder } = useVedtaksperioderContext();
 
     const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
@@ -54,7 +55,7 @@ const Vedtaksperioder: React.FC<VedtaksperioderProps> = ({ åpenBehandling }) =>
     );
 };
 
-const GrupperteVedtaksperioder: React.FC<{
+const GrupperteVedtaksperioder: FC<{
     vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     overskrift: string;
     åpenBehandling: IBehandling;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperioderContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperioderContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/EndreEndringstidspunkt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/EndreEndringstidspunkt.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { CalendarIcon } from '@navikt/aksel-icons';
 import { ActionMenu } from '@navikt/ds-react';
 
@@ -7,7 +5,7 @@ interface Props {
     åpneModal: () => void;
 }
 
-const EndreEndringstidspunkt: FC<Props> = ({ åpneModal }) => {
+const EndreEndringstidspunkt = ({ åpneModal }: Props) => {
     return (
         <ActionMenu.Item onSelect={åpneModal}>
             <CalendarIcon fontSize={'1.4rem'} />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/EndreEndringstidspunkt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/EndreEndringstidspunkt.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { CalendarIcon } from '@navikt/aksel-icons';
 import { ActionMenu } from '@navikt/ds-react';
@@ -7,7 +7,7 @@ interface Props {
     åpneModal: () => void;
 }
 
-const EndreEndringstidspunkt: React.FC<Props> = ({ åpneModal }) => {
+const EndreEndringstidspunkt: FC<Props> = ({ åpneModal }) => {
     return (
         <ActionMenu.Item onSelect={åpneModal}>
             <CalendarIcon fontSize={'1.4rem'} />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/EndringstidspunktFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/EndringstidspunktFelt.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useRef } from 'react';
 
 import { format, parseISO, startOfToday } from 'date-fns';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import { useId } from 'react';
 
 import { FormProvider } from 'react-hook-form';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/FyllUtVilkårsvurderingITestmiljøKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/FyllUtVilkårsvurderingITestmiljøKnapp.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { Button } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
@@ -11,7 +9,7 @@ interface IProps {
     behandlingId: number;
 }
 
-export const FyllUtVilkårsvurderingITestmiljøKnapp: FunctionComponent<IProps> = ({ behandlingId }) => {
+export const FyllUtVilkårsvurderingITestmiljøKnapp = ({ behandlingId }: IProps) => {
     const { request } = useHttp();
 
     const fyllUtVilkårsvurdering = () => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/FyllUtVilkårsvurderingITestmiljøKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/FyllUtVilkårsvurderingITestmiljøKnapp.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Button } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
@@ -11,7 +11,7 @@ interface IProps {
     behandlingId: number;
 }
 
-export const FyllUtVilkårsvurderingITestmiljøKnapp: React.FunctionComponent<IProps> = ({ behandlingId }) => {
+export const FyllUtVilkårsvurderingITestmiljøKnapp: FunctionComponent<IProps> = ({ behandlingId }) => {
     const { request } = useHttp();
 
     const fyllUtVilkårsvurdering = () => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
@@ -1,4 +1,4 @@
-import type { FC, FocusEvent } from 'react';
+import type { FocusEvent } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -36,7 +36,7 @@ const Knapperad = styled.div`
     margin: 1rem 0;
 `;
 
-const AnnenVurderingRadEndre: FC<IProps> = ({
+const AnnenVurderingRadEndre = ({
     person,
     annenVurderingConfig,
     visFeilmeldinger,
@@ -44,7 +44,7 @@ const AnnenVurderingRadEndre: FC<IProps> = ({
     redigerbartAnnenVurdering,
     settRedigerbartAnnenVurdering,
     settEkspandertAnnenVurdering,
-}) => {
+}: IProps) => {
     const { vilkårsvurdering, putAnnenVurdering, vilkårSubmit, settVilkårSubmit } = useVilkårsvurderingContext();
 
     const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC, FocusEvent } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -35,7 +36,7 @@ const Knapperad = styled.div`
     margin: 1rem 0;
 `;
 
-const AnnenVurderingRadEndre: React.FC<IProps> = ({
+const AnnenVurderingRadEndre: FC<IProps> = ({
     person,
     annenVurderingConfig,
     visFeilmeldinger,
@@ -192,7 +193,7 @@ const AnnenVurderingRadEndre: React.FC<IProps> = ({
                             ? redigerbartAnnenVurdering.verdi.begrunnelse.feilmelding
                             : ''
                     }
-                    onChange={(event: React.FocusEvent<HTMLTextAreaElement>) => {
+                    onChange={(event: FocusEvent<HTMLTextAreaElement>) => {
                         validerOgSettRedigerbartAnnenVurdering({
                             ...redigerbartAnnenVurdering,
                             verdi: {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Table } from '@navikt/ds-react';
@@ -43,7 +41,7 @@ const TabellHeader = styled(Table.HeaderCell)`
     }
 `;
 
-const AnnenVurderingTabell: FC<IProps> = ({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }) => {
+const AnnenVurderingTabell = ({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }: IProps) => {
     return (
         <Table>
             <Table.Header>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -43,12 +43,7 @@ const TabellHeader = styled(Table.HeaderCell)`
     }
 `;
 
-const AnnenVurderingTabell: React.FC<IProps> = ({
-    person,
-    annenVurderingConfig,
-    andreVurderinger,
-    visFeilmeldinger,
-}) => {
+const AnnenVurderingTabell: FC<IProps> = ({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }) => {
     return (
         <Table>
             <Table.Header>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import deepEqual from 'deep-equal';
 import styled from 'styled-components';
@@ -52,12 +53,7 @@ const StyledPersonIcon = styled(PersonIcon)`
     min-width: 1.5rem;
 `;
 
-const AnnenVurderingTabellRad: React.FC<IProps> = ({
-    person,
-    annenVurderingConfig,
-    visFeilmeldinger,
-    annenVurdering,
-}) => {
+const AnnenVurderingTabellRad: FC<IProps> = ({ person, annenVurderingConfig, visFeilmeldinger, annenVurdering }) => {
     const { vurderErLesevisning } = useBehandlingContext();
 
     const [ekspandertAnnenVurdering, settEkspandertAnnenVurdering] = useState(

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import deepEqual from 'deep-equal';
@@ -53,7 +52,7 @@ const StyledPersonIcon = styled(PersonIcon)`
     min-width: 1.5rem;
 `;
 
-const AnnenVurderingTabellRad: FC<IProps> = ({ person, annenVurderingConfig, visFeilmeldinger, annenVurdering }) => {
+const AnnenVurderingTabellRad = ({ person, annenVurderingConfig, visFeilmeldinger, annenVurdering }: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
 
     const [ekspandertAnnenVurdering, settEkspandertAnnenVurdering] = useState(

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/GeneriskAnnenVurdering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/GeneriskAnnenVurdering.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -24,12 +25,7 @@ const Container = styled.div`
     }
 `;
 
-const GeneriskAnnenVurdering: React.FC<IProps> = ({
-    person,
-    annenVurderingConfig,
-    andreVurderinger,
-    visFeilmeldinger,
-}) => {
+const GeneriskAnnenVurdering: FC<IProps> = ({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }) => {
     const [visFeilmeldingerForAnnenVurdering] = useState(false);
     const [feilmelding] = useState('');
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/GeneriskAnnenVurdering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/GeneriskAnnenVurdering.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -25,7 +24,7 @@ const Container = styled.div`
     }
 `;
 
-const GeneriskAnnenVurdering: FC<IProps> = ({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }) => {
+const GeneriskAnnenVurdering = ({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }: IProps) => {
     const [visFeilmeldingerForAnnenVurdering] = useState(false);
     const [feilmelding] = useState('');
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { ErrorMessage, LocalAlert, Stack, UNSAFE_Combobox } from '@navikt/ds-react';
 
@@ -23,7 +23,7 @@ interface IOptionType {
     label: string;
 }
 
-const AvslagBegrunnelseMultiselect: React.FC<IProps> = ({ vilkårType, begrunnelser, onChange, regelverk }) => {
+const AvslagBegrunnelseMultiselect: FC<IProps> = ({ vilkårType, begrunnelser, onChange, regelverk }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
     const { vilkårSubmit } = useVilkårsvurderingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { ErrorMessage, LocalAlert, Stack, UNSAFE_Combobox } from '@navikt/ds-react';
 
 import useAvslagBegrunnelseMultiselect from './useAvslagBegrunnelseMultiselect';
@@ -23,7 +21,7 @@ interface IOptionType {
     label: string;
 }
 
-const AvslagBegrunnelseMultiselect: FC<IProps> = ({ vilkårType, begrunnelser, onChange, regelverk }) => {
+const AvslagBegrunnelseMultiselect = ({ vilkårType, begrunnelser, onChange, regelverk }: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
     const { vilkårSubmit } = useVilkårsvurderingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import classNames from 'classnames';
 
 import { BodyShort, Checkbox, Fieldset, VStack } from '@navikt/ds-react';
@@ -18,12 +16,12 @@ interface IProps {
     settVisFeilmeldingerForEttVilkår: (visFeilmeldinger: boolean) => void;
 }
 
-const AvslagSkjema: FC<IProps> = ({
+const AvslagSkjema = ({
     redigerbartVilkår,
     settRedigerbartVilkår,
     visFeilmeldinger,
     settVisFeilmeldingerForEttVilkår,
-}) => {
+}: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import classNames from 'classnames';
 
@@ -18,7 +18,7 @@ interface IProps {
     settVisFeilmeldingerForEttVilkår: (visFeilmeldinger: boolean) => void;
 }
 
-const AvslagSkjema: React.FC<IProps> = ({
+const AvslagSkjema: FC<IProps> = ({
     redigerbartVilkår,
     settRedigerbartVilkår,
     visFeilmeldinger,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/FjernUtvidetBarnetrygdVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/FjernUtvidetBarnetrygdVilkår.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -22,7 +21,7 @@ interface IProps {
     slettVilkårId: string;
 }
 
-const FjernUtvidetBarnetrygdVilkår: FC<IProps> = ({ personIdent, slettVilkårId }) => {
+const FjernUtvidetBarnetrygdVilkår = ({ personIdent, slettVilkårId }: IProps) => {
     const { request } = useHttp();
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const [visModal, settVisModal] = useState<boolean>(false);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/FjernUtvidetBarnetrygdVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/FjernUtvidetBarnetrygdVilkår.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -21,7 +22,7 @@ interface IProps {
     slettVilkårId: string;
 }
 
-const FjernUtvidetBarnetrygdVilkår: React.FC<IProps> = ({ personIdent, slettVilkårId }) => {
+const FjernUtvidetBarnetrygdVilkår: FC<IProps> = ({ personIdent, slettVilkårId }) => {
     const { request } = useHttp();
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const [visModal, settVisModal] = useState<boolean>(false);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -36,7 +37,7 @@ const Container = styled.div`
     }
 `;
 
-const GeneriskVilkår: React.FC<IProps> = ({
+const GeneriskVilkår: FC<IProps> = ({
     person,
     vilkårFraConfig,
     vilkårResultater,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -37,13 +36,7 @@ const Container = styled.div`
     }
 `;
 
-const GeneriskVilkår: FC<IProps> = ({
-    person,
-    vilkårFraConfig,
-    vilkårResultater,
-    visFeilmeldinger,
-    generiskVilkårKey,
-}) => {
+const GeneriskVilkår = ({ person, vilkårFraConfig, vilkårResultater, visFeilmeldinger, generiskVilkårKey }: IProps) => {
     const toggles = useFeatureToggles();
     const { behandling, vurderErLesevisning, settÅpenBehandling, erMigreringsbehandling } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import React, { useEffect } from 'react';
+import type { FC, ReactNode } from 'react';
+import { useEffect } from 'react';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
@@ -78,7 +78,7 @@ function mapOgLeggTilUtdypendeVilkårsvurdering(option: OptionType, vilkår: IVi
         : vilkår;
 }
 
-export const UtdypendeVilkårsvurderingMultiselect: React.FC<Props> = ({
+export const UtdypendeVilkårsvurderingMultiselect: FC<Props> = ({
     redigerbartVilkår,
     validerOgSettRedigerbartVilkår,
     erLesevisning,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/UtdypendeVilkårsvurderingMultiselect.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';
@@ -78,13 +78,13 @@ function mapOgLeggTilUtdypendeVilkårsvurdering(option: OptionType, vilkår: IVi
         : vilkår;
 }
 
-export const UtdypendeVilkårsvurderingMultiselect: FC<Props> = ({
+export const UtdypendeVilkårsvurderingMultiselect = ({
     redigerbartVilkår,
     validerOgSettRedigerbartVilkår,
     erLesevisning,
     personType,
     feilhåndtering,
-}) => {
+}: Props) => {
     const utdypendeVilkårsvurderingAvhengigheter: UtdypendeVilkårsvurderingAvhengigheter = {
         personType,
         vilkårType: redigerbartVilkår.verdi.vilkårType,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { endOfMonth } from 'date-fns';
 import styled from 'styled-components';
@@ -37,7 +37,7 @@ const FlexDiv = styled.div`
     gap: 1.125rem;
 `;
 
-const VelgPeriode: React.FC<IProps> = ({ redigerbartVilkår, validerOgSettRedigerbartVilkår, visFeilmeldinger }) => {
+const VelgPeriode: FC<IProps> = ({ redigerbartVilkår, validerOgSettRedigerbartVilkår, visFeilmeldinger }) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { endOfMonth } from 'date-fns';
 import styled from 'styled-components';
 
@@ -37,7 +35,7 @@ const FlexDiv = styled.div`
     gap: 1.125rem;
 `;
 
-const VelgPeriode: FC<IProps> = ({ redigerbartVilkår, validerOgSettRedigerbartVilkår, visFeilmeldinger }) => {
+const VelgPeriode = ({ redigerbartVilkår, validerOgSettRedigerbartVilkår, visFeilmeldinger }: IProps) => {
     const { vurderErLesevisning } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -47,7 +47,7 @@ const TabellHeader = styled(Table.HeaderCell)`
     }
 `;
 
-const VilkårTabell: React.FC<IProps> = ({
+const VilkårTabell: FC<IProps> = ({
     person,
     vilkårFraConfig,
     vilkårResultater,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Table } from '@navikt/ds-react';
@@ -47,13 +45,7 @@ const TabellHeader = styled(Table.HeaderCell)`
     }
 `;
 
-const VilkårTabell: FC<IProps> = ({
-    person,
-    vilkårFraConfig,
-    vilkårResultater,
-    visFeilmeldinger,
-    settFokusPåKnapp,
-}) => {
+const VilkårTabell = ({ person, vilkårFraConfig, vilkårResultater, visFeilmeldinger, settFokusPåKnapp }: IProps) => {
     return (
         <Table>
             <Table.Header>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 
 import deepEqual from 'deep-equal';
 import styled from 'styled-components';
@@ -71,7 +72,7 @@ const StyledPersonIcon = styled(PersonIcon)`
     min-width: 1.5rem;
 `;
 
-const VilkårTabellRad: React.FC<IProps> = ({
+const VilkårTabellRad: FC<IProps> = ({
     person,
     vilkårFraConfig,
     vilkårResultat,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 
 import deepEqual from 'deep-equal';
@@ -72,13 +71,7 @@ const StyledPersonIcon = styled(PersonIcon)`
     min-width: 1.5rem;
 `;
 
-const VilkårTabellRad: FC<IProps> = ({
-    person,
-    vilkårFraConfig,
-    vilkårResultat,
-    visFeilmeldinger,
-    settFokusPåKnapp,
-}) => {
+const VilkårTabellRad = ({ person, vilkårFraConfig, vilkårResultat, visFeilmeldinger, settFokusPåKnapp }: IProps) => {
     const { vurderErLesevisning, behandling, aktivSettPåVent } = useBehandlingContext();
     const erLesevisning = vurderErLesevisning();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
@@ -1,4 +1,4 @@
-import type { FC, ChangeEvent, FocusEvent, ReactNode } from 'react';
+import type { ChangeEvent, FocusEvent, ReactNode } from 'react';
 import { useState } from 'react';
 
 import styled from 'styled-components';
@@ -68,7 +68,7 @@ const Knapperad = styled.div`
     margin: 1rem 0;
 `;
 
-const VilkårTabellRadEndre: FC<IProps> = ({
+const VilkårTabellRadEndre = ({
     person,
     vilkårFraConfig,
     vilkårResultat,
@@ -79,7 +79,7 @@ const VilkårTabellRadEndre: FC<IProps> = ({
     settEkspandertVilkår,
     settFokusPåKnapp,
     lesevisning,
-}) => {
+}: IProps) => {
     const { vilkårsvurdering, putVilkår, deleteVilkår, vilkårSubmit, settVilkårSubmit } = useVilkårsvurderingContext();
 
     const { behandling, settÅpenBehandling, gjelderEnsligMindreårig, gjelderInstitusjon } = useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRadEndre.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import type { FC, ChangeEvent, FocusEvent, ReactNode } from 'react';
+import { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -68,7 +68,7 @@ const Knapperad = styled.div`
     margin: 1rem 0;
 `;
 
-const VilkårTabellRadEndre: React.FC<IProps> = ({
+const VilkårTabellRadEndre: FC<IProps> = ({
     person,
     vilkårFraConfig,
     vilkårResultat,
@@ -212,7 +212,7 @@ const VilkårTabellRadEndre: React.FC<IProps> = ({
                             redigerbartVilkår.verdi.vurderesEtter ? redigerbartVilkår.verdi.vurderesEtter : undefined
                         }
                         label={'Vurderes etter'}
-                        onChange={(event: React.ChangeEvent<HTMLSelectElement>): void => {
+                        onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
                             settRedigerbartVilkår({
                                 ...redigerbartVilkår,
                                 verdi: {
@@ -326,7 +326,7 @@ const VilkårTabellRadEndre: React.FC<IProps> = ({
                             ? redigerbartVilkår.verdi.begrunnelse.feilmelding
                             : ''
                     }
-                    onChange={(event: React.FocusEvent<HTMLTextAreaElement>) => {
+                    onChange={(event: FocusEvent<HTMLTextAreaElement>) => {
                         validerOgSettRedigerbartVilkår({
                             ...redigerbartVilkår,
                             verdi: {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
 import { Button, Detail, ErrorMessage, HStack, VStack } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import {
     BriefcaseIcon,
@@ -26,7 +26,7 @@ interface IRegisteropplysningerProps {
     fødselsdato: string;
 }
 
-const Registeropplysninger: React.FC<IRegisteropplysningerProps> = ({ registerHistorikk, fødselsdato }) => {
+const Registeropplysninger: FC<IRegisteropplysningerProps> = ({ registerHistorikk, fødselsdato }) => {
     const personErDød = registerHistorikk.dødsboadresse.length > 0;
     const toggles = useFeatureToggles();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/Registeropplysninger.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import {
     BriefcaseIcon,
     CalendarIcon,
@@ -26,7 +24,7 @@ interface IRegisteropplysningerProps {
     fødselsdato: string;
 }
 
-const Registeropplysninger: FC<IRegisteropplysningerProps> = ({ registerHistorikk, fødselsdato }) => {
+const Registeropplysninger = ({ registerHistorikk, fødselsdato }: IRegisteropplysningerProps) => {
     const personErDød = registerHistorikk.dødsboadresse.length > 0;
     const toggles = useFeatureToggles();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { differenceInMilliseconds } from 'date-fns';
@@ -62,7 +62,7 @@ const sorterPerioderSynkende = (a: IRestRegisteropplysning, b: IRestRegisteroppl
 
 const GRENSE_FOR_EKSPANDERBAR_HISTORIKK = 3;
 
-const RegisteropplysningerTabell: FC<IRegisteropplysningerTabellProps> = ({ opplysningstype, ikon, historikk }) => {
+const RegisteropplysningerTabell = ({ opplysningstype, ikon, historikk }: IRegisteropplysningerTabellProps) => {
     const [erEkspandert, settEkspandert] = useState<boolean>(false);
     const manglerOpplysninger = historikk.length === 0;
     const skalVæreEkspanderbar =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Registeropplysninger/RegisteropplysningerTabell.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import type { FC, ReactNode } from 'react';
+import { useState } from 'react';
 
 import { differenceInMilliseconds } from 'date-fns';
 
@@ -62,11 +62,7 @@ const sorterPerioderSynkende = (a: IRestRegisteropplysning, b: IRestRegisteroppl
 
 const GRENSE_FOR_EKSPANDERBAR_HISTORIKK = 3;
 
-const RegisteropplysningerTabell: React.FC<IRegisteropplysningerTabellProps> = ({
-    opplysningstype,
-    ikon,
-    historikk,
-}) => {
+const RegisteropplysningerTabell: FC<IRegisteropplysningerTabellProps> = ({ opplysningstype, ikon, historikk }) => {
     const [erEkspandert, settEkspandert] = useState<boolean>(false);
     const manglerOpplysninger = historikk.length === 0;
     const skalVæreEkspanderbar =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjema.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import VilkårsvurderingSkjemaEnsligMindreårig from './VilkårsvurderingSkjemaEnsligMindreårig';
 import VilkårsvurderingSkjemaInstitusjon from './VilkårsvurderingSkjemaInstitusjon';
 import VilkårsvurderingSkjemaNormal from './VilkårsvurderingSkjemaNormal';
@@ -11,7 +9,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjema: FC<IProps> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjema = ({ visFeilmeldinger }: IProps) => {
     const { fagsak } = useFagsakContext();
 
     const { samhandlerOrgnr } = useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjema.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import VilkårsvurderingSkjemaEnsligMindreårig from './VilkårsvurderingSkjemaEnsligMindreårig';
 import VilkårsvurderingSkjemaInstitusjon from './VilkårsvurderingSkjemaInstitusjon';
@@ -11,7 +11,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjema: React.FC<IProps> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjema: FC<IProps> = ({ visFeilmeldinger }) => {
     const { fagsak } = useFagsakContext();
 
     const { samhandlerOrgnr } = useBehandlingContext();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { Alert, Box, HStack } from '@navikt/ds-react';
 
 import { PersonInformasjon } from '../../../../../../komponenter/PersonInformasjon/PersonInformasjon';
@@ -21,7 +19,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjemaEnsligMindreårig: FC<IProps> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjemaEnsligMindreårig = ({ visFeilmeldinger }: IProps) => {
     const { vilkårsvurdering } = useVilkårsvurderingContext();
 
     const personResultat = vilkårsvurdering.find((value: IPersonResultat) => value.person.type === PersonType.BARN);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaEnsligMindreårig.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { Alert, Box, HStack } from '@navikt/ds-react';
 
@@ -21,7 +21,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjemaEnsligMindreårig: React.FC<IProps> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjemaEnsligMindreårig: FC<IProps> = ({ visFeilmeldinger }) => {
     const { vilkårsvurdering } = useVilkårsvurderingContext();
 
     const personResultat = vilkårsvurdering.find((value: IPersonResultat) => value.person.type === PersonType.BARN);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { Alert, Bleed, Box, HStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -20,7 +18,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjemaInstitusjon: FunctionComponent<IProps> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjemaInstitusjon = ({ visFeilmeldinger }: IProps) => {
     const { behandling } = useBehandlingContext();
     const { vilkårsvurdering } = useVilkårsvurderingContext();
     const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaInstitusjon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Alert, Bleed, Box, HStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -20,7 +20,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjemaInstitusjon: React.FunctionComponent<IProps> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjemaInstitusjon: FunctionComponent<IProps> = ({ visFeilmeldinger }) => {
     const { behandling } = useBehandlingContext();
     const { vilkårsvurdering } = useVilkårsvurderingContext();
     const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -1,4 +1,5 @@
-import React, { Activity, useEffect, useState } from 'react';
+import type { FunctionComponent } from 'react';
+import { Activity, useEffect, useState } from 'react';
 
 import { ChevronDownIcon, ChevronUpIcon, PlusCircleIcon, ShieldLockFillIcon } from '@navikt/aksel-icons';
 import { Alert, BodyShort, Box, Button, Heading, HStack, List } from '@navikt/ds-react';
@@ -29,7 +30,7 @@ interface IVilkårsvurderingSkjemaNormal {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjemaNormal: React.FunctionComponent<IVilkårsvurderingSkjemaNormal> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjemaNormal: FunctionComponent<IVilkårsvurderingSkjemaNormal> = ({ visFeilmeldinger }) => {
     const toggles = useFeatureToggles();
     const { vilkårsvurdering, settVilkårSubmit, postVilkår } = useVilkårsvurderingContext();
     const { vurderErLesevisning, erMigreringsbehandling, settÅpenBehandling, aktivSettPåVent, behandling } =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { Activity, useEffect, useState } from 'react';
 
 import { ChevronDownIcon, ChevronUpIcon, PlusCircleIcon, ShieldLockFillIcon } from '@navikt/aksel-icons';
@@ -30,7 +29,7 @@ interface IVilkårsvurderingSkjemaNormal {
     visFeilmeldinger: boolean;
 }
 
-const VilkårsvurderingSkjemaNormal: FunctionComponent<IVilkårsvurderingSkjemaNormal> = ({ visFeilmeldinger }) => {
+const VilkårsvurderingSkjemaNormal = ({ visFeilmeldinger }: IVilkårsvurderingSkjemaNormal) => {
     const toggles = useFeatureToggles();
     const { vilkårsvurdering, settVilkårSubmit, postVilkår } = useVilkårsvurderingContext();
     const { vurderErLesevisning, erMigreringsbehandling, settÅpenBehandling, aktivSettPåVent, behandling } =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/TømPersonopplysningerCacheITestmiljøKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/TømPersonopplysningerCacheITestmiljøKnapp.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Varsel/ManglendeFinnmarkmerkingVarsel.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Varsel/ManglendeFinnmarkmerkingVarsel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert, BodyLong, Heading, Table, VStack } from '@navikt/ds-react';
 
 import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Varsel/ManglendeSvalbardmerkingVarsel.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Varsel/ManglendeSvalbardmerkingVarsel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Alert, BodyLong, Heading, Table, VStack } from '@navikt/ds-react';
 
 import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
 
@@ -43,7 +43,7 @@ export function Vilkårsvurdering() {
 
     const erLesevisning = vurderErLesevisning();
 
-    const [visFeilmeldinger, settVisFeilmeldinger] = React.useState(false);
+    const [visFeilmeldinger, settVisFeilmeldinger] = useState(false);
 
     const navigate = useNavigate();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import type { PropsWithChildren, SetStateAction, Dispatch } from 'react';
+import { createContext, useState, useEffect, useContext } from 'react';
 
 import { useHttp } from '@navikt/familie-http';
 import type { FeltState } from '@navikt/familie-skjema';
@@ -17,7 +18,7 @@ import type {
     VilkårType,
 } from '../../../../../typer/vilkår';
 
-interface IProps extends React.PropsWithChildren {
+interface IProps extends PropsWithChildren {
     åpenBehandling: IBehandling;
 }
 
@@ -29,10 +30,10 @@ export enum VilkårSubmit {
 }
 
 interface VilkårsvurderingContextValue {
-    settVilkårsvurdering: React.Dispatch<React.SetStateAction<IPersonResultat[]>>;
+    settVilkårsvurdering: Dispatch<SetStateAction<IPersonResultat[]>>;
     vilkårsvurdering: IPersonResultat[];
     vilkårSubmit: VilkårSubmit;
-    settVilkårSubmit: React.Dispatch<React.SetStateAction<VilkårSubmit>>;
+    settVilkårSubmit: Dispatch<SetStateAction<VilkårSubmit>>;
     putVilkår: (
         vilkårsvurderingForPerson: IPersonResultat,
         redigerbartVilkår: FeltState<IVilkårResultat>
@@ -45,17 +46,17 @@ interface VilkårsvurderingContextValue {
     hentAndreVurderingerMedFeil: () => IAnnenVurdering[];
 }
 
-const VilkårsvurderingContext = React.createContext<VilkårsvurderingContextValue | undefined>(undefined);
+const VilkårsvurderingContext = createContext<VilkårsvurderingContextValue | undefined>(undefined);
 
 export const VilkårsvurderingProvider = ({ åpenBehandling, children }: IProps) => {
     const { request } = useHttp();
-    const [vilkårSubmit, settVilkårSubmit] = React.useState(VilkårSubmit.NONE);
+    const [vilkårSubmit, settVilkårSubmit] = useState(VilkårSubmit.NONE);
 
-    const [vilkårsvurdering, settVilkårsvurdering] = React.useState<IPersonResultat[]>(
+    const [vilkårsvurdering, settVilkårsvurdering] = useState<IPersonResultat[]>(
         åpenBehandling ? mapFraRestVilkårsvurderingTilUi(åpenBehandling.personResultater, åpenBehandling.personer) : []
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         settVilkårsvurdering(
             åpenBehandling
                 ? mapFraRestVilkårsvurderingTilUi(åpenBehandling.personResultater, åpenBehandling.personer)
@@ -206,7 +207,7 @@ export const VilkårsvurderingProvider = ({ åpenBehandling, children }: IProps)
 };
 
 export const useVilkårsvurderingContext = () => {
-    const context = React.useContext(VilkårsvurderingContext);
+    const context = useContext(VilkårsvurderingContext);
 
     if (context === undefined) {
         throw new Error('useVilkårsvurderingContext må brukes innenfor en VilkårsvurderingProvider');

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { MouseEvent } from 'react';
 import { Activity } from 'react';
 
 import classNames from 'classnames';
@@ -20,7 +20,7 @@ export function Venstremeny() {
     const fagsakId = useFagsakId();
     const [erÅpen, settErÅpen] = useVenstremeny();
 
-    function stansNavigeringDersomSidenIkkeErAktiv(event: React.MouseEvent, sidenErAktiv: boolean) {
+    function stansNavigeringDersomSidenIkkeErAktiv(event: MouseEvent, sidenErAktiv: boolean) {
         if (!sidenErAktiv) {
             event.preventDefault();
         }

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useEffect } from 'react';
+import type { PropsWithChildren } from 'react';
+import { useState, createContext, useContext, useEffect } from 'react';
 
 import { useLocation } from 'react-router';
 
@@ -22,7 +23,7 @@ import { useFagsakContext } from '../../FagsakContext';
 import type { ITrinn, SideId } from '../Sider/sider';
 import { hentTrinnForBehandling, KontrollertStatus } from '../Sider/sider';
 
-interface Props extends React.PropsWithChildren {
+interface Props extends PropsWithChildren {
     behandling: IBehandling;
 }
 
@@ -70,7 +71,7 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
     const saksbehandler = useSaksbehandler();
 
     const location = useLocation();
-    const [trinnPåBehandling, settTrinnPåBehandling] = React.useState<{ [sideId: string]: ITrinn }>({});
+    const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: ITrinn }>({});
 
     useEffect(() => {
         const siderPåBehandling = hentTrinnForBehandling(behandling);

--- a/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';

--- a/src/frontend/sider/Fagsak/BrukerContext.tsx
+++ b/src/frontend/sider/Fagsak/BrukerContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import type { IPersonInfo } from '../../typer/person';
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnCheckbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -46,7 +46,7 @@ interface IProps {
     barnIBrevFelt: Felt<IBarnMedOpplysninger[]>;
 }
 
-const BarnCheckbox: React.FC<IProps> = ({ barn, barnIBrevFelt }) => {
+const BarnCheckbox: FC<IProps> = ({ barn, barnIBrevFelt }) => {
     const navnOgIdentTekst = lagBarnLabel(barn);
 
     return (

--- a/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnCheckbox.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -46,7 +44,7 @@ interface IProps {
     barnIBrevFelt: Felt<IBarnMedOpplysninger[]>;
 }
 
-const BarnCheckbox: FC<IProps> = ({ barn, barnIBrevFelt }) => {
+const BarnCheckbox = ({ barn, barnIBrevFelt }: IProps) => {
     const navnOgIdentTekst = lagBarnLabel(barn);
 
     return (

--- a/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnIBrevSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/BarnIBrev/BarnIBrevSkjema.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { differenceInMilliseconds } from 'date-fns';
 
 import { CheckboxGroup } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/BarnCheckbox.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -49,12 +47,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const BarnCheckbox: FC<IProps> = ({
-    barn,
-    barnMedDeltBostedFelt,
-    avtalerOmDeltBostedPerBarnFelt,
-    visFeilmeldinger,
-}) => {
+const BarnCheckbox = ({ barn, barnMedDeltBostedFelt, avtalerOmDeltBostedPerBarnFelt, visFeilmeldinger }: IProps) => {
     const navnOgIdentTekst = lagBarnLabel(barn);
 
     return (

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/BarnCheckbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -49,7 +49,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-const BarnCheckbox: React.FC<IProps> = ({
+const BarnCheckbox: FC<IProps> = ({
     barn,
     barnMedDeltBostedFelt,
     avtalerOmDeltBostedPerBarnFelt,

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/DeltBostedAvtaler.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/DeltBostedAvtaler.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -39,7 +39,7 @@ const LeggTilAvtaleKnapp = styled(Button)`
     margin-bottom: 1rem;
 `;
 
-const DeltBostedAvtaler: React.FC<IProps> = ({ barn, avtalerOmDeltBostedPerBarnFelt, visFeilmeldinger }) => {
+const DeltBostedAvtaler: FC<IProps> = ({ barn, avtalerOmDeltBostedPerBarnFelt, visFeilmeldinger }) => {
     const avtalerOmDeltBosted: IsoDatoString[] = avtalerOmDeltBostedPerBarnFelt.verdi[barn.ident] ?? [];
 
     const hentFeilmelding = (avtaleDato?: IsoDatoString) => {

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/DeltBostedAvtaler.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/DeltBostedAvtaler.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
@@ -39,7 +37,7 @@ const LeggTilAvtaleKnapp = styled(Button)`
     margin-bottom: 1rem;
 `;
 
-const DeltBostedAvtaler: FC<IProps> = ({ barn, avtalerOmDeltBostedPerBarnFelt, visFeilmeldinger }) => {
+const DeltBostedAvtaler = ({ barn, avtalerOmDeltBostedPerBarnFelt, visFeilmeldinger }: IProps) => {
     const avtalerOmDeltBosted: IsoDatoString[] = avtalerOmDeltBostedPerBarnFelt.verdi[barn.ident] ?? [];
 
     const hentFeilmelding = (avtaleDato?: IsoDatoString) => {

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/DeltBostedSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DeltBosted/DeltBostedSkjema.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { differenceInMilliseconds } from 'date-fns';
 
 import { CheckboxGroup } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Dokumentutsending/Dokumentutsending.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/Dokumentutsending.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext, useEffect, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 import deepEqual from 'deep-equal';
 

--- a/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/DokumentutsendingSkjema.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import type { ChangeEvent } from 'react';
+import { useEffect } from 'react';
 
 import styled from 'styled-components';
 
@@ -204,7 +205,7 @@ export function DokumentutsendingSkjema() {
                         {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                         label={'Velg årsak'}
                         value={skjema.felter.årsak.verdi || ''}
-                        onChange={(event: React.ChangeEvent<HTMLSelectElement>): void => {
+                        onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
                             skjema.felter.årsak.onChange(event.target.value as DokumentÅrsakPerson);
                         }}
                         size={'medium'}

--- a/src/frontend/sider/Fagsak/Dokumentutsending/FritekstAvsnitt/FritekstAvsnitt.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/FritekstAvsnitt/FritekstAvsnitt.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 
 import { Textarea } from '@navikt/ds-react';
 
@@ -13,7 +13,7 @@ const FritekstAvsnitt = () => {
             label="Skriv inn fritekst avsnitt"
             value={skjema.felter.fritekstAvsnitt.verdi}
             maxLength={maksLengdeFritekstAvsnitt}
-            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+            onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
                 skjema.felter.fritekstAvsnitt.validerOgSettFelt(event.target.value)
             }
             error={skjema.visFeilmeldinger && skjema.felter.fritekstAvsnitt?.feilmelding}

--- a/src/frontend/sider/Fagsak/Dokumentutsending/KanSøke/Dokumentvelger.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/KanSøke/Dokumentvelger.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/KanSøke/KanSøkeFritekst.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
@@ -45,7 +45,7 @@ const KanSøkeFritekst = ({
         ]);
     };
 
-    const onChangeFritekst = (event: React.ChangeEvent<HTMLTextAreaElement>, fritekstId: number) =>
+    const onChangeFritekst = (event: ChangeEvent<HTMLTextAreaElement>, fritekstId: number) =>
         friteksterFelt.validerOgSettFelt([
             ...friteksterFelt.verdi.map(mapFritekst => {
                 if (mapFritekst.verdi.id === fritekstId) {
@@ -82,14 +82,13 @@ const KanSøkeFritekst = ({
                                 label={`Kulepunkt ${fritekstId}`}
                                 hideLabel={true}
                                 maxLength={makslengdeFritekst}
-                                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+                                onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
                                     onChangeFritekst(event, fritekstId)
                                 }
                                 error={skjema.visFeilmeldinger && fritekst.feilmelding}
                                 /* eslint-disable-next-line jsx-a11y/no-autofocus */
                                 autoFocus
                             />
-
                             <SletteKnapp
                                 variant={'tertiary'}
                                 onClick={() => {
@@ -110,7 +109,6 @@ const KanSøkeFritekst = ({
                     );
                 })}
             </Fieldset>
-
             {!erMaksAntallKulepunkter && (
                 <Button
                     variant={'tertiary'}

--- a/src/frontend/sider/Fagsak/Dokumentutsending/KanSøke/KanSøkeSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/KanSøke/KanSøkeSkjema.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Dokumentvelger } from './Dokumentvelger';
 import KanSøkeFritekst from './KanSøkeFritekst';
 import { useDokumentutsendingContext } from '../DokumentutsendingContext';

--- a/src/frontend/sider/Fagsak/Dokumentutsending/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Dokumentutsending/LeggTilBarnKnapp.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Navigate, Route, Routes } from 'react-router';
 
 import { Alert, Box, HStack, Loader } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/FagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
 
 import { type IMinimalFagsak } from '../../typer/fagsak';
 

--- a/src/frontend/sider/Fagsak/Infotrygd/InfotrygdFagsak.tsx
+++ b/src/frontend/sider/Fagsak/Infotrygd/InfotrygdFagsak.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 
 import { Alert, BodyShort, Box, Heading, HStack, Loader } from '@navikt/ds-react';
 
@@ -10,7 +10,7 @@ interface InfotrygdFagsakProps {
     minimalFagsak: IMinimalFagsak;
 }
 
-const InnholdContainer = ({ children }: { children: React.ReactNode }) => (
+const InnholdContainer = ({ children }: { children: ReactNode }) => (
     <Box maxWidth="70rem" marginBlock="space-40" marginInline="space-64">
         {children}
     </Box>

--- a/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.test.tsx
+++ b/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.test.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { act, renderHook } from '@testing-library/react';
 

--- a/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
+++ b/src/frontend/sider/Fagsak/ManuelleBrevmottakerePåFagsakContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type PropsWithChildren, useContext, useMemo, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
 
 import type { SkjemaBrevmottaker } from '../../komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandling.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Table } from '@navikt/ds-react';
 
 import type { Saksoversiktsbehandling } from './utils';

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.test.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.test.tsx
@@ -1,5 +1,4 @@
 import type { PropsWithChildren } from 'react';
-import React from 'react';
 
 import { waitFor, waitForElementToBeRemoved, within } from '@testing-library/dom';
 import { delay, http, HttpResponse } from 'msw';

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from 'styled-components';
 
 import { Alert, BodyShort, Heading, HStack, Skeleton, Table, VStack } from '@navikt/ds-react';

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Link as ReactRouterLink } from 'react-router';
 import styled from 'styled-components';
 

--- a/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
@@ -19,7 +18,7 @@ const StyledButton = styled(Button)`
     margin-top: 1rem;
 `;
 
-export const GjennomførValutajusteringKnapp: FunctionComponent<Props> = ({ fagsakId }) => {
+export const GjennomførValutajusteringKnapp = ({ fagsakId }: Props) => {
     const { request } = useHttp();
     const queryClient = useQueryClient();
     const [visFeilmelidng, settVisFeilmelding] = useState(false);

--- a/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FunctionComponent } from 'react';
+import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
@@ -18,7 +19,7 @@ const StyledButton = styled(Button)`
     margin-top: 1rem;
 `;
 
-export const GjennomførValutajusteringKnapp: React.FunctionComponent<Props> = ({ fagsakId }) => {
+export const GjennomførValutajusteringKnapp: FunctionComponent<Props> = ({ fagsakId }) => {
     const { request } = useHttp();
     const queryClient = useQueryClient();
     const [visFeilmelidng, settVisFeilmelding] = useState(false);

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { BodyShort, CopyButton, HStack } from '@navikt/ds-react';
 
 import { useBruker } from '../../../hooks/useBruker';

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort, HStack } from '@navikt/ds-react';
@@ -23,7 +21,7 @@ interface IPersonUtbetalingProps {
     utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
 }
 
-const PersonUtbetaling: FC<IPersonUtbetalingProps> = ({ utbetalingsperiodeDetaljer }) => {
+const PersonUtbetaling = ({ utbetalingsperiodeDetaljer }: IPersonUtbetalingProps) => {
     const genererTekstForOrdinær = (fødselsdato: string) =>
         hentAlder(fødselsdato) < 6 ? 'Ordinær (under 6 år)' : 'Ordinær (fra 6 år)';
 

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -23,7 +23,7 @@ interface IPersonUtbetalingProps {
     utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
 }
 
-const PersonUtbetaling: React.FC<IPersonUtbetalingProps> = ({ utbetalingsperiodeDetaljer }) => {
+const PersonUtbetaling: FC<IPersonUtbetalingProps> = ({ utbetalingsperiodeDetaljer }) => {
     const genererTekstForOrdinær = (fødselsdato: string) =>
         hentAlder(fødselsdato) < 6 ? 'Ordinær (under 6 år)' : 'Ordinær (fra 6 år)';
 

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { addMonths, differenceInMilliseconds, format } from 'date-fns';
 import { Link as ReactRouterLink } from 'react-router';
 import styled from 'styled-components';

--- a/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -26,7 +26,7 @@ interface IUtbetalingerProps {
     vedtaksperiode?: Vedtaksperiode;
 }
 
-const Utbetalinger: React.FC<IUtbetalingerProps> = ({ vedtaksperiode }) => {
+const Utbetalinger: FC<IUtbetalingerProps> = ({ vedtaksperiode }) => {
     if (vedtaksperiode?.vedtaksperiodetype !== Vedtaksperiodetype.UTBETALING) return null;
 
     const utbetalingsperiodeDetaljerGruppertPåPerson =

--- a/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort, HStack, VStack } from '@navikt/ds-react';
@@ -26,7 +24,7 @@ interface IUtbetalingerProps {
     vedtaksperiode?: Vedtaksperiode;
 }
 
-const Utbetalinger: FC<IUtbetalingerProps> = ({ vedtaksperiode }) => {
+const Utbetalinger = ({ vedtaksperiode }: IUtbetalingerProps) => {
     if (vedtaksperiode?.vedtaksperiodetype !== Vedtaksperiodetype.UTBETALING) return null;
 
     const utbetalingsperiodeDetaljerGruppertPåPerson =

--- a/src/frontend/sider/Fagsak/Saksoversikt/VisHenlagtBehandlingerSwitch.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/VisHenlagtBehandlingerSwitch.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Switch } from '@navikt/ds-react';
 
 import { type Saksoversiktsbehandling, skalVisesNårHenlagtBehandlingerSkjules } from './utils';

--- a/src/frontend/sider/Fagsak/Saksoversikt/VisMånedligValutajuseringBehandlingerSwitch.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/VisMånedligValutajuseringBehandlingerSwitch.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Switch } from '@navikt/ds-react';
 
 import { type Saksoversiktsbehandling, skalVisesNårMånedligeValutajusteringerSkjules } from './utils';

--- a/src/frontend/sider/Fagsak/Saksoversikt/utils.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/utils.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import { differenceInMilliseconds } from 'date-fns';
 import { Link as ReactRouterLink } from 'react-router';

--- a/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { ExternalLinkIcon, PadlockLockedIcon } from '@navikt/aksel-icons';
@@ -24,7 +22,7 @@ interface IProps {
     tilgangsstyrtJournalpost: ITilgangsstyrtJournalpost;
 }
 
-export const JournalpostDokument: FC<IProps> = ({ dokument, hentForhåndsvisning, tilgangsstyrtJournalpost }) => {
+export const JournalpostDokument = ({ dokument, hentForhåndsvisning, tilgangsstyrtJournalpost }: IProps) => {
     const { journalpost, journalpostTilgang } = tilgangsstyrtJournalpost;
 
     const hentPdfDokument = (dokumentId: string | undefined) => {

--- a/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/JournalpostDokument.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -24,7 +24,7 @@ interface IProps {
     tilgangsstyrtJournalpost: ITilgangsstyrtJournalpost;
 }
 
-export const JournalpostDokument: React.FC<IProps> = ({ dokument, hentForhåndsvisning, tilgangsstyrtJournalpost }) => {
+export const JournalpostDokument: FC<IProps> = ({ dokument, hentForhåndsvisning, tilgangsstyrtJournalpost }) => {
     const { journalpost, journalpostTilgang } = tilgangsstyrtJournalpost;
 
     const hentPdfDokument = (dokumentId: string | undefined) => {

--- a/src/frontend/sider/Fagsak/journalposter/JournalpostListe.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/JournalpostListe.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 

--- a/src/frontend/sider/Fagsak/journalposter/UtsendingsinfoModal.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/UtsendingsinfoModal.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { Modal } from '@navikt/ds-react';
 import type { Utsendingsinfo } from '@navikt/familie-typer';
 
@@ -8,7 +6,7 @@ interface IProps {
     data: Utsendingsinfo;
 }
 
-export const UtsendingsinfoModal: FC<IProps> = ({ onClose, data: { digitalpostSendt, fysiskpostSendt } }) => {
+export const UtsendingsinfoModal = ({ onClose, data: { digitalpostSendt, fysiskpostSendt } }: IProps) => {
     const tittel = digitalpostSendt ? 'Digital post sendt' : 'Sendt per post';
     const adresse = digitalpostSendt?.adresse || fysiskpostSendt?.adressetekstKonvolutt;
     return (

--- a/src/frontend/sider/Fagsak/journalposter/UtsendingsinfoModal.tsx
+++ b/src/frontend/sider/Fagsak/journalposter/UtsendingsinfoModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { Modal } from '@navikt/ds-react';
 import type { Utsendingsinfo } from '@navikt/familie-typer';
@@ -8,7 +8,7 @@ interface IProps {
     data: Utsendingsinfo;
 }
 
-export const UtsendingsinfoModal: React.FC<IProps> = ({ onClose, data: { digitalpostSendt, fysiskpostSendt } }) => {
+export const UtsendingsinfoModal: FC<IProps> = ({ onClose, data: { digitalpostSendt, fysiskpostSendt } }) => {
     const tittel = digitalpostSendt ? 'Digital post sendt' : 'Sendt per post';
     const adresse = digitalpostSendt?.adresse || fysiskpostSendt?.adressetekstKonvolutt;
     return (

--- a/src/frontend/sider/Infotrygd/Infotrygd.tsx
+++ b/src/frontend/sider/Infotrygd/Infotrygd.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect } from 'react';
 
 import { useLocation } from 'react-router';
@@ -29,7 +28,7 @@ const HentSakerButton = styled(Button)`
     margin-bottom: auto;
 `;
 
-export const Infotrygd: FC = () => {
+export const Infotrygd = () => {
     const { ident, onSubmitWrapper, skjema } = useInfotrygdSkjema();
 
     const location = useLocation();

--- a/src/frontend/sider/Infotrygd/Infotrygd.tsx
+++ b/src/frontend/sider/Infotrygd/Infotrygd.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import type { FC } from 'react';
+import { useEffect } from 'react';
 
 import { useLocation } from 'react-router';
 import styled from 'styled-components';
@@ -28,7 +29,7 @@ const HentSakerButton = styled(Button)`
     margin-bottom: auto;
 `;
 
-export const Infotrygd: React.FC = () => {
+export const Infotrygd: FC = () => {
     const { ident, onSubmitWrapper, skjema } = useInfotrygdSkjema();
 
     const location = useLocation();

--- a/src/frontend/sider/Infotrygd/Infotrygdtabeller.tsx
+++ b/src/frontend/sider/Infotrygd/Infotrygdtabeller.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Alert, Heading } from '@navikt/ds-react';
@@ -33,7 +31,7 @@ const sorterSakerEtterSaksnr = (saker: IInfotrygdSak[]): IInfotrygdSak[] =>
         return saksnrA - saksnrB;
     });
 
-export const Infotrygdtabeller: FC<InfotrygdtabellerProps> = ({ ident, saker, minimalFagsak }) => {
+export const Infotrygdtabeller = ({ ident, saker, minimalFagsak }: InfotrygdtabellerProps) => {
     return (
         <>
             {minimalFagsak?.migreringsdato !== null && (

--- a/src/frontend/sider/Infotrygd/Infotrygdtabeller.tsx
+++ b/src/frontend/sider/Infotrygd/Infotrygdtabeller.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -33,7 +33,7 @@ const sorterSakerEtterSaksnr = (saker: IInfotrygdSak[]): IInfotrygdSak[] =>
         return saksnrA - saksnrB;
     });
 
-export const Infotrygdtabeller: React.FC<InfotrygdtabellerProps> = ({ ident, saker, minimalFagsak }) => {
+export const Infotrygdtabeller: FC<InfotrygdtabellerProps> = ({ ident, saker, minimalFagsak }) => {
     return (
         <>
             {minimalFagsak?.migreringsdato !== null && (

--- a/src/frontend/sider/Infotrygd/Sakstabell.tsx
+++ b/src/frontend/sider/Infotrygd/Sakstabell.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort, Table } from '@navikt/ds-react';
@@ -10,7 +8,7 @@ const IngenSakerTekst = styled(BodyShort)`
     margin: 1rem;
 `;
 
-export const Sakstabell: FC<{ saker: IInfotrygdSak[] }> = ({ saker }) => {
+export const Sakstabell = ({ saker }: { saker: IInfotrygdSak[] }) => {
     return (
         <>
             <Table>

--- a/src/frontend/sider/Infotrygd/Sakstabell.tsx
+++ b/src/frontend/sider/Infotrygd/Sakstabell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -10,7 +10,7 @@ const IngenSakerTekst = styled(BodyShort)`
     margin: 1rem;
 `;
 
-export const Sakstabell: React.FC<{ saker: IInfotrygdSak[] }> = ({ saker }) => {
+export const Sakstabell: FC<{ saker: IInfotrygdSak[] }> = ({ saker }) => {
     return (
         <>
             <Table>

--- a/src/frontend/sider/Infotrygd/Vedtakstabell.tsx
+++ b/src/frontend/sider/Infotrygd/Vedtakstabell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -51,7 +51,7 @@ const visDelytelseTom = (stønad: IInfotrygdStønad) => {
     });
 };
 
-export const Vedtakstabell: React.FC<{ saker: IInfotrygdSak[] }> = ({ saker }) => {
+export const Vedtakstabell: FC<{ saker: IInfotrygdSak[] }> = ({ saker }) => {
     const sakerMedVedtak = saker.filter(sak => sak.stønad);
 
     return (

--- a/src/frontend/sider/Infotrygd/Vedtakstabell.tsx
+++ b/src/frontend/sider/Infotrygd/Vedtakstabell.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort, Table } from '@navikt/ds-react';
@@ -51,7 +49,7 @@ const visDelytelseTom = (stønad: IInfotrygdStønad) => {
     });
 };
 
-export const Vedtakstabell: FC<{ saker: IInfotrygdSak[] }> = ({ saker }) => {
+export const Vedtakstabell = ({ saker }: { saker: IInfotrygdSak[] }) => {
     const sakerMedVedtak = saker.filter(sak => sak.stønad);
 
     return (

--- a/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 
 import classNames from 'classnames';
@@ -17,7 +16,7 @@ const StyledExpansionCard = styled(ExpansionCard)`
     margin-top: 1rem;
 `;
 
-export const AvsenderPanel: FC = () => {
+export const AvsenderPanel = () => {
     const { skjema, erLesevisning, settAvsenderLikBruker, tilbakestillAvsender, erDigitaltInnsendtDokument } =
         useManuellJournalføringContext();
     const [åpen, settÅpen] = useState(false);

--- a/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/AvsenderPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 import styled from 'styled-components';
@@ -16,7 +17,7 @@ const StyledExpansionCard = styled(ExpansionCard)`
     margin-top: 1rem;
 `;
 
-export const AvsenderPanel: React.FC = () => {
+export const AvsenderPanel: FC = () => {
     const { skjema, erLesevisning, settAvsenderLikBruker, tilbakestillAvsender, erDigitaltInnsendtDokument } =
         useManuellJournalføringContext();
     const [åpen, settÅpen] = useState(false);

--- a/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import type { FC, ChangeEvent } from 'react';
+import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -48,7 +49,7 @@ const StyledAlert = styled(Alert)`
     margin-top: 2rem;
 `;
 
-export const BrukerPanel: React.FC = () => {
+export const BrukerPanel: FC = () => {
     const {
         skjema,
         endreBrukerOgSettNormalFagsak,
@@ -176,7 +177,7 @@ export const BrukerPanel: React.FC = () => {
                                 <StyledSelect
                                     label="Fagsaktype"
                                     size="small"
-                                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                                    onChange={(event: ChangeEvent<HTMLSelectElement>) =>
                                         oppdaterFagsaktype(event.target.value as FagsakType)
                                     }
                                     value={skjema.felter.fagsakType.verdi}
@@ -189,7 +190,7 @@ export const BrukerPanel: React.FC = () => {
                                     <StyledSelect
                                         label="Institusjon"
                                         size="small"
-                                        onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                                        onChange={(event: ChangeEvent<HTMLSelectElement>) =>
                                             settValgtInstitusjon(event.target.value)
                                         }
                                         value={valgtInstitusjon}

--- a/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/BrukerPanel.tsx
@@ -1,4 +1,4 @@
-import type { FC, ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
@@ -49,7 +49,7 @@ const StyledAlert = styled(Alert)`
     margin-top: 2rem;
 `;
 
-export const BrukerPanel: FC = () => {
+export const BrukerPanel = () => {
     const {
         skjema,
         endreBrukerOgSettNormalFagsak,

--- a/src/frontend/sider/ManuellJournalføring/DeltagerInfo.tsx
+++ b/src/frontend/sider/ManuellJournalføring/DeltagerInfo.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, FC } from 'react';
+import type { ReactNode } from 'react';
 
 import styled from 'styled-components';
 
@@ -21,7 +21,7 @@ const MarginedDiv = styled.div`
     margin-right: 1rem;
 `;
 
-export const DeltagerInfo: FC<DeltagerProps> = ({ ikon, navn, undertittel, ident }) => {
+export const DeltagerInfo = ({ ikon, navn, undertittel, ident }: DeltagerProps) => {
     return (
         <div>
             <HSplit>

--- a/src/frontend/sider/ManuellJournalføring/DeltagerInfo.tsx
+++ b/src/frontend/sider/ManuellJournalføring/DeltagerInfo.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import type { ReactNode, FC } from 'react';
 
 import styled from 'styled-components';
 
 import { BodyShort, Heading } from '@navikt/ds-react';
 
 interface DeltagerProps {
-    ikon: React.ReactNode;
+    ikon: ReactNode;
     navn: string;
     ident: string;
     undertittel: string;
-    children?: React.ReactNode | React.ReactNode[];
+    children?: ReactNode | ReactNode[];
 }
 
 const HSplit = styled.div`
@@ -21,7 +21,7 @@ const MarginedDiv = styled.div`
     margin-right: 1rem;
 `;
 
-export const DeltagerInfo: React.FC<DeltagerProps> = ({ ikon, navn, undertittel, ident }) => {
+export const DeltagerInfo: FC<DeltagerProps> = ({ ikon, navn, undertittel, ident }) => {
     return (
         <div>
             <HSplit>

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { BodyShort } from '@navikt/ds-react';
@@ -44,7 +42,7 @@ interface IDokumentInfoStripeProps {
     dokument: IDokumentInfo;
 }
 
-export const DokumentInfoStripe: FC<IDokumentInfoStripeProps> = ({ valgt, journalpostId, dokument }) => {
+export const DokumentInfoStripe = ({ valgt, journalpostId, dokument }: IDokumentInfoStripeProps) => {
     return (
         <DokumentInfoStripeContainer>
             <StyledDokumentIkonDiv>

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -44,7 +44,7 @@ interface IDokumentInfoStripeProps {
     dokument: IDokumentInfo;
 }
 
-export const DokumentInfoStripe: React.FC<IDokumentInfoStripeProps> = ({ valgt, journalpostId, dokument }) => {
+export const DokumentInfoStripe: FC<IDokumentInfoStripeProps> = ({ valgt, journalpostId, dokument }) => {
     return (
         <DokumentInfoStripeContainer>
             <StyledDokumentIkonDiv>

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentPanel.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
@@ -17,7 +15,7 @@ const DokumentDataAlert = styled(Alert)`
     width: 100%;
 `;
 
-export const DokumentPanel: FC = () => {
+export const DokumentPanel = () => {
     const { hentetDokument } = useManuellJournalføringContext();
     return (
         <DokumentDiv>

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -17,7 +17,7 @@ const DokumentDataAlert = styled(Alert)`
     width: 100%;
 `;
 
-export const DokumentPanel: React.FC = () => {
+export const DokumentPanel: FC = () => {
     const { hentetDokument } = useManuellJournalføringContext();
     return (
         <DokumentDiv>

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -20,7 +21,7 @@ const StyledExpansionCard = styled(ExpansionCard)`
     width: 100%;
 `;
 
-export const DokumentVelger: React.FC<IDokumentVelgerProps> = ({ dokument, visFeilmeldinger }) => {
+export const DokumentVelger: FC<IDokumentVelgerProps> = ({ dokument, visFeilmeldinger }) => {
     const { dataForManuellJournalføring, valgtDokumentId, velgOgHentDokumentData } = useManuellJournalføringContext();
     const [åpen, settÅpen] = useState(false);
 

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
@@ -21,7 +20,7 @@ const StyledExpansionCard = styled(ExpansionCard)`
     width: 100%;
 `;
 
-export const DokumentVelger: FC<IDokumentVelgerProps> = ({ dokument, visFeilmeldinger }) => {
+export const DokumentVelger = ({ dokument, visFeilmeldinger }: IDokumentVelgerProps) => {
     const { dataForManuellJournalføring, valgtDokumentId, velgOgHentDokumentData } = useManuellJournalføringContext();
     const [åpen, settÅpen] = useState(false);
 

--- a/src/frontend/sider/ManuellJournalføring/Dokument/Dokumenter.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/Dokumenter.tsx
@@ -1,12 +1,10 @@
-import type { FC } from 'react';
-
 import { Alert, ErrorMessage } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { DokumentVelger } from './DokumentVelger';
 import { useManuellJournalføringContext } from '../ManuellJournalføringContext';
 
-export const Dokumenter: FC = () => {
+export const Dokumenter = () => {
     const { skjema } = useManuellJournalføringContext();
 
     return skjema.felter.dokumenter.verdi.length === 0 ? (

--- a/src/frontend/sider/ManuellJournalføring/Dokument/Dokumenter.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/Dokumenter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { Alert, ErrorMessage } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
@@ -6,7 +6,7 @@ import { Valideringsstatus } from '@navikt/familie-skjema';
 import { DokumentVelger } from './DokumentVelger';
 import { useManuellJournalføringContext } from '../ManuellJournalføringContext';
 
-export const Dokumenter: React.FC = () => {
+export const Dokumenter: FC = () => {
     const { skjema } = useManuellJournalføringContext();
 
     return skjema.felter.dokumenter.verdi.length === 0 ? (

--- a/src/frontend/sider/ManuellJournalføring/Dokument/EndreDokumentInfoPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/EndreDokumentInfoPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';
 import type { IDokumentInfo, ILogiskVedlegg } from '@navikt/familie-typer';
@@ -13,7 +13,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-export const EndreDokumentInfoPanel: React.FC<IProps> = ({ dokument, visFeilmeldinger }) => {
+export const EndreDokumentInfoPanel: FC<IProps> = ({ dokument, visFeilmeldinger }) => {
     const { skjema, erLesevisning } = useManuellJournalføringContext();
 
     const dokumentFraSkjema: IDokumentInfo | undefined = skjema.felter.dokumenter.verdi.find(

--- a/src/frontend/sider/ManuellJournalføring/Dokument/EndreDokumentInfoPanel.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/EndreDokumentInfoPanel.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { UNSAFE_Combobox } from '@navikt/ds-react';
 import type { IDokumentInfo, ILogiskVedlegg } from '@navikt/familie-typer';
 
@@ -13,7 +11,7 @@ interface IProps {
     visFeilmeldinger: boolean;
 }
 
-export const EndreDokumentInfoPanel: FC<IProps> = ({ dokument, visFeilmeldinger }) => {
+export const EndreDokumentInfoPanel = ({ dokument, visFeilmeldinger }: IProps) => {
     const { skjema, erLesevisning } = useManuellJournalføringContext();
 
     const dokumentFraSkjema: IDokumentInfo | undefined = skjema.felter.dokumenter.verdi.find(

--- a/src/frontend/sider/ManuellJournalføring/Journalpost.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Journalpost.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import { BodyShort, Box, ExpansionCard, UNSAFE_Combobox } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -7,7 +7,7 @@ import { useManuellJournalføringContext } from './ManuellJournalføringContext'
 import { JournalpostTittel } from '../../typer/manuell-journalføring';
 import { Datoformat, isoStringTilFormatertString } from '../../utils/dato';
 
-const EndreJournalpost: React.FC = () => {
+const EndreJournalpost: FC = () => {
     const { skjema, erLesevisning } = useManuellJournalføringContext();
     const navInputProps = skjema.felter.journalpostTittel.hentNavInputProps(skjema.visFeilmeldinger);
 
@@ -35,7 +35,7 @@ const EndreJournalpost: React.FC = () => {
     );
 };
 
-const Journalpost: React.FC = () => {
+const Journalpost: FC = () => {
     const { dataForManuellJournalføring, skjema } = useManuellJournalføringContext();
     const datoMottatt =
         dataForManuellJournalføring.status === RessursStatus.SUKSESS

--- a/src/frontend/sider/ManuellJournalføring/Journalpost.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Journalpost.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import { BodyShort, Box, ExpansionCard, UNSAFE_Combobox } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -7,7 +5,7 @@ import { useManuellJournalføringContext } from './ManuellJournalføringContext'
 import { JournalpostTittel } from '../../typer/manuell-journalføring';
 import { Datoformat, isoStringTilFormatertString } from '../../utils/dato';
 
-const EndreJournalpost: FC = () => {
+const EndreJournalpost = () => {
     const { skjema, erLesevisning } = useManuellJournalføringContext();
     const navInputProps = skjema.felter.journalpostTittel.hentNavInputProps(skjema.visFeilmeldinger);
 
@@ -35,7 +33,7 @@ const EndreJournalpost: FC = () => {
     );
 };
 
-const Journalpost: FC = () => {
+const Journalpost = () => {
     const { dataForManuellJournalføring, skjema } = useManuellJournalføringContext();
     const datoMottatt =
         dataForManuellJournalføring.status === RessursStatus.SUKSESS

--- a/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
+++ b/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
 import styled from 'styled-components';
@@ -27,7 +28,7 @@ const StyledSectionDiv = styled.div`
     margin-top: 2.5rem;
 `;
 
-export const JournalpostSkjema: React.FC = () => {
+export const JournalpostSkjema: FC = () => {
     const {
         dataForManuellJournalføring,
         skjema,

--- a/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
+++ b/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
@@ -28,7 +27,7 @@ const StyledSectionDiv = styled.div`
     margin-top: 2.5rem;
 `;
 
-export const JournalpostSkjema: FC = () => {
+export const JournalpostSkjema = () => {
     const {
         dataForManuellJournalføring,
         skjema,

--- a/src/frontend/sider/ManuellJournalføring/KnyttJournalpostTilBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalføring/KnyttJournalpostTilBehandling.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Alert, BodyShort, Checkbox, Heading, Table, VStack } from '@navikt/ds-react';
@@ -23,7 +21,7 @@ const StyledAlert = styled(Alert)`
     margin-top: var(--ax-space-32);
 `;
 
-export const KnyttJournalpostTilBehandling: FC = () => {
+export const KnyttJournalpostTilBehandling = () => {
     const {
         skjema,
         hentSorterteJournalføringsbehandlinger,

--- a/src/frontend/sider/ManuellJournalføring/KnyttJournalpostTilBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalføring/KnyttJournalpostTilBehandling.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -23,7 +23,7 @@ const StyledAlert = styled(Alert)`
     margin-top: var(--ax-space-32);
 `;
 
-export const KnyttJournalpostTilBehandling: React.FC = () => {
+export const KnyttJournalpostTilBehandling: FC = () => {
     const {
         skjema,
         hentSorterteJournalføringsbehandlinger,

--- a/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -16,7 +16,7 @@ const StyledFieldset = styled(Fieldset)`
  * så kan man kanskje sjekke hvilken behandling
  * journalposten er journalført på slik at man kan klikke seg inn på behandlingen
  */
-export const KnyttTilNyBehandling: React.FC = () => {
+export const KnyttTilNyBehandling: FC = () => {
     const { skjema, minimalFagsak, kanKnytteJournalpostTilBehandling } = useManuellJournalføringContext();
     const { knyttTilNyBehandling, behandlingstype } = skjema.felter;
     return (

--- a/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Checkbox, Fieldset, Heading } from '@navikt/ds-react';
@@ -16,7 +14,7 @@ const StyledFieldset = styled(Fieldset)`
  * så kan man kanskje sjekke hvilken behandling
  * journalposten er journalført på slik at man kan klikke seg inn på behandlingen
  */
-export const KnyttTilNyBehandling: FC = () => {
+export const KnyttTilNyBehandling = () => {
     const { skjema, minimalFagsak, kanKnytteJournalpostTilBehandling } = useManuellJournalføringContext();
     const { knyttTilNyBehandling, behandlingstype } = skjema.felter;
     return (

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
@@ -1,5 +1,3 @@
-import type { FC } from 'react';
-
 import styled from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
@@ -18,7 +16,7 @@ const ToKolonnerDiv = styled.div<{ $viserAlert?: boolean }>`
     height: calc(100vh - ${props => (props.$viserAlert ? fagsakHeaderHøydeRem + 5.25 : fagsakHeaderHøydeRem)}rem);
 `;
 
-const ManuellJournalføringContent: FC = () => {
+const ManuellJournalføringContent = () => {
     const { dataForManuellJournalføring, minimalFagsak, skjema } = useManuellJournalføringContext();
 
     switch (dataForManuellJournalføring.status) {
@@ -61,7 +59,7 @@ const ManuellJournalføringContent: FC = () => {
     }
 };
 
-const ManuellJournalføring: FC = () => {
+const ManuellJournalføring = () => {
     return (
         <ManuellJournalføringProvider>
             <ManuellJournalføringContent />

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -18,7 +18,7 @@ const ToKolonnerDiv = styled.div<{ $viserAlert?: boolean }>`
     height: calc(100vh - ${props => (props.$viserAlert ? fagsakHeaderHøydeRem + 5.25 : fagsakHeaderHøydeRem)}rem);
 `;
 
-const ManuellJournalføringContent: React.FC = () => {
+const ManuellJournalføringContent: FC = () => {
     const { dataForManuellJournalføring, minimalFagsak, skjema } = useManuellJournalføringContext();
 
     switch (dataForManuellJournalføring.status) {
@@ -61,7 +61,7 @@ const ManuellJournalføringContent: React.FC = () => {
     }
 };
 
-const ManuellJournalføring: React.FC = () => {
+const ManuellJournalføring: FC = () => {
     return (
         <ManuellJournalføringProvider>
             <ManuellJournalføringContent />

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, useContext, useEffect, useState, type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
+import * as React from 'react';
 
 import type { AxiosError } from 'axios';
 import { differenceInMilliseconds } from 'date-fns';

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
-import * as React from 'react';
 
 import type { AxiosError } from 'axios';
 import { differenceInMilliseconds } from 'date-fns';
@@ -144,7 +143,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
         },
     });
 
-    const [valgtDokumentId, settValgtDokumentId] = React.useState<string | undefined>(undefined);
+    const [valgtDokumentId, settValgtDokumentId] = useState<string | undefined>(undefined);
     const { skjema, nullstillSkjema, onSubmit, hentFeilTilOppsummering } = useSkjema<
         ManuellJournalføringSkjemaFelter,
         string

--- a/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
+++ b/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { Button, Fieldset, HStack, Select, VStack } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -11,7 +9,7 @@ import DatovelgerForGammelSkjemaløsning from '../../komponenter/Datovelger/Dato
 import type { IPar } from '../../typer/common';
 import type { IsoDatoString } from '../../utils/dato';
 
-const FilterSkjema: FunctionComponent = () => {
+const FilterSkjema = () => {
     const { hentOppgaver, oppgaver, oppgaveFelter, settVerdiPåOppgaveFelt, tilbakestillOppgaveFelter, validerSkjema } =
         useOppgavebenkContext();
 

--- a/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
+++ b/src/frontend/sider/Oppgavebenk/FilterSkjema.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Button, Fieldset, HStack, Select, VStack } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
@@ -11,7 +11,7 @@ import DatovelgerForGammelSkjemaløsning from '../../komponenter/Datovelger/Dato
 import type { IPar } from '../../typer/common';
 import type { IsoDatoString } from '../../utils/dato';
 
-const FilterSkjema: React.FunctionComponent = () => {
+const FilterSkjema: FunctionComponent = () => {
     const { hentOppgaver, oppgaver, oppgaveFelter, settVerdiPåOppgaveFelt, tilbakestillOppgaveFelter, validerSkjema } =
         useOppgavebenkContext();
 

--- a/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
@@ -16,7 +15,7 @@ interface IOppgaveDirektelenke {
     oppgave: IOppgave;
 }
 
-const OppgaveDirektelenke: FC<IOppgaveDirektelenke> = ({ oppgave }) => {
+const OppgaveDirektelenke = ({ oppgave }: IOppgaveDirektelenke) => {
     const { settToast } = useAppContext();
     const { gåTilFagsakEllerVisFeilmelding } = useOppgavebenkContext();
     const { sjekkTilgang } = useAppContext();

--- a/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 import { useNavigate } from 'react-router';
 
@@ -15,7 +16,7 @@ interface IOppgaveDirektelenke {
     oppgave: IOppgave;
 }
 
-const OppgaveDirektelenke: React.FC<IOppgaveDirektelenke> = ({ oppgave }) => {
+const OppgaveDirektelenke: FC<IOppgaveDirektelenke> = ({ oppgave }) => {
     const { settToast } = useAppContext();
     const { gåTilFagsakEllerVisFeilmelding } = useOppgavebenkContext();
     const { sjekkTilgang } = useAppContext();

--- a/src/frontend/sider/Oppgavebenk/OppgaveHeader.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveHeader.tsx
@@ -1,10 +1,8 @@
-import type { FunctionComponent } from 'react';
-
 import { Heading, VStack } from '@navikt/ds-react';
 
 import FilterSkjema from './FilterSkjema';
 
-const OppgaveHeader: FunctionComponent = () => {
+const OppgaveHeader = () => {
     return (
         <VStack gap="space-8">
             <Heading size={'medium'} level={'2'}>

--- a/src/frontend/sider/Oppgavebenk/OppgaveHeader.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveHeader.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Heading, VStack } from '@navikt/ds-react';
 
 import FilterSkjema from './FilterSkjema';
 
-const OppgaveHeader: React.FunctionComponent = () => {
+const OppgaveHeader: FunctionComponent = () => {
     return (
         <VStack gap="space-8">
             <Heading size={'medium'} level={'2'}>

--- a/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 import styled from 'styled-components';
 
@@ -46,7 +46,7 @@ const StyledColumnHeader = styled(Table.ColumnHeader)`
     white-space: nowrap;
 `;
 
-const OppgaveList: React.FunctionComponent = () => {
+const OppgaveList: FunctionComponent = () => {
     const { oppgaver, sorterteOppgaverader, sortering, settOgLagreSortering, side } = useOppgavebenkContext();
 
     const oppgaverPåDenneSiden = sorterteOppgaverader.slice((side - 1) * oppgaveSideLimit, side * oppgaveSideLimit);

--- a/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveList.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import styled from 'styled-components';
 
 import { Alert, Heading, Table, Tooltip } from '@navikt/ds-react';
@@ -46,7 +44,7 @@ const StyledColumnHeader = styled(Table.ColumnHeader)`
     white-space: nowrap;
 `;
 
-const OppgaveList: FunctionComponent = () => {
+const OppgaveList = () => {
     const { oppgaver, sorterteOppgaverader, sortering, settOgLagreSortering, side } = useOppgavebenkContext();
 
     const oppgaverPåDenneSiden = sorterteOppgaverader.slice((side - 1) * oppgaveSideLimit, side * oppgaveSideLimit);

--- a/src/frontend/sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/sider/Oppgavebenk/Oppgavebenk.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent, FC } from 'react';
-
 import styled from 'styled-components';
 
 import { VStack } from '@navikt/ds-react';
@@ -19,7 +17,7 @@ const Container = styled.article`
     }
 `;
 
-const OppgavebenkInnhold: FunctionComponent = () => {
+const OppgavebenkInnhold = () => {
     return (
         <Container>
             <VStack gap="space-16">
@@ -30,7 +28,7 @@ const OppgavebenkInnhold: FunctionComponent = () => {
     );
 };
 
-export const Oppgavebenk: FC = () => {
+export const Oppgavebenk = () => {
     return (
         <OppgavebenkProvider>
             <OppgavebenkInnhold />

--- a/src/frontend/sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/sider/Oppgavebenk/Oppgavebenk.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent, FC } from 'react';
 
 import styled from 'styled-components';
 
@@ -19,7 +19,7 @@ const Container = styled.article`
     }
 `;
 
-const OppgavebenkInnhold: React.FunctionComponent = () => {
+const OppgavebenkInnhold: FunctionComponent = () => {
     return (
         <Container>
             <VStack gap="space-16">
@@ -30,7 +30,7 @@ const OppgavebenkInnhold: React.FunctionComponent = () => {
     );
 };
 
-export const Oppgavebenk: React.FC = () => {
+export const Oppgavebenk: FC = () => {
     return (
         <OppgavebenkProvider>
             <OppgavebenkInnhold />

--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import * as React from 'react';
 
 import type { AxiosError } from 'axios';
 import { useNavigate } from 'react-router';

--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import * as React from 'react';
 
 import type { AxiosError } from 'axios';
 import { useNavigate } from 'react-router';
@@ -62,7 +61,7 @@ export const OppgavebenkProvider = (props: PropsWithChildren) => {
     const [hentOppgaverVedSidelast, settHentOppgaverVedSidelast] = useState(true);
     const [side, settSide] = useState<number>(1);
 
-    const [oppgaver, settOppgaver] = React.useState<Ressurs<IHentOppgaveDto>>(byggTomRessurs<IHentOppgaveDto>());
+    const [oppgaver, settOppgaver] = useState<Ressurs<IHentOppgaveDto>>(byggTomRessurs<IHentOppgaveDto>());
 
     const [oppgaveFelter, settOppgaveFelter] = useState<IOppgaveFelter>(initialOppgaveFelter(saksbehandler));
 

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteNavigator.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteNavigator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FunctionComponent } from 'react';
 
 import { Box, HStack, Pagination } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -8,7 +8,7 @@ import type { IOppgave } from '../../typer/oppgave';
 
 const beregnAntallSider = (oppgaver: IOppgave[]): number => Math.ceil(oppgaver.length / oppgaveSideLimit);
 
-const OppgavelisteNavigator: React.FunctionComponent = () => {
+const OppgavelisteNavigator: FunctionComponent = () => {
     const { oppgaver, side, settSide } = useOppgavebenkContext();
 
     if (oppgaver.status !== RessursStatus.SUKSESS) {

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteNavigator.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteNavigator.tsx
@@ -1,5 +1,3 @@
-import type { FunctionComponent } from 'react';
-
 import { Box, HStack, Pagination } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -8,7 +6,7 @@ import type { IOppgave } from '../../typer/oppgave';
 
 const beregnAntallSider = (oppgaver: IOppgave[]): number => Math.ceil(oppgaver.length / oppgaveSideLimit);
 
-const OppgavelisteNavigator: FunctionComponent = () => {
+const OppgavelisteNavigator = () => {
     const { oppgaver, side, settSide } = useOppgavebenkContext();
 
     if (oppgaver.status !== RessursStatus.SUKSESS) {

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
@@ -1,4 +1,3 @@
-import type { FunctionComponent } from 'react';
 import { useEffect, useRef } from 'react';
 
 import { BodyShort, Button, HGrid } from '@navikt/ds-react';
@@ -15,7 +14,7 @@ interface IOppgavelisteSaksbehandler {
     saksbehandler: Saksbehandler;
 }
 
-const OppgavelisteSaksbehandler: FunctionComponent<IOppgavelisteSaksbehandler> = ({ oppgave, saksbehandler }) => {
+const OppgavelisteSaksbehandler = ({ oppgave, saksbehandler }: IOppgavelisteSaksbehandler) => {
     const { fordelOppgave, tilbakestillFordelingPåOppgave } = useOppgavebenkContext();
     const { sjekkTilgang } = useAppContext();
     const oppgaveRef = useRef<IOppgave | null>(null);

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import type { FunctionComponent } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { BodyShort, Button, HGrid } from '@navikt/ds-react';
 
@@ -14,7 +15,7 @@ interface IOppgavelisteSaksbehandler {
     saksbehandler: Saksbehandler;
 }
 
-const OppgavelisteSaksbehandler: React.FunctionComponent<IOppgavelisteSaksbehandler> = ({ oppgave, saksbehandler }) => {
+const OppgavelisteSaksbehandler: FunctionComponent<IOppgavelisteSaksbehandler> = ({ oppgave, saksbehandler }) => {
     const { fordelOppgave, tilbakestillFordelingPåOppgave } = useOppgavebenkContext();
     const { sjekkTilgang } = useAppContext();
     const oppgaveRef = useRef<IOppgave | null>(null);

--- a/src/frontend/sider/Samhandler/OrganisasjonsnummerFelt.tsx
+++ b/src/frontend/sider/Samhandler/OrganisasjonsnummerFelt.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useController, useFormContext } from 'react-hook-form';
 
 import { TextField } from '@navikt/ds-react';

--- a/src/frontend/sider/Samhandler/Samhandler.tsx
+++ b/src/frontend/sider/Samhandler/Samhandler.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 
 import { FormProvider } from 'react-hook-form';
 import { useLocation } from 'react-router';
@@ -9,7 +10,7 @@ import { OrganisasjonsnummerFelt } from './OrganisasjonsnummerFelt';
 import { SamhandlerFeltnavn, useSamhandlerForm } from './useSamhandlerForm';
 import type { ISamhandlerInfo } from '../../typer/samhandler';
 
-export const Samhandler: React.FC = () => {
+export const Samhandler: FC = () => {
     const location = useLocation();
     const [samhandler, setSamhandler] = useState<ISamhandlerInfo | null>(null);
 

--- a/src/frontend/sider/Samhandler/Samhandler.tsx
+++ b/src/frontend/sider/Samhandler/Samhandler.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 
 import { FormProvider } from 'react-hook-form';
@@ -10,7 +9,7 @@ import { OrganisasjonsnummerFelt } from './OrganisasjonsnummerFelt';
 import { SamhandlerFeltnavn, useSamhandlerForm } from './useSamhandlerForm';
 import type { ISamhandlerInfo } from '../../typer/samhandler';
 
-export const Samhandler: FC = () => {
+export const Samhandler = () => {
     const location = useLocation();
     const [samhandler, setSamhandler] = useState<ISamhandlerInfo | null>(null);
 

--- a/src/frontend/testutils/testrender.tsx
+++ b/src/frontend/testutils/testrender.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren } from 'react';
+import type { ReactNode, PropsWithChildren } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, type RenderOptions, screen as rtlScreen } from '@testing-library/react';
@@ -61,7 +61,7 @@ export function TestProviders({
     );
 }
 
-export function render(ui: React.ReactNode, options?: RenderOptions) {
+export function render(ui: ReactNode, options?: RenderOptions) {
     return {
         user: userEvent.setup(),
         screen: rtlScreen,

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -8,8 +8,7 @@
       "DOM.Iterable",
       "ESNext"
     ],
-    /* TODO: bytt til react-jsx*/
-    "jsx": "react",
+    "jsx": "react-jsx",
 
     /* Emit */
     "noEmit": true,

--- a/src/frontend/utils/vilkår.tsx
+++ b/src/frontend/utils/vilkår.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 
 import styled from 'styled-components';
 


### PR DESCRIPTION
### 📮 Favro: NAV-28201

### 💰 Hva skal gjøres, og hvorfor?
Tilsvarende endring i ks-sak-frontend: https://github.com/navikt/familie-ks-sak-frontend/pull/1404.

Tar i bruk JSX-Transform, som er den moderne måten for TypeScript å kompilere JSX. Bra for bundle size, bedre feilmeldinger, pluss at det er der fremtidige features går.

Manuell import av React er nå ikke lengre nødvendig, og validering blir kranglete. Røsker det derfor ut i en bolk for penere diff i fremtiden. La til noen lint-regler for å håndheve god praksis for React imports. 

Gigantisk diff, jeg vet, men det er 99% import endringer. Unntaket er eslint og et par linjer i index.tsx. Det kjører OK lokalt, ved kompilering, og bygger.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei