### PR TITLE
Fikser person ikon for skjermet barn fagsaker

### DIFF
--- a/src/frontend/komponenter/Personlinje/Personlinje.test.ts
+++ b/src/frontend/komponenter/Personlinje/Personlinje.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+
+import { utledAdressebeskyttelseGradering } from './Personlinje';
+import { lagPerson } from '../../testutils/testdata/personTestdata';
+import { FagsakType } from '../../typer/fagsak';
+import { Adressebeskyttelsegradering } from '../../typer/person';
+
+describe('utledAdressebeskyttelseGradering', () => {
+    test('skal bruke barns gradering når fagsakType er SKJERMET_BARN', () => {
+        const barn = lagPerson({
+            adressebeskyttelseGradering: Adressebeskyttelsegradering.STRENGT_FORTROLIG,
+        });
+        const søkerData = lagPerson({
+            adressebeskyttelseGradering: Adressebeskyttelsegradering.UGRADERT,
+        });
+
+        const resultat = utledAdressebeskyttelseGradering(FagsakType.SKJERMET_BARN, barn, søkerData);
+
+        expect(resultat).toBe(Adressebeskyttelsegradering.STRENGT_FORTROLIG);
+    });
+
+    test('skal bruke søkers gradering når fagsakType er NORMAL', () => {
+        const barn = lagPerson({
+            adressebeskyttelseGradering: Adressebeskyttelsegradering.UGRADERT,
+        });
+        const søkerData = lagPerson({
+            adressebeskyttelseGradering: Adressebeskyttelsegradering.FORTROLIG,
+        });
+
+        const resultat = utledAdressebeskyttelseGradering(FagsakType.NORMAL, barn, søkerData);
+
+        expect(resultat).toBe(Adressebeskyttelsegradering.FORTROLIG);
+    });
+});

--- a/src/frontend/komponenter/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Personlinje/Personlinje.tsx
@@ -54,6 +54,12 @@ function utledSøker(fagsak?: IMinimalFagsak, søkerData?: IPersonInfo) {
     return undefined;
 }
 
+export const utledAdressebeskyttelseGradering = (
+    fagsakType?: FagsakType,
+    bruker?: IPersonInfo,
+    søkerData?: IPersonInfo
+) => (fagsakType === FagsakType.SKJERMET_BARN ? bruker : søkerData)?.adressebeskyttelseGradering;
+
 interface Props {
     bruker?: IPersonInfo;
     fagsak?: IMinimalFagsak;
@@ -76,7 +82,9 @@ export function Personlinje({ bruker, fagsak }: Props) {
                         fagsakType={fagsak?.fagsakType}
                         kjønn={fagsakeier.kjønn}
                         erBarn={fagsakeier.alder < 18}
-                        erAdresseBeskyttet={erAdresseBeskyttet(søkerData?.adressebeskyttelseGradering)}
+                        erAdresseBeskyttet={erAdresseBeskyttet(
+                            utledAdressebeskyttelseGradering(fagsak?.fagsakType, bruker, søkerData)
+                        )}
                         erEgenAnsatt={fagsakeier.erEgenAnsatt}
                     />
                     <HStack align={'center'} gap={'space-12 space-16'}>


### PR DESCRIPTION
### 📮 Favro: Nav-29046

### 💰 Hva skal gjøres, og hvorfor?
I skjermet barn saker så har vanligvis søker ikke diskresjonskode, men barnet.
Det vises derfor fram feil ikon i disse sakene fordi vi bruker søker sin diskresjonskode for å sette farge på ikonet.

FØR:
<img width="1051" height="692" alt="image (7)" src="https://github.com/user-attachments/assets/f455f15d-2e5e-45cc-b955-61bd2f08a2de" />

ETTER:
<img width="1207" height="744" alt="Screenshot 2026-05-11 at 10 27 52" src="https://github.com/user-attachments/assets/af81d215-28d5-4578-a04e-f99d571f8a8d" />
