### PR TITLE
NAV-29007: Tar i bruk useErLesevisning hooken i enkelte komponenter

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -1,5 +1,25 @@
 import { type PropsWithChildren, useEffect, useState } from 'react';
 
+import { useAppContext } from '@context/AppContext';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { FalskIdentitet } from '@komponenter/FalskIdentitet/FalskIdentitet';
+import { Skillelinje } from '@komponenter/PersonInformasjon/PersonInformasjon';
+import { useTidslinjeContext } from '@komponenter/Tidslinje/TidslinjeContext';
+import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
+import type { IBehandling } from '@typer/behandling';
+import { Behandlingstype } from '@typer/behandling';
+import { ytelsetype } from '@typer/beregning';
+import type {
+    IEøsPeriodeStatus,
+    IRestEøsPeriode,
+    IRestKompetanse,
+    IRestUtenlandskPeriodeBeløp,
+    IRestValutakurs,
+} from '@typer/eøsPerioder';
+import { EøsPeriodeStatus, KompetanseResultat } from '@typer/eøsPerioder';
+import type { Utbetalingsperiode } from '@typer/vedtaksperiode';
+import { dateTilFormatertString, Datoformat } from '@utils/dato';
+import { formaterBeløp, formaterIdent, hentAlderSomString, sorterUtbetaling } from '@utils/formatter';
 import styled from 'styled-components';
 
 import { PlusCircleIcon, TrashIcon, XMarkIcon } from '@navikt/aksel-icons';
@@ -10,25 +30,6 @@ import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { kanFjerneSmåbarnstilleggFraPeriode, kanLeggeSmåbarnstilleggTilPeriode } from './OppsummeringsboksUtils';
-import { useAppContext } from '../../../../../context/AppContext';
-import { FalskIdentitet } from '../../../../../komponenter/FalskIdentitet/FalskIdentitet';
-import { Skillelinje } from '../../../../../komponenter/PersonInformasjon/PersonInformasjon';
-import { useTidslinjeContext } from '../../../../../komponenter/Tidslinje/TidslinjeContext';
-import { AlertType, ToastTyper } from '../../../../../komponenter/Toast/typer';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { Behandlingstype } from '../../../../../typer/behandling';
-import { ytelsetype } from '../../../../../typer/beregning';
-import type {
-    IEøsPeriodeStatus,
-    IRestEøsPeriode,
-    IRestKompetanse,
-    IRestUtenlandskPeriodeBeløp,
-    IRestValutakurs,
-} from '../../../../../typer/eøsPerioder';
-import { EøsPeriodeStatus, KompetanseResultat } from '../../../../../typer/eøsPerioder';
-import type { Utbetalingsperiode } from '../../../../../typer/vedtaksperiode';
-import { dateTilFormatertString, Datoformat } from '../../../../../utils/dato';
-import { formaterBeløp, formaterIdent, hentAlderSomString, sorterUtbetaling } from '../../../../../utils/formatter';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
 const UtbetalingsbeløpStack = styled(VStack)`
@@ -108,10 +109,11 @@ const Oppsummeringsboks = ({
     valutakurser,
 }: IProps) => {
     const { request } = useHttp();
-    const { settÅpenBehandling, behandling, vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { settToast } = useAppContext();
     const { settAktivEtikett } = useTidslinjeContext();
+
+    const erLesevisning = useErLesevisning();
 
     const [utbetalingsBeløpStatusMap, setUtbetalingsBeløpStatusMap] = useState(new Map<string, boolean>());
     const [restFeil, settRestFeil] = useState<string | undefined>(undefined);

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/AvregningAlert.tsx
@@ -1,14 +1,16 @@
 import { useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IAvregningsperiode } from '@typer/simulering';
+import { erProd } from '@utils/miljø';
+
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { BodyLong, Box, Button, CopyButton, Link, List, LocalAlert } from '@navikt/ds-react';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { utledTekstTilModia } from './modiaStandardtekst';
 import { SettBehandlingPåVentModalMotregning } from './SettBehandlingPåVentModalMotregning';
-import type { IAvregningsperiode } from '../../../../../../typer/simulering';
-import { erProd } from '../../../../../../utils/miljø';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface AvregningAlertProps {
     avregningsperioder: IAvregningsperiode[];
@@ -16,9 +18,10 @@ interface AvregningAlertProps {
 }
 
 const AvregningAlert = ({ avregningsperioder, harÅpenTilbakekrevingRessurs }: AvregningAlertProps) => {
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
     const [visModal, settVisModal] = useState(false);
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
-    const erLesevisning = vurderErLesevisning();
 
     const modiaPersonoversiktUrl = erProd()
         ? 'https://modiapersonoversikt.intern.nav.no'

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/TilbakekrevingsvedtakMotregning.tsx
@@ -1,3 +1,8 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { type IBehandling, SettPåVentÅrsak } from '@typer/behandling';
+import type { IAvregningsperiode } from '@typer/simulering';
+import type { TilbakekrevingsvedtakMotregningDTO } from '@typer/tilbakekrevingsvedtakMotregning';
+
 import { ArrowUndoIcon, InformationSquareIcon } from '@navikt/aksel-icons';
 import { BodyShort, Box, Button, ConfirmationPanel, Heading, InfoCard, VStack } from '@navikt/ds-react';
 import type { Ressurs } from '@navikt/familie-typer';
@@ -8,10 +13,6 @@ import {
     dagerFristForAvventerSamtykkeUlovfestetMotregning,
     useTilbakekrevingsvedtakMotregning,
 } from './useTilbakekrevingsvedtakMotregning';
-import { type IBehandling, SettPåVentÅrsak } from '../../../../../../typer/behandling';
-import type { IAvregningsperiode } from '../../../../../../typer/simulering';
-import type { TilbakekrevingsvedtakMotregningDTO } from '../../../../../../typer/tilbakekrevingsvedtakMotregning';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface TilbakekrevingsvedtakMotregningProps {
     åpenBehandling: IBehandling;
@@ -29,9 +30,7 @@ export const TilbakekrevingsvedtakMotregning = ({
     const { slettTilbakekrevingsvedtakMotregning, oppdaterTilbakekrevingsvedtakMotregning } =
         useTilbakekrevingsvedtakMotregning(åpenBehandling);
 
-    const { vurderErLesevisning } = useBehandlingContext();
-
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const erBehandlingSattPåVentMedÅrsakAvventerSamtykke =
         åpenBehandling.aktivSettPåVent?.årsak === SettPåVentÅrsak.AVVENTER_SAMTYKKE_ULOVFESTET_MOTREGNING;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
@@ -1,15 +1,15 @@
 import type { ReactNode, PropsWithChildren } from 'react';
 import { useEffect } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { BehandlingPåVentAlert } from '@komponenter/Alert/BehandlingPåVentAlert';
+import { MidlertidigEnhetAlert } from '@komponenter/Alert/MidlertidigEnhetAlert';
+import { BehandlingSteg } from '@typer/behandling';
+import { behandlingErEtterSteg } from '@utils/steg';
 import styled from 'styled-components';
 
 import { Box, Button, ErrorMessage, Heading, VStack } from '@navikt/ds-react';
-
-import { BehandlingPåVentAlert } from '../../../../komponenter/Alert/BehandlingPåVentAlert';
-import { MidlertidigEnhetAlert } from '../../../../komponenter/Alert/MidlertidigEnhetAlert';
-import { BehandlingSteg } from '../../../../typer/behandling';
-import { behandlingErEtterSteg } from '../../../../utils/steg';
-import { useBehandlingContext } from '../context/BehandlingContext';
 
 export const MAX_SKJEMASTEG_BREDDE = '1440px';
 
@@ -59,7 +59,8 @@ const Skjemasteg = ({
     skalViseForrigeKnapp = true,
     feilmelding = '',
 }: IProps) => {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     useEffect(() => {
         const skjema = document.getElementById('skjemasteg');
@@ -94,7 +95,7 @@ const Skjemasteg = ({
                     {children}
                     {feilmelding !== '' && <StyledErrorMessage>{feilmelding}</StyledErrorMessage>}
                     <Navigering>
-                        {nesteOnClick && skalViseNesteKnapp && (!vurderErLesevisning() || kanGåVidereILesevisning) && (
+                        {nesteOnClick && skalViseNesteKnapp && (!erLesevisning || kanGåVidereILesevisning) && (
                             <Button
                                 variant={'primary'}
                                 onClick={onNesteClicked}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaRad.tsx
@@ -1,29 +1,28 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IRestFeilutbetaltValuta } from '@typer/eøs-feilutbetalt-valuta';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { Table } from '@navikt/ds-react';
 
 import { FeilutbetaltValutaForm } from './form/FeilutbetaltValutaForm';
 import { Type } from './form/useFeilutbetaltValutaForm';
 import { SlettFeilutbetaltValuta } from './SlettFeilutbetaltValuta';
 import { useSlettFeilutbetaltValutaIsPending } from './useSlettFeilutbetaltValutaIsPending';
-import type { IRestFeilutbetaltValuta } from '../../../../../../typer/eøs-feilutbetalt-valuta';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
     feilutbetaltValuta: IRestFeilutbetaltValuta;
 }
 
 export function FeilutbetaltValutaRad({ feilutbetaltValuta }: Props) {
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const slettFeilutbetaltValutaIsPending = useSlettFeilutbetaltValutaIsPending({
         feilutbetaltValutaId: feilutbetaltValuta.id,
     });
 
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
-
-    const readOnly = vurderErLesevisning() || slettFeilutbetaltValutaIsPending;
 
     return (
         <Table.ExpandableRow
@@ -35,7 +34,7 @@ export function FeilutbetaltValutaRad({ feilutbetaltValuta }: Props) {
                     type={Type.OPPDATER}
                     feilutbetaltValuta={feilutbetaltValuta}
                     skjulForm={() => settErRadEkspandert(false)}
-                    readOnly={readOnly}
+                    readOnly={erLesevisning || slettFeilutbetaltValutaIsPending}
                 />
             }
         >

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabell.tsx
@@ -1,15 +1,17 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import type { IBehandling } from '@typer/behandling';
+import type { IMinimalFagsak } from '@typer/fagsak';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, CopyButton, Heading, Stack, Table } from '@navikt/ds-react';
 
 import { FeilutbetaltValutaRad } from './FeilutbetaltValutaRad';
 import { useFeilutbetaltValutaTabellContext } from './FeilutbetaltValutaTabellContext';
-import { FeilutbetaltValutaForm } from './form/FeilutbetaltValutaForm';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { IMinimalFagsak } from '../../../../../../typer/fagsak';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useFagsakContext } from '../../../../FagsakContext';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { summerBeløpForPerioder } from '../utils';
+import { FeilutbetaltValutaForm } from './form/FeilutbetaltValutaForm';
 import { Type } from './form/useFeilutbetaltValutaForm';
 import { SlettFeilutbetaltValutaError } from './SlettFeilutbetaltValutaError';
 
@@ -41,16 +43,15 @@ function lagTekstTilNøs(fagsak: IMinimalFagsak, behandling: IBehandling) {
 }
 
 export function FeilutbetaltValutaTabell() {
-    const { fagsak } = useFagsakContext();
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
-
     const {
         erLeggTilFeilutbetaltValutaFormÅpen,
         visLeggTilFeilutbetaltValutaForm,
         skjulLeggTilFeilutbetaltValutaForm,
     } = useFeilutbetaltValutaTabellContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     return (
         <Stack direction={'column'} gap={'space-20'} marginBlock={'space-48 space-48'}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValuta.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/FeilutbetaltValuta/SlettFeilutbetaltValuta.tsx
@@ -1,9 +1,11 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useSlettFeilutbetaltValuta } from '@hooks/useSlettFeilutbetaltValuta';
+
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Tooltip } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useFeilutbetaltValutaTabellContext } from './FeilutbetaltValutaTabellContext';
-import { useSlettFeilutbetaltValuta } from '../../../../../../hooks/useSlettFeilutbetaltValuta';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
@@ -11,7 +13,7 @@ interface Props {
 }
 
 export function SlettFeilutbetaltValuta({ feilutbetaltValutaId }: Props) {
-    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { erLeggTilFeilutbetaltValutaFormÅpen, skjulFeilutbetaltValutaTabell } = useFeilutbetaltValutaTabellContext();
 
     const { mutate, isPending } = useSlettFeilutbetaltValuta({
@@ -24,7 +26,7 @@ export function SlettFeilutbetaltValuta({ feilutbetaltValutaId }: Props) {
         },
     });
 
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     if (erLesevisning) {
         return null;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal.tsx
@@ -1,3 +1,8 @@
+import { ModalType } from '@context/ModalContext';
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useModal } from '@hooks/useModal';
+
 import { ArrowUndoIcon } from '@navikt/aksel-icons';
 import {
     Button,
@@ -14,12 +19,8 @@ import {
 
 import { useKorrigerEtterbetalingForm, årsaker } from './useKorrigerEtterbetalingForm';
 import { erEtterbetalingsbeløpGyldig, erÅrsakForKorrigeringGyldig } from './validering';
-import { ModalType } from '../../../../../../context/ModalContext';
-import { useModal } from '../../../../../../hooks/useModal';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 export function KorrigerEtterbetalingModal() {
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
     const {
         form,
         korrigerEtterbetaling,
@@ -28,10 +29,11 @@ export function KorrigerEtterbetalingModal() {
         angreKorrigertEtterbetalingPending,
     } = useKorrigerEtterbetalingForm();
 
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
     const { lukkModal, erModalÅpen, bredde, tittel } = useModal(ModalType.KORRIGER_ETTERBETALING);
 
     const korrigertEtterbetaling = behandling.korrigertEtterbetaling;
-    const erLesevisning = vurderErLesevisning();
 
     function handleLukkModal() {
         form.reset();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsRad.tsx
@@ -1,27 +1,26 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import type { IRestRefusjonEøs } from '@typer/refusjon-eøs';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { Table } from '@navikt/ds-react';
 
 import { RefusjonEøsForm } from './form/RefusjonEøsForm';
 import { Type } from './form/useRefusjonEøsForm';
 import { SlettRefusjonEøs } from './SlettRefusjonEøs';
 import { useSlettRefusjonEøsIsPending } from './useSlettRefusjonEøsIsPending';
-import type { IRestRefusjonEøs } from '../../../../../../typer/refusjon-eøs';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
     refusjonEøs: IRestRefusjonEøs;
 }
 
 export function RefusjonEøsRad({ refusjonEøs }: Props) {
-    const { vurderErLesevisning } = useBehandlingContext();
+    const erLesevisning = useErLesevisning();
 
     const slettRefusjonEøsIsPending = useSlettRefusjonEøsIsPending({ refusjonEøsId: refusjonEøs.id });
 
     const [erRadEkspandert, settErRadEkspandert] = useState<boolean>(false);
-
-    const readOnly = vurderErLesevisning() || slettRefusjonEøsIsPending;
 
     return (
         <Table.ExpandableRow
@@ -33,7 +32,7 @@ export function RefusjonEøsRad({ refusjonEøs }: Props) {
                     type={Type.OPPDATER}
                     refusjonEøs={refusjonEøs}
                     skjulForm={() => settErRadEkspandert(false)}
-                    readOnly={readOnly}
+                    readOnly={erLesevisning || slettRefusjonEøsIsPending}
                 />
             }
         >

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/RefusjonEøsTabell.tsx
@@ -1,3 +1,10 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import type { IBehandling } from '@typer/behandling';
+import type { IMinimalFagsak } from '@typer/fagsak';
+import { isoDatoPeriodeTilFormatertString } from '@utils/dato';
+
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, CopyButton, Heading, Stack, Table } from '@navikt/ds-react';
 
@@ -5,11 +12,6 @@ import { RefusjonEøsForm } from './form/RefusjonEøsForm';
 import { Type } from './form/useRefusjonEøsForm';
 import { RefusjonEøsRad } from './RefusjonEøsRad';
 import { useRefusjonEøsTabellContext } from './RefusjonEøsTabellContext';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { IMinimalFagsak } from '../../../../../../typer/fagsak';
-import { isoDatoPeriodeTilFormatertString } from '../../../../../../utils/dato';
-import { useFagsakContext } from '../../../../FagsakContext';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { summerTotalBeløpForPerioder } from '../utils';
 import { SlettRefusjonEøsError } from './SlettRefusjonEøsError';
 
@@ -37,12 +39,12 @@ function lagKopieringstekstTilNØS(fagsak: IMinimalFagsak, behandling: IBehandli
 }
 
 export function RefusjonEøsTabell() {
-    const { fagsak } = useFagsakContext();
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
     const { erLeggTilRefusjonEøsFormÅpen, visLeggTilRefusjonEøsForm, skjulLeggTilRefusjonEøsForm } =
         useRefusjonEøsTabellContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     return (
         <Stack direction={'column'} gap={'space-20'} marginBlock={'space-48 space-48'}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/SlettRefusjonEøs.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/RefusjonEøs/SlettRefusjonEøs.tsx
@@ -1,9 +1,11 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useSlettRefusjonEøs } from '@hooks/useSlettRefusjonEøs';
+
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Tooltip } from '@navikt/ds-react';
 import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { useRefusjonEøsTabellContext } from './RefusjonEøsTabellContext';
-import { useSlettRefusjonEøs } from '../../../../../../hooks/useSlettRefusjonEøs';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface Props {
@@ -11,7 +13,7 @@ interface Props {
 }
 
 export function SlettRefusjonEøs({ refusjonEøsId }: Props) {
-    const { behandling, settÅpenBehandling, vurderErLesevisning } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
     const { erLeggTilRefusjonEøsFormÅpen, skjulRefusjonEøsTabell } = useRefusjonEøsTabellContext();
 
     const { mutate, isPending } = useSlettRefusjonEøs({
@@ -24,7 +26,7 @@ export function SlettRefusjonEøs({ refusjonEøsId }: Props) {
         },
     });
 
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     if (erLesevisning) {
         return null;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsak.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
 import styled from 'styled-components';
 
 import { Button, ErrorMessage, LocalAlert, Textarea, VStack } from '@navikt/ds-react';
 
 import { useSammensattKontrollsakContext } from './SammensattKontrollsakContext';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 const StyledVStack = styled(VStack)`
     margin-bottom: var(--ax-space-24);
@@ -16,15 +16,14 @@ const StyledButton = styled(Button)`
 `;
 
 const SammensattKontrollsak = () => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { sammensattKontrollsak, opprettEllerOppdaterSammensattKontrollsak, feilmelding } =
         useSammensattKontrollsakContext();
+
+    const erLesevisning = useErLesevisning();
 
     const [fritekst, settFritekst] = useState<string>(sammensattKontrollsak?.fritekst ?? '');
 
     const fritekstErEndret = fritekst !== (sammensattKontrollsak?.fritekst ?? '');
-
-    const erLesevisning = vurderErLesevisning();
 
     return (
         <StyledVStack gap="space-20">

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -1,3 +1,17 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { BrevmottakereAlert } from '@komponenter/Brevmottaker/BrevmottakereAlert';
+import {
+    BehandlerRolle,
+    BehandlingResultat,
+    BehandlingStatus,
+    BehandlingSteg,
+    BehandlingÅrsak,
+    hentStegNummer,
+    type IBehandling,
+} from '@typer/behandling';
+import type { IPersonInfo } from '@typer/person';
+
 import { FileTextIcon, InformationSquareIcon } from '@navikt/aksel-icons';
 import { Box, Button, InfoCard } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -11,20 +25,7 @@ import { useSammensattKontrollsakContext } from './SammensattKontrollsak/Sammens
 import { TilbakekrevingsvedtakMotregning } from './UlovfestetMotregning/TilbakekrevingsvedtakMotregning';
 import Vedtaksperioder from './Vedtaksperioder/Vedtaksperioder';
 import useDokument from '../../../../../hooks/useDokument';
-import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
-import { BrevmottakereAlert } from '../../../../../komponenter/Brevmottaker/BrevmottakereAlert';
 import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
-import {
-    BehandlerRolle,
-    BehandlingResultat,
-    BehandlingStatus,
-    BehandlingSteg,
-    BehandlingÅrsak,
-    hentStegNummer,
-    type IBehandling,
-} from '../../../../../typer/behandling';
-import type { IPersonInfo } from '../../../../../typer/person';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 import { useTilbakekrevingsvedtakMotregning } from '../Simulering/UlovfestetMotregning/useTilbakekrevingsvedtakMotregning';
 
 interface Props {
@@ -33,7 +34,6 @@ interface Props {
 }
 
 export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
-    const { vurderErLesevisning } = useBehandlingContext();
     const { hentForhåndsvisning, nullstillDokument, visDokumentModal, hentetDokument, settVisDokumentModal } =
         useDokument();
 
@@ -45,8 +45,7 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
     const { oppdaterTilbakekrevingsvedtakMotregning } = useTilbakekrevingsvedtakMotregning(åpenBehandling);
 
     const saksbehandler = useSaksbehandler();
-
-    const erLesevisning = vurderErLesevisning();
+    const erLesevisning = useErLesevisning();
 
     const automatiskBehandlingMedFortsattInnvilgetSomResultat =
         åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && åpenBehandling.skalBehandlesAutomatisk;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksmeny/Vedtaksmeny.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import { Behandlingstype } from '@typer/behandling';
+import { BehandlingKategori } from '@typer/behandlingstema';
+import { FagsakType } from '@typer/fagsak';
+import { vedtakHarFortsattUtbetaling } from '@utils/vedtakUtils';
+
 import { ArrowUndoIcon, CalculatorIcon, ChevronDownIcon, StarsEuIcon, TasklistStartIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button, Stack } from '@navikt/ds-react';
 
 import Styles from './Vedtaksmeny.module.css';
-import { Behandlingstype } from '../../../../../../typer/behandling';
-import { BehandlingKategori } from '../../../../../../typer/behandlingstema';
-import { FagsakType } from '../../../../../../typer/fagsak';
-import { vedtakHarFortsattUtbetaling } from '../../../../../../utils/vedtakUtils';
-import { useFagsakContext } from '../../../../FagsakContext';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import EndreEndringstidspunkt from '../endringstidspunkt/EndreEndringstidspunkt';
 import { OppdaterEndringstidspunktModal } from '../endringstidspunkt/OppdaterEndringstidspunktModal';
 import { useFeilutbetaltValutaTabellContext } from '../FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
@@ -20,8 +22,6 @@ import { useRefusjonEøsTabellContext } from '../RefusjonEøs/RefusjonEøsTabell
 import { useSammensattKontrollsakContext } from '../SammensattKontrollsak/SammensattKontrollsakContext';
 
 export function Vedtaksmeny() {
-    const { fagsak } = useFagsakContext();
-    const { behandling, vurderErLesevisning } = useBehandlingContext();
     const { erFeilutbetaltValutaTabellSynlig, visFeilutbetaltValutaTabell } = useFeilutbetaltValutaTabellContext();
     const { erRefusjonEøsTabellSynlig, visRefusjonEøsTabell } = useRefusjonEøsTabellContext();
 
@@ -33,7 +33,9 @@ export function Vedtaksmeny() {
         sammensattKontrollsak,
     } = useSammensattKontrollsakContext();
 
-    const erLesevisning = vurderErLesevisning();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const visSammensattKontrollsakMenyValg = skalViseSammensattKontrollsakMenyValg();
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,22 +1,22 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useHentGenererteBrevbegrunnelser } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { useOppdaterStandardbegrunnelserMutationState } from '@hooks/useOppdaterStandardbegrunnelserMutationState';
+import { useOppdaterVedtaksperioderMedFriteksterMutationState } from '@hooks/useOppdaterVedtaksperioderMedFriteksterMutationState';
+import type { OptionType } from '@typer/common';
+import type { VedtakBegrunnelse, VedtakBegrunnelseType } from '@typer/vedtak';
+import { Standardbegrunnelse, vedtakBegrunnelseTyper } from '@typer/vedtak';
+import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
+import { finnVedtakBegrunnelseType, hentBakgrunnsfarge, hentBorderfarge } from '@utils/vedtakUtils';
 import styled from 'styled-components';
 
 import { BodyShort, Label } from '@navikt/ds-react';
-import type { ActionMeta, FormatOptionLabelMeta, GroupBase, StylesConfig } from '@navikt/familie-form-elements';
 import { FamilieReactSelect } from '@navikt/familie-form-elements';
+import type { ActionMeta, FormatOptionLabelMeta, GroupBase, StylesConfig } from '@navikt/familie-form-elements';
 
 import { mapBegrunnelserTilSelectOptions } from './utils';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
-import { useHentGenererteBrevbegrunnelser } from '../../../../../../hooks/useHentGenererteBrevbegrunnelser';
-import { useOppdaterStandardbegrunnelserMutationState } from '../../../../../../hooks/useOppdaterStandardbegrunnelserMutationState';
-import { useOppdaterVedtaksperioderMedFriteksterMutationState } from '../../../../../../hooks/useOppdaterVedtaksperioderMedFriteksterMutationState';
-import type { OptionType } from '../../../../../../typer/common';
-import type { VedtakBegrunnelse, VedtakBegrunnelseType } from '../../../../../../typer/vedtak';
-import { Standardbegrunnelse, vedtakBegrunnelseTyper } from '../../../../../../typer/vedtak';
-import { Vedtaksperiodetype } from '../../../../../../typer/vedtaksperiode';
-import { finnVedtakBegrunnelseType, hentBakgrunnsfarge, hentBorderfarge } from '../../../../../../utils/vedtakUtils';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { useAlleBegrunnelserContext } from '../AlleBegrunnelserContext';
 
 interface IProps {
@@ -28,8 +28,8 @@ const GroupLabel = styled.div`
 `;
 
 const BegrunnelserMultiselect = ({ vedtaksperiodetype }: IProps) => {
-    const { vurderErLesevisning } = useBehandlingContext();
-    const skalIkkeEditeres = vurderErLesevisning() || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
+    const erLesevisning = useErLesevisning();
+    const skalIkkeEditeres = erLesevisning || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
 
     const { alleBegrunnelser } = useAlleBegrunnelserContext();
     const { id, onChangeBegrunnelse, grupperteBegrunnelser, vedtaksperiodeMedBegrunnelser } =


### PR DESCRIPTION
### 📮 Favro
NAV-29007

### 💰 Hva skal gjøres, og hvorfor?
- Tar i bruk `useErLesevisning` hooken. 
- Bytter til `useFagsak`, `useBehandling`, og `useBruker` hvor det gir mening. 
- Forenkler imports

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 