### PR TITLE
Opprett visning for låst fagsak

### DIFF
--- a/src/frontend/hooks/useErLesevisning.test.ts
+++ b/src/frontend/hooks/useErLesevisning.test.ts
@@ -3,26 +3,32 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useBehandling } from './useBehandling';
 import { useErLesevisning } from './useErLesevisning';
+import { useFagsak } from './useFagsak';
 import { useSaksbehandler } from './useSaksbehandler';
 import { lagBehandling } from '../testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '../testutils/testdata/fagsakTestdata';
 import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
 import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak } from '../typer/behandling';
 import { harTilgangTilEnhet } from '../typer/enhet';
+import { FagsakStatus } from '../typer/fagsak';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
 
 vi.mock('./useBehandling');
 vi.mock('./useSaksbehandler');
+vi.mock('./useFagsak');
 vi.mock('../typer/enhet');
 
 const mockUseBehandling = vi.mocked(useBehandling);
 const mockUseSaksbehandler = vi.mocked(useSaksbehandler);
 const mockHarTilgangTilEnhet = vi.mocked(harTilgangTilEnhet);
+const mockUseFagsak = vi.mocked(useFagsak);
 
 beforeEach(() => {
     vi.resetAllMocks();
     mockUseBehandling.mockReturnValue(lagBehandling());
     mockUseSaksbehandler.mockReturnValue(lagSaksbehandler());
     mockHarTilgangTilEnhet.mockReturnValue(true);
+    mockUseFagsak.mockReturnValue(lagFagsak());
 });
 
 describe('useErLesevisning', () => {
@@ -144,5 +150,13 @@ describe('useErLesevisning', () => {
         const { result } = renderHook(() => useErLesevisning());
 
         expect(result.current).toBe(false);
+    });
+
+    it('returnerer true når fagsaken er låst', () => {
+        mockUseFagsak.mockReturnValue(lagFagsak({ status: FagsakStatus.LÅST }));
+
+        const { result } = renderHook(() => useErLesevisning());
+
+        expect(result.current).toBe(true);
     });
 });

--- a/src/frontend/hooks/useErLesevisning.ts
+++ b/src/frontend/hooks/useErLesevisning.ts
@@ -1,7 +1,9 @@
 import { useBehandling } from './useBehandling';
+import { useFagsak } from './useFagsak';
 import { useSaksbehandler } from './useSaksbehandler';
 import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak, hentStegNummer } from '../typer/behandling';
 import { harTilgangTilEnhet } from '../typer/enhet';
+import { FagsakStatus } from '../typer/fagsak';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
 
 const ÅRSAKER_ÅPEN_FOR_ALLE = new Set([BehandlingÅrsak.TEKNISK_ENDRING, BehandlingÅrsak.KORREKSJON_VEDTAKSBREV]);
@@ -17,6 +19,11 @@ export function useErLesevisning({
 }: Parameters = {}) {
     const saksbehandler = useSaksbehandler();
     const behandling = useBehandling();
+    const fagsak = useFagsak();
+
+    if (fagsak.status === FagsakStatus.LÅST) {
+        return true;
+    }
 
     const behandlendeEnhetId = behandling.arbeidsfordelingPåBehandling.behandlendeEnhetId;
     const erBehandlingenAvsluttet = behandling.status === BehandlingStatus.AVSLUTTET;

--- a/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Behandlingslinje.tsx
@@ -6,6 +6,7 @@ import { Box, Button, HStack } from '@navikt/ds-react';
 import { Behandlingsmeny } from './Meny/Behandlingsmeny';
 import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
+import { FagsakStatus } from '../../typer/fagsak';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
     const urlSplit = pathname.split('/');
@@ -53,7 +54,7 @@ export function Behandlingslinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {saksbehandler.harSkrivetilgang && <Behandlingsmeny />}
+                {saksbehandler.harSkrivetilgang && fagsak.status !== FagsakStatus.LÅST && <Behandlingsmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
@@ -12,6 +12,7 @@ import { lagPerson } from '../../testutils/testdata/personTestdata';
 import { lagSaksbehandler } from '../../testutils/testdata/saksbehandlerTestdata';
 import { render, TestProviders } from '../../testutils/testrender';
 import type { IMinimalFagsak } from '../../typer/fagsak';
+import { FagsakStatus } from '../../typer/fagsak';
 import type { IPersonInfo } from '../../typer/person';
 import type { Saksbehandler } from '../../typer/saksbehandler';
 
@@ -99,6 +100,15 @@ describe('Fagsaklinje', () => {
 
         expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Dokumenter' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Meny' })).not.toBeInTheDocument();
+    });
+
+    test('skal ikke vise meny hvis fagsaken er låst', async () => {
+        const { screen } = render(<Fagsaklinje />, {
+            wrapper: props => <Wrapper {...props} fagsak={lagFagsak({ status: FagsakStatus.LÅST })} />,
+        });
+
+        expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Meny' })).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
@@ -6,6 +6,7 @@ import { Box, Button, HStack } from '@navikt/ds-react';
 import { Fagsakmeny } from './Meny/Fagsakmeny';
 import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
+import { FagsakStatus } from '../../typer/fagsak';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
     const urlSplit = pathname.split('/');
@@ -53,7 +54,7 @@ export function Fagsaklinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {saksbehandler.harSkrivetilgang && <Fagsakmeny />}
+                {saksbehandler.harSkrivetilgang && fagsak.status !== FagsakStatus.LÅST && <Fagsakmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -13,7 +13,7 @@ import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
 import type { BehandlingSteg, IBehandling, ISettPåVent } from '../../../../typer/behandling';
 import { BehandlerRolle, BehandlingStatus, Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
 import { harTilgangTilEnhet } from '../../../../typer/enhet';
-import { FagsakType } from '../../../../typer/fagsak';
+import { FagsakStatus, FagsakType } from '../../../../typer/fagsak';
 import { PersonType } from '../../../../typer/person';
 import { Målform } from '../../../../typer/søknad';
 import type { IVedtaksperiodeMedBegrunnelser } from '../../../../typer/vedtaksperiode';
@@ -130,6 +130,9 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
      * @Deprecated - Erstattes av {@link useErLesevisning}.
      */
     const vurderErLesevisning = (sjekkTilgangTilEnhet = true, skalIgnorereOmEnhetErMidlertidig = false): boolean => {
+        if (fagsak.status === FagsakStatus.LÅST) {
+            return true;
+        }
         const åpenBehandlingData = behandling;
         if (
             åpenBehandlingData?.status === BehandlingStatus.SATT_PÅ_VENT ||

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -9,7 +9,8 @@ import type { VisningBehandling } from './visningBehandling';
 import { BehandlingStatus } from '../../../typer/behandling';
 import type { IBehandlingstema } from '../../../typer/behandlingstema';
 import { tilBehandlingstema } from '../../../typer/behandlingstema';
-import { FagsakType } from '../../../typer/fagsak';
+import { FagsakStatus, FagsakType } from '../../../typer/fagsak';
+import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '../../../utils/fagsak';
 import { useFagsakContext } from '../FagsakContext';
 
@@ -30,6 +31,7 @@ function Innholdstabell() {
         fagsak.løpendeKategori &&
         fagsak.løpendeUnderkategori &&
         tilBehandlingstema(fagsak.løpendeKategori, fagsak.løpendeUnderkategori);
+    const fagsakErLåst = fagsak.status === FagsakStatus.LÅST;
     return (
         <HStack gap="space-80">
             <div>
@@ -40,6 +42,17 @@ function Innholdstabell() {
                 <HeaderTekst spacing>Status</HeaderTekst>
                 <BodyTekst weight="semibold">{hentFagsakStatusVisning(fagsak)}</BodyTekst>
             </div>
+            {fagsakErLåst && fagsak.låstTidspunkt && (
+                <div>
+                    <HeaderTekst spacing>Låst dato</HeaderTekst>
+                    <BodyTekst weight="semibold">
+                        {isoStringTilFormatertString({
+                            isoString: fagsak.låstTidspunkt,
+                            tilFormat: Datoformat.DATO,
+                        })}
+                    </BodyTekst>
+                </div>
+            )}
         </HStack>
     );
 }

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -9,6 +9,7 @@ export enum FagsakStatus {
     OPPRETTET = 'OPPRETTET',
     LØPENDE = 'LØPENDE',
     AVSLUTTET = 'AVSLUTTET',
+    LÅST = 'LÅST',
 }
 
 export enum FagsakType {
@@ -32,6 +33,7 @@ export interface IBaseFagsak {
     fagsakType: FagsakType;
     institusjon?: IInstitusjon;
     finnesStrengtFortroligPersonIFagsak: boolean;
+    låstTidspunkt?: string;
 }
 
 export function sjekkHarNormalFagsak(fagsaker: IBaseFagsak[] | undefined): boolean {
@@ -73,6 +75,7 @@ export const mapMinimalFagsakTilBaseFagsak = (it: IMinimalFagsak): IBaseFagsak =
     fagsakType: it.fagsakType,
     institusjon: it.institusjon,
     finnesStrengtFortroligPersonIFagsak: it.finnesStrengtFortroligPersonIFagsak,
+    låstTidspunkt: it.låstTidspunkt,
 });
 
 export const fagsakStatus: INøkkelPar = {
@@ -87,5 +90,9 @@ export const fagsakStatus: INøkkelPar = {
     AVSLUTTET: {
         id: 'AVSLUTTET',
         navn: 'Avsluttet',
+    },
+    LÅST: {
+        id: 'LÅST',
+        navn: 'Låst',
     },
 };


### PR DESCRIPTION
### 📮 Favro: Nav-28952

### 💰 Hva skal gjøres, og hvorfor?

Vi introduserer nytt fagsak status i backend (LÅST) og bruker denne i frontend.
Ved fagsak som er låst vises nå også dato for når den ble låst, i tillegg til at man ikke får opprettet noe nye behandlinger (det blir som man har bare veileder tilgang)

<img width="1153" height="433" alt="Screenshot 2026-05-05 at 10 00 57" src="https://github.com/user-attachments/assets/1f77ae5e-b443-47ee-a63b-28458af74d31" />
