### PR TITLE
Retter opp i visning av skjermet barn i frontend

### DIFF
--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonInformasjonUtbetaling.tsx
@@ -24,8 +24,9 @@ export function PersonInformasjonUtbetaling({ person }: Props) {
     const fagsak = useFagsak();
     const bruker = useBruker();
 
+    const personSkalSkjermesForBruker = person.skjermesForBruker;
     const alder = hentAlder(person.fødselsdato);
-    const navnOgAlder = `${person.navn} (${alder} år)`;
+    const navnOgAlder = personSkalSkjermesForBruker ? person.navn : `${person.navn} (${alder} år)`;
     const formattertIdent = formaterIdent(person.personIdent);
 
     const erAdresseBeskyttet = hentAdresseBeskyttelseGradering(bruker, person.personIdent);
@@ -42,11 +43,15 @@ export function PersonInformasjonUtbetaling({ person }: Props) {
             <BodyShort className={'navn'} title={navnOgAlder}>
                 {navnOgAlder}
             </BodyShort>
-            <BodyShort>|</BodyShort>
-            <HStack gap={'space-4'} wrap={false} align={'center'}>
-                <BodyShort>{formattertIdent}</BodyShort>
-                <CopyButton size={'small'} copyText={person.personIdent} />
-            </HStack>
+            {!personSkalSkjermesForBruker && (
+                <>
+                    <BodyShort>|</BodyShort>
+                    <HStack gap={'space-4'} wrap={false} align={'center'}>
+                        <BodyShort>{formattertIdent}</BodyShort>
+                        <CopyButton size={'small'} copyText={person.personIdent} />
+                    </HStack>
+                </>
+            )}
             <BodyShort>|</BodyShort>
             <BodyShort>{`${personTypeMap[person.type]}`}</BodyShort>
         </HStack>

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -22,8 +22,14 @@ interface IPersonUtbetalingProps {
 }
 
 const PersonUtbetaling = ({ utbetalingsperiodeDetaljer }: IPersonUtbetalingProps) => {
-    const genererTekstForOrdinær = (fødselsdato: string) =>
-        hentAlder(fødselsdato) < 6 ? 'Ordinær (under 6 år)' : 'Ordinær (fra 6 år)';
+    const genererTekstForOrdinær = (utbetalingsperiodeDetalj: IUtbetalingsperiodeDetalj) => {
+        if (utbetalingsperiodeDetalj.person.skjermesForBruker) {
+            return ytelsetype[utbetalingsperiodeDetalj.ytelseType].navn;
+        }
+        return hentAlder(utbetalingsperiodeDetalj.person.fødselsdato) < 6
+            ? 'Ordinær (under 6 år)'
+            : 'Ordinær (fra 6 år)';
+    };
 
     return (
         <section>
@@ -34,7 +40,7 @@ const PersonUtbetaling = ({ utbetalingsperiodeDetaljer }: IPersonUtbetalingProps
                         <Ytelselinje justify="space-between" key={utbetalingsperiodeDetalj.person.personIdent}>
                             <BodyShort>
                                 {utbetalingsperiodeDetalj.ytelseType === YtelseType.ORDINÆR_BARNETRYGD
-                                    ? genererTekstForOrdinær(utbetalingsperiodeDetalj.person.fødselsdato)
+                                    ? genererTekstForOrdinær(utbetalingsperiodeDetalj)
                                     : ytelsetype[utbetalingsperiodeDetalj.ytelseType].navn}
                             </BodyShort>
                             <BodyShort>{formaterBeløp(utbetalingsperiodeDetalj.utbetaltPerMnd)}</BodyShort>


### PR DESCRIPTION
### 📮 Favro: Nav-28984

### 💰 Hva skal gjøres, og hvorfor?
Vi må rette opp i visningen av skjermet barn i frontend.
Når vi anonymiserer barnet i backend så setter vi anonymisert fødselsdato så vi må ikke vise det i frontend.

Før
<img width="759" height="293" alt="image (6)" src="https://github.com/user-attachments/assets/16125e2d-b1b8-4dcc-899d-d4e6816bbe9b" />

Etter
<img width="1045" height="466" alt="Screenshot 2026-05-08 at 13 14 04" src="https://github.com/user-attachments/assets/2b3fce32-c408-4407-ac4c-3af75b96d69b" />

