### PR TITLE
NAV-28170: Tilpasser annen vurdering for mindre skjermer

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.module.css
@@ -1,0 +1,26 @@
+.table {
+    width: 100%;
+    table-layout: auto;
+    border-collapse: collapse;
+}
+
+.table,
+.table * {
+    box-sizing: border-box;
+}
+
+.col1 {
+    width: 36%;
+}
+
+.col2 {
+    width: 34%;
+}
+
+.col3 {
+    width: 26%;
+}
+
+.col4 {
+    width: 4%;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabell.tsx
@@ -1,11 +1,11 @@
-import styled from 'styled-components';
+import type { IGrunnlagPerson } from '@typer/person';
+import type { IAnnenVurdering, IAnnenVurderingConfig } from '@typer/vilkår';
 
 import { Table } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
 
-import AnnenVurderingTabellRad from './AnnenVurderingTabellRad';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import type { IAnnenVurdering, IAnnenVurderingConfig } from '../../../../../../typer/vilkår';
+import Styles from './AnnenVurderingTabell.module.css';
+import { AnnenVurderingTabellRad } from './AnnenVurderingTabellRad';
 
 export const annenVurderingFeilmeldingId = (annenVurdering: IAnnenVurdering) =>
     `annen-vurdering_${annenVurdering.type}_${annenVurdering.id}`;
@@ -16,40 +16,22 @@ export const annenVurderingResultatFeilmeldingId = (annenVurdering: IAnnenVurder
 export const annenVurderingBegrunnelseFeilmeldingId = (annenVurdering: IAnnenVurdering) =>
     `annen-vurdering-begrunnelse_${annenVurdering.type}_${annenVurdering.id}`;
 
-interface IProps {
+interface Props {
     person: IGrunnlagPerson;
     andreVurderinger: FeltState<IAnnenVurdering>[];
     annenVurderingConfig: IAnnenVurderingConfig;
     visFeilmeldinger: boolean;
 }
 
-const TabellHeader = styled(Table.HeaderCell)`
-    &:nth-of-type(1) {
-        width: 21rem;
-    }
-
-    &:nth-of-type(2) {
-        width: 20rem;
-    }
-
-    &:nth-of-type(3) {
-        width: 15rem;
-    }
-
-    &:nth-of-type(4) {
-        width: 2.25rem;
-    }
-`;
-
-const AnnenVurderingTabell = ({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }: IProps) => {
+export function AnnenVurderingTabell({ person, annenVurderingConfig, andreVurderinger, visFeilmeldinger }: Props) {
     return (
-        <Table>
+        <Table className={Styles.table}>
             <Table.Header>
                 <Table.Row>
-                    <TabellHeader>Vurdering</TabellHeader>
-                    <TabellHeader>Begrunnelse</TabellHeader>
-                    <TabellHeader>Vurdert av</TabellHeader>
-                    <TabellHeader />
+                    <Table.HeaderCell className={Styles.col1}>Vurdering</Table.HeaderCell>
+                    <Table.HeaderCell className={Styles.col2}>Begrunnelse</Table.HeaderCell>
+                    <Table.HeaderCell className={Styles.col3}>Vurdert av</Table.HeaderCell>
+                    <Table.HeaderCell className={Styles.col4} />
                 </Table.Row>
             </Table.Header>
             <Table.Body>
@@ -67,6 +49,4 @@ const AnnenVurderingTabell = ({ person, annenVurderingConfig, andreVurderinger, 
             </Table.Body>
         </Table>
     );
-};
-
-export default AnnenVurderingTabell;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.module.css
@@ -1,0 +1,10 @@
+.beskrivelse {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ikon {
+    font-size: 1.5rem;
+    min-width: 1.5rem;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
@@ -5,54 +5,24 @@ import type { IGrunnlagPerson } from '@typer/person';
 import type { IAnnenVurdering, IAnnenVurderingConfig } from '@typer/vilkår';
 import { Resultat, resultatVisningsnavn } from '@typer/vilkår';
 import deepEqual from 'deep-equal';
-import styled from 'styled-components';
 
 import { PersonIcon } from '@navikt/aksel-icons';
-import { BodyShort, Table } from '@navikt/ds-react';
+import { BodyShort, HStack, Table } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
 
 import AnnenVurderingRadEndre from './AnnenVurderingRadEndre';
 import { annenVurderingFeilmeldingId } from './AnnenVurderingTabell';
+import Styles from './AnnenVurderingTabellRad.module.css';
 import VilkårResultatIkon from '../../../../../../ikoner/VilkårResultatIkon';
 
-interface IProps {
+interface Props {
     person: IGrunnlagPerson;
     annenVurderingConfig: IAnnenVurderingConfig;
     annenVurdering: FeltState<IAnnenVurdering>;
     visFeilmeldinger: boolean;
 }
 
-const BeskrivelseCelle = styled(BodyShort)`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
-const VurderingCelle = styled.div`
-    display: flex;
-
-    svg {
-        margin-right: 1rem;
-    }
-`;
-
-const FlexDiv = styled.div`
-    display: flex;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    align-items: center;
-
-    > div:nth-child(n + 2) {
-        padding-left: 0.5rem;
-    }
-`;
-
-const StyledPersonIcon = styled(PersonIcon)`
-    font-size: 1.5rem;
-    min-width: 1.5rem;
-`;
-
-const AnnenVurderingTabellRad = ({ person, annenVurderingConfig, visFeilmeldinger, annenVurdering }: IProps) => {
+export function AnnenVurderingTabellRad({ person, annenVurderingConfig, visFeilmeldinger, annenVurdering }: Props) {
     const erLesevisning = useErLesevisning();
 
     const [ekspandertAnnenVurdering, settEkspandertAnnenVurdering] = useState(
@@ -73,7 +43,7 @@ const AnnenVurderingTabellRad = ({ person, annenVurderingConfig, visFeilmeldinge
     return (
         <Table.ExpandableRow
             open={ekspandertAnnenVurdering}
-            togglePlacement="right"
+            togglePlacement={'right'}
             onOpenChange={() => toggleForm(true)}
             id={annenVurderingFeilmeldingId(annenVurdering.verdi)}
             content={
@@ -90,22 +60,22 @@ const AnnenVurderingTabellRad = ({ person, annenVurderingConfig, visFeilmeldinge
             }
         >
             <Table.DataCell>
-                <VurderingCelle>
+                <HStack justify={'start'} align={'center'} gap={'space-6'} wrap={false}>
                     <VilkårResultatIkon resultat={annenVurdering.verdi.resultat.verdi} />
-                    <BodyShort children={resultatVisningsnavn[annenVurdering.verdi.resultat.verdi]} />
-                </VurderingCelle>
+                    <BodyShort>{resultatVisningsnavn[annenVurdering.verdi.resultat.verdi]}</BodyShort>
+                </HStack>
             </Table.DataCell>
             <Table.DataCell>
-                <BeskrivelseCelle children={annenVurdering.verdi.begrunnelse.verdi} />
+                <BodyShort className={Styles.beskrivelse}>{annenVurdering.verdi.begrunnelse.verdi}</BodyShort>
             </Table.DataCell>
             <Table.DataCell>
-                <FlexDiv>
-                    <StyledPersonIcon title={'Manuell vurdering'} />
-                    <div>{annenVurdering.verdi.erVurdert ? 'Vurdert i denne behandlingen' : ''}</div>
-                </FlexDiv>
+                {annenVurdering.verdi.erVurdert && (
+                    <HStack justify={'start'} align={'center'} gap={'space-6'} wrap={false}>
+                        <PersonIcon title={'Manuell vurdering'} className={Styles.ikon} />
+                        <BodyShort>Vurdert i denne behandlingen</BodyShort>
+                    </HStack>
+                )}
             </Table.DataCell>
         </Table.ExpandableRow>
     );
-};
-
-export default AnnenVurderingTabellRad;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/GeneriskAnnenVurdering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/GeneriskAnnenVurdering.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 
+import type { IGrunnlagPerson } from '@typer/person';
+import type { IAnnenVurdering, IAnnenVurderingConfig } from '@typer/vilkår';
 import styled from 'styled-components';
 
 import { Fieldset, Heading } from '@navikt/ds-react';
 import type { FeltState } from '@navikt/familie-skjema';
 
-import AnnenVurderingTabell from './AnnenVurderingTabell';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import type { IAnnenVurdering, IAnnenVurderingConfig } from '../../../../../../typer/vilkår';
+import { AnnenVurderingTabell } from './AnnenVurderingTabell';
 
 interface IProps {
     person: IGrunnlagPerson;


### PR DESCRIPTION
### 📮 Favro
NAV-28170

### 💰 Hva skal gjøres, og hvorfor?
Tilpasser annen vurdering slik at det ser bedre ut på småe skjermer.  

Endringene ble ikke så store, men det samsvarer bedre med hvordan det er løst andre plasser. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Kun visuelle endringer.

### 👀 Screen shots
1280x720 ny:
<img width="1093" height="617" alt="image" src="https://github.com/user-attachments/assets/eedbb701-6d39-428c-942f-4567d6e3697f" />

1280x720 gammel:
<img width="1093" height="617" alt="image" src="https://github.com/user-attachments/assets/1be8fa01-48f0-4762-babc-47afd0cf2e4f" />
