### PR TITLE
NAV-29007: Tar i bruk useErLesevisning i enkelte komponenter

### DIFF
--- a/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
+++ b/src/frontend/komponenter/PersonInformasjon/PersonInformasjon.tsx
@@ -1,12 +1,13 @@
+import { useBruker } from '@hooks/useBruker';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '@typer/person';
+import { formaterIdent, hentAlder } from '@utils/formatter';
+import { erAdresseBeskyttet } from '@utils/validators';
+
 import { BodyShort, CopyButton, Heading, HStack } from '@navikt/ds-react';
 
 import RegistrerDødsfallDatoMeny from './RegistrerDødsfallDatoMeny';
-import { useBruker } from '../../hooks/useBruker';
-import { useFagsak } from '../../hooks/useFagsak';
-import { useBehandlingContext } from '../../sider/Fagsak/Behandling/context/BehandlingContext';
-import { type IGrunnlagPerson, type IPersonInfo, personTypeMap } from '../../typer/person';
-import { formaterIdent, hentAlder } from '../../utils/formatter';
-import { erAdresseBeskyttet } from '../../utils/validators';
 import DødsfallTag from '../DødsfallTag';
 import { FalskIdentitet } from '../FalskIdentitet/FalskIdentitet';
 import { PersonIkon } from '../PersonIkon';
@@ -39,14 +40,12 @@ interface Props {
 export function PersonInformasjon({ person }: Props) {
     const fagsak = useFagsak();
     const bruker = useBruker();
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const alder = hentAlder(person.fødselsdato);
     const navnOgAlder = `${person.navn} (${alder} år)`;
     const formattertIdent = formaterIdent(person.personIdent);
     const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(bruker, person.personIdent);
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <HStack gap={'space-24'} wrap={false} align={'center'}>

--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstemaModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/EndreBehandlingstemaModal.tsx
@@ -1,18 +1,17 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
 import { FormProvider } from 'react-hook-form';
 
 import { Button, Fieldset, Modal } from '@navikt/ds-react';
 
 import { BehandlingstemaSelect } from './BehandlingstemaSelect';
 import { useEndreBehandlingstemaSkjema } from './useEndreBehandlingstemaSkjema';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 
 interface Props {
     lukkModal: () => void;
 }
 
 export const EndreBehandlingstemaModal = ({ lukkModal }: Props) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const { form, onSubmit } = useEndreBehandlingstemaSkjema({ lukkModal });
 

--- a/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandling.tsx
@@ -1,18 +1,19 @@
+import { ModalType } from '@context/ModalContext';
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useModal } from '@hooks/useModal';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { erPåHenleggbartSteg } from '@typer/behandling';
+
 import { ActionMenu } from '@navikt/ds-react';
 
-import { ModalType } from '../../../../context/ModalContext';
-import { useModal } from '../../../../hooks/useModal';
-import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import { erPåHenleggbartSteg } from '../../../../typer/behandling';
-
 export function HenleggBehandling() {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const saksbehandler = useSaksbehandler();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
     const { åpneModal } = useModal(ModalType.HENLEGG_BEHANDLING);
 
-    const saksbehandler = useSaksbehandler();
-
-    const erLesevisning = vurderErLesevisning();
     const harTilgangTilTekniskVedlikeholdHenleggelse = saksbehandler.harSuperbrukertilgang;
 
     const kanHenlegge =

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalBehandling.tsx
@@ -1,19 +1,20 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+
 import { LeggTilBrevmottakerModal } from './LeggTilBrevmottakerModal';
 import { useLagreEllerFjernMottakerPåBehandling } from './useLagreOgFjernMottakerPåBehandling';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
 
 interface IBehandlingModalProps {
     lukkModal: () => void;
 }
 
 export const LeggTilBrevmottakerModalBehandling = ({ lukkModal }: IBehandlingModalProps) => {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const { lagreMottaker, fjernMottaker } = useLagreEllerFjernMottakerPåBehandling({
         behandlingId: behandling.behandlingId,
     });
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <LeggTilBrevmottakerModal

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.tsx
@@ -1,10 +1,12 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import { Behandlingstype } from '@typer/behandling';
+import { FagsakType } from '@typer/fagsak';
+
 import { ActionMenu } from '@navikt/ds-react';
 
 import type { SkjemaBrevmottaker } from './useBrevmottakerSkjema';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
-import { Behandlingstype } from '../../../../typer/behandling';
-import { FagsakType } from '../../../../typer/fagsak';
 
 function utledLabel(brevmottakere: SkjemaBrevmottaker[], erLesevisning: boolean) {
     if (erLesevisning) {
@@ -26,8 +28,9 @@ interface Props {
 }
 
 export function LeggTilEllerFjernBrevmottakerePåBehandling({ åpneModal }: Props) {
-    const { fagsak } = useFagsakContext();
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const erInstitusjonssak = fagsak.fagsakType === FagsakType.INSTITUSJON;
     const erRelevantBehandlingstype = relevanteBehandlingstype.includes(behandling.type);
@@ -36,7 +39,6 @@ export function LeggTilEllerFjernBrevmottakerePåBehandling({ åpneModal }: Prop
         return null;
     }
 
-    const erLesevisning = vurderErLesevisning();
     const harBrevmottaker = behandling.brevmottakere.length > 0;
 
     if (erLesevisning && !harBrevmottaker) {

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
@@ -1,5 +1,24 @@
 import type { ChangeEvent } from 'react';
 
+import { ModalType } from '@context/ModalContext';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useModal } from '@hooks/useModal';
+import {
+    mutationKey,
+    useOpprettForhåndsvisbarBehandlingBrevPdf,
+} from '@hooks/useOpprettForhåndsvisbarBehandlingBrevPdf';
+import { EØS_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '@komponenter/FlaggCombobox';
+import { LeggTilBarnModal } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
+import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
+import { useSamhandlerRequest } from '@komponenter/Samhandler/useSamhandler';
+import type { IBehandling } from '@typer/behandling';
+import type { IManueltBrevRequestPåBehandling } from '@typer/dokument';
+import type { IPersonInfo } from '@typer/person';
+import { type IBarnMedOpplysninger, målform } from '@typer/søknad';
+import type { IFritekstFelt } from '@utils/fritekstfelter';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
+import { onOptionSelected } from '@utils/skjema';
+
 import { FileTextIcon, PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
 import {
     Button,
@@ -30,26 +49,9 @@ import {
     opplysningsdokumenterTilInstitusjon,
 } from './typer';
 import { useBrevModul } from './useBrevModul';
-import { ModalType } from '../../../../../context/ModalContext';
-import { useModal } from '../../../../../hooks/useModal';
-import {
-    mutationKey,
-    useOpprettForhåndsvisbarBehandlingBrevPdf,
-} from '../../../../../hooks/useOpprettForhåndsvisbarBehandlingBrevPdf';
 import BrevmottakerListe from '../../../../../komponenter/Brevmottaker/BrevmottakerListe';
 import Datovelger from '../../../../../komponenter/Datovelger/Datovelger';
-import { EØS_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '../../../../../komponenter/FlaggCombobox';
 import Knapperekke from '../../../../../komponenter/Knapperekke';
-import { LeggTilBarnModal } from '../../../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
-import { LeggTilBarnModalContextProvider } from '../../../../../komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
-import { useSamhandlerRequest } from '../../../../../komponenter/Samhandler/useSamhandler';
-import type { IBehandling } from '../../../../../typer/behandling';
-import type { IManueltBrevRequestPåBehandling } from '../../../../../typer/dokument';
-import type { IPersonInfo } from '../../../../../typer/person';
-import { type IBarnMedOpplysninger, målform } from '../../../../../typer/søknad';
-import type { IFritekstFelt } from '../../../../../utils/fritekstfelter';
-import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import { onOptionSelected } from '../../../../../utils/skjema';
 import DeltBostedSkjema from '../../../Dokumentutsending/DeltBosted/DeltBostedSkjema';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
@@ -59,7 +61,7 @@ interface IProps {
 }
 
 const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
-    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { hentOgSettSamhandler, samhandlerRessurs } = useSamhandlerRequest(true);
 
     const {
@@ -88,7 +90,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
             onMutate: () => åpneForhåndsvisOpprettingAvPdfModal({ mutationKey }),
         });
 
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const brevMaler = hentMuligeBrevMaler();
     const skjemaErLåst = skjema.submitRessurs.status === RessursStatus.HENTER || isOpprettForhåndsvisbarBrevPdfPending;
@@ -353,7 +355,7 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                                 visFeilmeldinger={skjema.visFeilmeldinger}
                                 settVisFeilmeldinger={settVisfeilmeldinger}
                                 manuelleBrevmottakere={brevmottakere}
-                                vurderErLesevisning={vurderErLesevisning}
+                                vurderErLesevisning={() => erLesevisning}
                             />
                             {!erLesevisning && <LeggTilBarnKnapp />}
                         </>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
@@ -1,6 +1,15 @@
 import type { ChangeEvent } from 'react';
 import { useEffect } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IBehandling } from '@typer/behandling';
+import type { ComboboxOption } from '@typer/common';
+import type { IEndretUtbetalingAndelÅrsak } from '@typer/utbetalingAndel';
+import { årsaker, årsakTekst } from '@typer/utbetalingAndel';
+import type { IsoMånedString } from '@utils/dato';
+import { lagPersonLabel } from '@utils/formatter';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
+import { onOptionSelected } from '@utils/skjema';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -12,15 +21,6 @@ import { type IEndretUtbetalingAndelSkjema } from './useEndretUtbetalingAndel';
 import Datovelger from '../../../../../../komponenter/Datovelger/Datovelger';
 import Knapperekke from '../../../../../../komponenter/Knapperekke';
 import MånedÅrVelger from '../../../../../../komponenter/MånedÅrInput/MånedÅrVelger';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { ComboboxOption } from '../../../../../../typer/common';
-import type { IEndretUtbetalingAndelÅrsak } from '../../../../../../typer/utbetalingAndel';
-import { årsaker, årsakTekst } from '../../../../../../typer/utbetalingAndel';
-import type { IsoMånedString } from '../../../../../../utils/dato';
-import { lagPersonLabel } from '../../../../../../utils/formatter';
-import { hentFrontendFeilmelding } from '../../../../../../utils/ressursUtils';
-import { onOptionSelected } from '../../../../../../utils/skjema';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { erUtbetalingTillattForÅrsak, Utbetaling, utbetalingTilLabel } from '../Utbetaling';
 
 const KnapperekkeVenstre = styled.div`
@@ -66,8 +66,7 @@ const EndretUtbetalingAndelSkjema = ({
     oppdaterEndretUtbetaling,
     slettEndretUtbetaling,
 }: IEndretUtbetalingAndelSkjemaProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const finnÅrTilbakeTilStønadFra = (): number => {
         return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/StatusOgBarnValutakurs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/StatusOgBarnValutakurs.tsx
@@ -1,14 +1,14 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { type IBehandling, VurderingsstrategiForValutakurser } from '@typer/behandling';
+import { type IRestValutakurs, Vurderingsform } from '@typer/eøsPerioder';
+import { mapEøsPeriodeStatusTilStatus } from '@utils/eøs';
+import { lagPersonLabel } from '@utils/formatter';
 import styled from 'styled-components';
 
 import { CogRotationIcon, PencilWritingIcon } from '@navikt/aksel-icons';
 import { BodyShort, HStack } from '@navikt/ds-react';
 
 import StatusIkon from '../../../../../../../ikoner/StatusIkon';
-import { type IBehandling, VurderingsstrategiForValutakurser } from '../../../../../../../typer/behandling';
-import { type IRestValutakurs, Vurderingsform } from '../../../../../../../typer/eøsPerioder';
-import { mapEøsPeriodeStatusTilStatus } from '../../../../../../../utils/eøs';
-import { lagPersonLabel } from '../../../../../../../utils/formatter';
-import { useBehandlingContext } from '../../../../context/BehandlingContext';
 
 const BlåPencilIcon = styled(PencilWritingIcon)`
     min-width: 1.5rem;
@@ -34,8 +34,7 @@ interface StatusProps {
 }
 
 const PeriodeStatus = ({ valutakurs, vurderingsstrategiForValutakurser }: StatusProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     if (valutakurs.vurderingsform === Vurderingsform.AUTOMATISK) {
         if (!erLesevisning && vurderingsstrategiForValutakurser === VurderingsstrategiForValutakurser.MANUELL) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { Behandlingstype, type IBehandling, VurderingsstrategiForValutakurser } from '@typer/behandling';
+import { EøsPeriodeStatus, type IRestValutakurs, Vurderingsform } from '@typer/eøsPerioder';
 import styled from 'styled-components';
 
 import {
@@ -19,13 +23,6 @@ import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import ValutakursTabellRad from './ValutakursTabellRad';
-import { useSaksbehandler } from '../../../../../../../hooks/useSaksbehandler';
-import {
-    Behandlingstype,
-    type IBehandling,
-    VurderingsstrategiForValutakurser,
-} from '../../../../../../../typer/behandling';
-import { EøsPeriodeStatus, type IRestValutakurs, Vurderingsform } from '../../../../../../../typer/eøsPerioder';
 import { useBehandlingContext } from '../../../../context/BehandlingContext';
 
 const ValutakurserContainer = styled.div`
@@ -66,17 +63,16 @@ interface IProps {
 }
 
 const Valutakurser = ({ valutakurser, erValutakurserGyldige, åpenBehandling, visFeilmeldinger }: IProps) => {
-    const { settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { settÅpenBehandling } = useBehandlingContext();
     const { request } = useHttp();
     const [erGjenopprettAutomatiskeValutakurserModalÅpen, settErGjenopprettAutomatiskeValutakurserModalÅpen] =
         useState(false);
 
     const saksbehandler = useSaksbehandler();
+    const erLesevisning = useErLesevisning();
 
     const kanOverstyreAutomatiskeValutakurser =
         åpenBehandling.type == Behandlingstype.TEKNISK_ENDRING && saksbehandler.harSuperbrukertilgang;
-
-    const erLesevisning = vurderErLesevisning();
 
     const hentNesteVurderingsstrategi = (
         vurderingsstrategiForValutakurser: VurderingsstrategiForValutakurser | null

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
@@ -1,12 +1,12 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+
 import { Heading, Textarea, VStack } from '@navikt/ds-react';
 
 import { useSøknadContext } from './SøknadContext';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 export const Annet = () => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { skjema } = useSøknadContext();
-    const lesevisning = vurderErLesevisning();
+    const lesevisning = useErLesevisning();
 
     return (
         <VStack marginBlock={'space-32'}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -1,3 +1,9 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsakId } from '@hooks/useFagsakId';
+import { BehandlingSteg, type IBehandling } from '@typer/behandling';
+import type { ITilbakekreving } from '@typer/simulering';
+import { hentSøkersMålform } from '@utils/behandling';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
 import { useNavigate } from 'react-router';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
@@ -7,16 +13,11 @@ import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 import { MigreringAlerts } from './MigreringAlerts';
 import { useSimuleringContext } from './SimuleringContext';
 import TilbakekrevingSkjema from './TilbakekrevingSkjema';
-import { useFagsakId } from '../../../../../hooks/useFagsakId';
-import { BehandlingSteg, type IBehandling } from '../../../../../typer/behandling';
-import type { ITilbakekreving } from '../../../../../typer/simulering';
-import { hentSøkersMålform } from '../../../../../utils/behandling';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 import Skjemasteg from '../Skjemasteg';
 import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
 import { TilbakekrevingsvedtakMotregning } from './UlovfestetMotregning/TilbakekrevingsvedtakMotregning';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
 
 interface ISimuleringProps {
     åpenBehandling: IBehandling;
@@ -39,12 +40,11 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
         behandlingErEndreMigreringsdato,
     } = useSimuleringContext();
 
-    const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
+    const { settÅpenBehandling } = useBehandlingContext();
 
     const fagsakId = useFagsakId();
+    const erLesevisning = useErLesevisning();
     const navigate = useNavigate();
-
-    const erLesevisning = vurderErLesevisning();
 
     const harOverlappendePerioderMedAndreFagsakerOgSkalStanses =
         !behandlingErEndreMigreringsdato &&

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/TilbakekrevingSkjema.tsx
@@ -1,3 +1,17 @@
+import { ModalType } from '@context/ModalContext';
+import { useBruker } from '@hooks/useBruker';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useModal } from '@hooks/useModal';
+import {
+    mutationKey,
+    useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf,
+} from '@hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf';
+import { BrevmottakereAlert } from '@komponenter/Brevmottaker/BrevmottakereAlert';
+import type { IBehandling } from '@typer/behandling';
+import { Tilbakekrevingsvalg, visTilbakekrevingsvalg } from '@typer/simulering';
+import type { Målform } from '@typer/søknad';
+import { målform } from '@typer/søknad';
+
 import { ExternalLinkIcon, FileTextIcon } from '@navikt/aksel-icons';
 import {
     BodyLong,
@@ -19,24 +33,11 @@ import {
     Textarea,
     VStack,
 } from '@navikt/ds-react';
-import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
+import type { Ressurs } from '@navikt/familie-typer';
 
 import { useSimuleringContext } from './SimuleringContext';
 import styles from './TilbakekrevingSkjema.module.css';
-import { ModalType } from '../../../../../context/ModalContext';
-import { useModal } from '../../../../../hooks/useModal';
-import {
-    mutationKey,
-    useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf,
-} from '../../../../../hooks/useOpprettForhåndsvisbarTilbakekrevingVarselbrevPdf';
-import { BrevmottakereAlert } from '../../../../../komponenter/Brevmottaker/BrevmottakereAlert';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { Tilbakekrevingsvalg, visTilbakekrevingsvalg } from '../../../../../typer/simulering';
-import type { Målform } from '../../../../../typer/søknad';
-import { målform } from '../../../../../typer/søknad';
-import { useBrukerContext } from '../../../BrukerContext';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const TilbakekrevingSkjema = ({
     søkerMålform,
@@ -47,7 +48,6 @@ const TilbakekrevingSkjema = ({
     harÅpenTilbakekrevingRessurs: Ressurs<boolean>;
     åpenBehandling: IBehandling;
 }) => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { tilbakekrevingSkjema, hentFeilTilOppsummering, maksLengdeTekst } = useSimuleringContext();
 
     const { åpneModal: åpneForhåndsvisOpprettingAvPdfModal } = useModal(ModalType.FORHÅNDSVIS_OPPRETTING_AV_PDF);
@@ -57,11 +57,11 @@ const TilbakekrevingSkjema = ({
             onMutate: () => åpneForhåndsvisOpprettingAvPdfModal({ mutationKey }),
         });
 
-    const { bruker } = useBrukerContext();
+    const bruker = useBruker();
+    const erLesevisning = useErLesevisning();
 
     const { fritekstVarsel, begrunnelse, tilbakekrevingsvalg } = tilbakekrevingSkjema.felter;
     const brevmottakere = åpenBehandling.brevmottakere ?? [];
-    const erLesevisning = vurderErLesevisning();
 
     const radioOnChange = (tilbakekrevingsalternativ: Tilbakekrevingsvalg) => {
         tilbakekrevingSkjema.felter.tilbakekrevingsvalg.validerOgSettFelt(tilbakekrevingsalternativ);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/endringstidspunkt/OppdaterEndringstidspunktModal.tsx
@@ -1,5 +1,9 @@
 import { useId } from 'react';
 
+import { useBehandlingId } from '@hooks/useBehandlingId';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useHentEndringstidspunkt } from '@hooks/useHentEndringstidspunkt';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
 import { FormProvider } from 'react-hook-form';
 
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
@@ -18,9 +22,6 @@ import {
 
 import { EndringstidspunktFelt } from './EndringstidspunktFelt';
 import { useEndringstidspunktForm } from './useEndringstidspunktForm';
-import { useHentEndringstidspunkt } from '../../../../../../hooks/useHentEndringstidspunkt';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const FALLBACK_ERROR_MESSAGE =
     'Systemet kan ikke hente endringstidspunktet. Prøv igjen senere eller kontakt brukerstøtte.';
@@ -34,14 +35,15 @@ interface Props {
 }
 
 export function OppdaterEndringstidspunktModal({ lukkModal }: Props) {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const behandlingId = useBehandlingId();
+    const erLesevisning = useErLesevisning();
     const hentetEndringstidspunktId = useId();
 
     const {
         data: endringstidspunkt,
         isPending: hentEndringstidspunktIsPending,
         error: hentEndringstidspunktError,
-    } = useHentEndringstidspunkt(behandling.behandlingId);
+    } = useHentEndringstidspunkt(behandlingId);
 
     const { form, onSubmit } = useEndringstidspunktForm({ lukkModal });
 
@@ -49,8 +51,6 @@ export function OppdaterEndringstidspunktModal({ lukkModal }: Props) {
         handleSubmit,
         formState: { errors, isSubmitting },
     } = form;
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <Modal

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingRadEndre.tsx
@@ -1,6 +1,11 @@
 import type { FocusEvent } from 'react';
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IBehandling } from '@typer/behandling';
+import type { IGrunnlagPerson } from '@typer/person';
+import type { IAnnenVurdering, IAnnenVurderingConfig, IPersonResultat } from '@typer/vilkår';
+import { Resultat, resultater } from '@typer/vilkår';
 import styled from 'styled-components';
 
 import { Button, Fieldset, Radio, RadioGroup, Textarea } from '@navikt/ds-react';
@@ -10,10 +15,6 @@ import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { annenVurderingBegrunnelseFeilmeldingId, annenVurderingResultatFeilmeldingId } from './AnnenVurderingTabell';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import type { IAnnenVurdering, IAnnenVurderingConfig, IPersonResultat } from '../../../../../../typer/vilkår';
-import { Resultat, resultater } from '../../../../../../typer/vilkår';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { StyledVStack } from '../GeneriskVilkår/VilkårTabellRadEndre';
 import { validerAnnenVurdering } from '../validering';
@@ -46,9 +47,9 @@ const AnnenVurderingRadEndre = ({
     settEkspandertAnnenVurdering,
 }: IProps) => {
     const { vilkårsvurdering, putAnnenVurdering, vilkårSubmit, settVilkårSubmit } = useVilkårsvurderingContext();
+    const { settÅpenBehandling } = useBehandlingContext();
 
-    const { vurderErLesevisning, settÅpenBehandling } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const [visFeilmeldingerForEttVilkår, settVisFeilmeldingerForEttVilkår] = useState(false);
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskAnnenVurdering/AnnenVurderingTabellRad.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IGrunnlagPerson } from '@typer/person';
+import type { IAnnenVurdering, IAnnenVurderingConfig } from '@typer/vilkår';
+import { Resultat, resultatVisningsnavn } from '@typer/vilkår';
 import deepEqual from 'deep-equal';
 import styled from 'styled-components';
 
@@ -10,10 +14,6 @@ import type { FeltState } from '@navikt/familie-skjema';
 import AnnenVurderingRadEndre from './AnnenVurderingRadEndre';
 import { annenVurderingFeilmeldingId } from './AnnenVurderingTabell';
 import VilkårResultatIkon from '../../../../../../ikoner/VilkårResultatIkon';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import type { IAnnenVurdering, IAnnenVurderingConfig } from '../../../../../../typer/vilkår';
-import { Resultat, resultatVisningsnavn } from '../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface IProps {
     person: IGrunnlagPerson;
@@ -53,10 +53,10 @@ const StyledPersonIcon = styled(PersonIcon)`
 `;
 
 const AnnenVurderingTabellRad = ({ person, annenVurderingConfig, visFeilmeldinger, annenVurdering }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const [ekspandertAnnenVurdering, settEkspandertAnnenVurdering] = useState(
-        vurderErLesevisning() || annenVurdering.verdi.resultat.verdi === Resultat.IKKE_VURDERT
+        erLesevisning || annenVurdering.verdi.resultat.verdi === Resultat.IKKE_VURDERT
     );
     const [redigerbartAnnenVurdering, settRedigerbartAnnenVurdering] =
         useState<FeltState<IAnnenVurdering>>(annenVurdering);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagBegrunnelseMultiselect.tsx
@@ -1,11 +1,12 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useHentAlleBegrunnelser } from '@hooks/useHentAlleBegrunnelser';
+import { type IRestVedtakBegrunnelseTilknyttetVilkår, type VedtakBegrunnelse } from '@typer/vedtak';
+import type { Regelverk, VilkårType } from '@typer/vilkår';
+import type { IIsoDatoPeriode } from '@utils/dato';
+
 import { ErrorMessage, LocalAlert, Stack, UNSAFE_Combobox } from '@navikt/ds-react';
 
 import useAvslagBegrunnelseMultiselect from './useAvslagBegrunnelseMultiselect';
-import { useHentAlleBegrunnelser } from '../../../../../../hooks/useHentAlleBegrunnelser';
-import { type IRestVedtakBegrunnelseTilknyttetVilkår, type VedtakBegrunnelse } from '../../../../../../typer/vedtak';
-import type { Regelverk, VilkårType } from '../../../../../../typer/vilkår';
-import type { IIsoDatoPeriode } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { useVilkårsvurderingContext, VilkårSubmit } from '../VilkårsvurderingContext';
 
 interface IProps {
@@ -22,9 +23,9 @@ interface IOptionType {
 }
 
 const AvslagBegrunnelseMultiselect = ({ vilkårType, begrunnelser, onChange, regelverk }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
     const { vilkårSubmit } = useVilkårsvurderingContext();
+
+    const erLesevisning = useErLesevisning();
 
     const {
         data: alleBegrunnelser,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/AvslagSkjema.tsx
@@ -1,3 +1,6 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { VedtakBegrunnelse } from '@typer/vedtak';
+import type { IVilkårResultat } from '@typer/vilkår';
 import classNames from 'classnames';
 
 import { BodyShort, Checkbox, Fieldset, VStack } from '@navikt/ds-react';
@@ -5,9 +8,6 @@ import type { FeltState } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import AvslagBegrunnelseMultiselect from './AvslagBegrunnelseMultiselect';
-import type { VedtakBegrunnelse } from '../../../../../../typer/vedtak';
-import type { IVilkårResultat } from '../../../../../../typer/vilkår';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface IProps {
     redigerbartVilkår: FeltState<IVilkårResultat>;
@@ -22,8 +22,7 @@ const AvslagSkjema = ({
     visFeilmeldinger,
     settVisFeilmeldingerForEttVilkår,
 }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     return (
         <Fieldset

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/GeneriskVilkår.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFeatureToggles } from '@hooks/useFeatureToggles';
+import { BehandlingSteg, type IBehandling } from '@typer/behandling';
+import { FeatureToggle } from '@typer/featureToggles';
+import type { IGrunnlagPerson } from '@typer/person';
+import { PersonType } from '@typer/person';
+import type { IVilkårConfig, IVilkårResultat } from '@typer/vilkår';
+import { Resultat, VilkårType } from '@typer/vilkår';
 import styled from 'styled-components';
 
 import { LightBulbFillIcon, PlusCircleIcon } from '@navikt/aksel-icons';
@@ -10,13 +18,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import FjernUtvidetBarnetrygdVilkår from './FjernUtvidetBarnetrygdVilkår';
 import VilkårTabell from './VilkårTabell';
-import { useFeatureToggles } from '../../../../../../hooks/useFeatureToggles';
-import { BehandlingSteg, type IBehandling } from '../../../../../../typer/behandling';
-import { FeatureToggle } from '../../../../../../typer/featureToggles';
-import type { IGrunnlagPerson } from '../../../../../../typer/person';
-import { PersonType } from '../../../../../../typer/person';
-import type { IVilkårConfig, IVilkårResultat } from '../../../../../../typer/vilkår';
-import { Resultat, VilkårType } from '../../../../../../typer/vilkår';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { useVilkårsvurderingContext, VilkårSubmit } from '../VilkårsvurderingContext';
 
@@ -37,10 +38,11 @@ const Container = styled.div`
 `;
 
 const GeneriskVilkår = ({ person, vilkårFraConfig, vilkårResultater, visFeilmeldinger, generiskVilkårKey }: IProps) => {
-    const toggles = useFeatureToggles();
-    const { behandling, vurderErLesevisning, settÅpenBehandling, erMigreringsbehandling } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const { behandling, settÅpenBehandling, erMigreringsbehandling } = useBehandlingContext();
     const { settVilkårSubmit, postVilkår, vilkårSubmit } = useVilkårsvurderingContext();
+
+    const toggles = useFeatureToggles();
+    const erLesevisning = useErLesevisning();
 
     const [visFeilmeldingerForVilkår, settVisFeilmeldingerForVilkår] = useState(false);
     const [feilmelding, settFeilmelding] = useState('');

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VelgPeriode.tsx
@@ -1,3 +1,8 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IVilkårResultat } from '@typer/vilkår';
+import { Resultat } from '@typer/vilkår';
+import type { IsoDatoString } from '@utils/dato';
+import { dagensDato, nyIsoDatoPeriode } from '@utils/dato';
 import { endOfMonth } from 'date-fns';
 import styled from 'styled-components';
 
@@ -7,11 +12,6 @@ import type { FeltState } from '@navikt/familie-skjema';
 
 import { vilkårPeriodeFeilmeldingId } from './VilkårTabell';
 import DatovelgerForGammelSkjemaløsning from '../../../../../../komponenter/Datovelger/DatovelgerForGammelSkjemaløsning';
-import type { IVilkårResultat } from '../../../../../../typer/vilkår';
-import { Resultat } from '../../../../../../typer/vilkår';
-import type { IsoDatoString } from '../../../../../../utils/dato';
-import { dagensDato, nyIsoDatoPeriode } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface IProps {
     redigerbartVilkår: FeltState<IVilkårResultat>;
@@ -36,8 +36,7 @@ const FlexDiv = styled.div`
 `;
 
 const VelgPeriode = ({ redigerbartVilkår, validerOgSettRedigerbartVilkår, visFeilmeldinger }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     return (
         <Fieldset

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/OppdaterRegisteropplysninger.tsx
@@ -1,10 +1,12 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useOppdaterRegisteropplysninger } from '@hooks/useOppdaterRegisteropplysninger';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+
 import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
 import { Button, Detail, ErrorMessage, HStack, VStack } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useVilkårsvurderingContext } from './VilkårsvurderingContext';
-import { useOppdaterRegisteropplysninger } from '../../../../../hooks/useOppdaterRegisteropplysninger';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const FALLBACK_MESSAGE =
@@ -22,16 +24,16 @@ function formaterTidspunkt(registeropplysningerHentetTidpsunkt: string | undefin
 }
 
 export function OppdaterRegisteropplysninger() {
-    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { vilkårsvurdering } = useVilkårsvurderingContext();
+
+    const erLesevisning = useErLesevisning();
 
     const { mutate, isPending, error } = useOppdaterRegisteropplysninger({
         onSuccess: behandling => settÅpenBehandling(byggSuksessRessurs(behandling)),
     });
 
     const registeropplysningerHentetTidpsunkt = vilkårsvurdering[0]?.person?.registerhistorikk?.hentetTidspunkt;
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <VStack gap={'space-8'}>


### PR DESCRIPTION
### 📮 Favro
NAV-29007

### 💰 Hva skal gjøres, og hvorfor?
- Tar i bruk `useErLesevisning` hooken. 
- Bytter til `useFagsak`, `useBehandling`, og `useBruker` hvor det gir mening. 
- Forenkler imports

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 