### PR TITLE
NAV-28170: Tilpasser tabell for mindre skjermer

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
@@ -11,6 +11,8 @@ import { BehandlingSteg } from '../../../../typer/behandling';
 import { behandlingErEtterSteg } from '../../../../utils/steg';
 import { useBehandlingContext } from '../context/BehandlingContext';
 
+export const MAX_SKJEMASTEG_BREDDE = '1440px';
+
 interface IProps extends PropsWithChildren {
     className?: string;
     forrigeKnappTittel?: string;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.module.css
@@ -1,0 +1,38 @@
+.wrapper {
+    width: 100%;
+}
+
+.table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+}
+
+.table,
+.table * {
+    box-sizing: border-box;
+}
+
+.col1 {
+    width: 17%;
+}
+
+.col2 {
+    width: 20%;
+}
+
+.col3 {
+    width: 18%;
+}
+
+.col4 {
+    width: 20%;
+}
+
+.col5 {
+    width: 20%;
+}
+
+.col6 {
+    width: 5%;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabell.tsx
@@ -1,11 +1,11 @@
-import styled from 'styled-components';
+import type { IGrunnlagPerson } from '@typer/person';
+import type { IVilkårConfig, IVilkårResultat } from '@typer/vilkår';
 
-import { Table } from '@navikt/ds-react';
+import { Box, Table } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
 
-import VilkårTabellRad from './VilkårTabellRad';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import type { IVilkårConfig, IVilkårResultat } from '../../../../../../typer/vilkår';
+import Styles from './VilkårTabell.module.css';
+import { VilkårTabellRad } from './VilkårTabellRad';
 
 export const vilkårFeilmeldingId = (vilkårResultat: IVilkårResultat) =>
     `vilkår_${vilkårResultat.vilkårType}_${vilkårResultat.id}`;
@@ -27,52 +27,46 @@ interface IProps {
     settFokusPåKnapp: () => void;
 }
 
-const TabellHeader = styled(Table.HeaderCell)`
-    &:nth-of-type(1) {
-        width: 10rem;
-    }
-    &:nth-of-type(2) {
-        width: 12rem;
-    }
-    &:nth-of-type(4) {
-        width: 12rem;
-    }
-    &:nth-of-type(5) {
-        width: 17rem;
-    }
-    &:nth-of-type(6) {
-        width: 2.25rem;
-    }
-`;
-
 const VilkårTabell = ({ person, vilkårFraConfig, vilkårResultater, visFeilmeldinger, settFokusPåKnapp }: IProps) => {
     return (
-        <Table>
-            <Table.Header>
-                <Table.Row>
-                    <TabellHeader scope="col">Vurdering</TabellHeader>
-                    <TabellHeader scope="col">Periode</TabellHeader>
-                    <TabellHeader scope="col">Begrunnelse</TabellHeader>
-                    <TabellHeader scope="col">Vurderes etter</TabellHeader>
-                    <TabellHeader scope="col">Vurdert av</TabellHeader>
-                    <TabellHeader />
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {vilkårResultater.map((vilkårResultat: FeltState<IVilkårResultat>, index: number) => {
-                    return (
-                        <VilkårTabellRad
-                            key={`${index}_${person.fødselsdato}_${vilkårResultat.verdi.vilkårType}_${vilkårResultat.verdi.id}`}
-                            vilkårFraConfig={vilkårFraConfig}
-                            person={person}
-                            vilkårResultat={vilkårResultat}
-                            visFeilmeldinger={visFeilmeldinger}
-                            settFokusPåKnapp={settFokusPåKnapp}
-                        />
-                    );
-                })}
-            </Table.Body>
-        </Table>
+        <Box className={Styles.wrapper}>
+            <Table className={Styles.table}>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell className={Styles.col1} scope={'col'}>
+                            Vurdering
+                        </Table.HeaderCell>
+                        <Table.HeaderCell className={Styles.col2} scope={'col'}>
+                            Periode
+                        </Table.HeaderCell>
+                        <Table.HeaderCell className={Styles.col3} scope={'col'}>
+                            Begrunnelse
+                        </Table.HeaderCell>
+                        <Table.HeaderCell className={Styles.col4} scope={'col'}>
+                            Vurderes etter
+                        </Table.HeaderCell>
+                        <Table.HeaderCell className={Styles.col5} scope={'col'}>
+                            Vurdert av
+                        </Table.HeaderCell>
+                        <Table.HeaderCell className={Styles.col6} scope={'col'} />
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {vilkårResultater.map((vilkårResultat: FeltState<IVilkårResultat>, index: number) => {
+                        return (
+                            <VilkårTabellRad
+                                key={`${index}_${person.fødselsdato}_${vilkårResultat.verdi.vilkårType}_${vilkårResultat.verdi.id}`}
+                                vilkårFraConfig={vilkårFraConfig}
+                                person={person}
+                                vilkårResultat={vilkårResultat}
+                                visFeilmeldinger={visFeilmeldinger}
+                                settFokusPåKnapp={settFokusPåKnapp}
+                            />
+                        );
+                    })}
+                </Table.Body>
+            </Table>
+        </Box>
     );
 };
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.module.css
@@ -1,0 +1,23 @@
+.celle {
+    word-break: keep-all;
+    white-space: normal;
+}
+
+.beskrivelse {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 20rem;
+}
+
+.tooltip {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    max-width: 500px;
+    text-align: left;
+}
+
+.ikon {
+    font-size: 1.5rem;
+    min-width: 1.5rem;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -1,23 +1,24 @@
 import { useEffect, useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IGrunnlagPerson } from '@typer/person';
+import type { IVilkårConfig, IVilkårResultat } from '@typer/vilkår';
+import { Resultat, resultatVisningsnavn } from '@typer/vilkår';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+import { alleRegelverk } from '@utils/vilkår';
 import deepEqual from 'deep-equal';
-import styled from 'styled-components';
 
 import { CogIcon, CogRotationIcon, PersonIcon } from '@navikt/aksel-icons';
-import { BodyShort, Table, Tooltip } from '@navikt/ds-react';
+import { BodyShort, HStack, Table, Tooltip } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
 
 import { vilkårFeilmeldingId } from './VilkårTabell';
+import Styles from './VilkårTabellRad.module.css';
 import VilkårTabellRadEndre from './VilkårTabellRadEndre';
 import VilkårResultatIkon from '../../../../../../ikoner/VilkårResultatIkon';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import type { IVilkårConfig, IVilkårResultat } from '../../../../../../typer/vilkår';
-import { Resultat, resultatVisningsnavn } from '../../../../../../typer/vilkår';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { alleRegelverk } from '../../../../../../utils/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
-interface IProps {
+interface Props {
     person: IGrunnlagPerson;
     vilkårFraConfig: IVilkårConfig;
     vilkårResultat: FeltState<IVilkårResultat>;
@@ -25,55 +26,15 @@ interface IProps {
     settFokusPåKnapp: () => void;
 }
 
-const BeskrivelseCelle = styled(BodyShort)`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 20rem;
-`;
-
-const VurderingCelle = styled.div`
-    display: flex;
-    svg {
-        margin-right: 1rem;
-    }
-`;
-
-const FlexDiv = styled.div`
-    display: flex;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    align-items: center;
-    > div:nth-child(n + 2) {
-        padding-left: 0.5rem;
-    }
-`;
-
-const StyledTooltip = styled(Tooltip)`
-    padding-top: 8px;
-    padding-bottom: 8px;
-    max-width: 500px;
-    text-align: left;
-`;
-
-const StyledCogIcon = styled(CogIcon)`
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const StyledCogRotationIcon = styled(CogRotationIcon)`
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const StyledPersonIcon = styled(PersonIcon)`
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const VilkårTabellRad = ({ person, vilkårFraConfig, vilkårResultat, visFeilmeldinger, settFokusPåKnapp }: IProps) => {
-    const { vurderErLesevisning, behandling, aktivSettPåVent } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+export function VilkårTabellRad({
+    person,
+    vilkårFraConfig,
+    vilkårResultat,
+    visFeilmeldinger,
+    settFokusPåKnapp,
+}: Props) {
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const vilkårResultatVerdi = vilkårResultat.verdi.resultat.verdi;
     const vilkårResultatbegrunnelse = vilkårResultat.verdi.resultatBegrunnelse;
@@ -82,6 +43,8 @@ const VilkårTabellRad = ({ person, vilkårFraConfig, vilkårResultat, visFeilme
 
     const [ekspandertVilkår, settEkspandertVilkår] = useState(hentInitiellEkspandering());
     const [redigerbartVilkår, settRedigerbartVilkår] = useState<FeltState<IVilkårResultat>>(vilkårResultat);
+
+    const aktivSettPåVent = behandling.aktivSettPåVent;
 
     useEffect(() => {
         settEkspandertVilkår(hentInitiellEkspandering());
@@ -101,7 +64,7 @@ const VilkårTabellRad = ({ person, vilkårFraConfig, vilkårResultat, visFeilme
     return (
         <Table.ExpandableRow
             open={ekspandertVilkår}
-            togglePlacement="right"
+            togglePlacement={'right'}
             onOpenChange={() => toggleForm(true)}
             id={vilkårFeilmeldingId(vilkårResultat.verdi)}
             content={
@@ -120,8 +83,8 @@ const VilkårTabellRad = ({ person, vilkårFraConfig, vilkårResultat, visFeilme
                 />
             }
         >
-            <Table.DataCell>
-                <VurderingCelle>
+            <Table.DataCell className={Styles.celle}>
+                <HStack justify={'start'} align={'center'} gap={'space-6'} wrap={false}>
                     <VilkårResultatIkon
                         resultat={vilkårResultatVerdi}
                         resultatBegrunnelse={vilkårResultatbegrunnelse}
@@ -131,51 +94,51 @@ const VilkårTabellRad = ({ person, vilkårFraConfig, vilkårResultat, visFeilme
                             ? resultatVisningsnavn[vilkårResultatbegrunnelse]
                             : resultatVisningsnavn[vilkårResultatVerdi]}
                     </BodyShort>
-                </VurderingCelle>
+                </HStack>
             </Table.DataCell>
-            <Table.DataCell>
+            <Table.DataCell className={Styles.celle}>
                 <BodyShort>
                     {periodeErTom ? '-' : isoDatoPeriodeTilFormatertString(vilkårResultat.verdi.periode.verdi)}
                 </BodyShort>
             </Table.DataCell>
-            <Table.DataCell>
+            <Table.DataCell className={Styles.celle}>
                 {vilkårResultat.verdi.begrunnelse.verdi && (
-                    <StyledTooltip content={vilkårResultat.verdi.begrunnelse.verdi}>
-                        <BeskrivelseCelle children={vilkårResultat.verdi.begrunnelse.verdi} />
-                    </StyledTooltip>
+                    <Tooltip content={vilkårResultat.verdi.begrunnelse.verdi} className={Styles.tooltip}>
+                        <BodyShort className={Styles.beskrivelse}>{vilkårResultat.verdi.begrunnelse.verdi}</BodyShort>
+                    </Tooltip>
                 )}
             </Table.DataCell>
-            <Table.DataCell>
-                {redigerbartVilkår.verdi.vurderesEtter ? (
-                    <FlexDiv>
-                        {alleRegelverk[redigerbartVilkår.verdi.vurderesEtter].symbol}
-                        <div>{alleRegelverk[redigerbartVilkår.verdi.vurderesEtter].tekst}</div>
-                    </FlexDiv>
-                ) : (
-                    <FlexDiv>
-                        <StyledCogIcon title={'Generell vurdering'} />
-                        <div>Generell vurdering</div>
-                    </FlexDiv>
-                )}
-            </Table.DataCell>
-            <Table.DataCell>
-                <FlexDiv>
-                    {vilkårResultat.verdi.erAutomatiskVurdert ? (
-                        <StyledCogRotationIcon title={'Automatisk Vurdering'} />
+            <Table.DataCell className={Styles.celle}>
+                <HStack justify={'start'} align={'center'} gap={'space-6'} wrap={false}>
+                    {redigerbartVilkår.verdi.vurderesEtter ? (
+                        <>
+                            {alleRegelverk[redigerbartVilkår.verdi.vurderesEtter].symbol}
+                            <BodyShort>{alleRegelverk[redigerbartVilkår.verdi.vurderesEtter].tekst}</BodyShort>
+                        </>
                     ) : (
-                        <StyledPersonIcon title={'Manuell vurdering'} />
+                        <>
+                            <CogIcon title={'Generell vurdering'} className={Styles.ikon} />
+                            <BodyShort>Generell vurdering</BodyShort>
+                        </>
                     )}
-                    <div>
+                </HStack>
+            </Table.DataCell>
+            <Table.DataCell className={Styles.celle}>
+                <HStack justify={'start'} align={'center'} gap={'space-6'} wrap={false}>
+                    {vilkårResultat.verdi.erAutomatiskVurdert ? (
+                        <CogRotationIcon title={'Automatisk Vurdering'} className={Styles.ikon} />
+                    ) : (
+                        <PersonIcon title={'Manuell vurdering'} className={Styles.ikon} />
+                    )}
+                    <BodyShort>
                         {vilkårResultat.verdi.erVurdert
                             ? vilkårResultat.verdi.behandlingId === behandling.behandlingId
                                 ? 'Vurdert i denne behandlingen'
                                 : 'Vurdert i tidligere behandling'
                             : ''}
-                    </div>
-                </FlexDiv>
+                    </BodyShort>
+                </HStack>
             </Table.DataCell>
         </Table.ExpandableRow>
     );
-};
-
-export default VilkårTabellRad;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -10,9 +10,9 @@ import { PersonType } from '@typer/person';
 import { annenVurderingConfig, harPersonIkkeVurdertVilkår, vilkårConfig, VilkårType } from '@typer/vilkår';
 
 import { ChevronDownIcon, ChevronUpIcon, PlusCircleIcon, ShieldLockFillIcon } from '@navikt/aksel-icons';
-import { BodyShort, Box, Button, Heading, HStack, List, LocalAlert } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
+import { BodyShort, Box, Button, Heading, HStack, List, LocalAlert, Stack } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
+import { RessursStatus } from '@navikt/familie-typer';
 
 import { EkspanderVilkårsvurderingProvider } from './EkspanderVilkårsvurderingContext';
 import styles from './VilkårsvurderingSkjema.module.css';
@@ -34,6 +34,8 @@ const VilkårsvurderingSkjemaNormal = ({ visFeilmeldinger }: IVilkårsvurderingS
     const toggles = useFeatureToggles();
     const skjermstørrelse = useSkjermstørrelse();
     const erLesevisning = useErLesevisning();
+
+    const erStorSkjerm = skjermstørrelse > Skjermstørrelse['2XL'];
 
     const leggTilVilkårUtvidet = (personIdent: string) => {
         const promise = postVilkår(personIdent, VilkårType.UTVIDET_BARNETRYGD);
@@ -116,7 +118,8 @@ const VilkårsvurderingSkjemaNormal = ({ visFeilmeldinger }: IVilkårsvurderingS
                                     </HStack>
                                 ) : (
                                     <>
-                                        <HStack
+                                        <Stack
+                                            direction={erStorSkjerm ? 'row' : 'column'}
                                             gap={'space-8'}
                                             justify={'space-between'}
                                             wrap={true}
@@ -127,7 +130,7 @@ const VilkårsvurderingSkjemaNormal = ({ visFeilmeldinger }: IVilkårsvurderingS
                                                 {ekspandert && skalKunneLeggeTilUtvidetBarnetrygdVilkår && (
                                                     <Button
                                                         variant={'tertiary'}
-                                                        size={skjermstørrelse > Skjermstørrelse.XL ? 'medium' : 'small'}
+                                                        size={erStorSkjerm ? 'medium' : 'small'}
                                                         onClick={() => leggTilVilkårUtvidet(personResultat.personIdent)}
                                                         icon={
                                                             <PlusCircleIcon title="Legg til vilkår utvidet barnetrygd" />
@@ -138,7 +141,7 @@ const VilkårsvurderingSkjemaNormal = ({ visFeilmeldinger }: IVilkårsvurderingS
                                                 )}
                                                 <Button
                                                     variant={'tertiary'}
-                                                    size={skjermstørrelse > Skjermstørrelse.XL ? 'medium' : 'small'}
+                                                    size={erStorSkjerm ? 'medium' : 'small'}
                                                     onClick={ekspander}
                                                     icon={
                                                         ekspandert ? (
@@ -152,15 +155,9 @@ const VilkårsvurderingSkjemaNormal = ({ visFeilmeldinger }: IVilkårsvurderingS
                                                     {ekspandert ? 'Skjul vilkårsvurdering' : 'Vis vilkårsvurdering'}
                                                 </Button>
                                             </HStack>
-                                        </HStack>
+                                        </Stack>
                                         <Activity mode={ekspandert ? 'visible' : 'hidden'}>
-                                            <Box
-                                                paddingInline={
-                                                    skjermstørrelse > Skjermstørrelse.XL
-                                                        ? 'space-56 space-0'
-                                                        : 'space-0'
-                                                }
-                                            >
+                                            <Box paddingInline={erStorSkjerm ? 'space-56 space-0' : 'space-0'}>
                                                 {personResultat.person.registerhistorikk ? (
                                                     <Registeropplysninger
                                                         registerHistorikk={personResultat.person.registerhistorikk}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Vilkårsvurdering.tsx
@@ -1,5 +1,14 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import { useFeatureToggles } from '@hooks/useFeatureToggles';
+import { BehandlingSteg, BehandlingÅrsak } from '@typer/behandling';
+import { FeatureToggle } from '@typer/featureToggles';
+import { annenVurderingConfig, type IAnnenVurdering, type IVilkårResultat, vilkårConfig } from '@typer/vilkår';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+import { erProd } from '@utils/miljø';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import { useNavigate } from 'react-router';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
@@ -15,38 +24,21 @@ import { TømPersonopplysningerCacheITestmiljøKnapp } from './TømPersonopplysn
 import { ManglendeFinnmarkmerkingVarsel } from './Varsel/ManglendeFinnmarkmerkingVarsel';
 import styles from './Vilkårsvurdering.module.css';
 import { useVilkårsvurderingContext } from './VilkårsvurderingContext';
-import { useFeatureToggles } from '../../../../../hooks/useFeatureToggles';
-import { BehandlingSteg, BehandlingÅrsak } from '../../../../../typer/behandling';
-import { FeatureToggle } from '../../../../../typer/featureToggles';
-import {
-    annenVurderingConfig,
-    type IAnnenVurdering,
-    type IVilkårResultat,
-    vilkårConfig,
-} from '../../../../../typer/vilkår';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
-import { erProd } from '../../../../../utils/miljø';
-import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
 import { useBehandlingContext } from '../../context/BehandlingContext';
-import Skjemasteg from '../Skjemasteg';
+import Skjemasteg, { MAX_SKJEMASTEG_BREDDE } from '../Skjemasteg';
 import { ManglendeSvalbardmerkingVarsel } from './Varsel/ManglendeSvalbardmerkingVarsel';
-import { useFagsakContext } from '../../../FagsakContext';
 
 export function Vilkårsvurdering() {
-    const toggles = useFeatureToggles();
-
-    const { fagsak } = useFagsakContext();
-    const { behandling, vurderErLesevisning, vilkårsvurderingNesteOnClick, behandlingsstegSubmitressurs } =
-        useBehandlingContext();
-
+    const { behandling, vilkårsvurderingNesteOnClick, behandlingsstegSubmitressurs } = useBehandlingContext();
     const { erVilkårsvurderingenGyldig, hentVilkårMedFeil, hentAndreVurderingerMedFeil, vilkårsvurdering } =
         useVilkårsvurderingContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const fagsak = useFagsak();
+    const erLesevisning = useErLesevisning();
+    const navigate = useNavigate();
+    const toggles = useFeatureToggles();
 
     const [visFeilmeldinger, settVisFeilmeldinger] = useState(false);
-
-    const navigate = useNavigate();
 
     const uregistrerteBarn =
         behandling.søknadsgrunnlag?.barnaMedOpplysninger.filter(barn => !barn.erFolkeregistrert) ?? [];
@@ -79,7 +71,7 @@ export function Vilkårsvurdering() {
                     settVisFeilmeldinger(true);
                 }
             }}
-            maxWidthStyle={'80rem'}
+            maxWidthStyle={MAX_SKJEMASTEG_BREDDE}
             senderInn={behandlingsstegSubmitressurs.status === RessursStatus.HENTER}
             steg={BehandlingSteg.VILKÅRSVURDERING}
         >

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
@@ -13,7 +13,8 @@
 
 .menylenke {
     text-decoration: none;
-    padding: var(--ax-space-6) var(--ax-space-8);
+    padding-inline: clamp(var(--ax-space-4), var(--ax-space-20), var(--ax-space-48));
+    padding-block: var(--ax-space-6);
     border-left: 5px solid transparent;
     user-select: text;
 }

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -10,7 +10,7 @@ import useBehandlingssteg from './useBehandlingssteg';
 import { saksbehandlerHarKunLesevisning } from './utils';
 import { useNavigerAutomatiskTilSideForBehandlingssteg } from '../../../../hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
 import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
-import type { BehandlingSteg, IBehandling, ISettPåVent } from '../../../../typer/behandling';
+import type { BehandlingSteg, IBehandling } from '../../../../typer/behandling';
 import { BehandlerRolle, BehandlingStatus, Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
 import { harTilgangTilEnhet } from '../../../../typer/enhet';
 import { FagsakStatus, FagsakType } from '../../../../typer/fagsak';
@@ -48,7 +48,6 @@ interface BehandlingContextValue {
         erSammensattKontrollsak: boolean
     ) => void;
     erMigreringsbehandling: boolean;
-    aktivSettPåVent?: ISettPåVent | undefined;
     gjelderInstitusjon: boolean;
     samhandlerOrgnr: string | undefined;
     gjelderEnsligMindreårig: boolean;
@@ -200,7 +199,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
                 behandlingresultatNesteOnClick,
                 sendTilBeslutterNesteOnClick,
                 erMigreringsbehandling,
-                aktivSettPåVent: behandling?.aktivSettPåVent,
                 gjelderInstitusjon,
                 samhandlerOrgnr,
                 gjelderEnsligMindreårig,


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
Tilpasser tabellen i vilkårsvurdering for mindre skjermer. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Bare visuelle endringer. 

### 👀 Screen shots
1280x720 ny:
<img width="1282" height="725" alt="image" src="https://github.com/user-attachments/assets/d663de6a-96da-4720-9083-2dc030f21d11" />

1280x720 gammel:
<img width="1282" height="725" alt="image" src="https://github.com/user-attachments/assets/914f1050-66a9-4f2f-a0b6-0a56f4b83aa9" />

---
1440x900 ny:
<img width="1301" height="817" alt="image" src="https://github.com/user-attachments/assets/f901e653-4300-485b-8982-6eac7a81ab9f" />

1440x900 gammel:
<img width="1303" height="815" alt="image" src="https://github.com/user-attachments/assets/508a2691-2718-4682-9ed9-b06c58654be7" />

---

1600x900 ny:
<img width="1511" height="847" alt="image" src="https://github.com/user-attachments/assets/6e96f7cd-21be-4346-8fc7-a188e9b34f51" />

1600x900 gammel:
<img width="1507" height="853" alt="image" src="https://github.com/user-attachments/assets/2021b286-4e41-40ec-9022-8f6e2e6bcc95" />