### PR TITLE
NAV-29004: Rydder i BehandlingContext

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
@@ -1,5 +1,11 @@
 import type { ChangeEvent } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { utledSøkersMålform } from '@typer/behandling';
+import { målform } from '@typer/søknad';
+import type { IFritekstFelt } from '@utils/fritekstfelter';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import styled from 'styled-components';
 
 import { ExternalLinkIcon, PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
@@ -9,10 +15,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
 import Knapperekke from '../../../../../../komponenter/Knapperekke';
-import { målform } from '../../../../../../typer/søknad';
-import type { IFritekstFelt } from '../../../../../../utils/fritekstfelter';
-import { hentFrontendFeilmelding } from '../../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const FritekstContainer = styled.div`
     padding: 1rem;
@@ -67,8 +69,9 @@ const ItalicText = styled(BodyLong)`
 `;
 
 const FritekstBegrunnelser = () => {
-    const { vurderErLesevisning, søkersMålform } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
     const {
         skjema,
         leggTilFritekst,
@@ -143,7 +146,7 @@ const FritekstBegrunnelser = () => {
                     </ItalicText>
                 </StyledHelpText>
                 <StyledTag variant="neutral" size="small">
-                    Skriv {målform[søkersMålform].toLowerCase()}
+                    Skriv {målform[utledSøkersMålform(behandling)].toLowerCase()}
                 </StyledTag>
             </InfoBoks>
             <Fieldset

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -1,6 +1,15 @@
 import type { PropsWithChildren } from 'react';
 import { useState, createContext, useContext, useEffect } from 'react';
 
+import { useNavigerAutomatiskTilSideForBehandlingssteg } from '@hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import type { BehandlingSteg, IBehandling } from '@typer/behandling';
+import { BehandlerRolle, BehandlingStatus, Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { harTilgangTilEnhet } from '@typer/enhet';
+import { FagsakStatus, FagsakType } from '@typer/fagsak';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '@utils/behandling';
+import { hentSideHref } from '@utils/miljø';
 import { useLocation } from 'react-router';
 
 import { type Ressurs } from '@navikt/familie-typer';
@@ -8,17 +17,6 @@ import { type Ressurs } from '@navikt/familie-typer';
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
 import useBehandlingssteg from './useBehandlingssteg';
 import { saksbehandlerHarKunLesevisning } from './utils';
-import { useNavigerAutomatiskTilSideForBehandlingssteg } from '../../../../hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
-import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
-import type { BehandlingSteg, IBehandling } from '../../../../typer/behandling';
-import { BehandlerRolle, BehandlingStatus, Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
-import { harTilgangTilEnhet } from '../../../../typer/enhet';
-import { FagsakStatus, FagsakType } from '../../../../typer/fagsak';
-import { PersonType } from '../../../../typer/person';
-import { Målform } from '../../../../typer/søknad';
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../typer/vedtaksperiode';
-import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../../../../utils/behandling';
-import { hentSideHref } from '../../../../utils/miljø';
 import { useFagsakContext } from '../../FagsakContext';
 import type { ITrinn, SideId } from '../Sider/sider';
 import { hentTrinnForBehandling, KontrollertStatus } from '../Sider/sider';
@@ -34,7 +32,6 @@ interface BehandlingContextValue {
     vurderErLesevisning: (sjekkTilgangTilEnhet?: boolean, skalIgnorereOmEnhetErMidlertidig?: boolean) => boolean;
     leggTilBesøktSide: (besøktSide: SideId) => void;
     settIkkeKontrollerteSiderTilManglerKontroll: () => void;
-    søkersMålform: Målform;
     trinnPåBehandling: { [sideId: string]: ITrinn };
     behandling: IBehandling;
     behandlingsstegSubmitressurs: Ressurs<IBehandling>;
@@ -166,9 +163,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
         );
     };
 
-    const søkersMålform: Målform =
-        behandling.personer.find(person => person.type === PersonType.SØKER)?.målform ?? Målform.NB;
-
     const kanBeslutteVedtak =
         behandling.status === BehandlingStatus.FATTER_VEDTAK &&
         BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
@@ -191,7 +185,6 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
                 vurderErLesevisning,
                 leggTilBesøktSide,
                 settIkkeKontrollerteSiderTilManglerKontroll,
-                søkersMålform,
                 trinnPåBehandling,
                 behandling: behandling,
                 behandlingsstegSubmitressurs,

--- a/src/frontend/testutils/testdata/personTestdata.ts
+++ b/src/frontend/testutils/testdata/personTestdata.ts
@@ -1,7 +1,8 @@
-import { kjønnType } from '@navikt/familie-typer';
+import { type IPersonMedAndelerTilkjentYtelse, YtelseType } from '@typer/beregning';
+import { Adressebeskyttelsegradering, type IGrunnlagPerson, type IPersonInfo, PersonType } from '@typer/person';
+import { Målform } from '@typer/søknad';
 
-import { type IPersonMedAndelerTilkjentYtelse, YtelseType } from '../../typer/beregning';
-import { Adressebeskyttelsegradering, type IPersonInfo, PersonType } from '../../typer/person';
+import { kjønnType } from '@navikt/familie-typer';
 
 export function lagPerson(person: Partial<IPersonInfo> = {}): IPersonInfo {
     return {
@@ -19,6 +20,23 @@ export function lagPerson(person: Partial<IPersonInfo> = {}): IPersonInfo {
         bostedsadresse: undefined,
         erEgenAnsatt: false,
         harFalskIdentitet: false,
+        ...person,
+    };
+}
+
+export function lagGrunnlagPerson(person: Partial<IGrunnlagPerson> = {}): IGrunnlagPerson {
+    return {
+        fødselsdato: '1995-01-01',
+        kjønn: kjønnType.MANN,
+        navn: 'Test Testersen',
+        personIdent: '12345678903',
+        registerhistorikk: undefined,
+        type: PersonType.SØKER,
+        målform: Målform.NB,
+        dødsfallDato: undefined,
+        erManueltLagtTilISøknad: false,
+        harFalskIdentitet: false,
+        skjermesForBruker: false,
         ...person,
     };
 }

--- a/src/frontend/typer/behandling.test.ts
+++ b/src/frontend/typer/behandling.test.ts
@@ -1,4 +1,7 @@
 import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { lagGrunnlagPerson } from '@testutils/testdata/personTestdata';
+import { PersonType } from '@typer/person';
+import { Målform } from '@typer/søknad';
 import { describe, expect } from 'vitest';
 
 import {
@@ -7,6 +10,7 @@ import {
     kanLeggeTilUtvidetVilkår,
     MIDLERTIDIG_BEHANDLENDE_ENHET_ID,
     sjekkErBehandleneEnhetMidlertidig,
+    utledSøkersMålform,
 } from './behandling';
 
 describe('behandling', () => {
@@ -116,6 +120,32 @@ describe('behandling', () => {
 
             // Assert
             expect(result).toBe(false);
+        });
+    });
+
+    describe('utledSøkersMålform', () => {
+        test('skal finne søkers målform', () => {
+            // Arrange
+            const behandling = lagBehandling({
+                personer: [lagGrunnlagPerson({ type: PersonType.SØKER, målform: Målform.NN })],
+            });
+
+            // Act
+            const målform = utledSøkersMålform(behandling);
+
+            // Assert
+            expect(målform).toBe(Målform.NN);
+        });
+
+        test('skal falle tilbake til NB målform hvis man ikke finner søker', () => {
+            // Arrange
+            const behandling = lagBehandling({ personer: [] });
+
+            // Act
+            const målform = utledSøkersMålform(behandling);
+
+            // Assert
+            expect(målform).toBe(Målform.NB);
         });
     });
 });

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -9,10 +9,10 @@ import type { IRestKompetanse, IRestUtenlandskPeriodeBeløp, IRestValutakurs } f
 import type { IFødselshendelsefiltreringResultat } from './fødselshendelser';
 import type { KlageResultat, KlageStatus, KlageÅrsak } from './klage';
 import type { ManglendeFinnmarkSvalbardMerking } from './ManglendeFinnmarkSvalbardMerking';
-import type { IGrunnlagPerson } from './person';
+import { type IGrunnlagPerson, PersonType } from './person';
 import type { IRestRefusjonEøs } from './refusjon-eøs';
 import type { ITilbakekreving } from './simulering';
-import type { ISøknadDTO } from './søknad';
+import { type ISøknadDTO, Målform } from './søknad';
 import type {
     Behandlingsstatus,
     TilbakekrevingsbehandlingResultat,
@@ -471,4 +471,9 @@ export function kanLeggeTilUtvidetVilkår(behandling: IBehandling) {
         behandling.årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO ||
         behandling.årsak === BehandlingÅrsak.IVERKSETTE_KA_VEDTAK
     );
+}
+
+export function utledSøkersMålform(behandling: IBehandling) {
+    const søker = behandling.personer.find(person => person.type === PersonType.SØKER);
+    return søker?.målform ?? Målform.NB;
 }


### PR DESCRIPTION
### 📮 Favro
NAV-29004

### 💰 Hva skal gjøres, og hvorfor?
Rydder i `BehandlingContext`. Fjerner `søkersMålform` og `behandlingPåVent`. Utleder det heller i komponentene som har behov for verdiene. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 