### PR TITLE
NAV-27893: Forbedrer logikk rundt genererte brevbegrunnelser

### DIFF
--- a/src/frontend/hooks/useHentGenererteBrevbegrunnelser.ts
+++ b/src/frontend/hooks/useHentGenererteBrevbegrunnelser.ts
@@ -1,22 +1,20 @@
+import { hentGenererteBrevbegrunnelser } from '@api/hentGenererteBrevbegrunnelser';
 import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
 import { useHttp } from '@navikt/familie-http';
-
-import { hentGenererteBrevbegrunnelser } from '../api/hentGenererteBrevbegrunnelser';
 
 export const HentGenererteBrevbegrunnelserQueryKeyFactory = {
     vedtaksperiode: (vedtaksperiodeId: number) => ['genererteBrevbegrunnelser', vedtaksperiodeId],
 };
 
-type Options = Omit<UseQueryOptions<string[], DefaultError, string[]>, 'queryKey' | 'queryFn' | 'gcTime'> & {
-    vedtaksperiodeId: number;
-};
+type Options = Omit<UseQueryOptions<string[], DefaultError, string[]>, 'queryKey' | 'queryFn' | 'select'>;
 
-export function useHentGenererteBrevbegrunnelser({ vedtaksperiodeId, ...options }: Options) {
+export function useHentGenererteBrevbegrunnelser(vedtaksperiodeId: number, options?: Options) {
     const { request } = useHttp();
     return useQuery({
         queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(vedtaksperiodeId),
         queryFn: () => hentGenererteBrevbegrunnelser(request, vedtaksperiodeId),
+        select: data => data.toSorted(),
         ...options,
     });
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -23,7 +23,7 @@ import { useRefusjonEøsTabellContext } from './RefusjonEøs/RefusjonEøsTabellC
 import SammensattKontrollsak from './SammensattKontrollsak/SammensattKontrollsak';
 import { useSammensattKontrollsakContext } from './SammensattKontrollsak/SammensattKontrollsakContext';
 import { TilbakekrevingsvedtakMotregning } from './UlovfestetMotregning/TilbakekrevingsvedtakMotregning';
-import Vedtaksperioder from './Vedtaksperioder/Vedtaksperioder';
+import { Vedtaksperioder } from './Vedtaksperioder/Vedtaksperioder';
 import useDokument from '../../../../../hooks/useDokument';
 import PdfVisningModal from '../../../../../komponenter/PdfVisningModal/PdfVisningModal';
 import { useTilbakekrevingsvedtakMotregning } from '../Simulering/UlovfestetMotregning/useTilbakekrevingsvedtakMotregning';
@@ -159,7 +159,7 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
                             <SammensattKontrollsak />
                         ) : (
                             <>
-                                <Vedtaksperioder åpenBehandling={åpenBehandling} />
+                                <Vedtaksperioder />
                                 {erFeilutbetaltValutaTabellSynlig && <FeilutbetaltValutaTabell />}
                                 {erRefusjonEøsTabellSynlig && <RefusjonEøsTabell />}
                             </>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -19,25 +19,29 @@ import { mapBegrunnelserTilSelectOptions } from './utils';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
 import { useAlleBegrunnelserContext } from '../AlleBegrunnelserContext';
 
-interface IProps {
-    vedtaksperiodetype: Vedtaksperiodetype;
-}
-
 const GroupLabel = styled.div`
     color: black;
 `;
 
-const BegrunnelserMultiselect = ({ vedtaksperiodetype }: IProps) => {
-    const erLesevisning = useErLesevisning();
-    const skalIkkeEditeres = erLesevisning || vedtaksperiodetype === Vedtaksperiodetype.AVSLAG;
+const enkeltverdierSomKanSettesAutomatisk = [
+    'Standardbegrunnelse$INNVILGET_SATSENDRING',
+    Standardbegrunnelse.REDUKSJON_SATSENDRING,
+    Standardbegrunnelse.REDUKSJON_UNDER_6_ÅR,
+    Standardbegrunnelse.REDUKSJON_UNDER_18_ÅR,
+];
 
+export function BegrunnelserMultiselect() {
+    const { vedtaksperiodeMedBegrunnelser, onChangeBegrunnelse, grupperteBegrunnelser } = useVedtaksperiodeContext();
     const { alleBegrunnelser } = useAlleBegrunnelserContext();
-    const { id, onChangeBegrunnelse, grupperteBegrunnelser, vedtaksperiodeMedBegrunnelser } =
-        useVedtaksperiodeContext();
-    const { data: genererteBrevbegrunnelser } = useHentGenererteBrevbegrunnelser({
-        vedtaksperiodeId: vedtaksperiodeMedBegrunnelser.id,
-    });
+
+    const {
+        data: genererteBrevbegrunnelser,
+        isPending: genererteBrevbegrunnelserIsPending,
+        error: genererteBrevbegrunnelserError,
+    } = useHentGenererteBrevbegrunnelser(vedtaksperiodeMedBegrunnelser.id);
+
     const [standardbegrunnelser, settStandardbegrunnelser] = useState<OptionType[]>([]);
+
     const oppdaterStandardbegrunnelserMutation = useOppdaterStandardbegrunnelserMutationState(
         vedtaksperiodeMedBegrunnelser.id
     );
@@ -45,36 +49,30 @@ const BegrunnelserMultiselect = ({ vedtaksperiodetype }: IProps) => {
         vedtaksperiodeMedBegrunnelser.id
     );
 
+    const erLesevisning = useErLesevisning();
+
+    const skalIkkeEditeres = erLesevisning || vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.AVSLAG;
+
     const skalAutomatiskUtfylle = useRef(!skalIkkeEditeres);
-    const enkeltverdierSomKanSettesAutomatisk = [
-        'Standardbegrunnelse$INNVILGET_SATSENDRING',
-        Standardbegrunnelse.REDUKSJON_SATSENDRING,
-        Standardbegrunnelse.REDUKSJON_UNDER_6_ÅR,
-        Standardbegrunnelse.REDUKSJON_UNDER_18_ÅR,
-    ];
 
     useEffect(() => {
         settStandardbegrunnelser(mapBegrunnelserTilSelectOptions(vedtaksperiodeMedBegrunnelser, alleBegrunnelser));
     }, [vedtaksperiodeMedBegrunnelser, alleBegrunnelser]);
 
     useEffect(() => {
-        if (!skalAutomatiskUtfylle.current) {
+        if (!skalAutomatiskUtfylle.current || genererteBrevbegrunnelser === undefined) {
             return;
         }
-        if (genererteBrevbegrunnelser !== undefined) {
-            const valgmuligheter = grupperteBegrunnelser.flatMap(gruppe => gruppe.options);
-            if (
-                genererteBrevbegrunnelser.length === 0 &&
-                valgmuligheter.length === 1 &&
-                enkeltverdierSomKanSettesAutomatisk.includes(valgmuligheter[0].value)
-            ) {
-                onChangeBegrunnelse({
-                    action: 'select-option',
-                    option: valgmuligheter[0],
-                });
-            }
-        } else {
-            return;
+        const valgmuligheter = grupperteBegrunnelser.flatMap(gruppe => gruppe.options);
+        if (
+            genererteBrevbegrunnelser.length === 0 &&
+            valgmuligheter.length === 1 &&
+            enkeltverdierSomKanSettesAutomatisk.includes(valgmuligheter[0].value)
+        ) {
+            onChangeBegrunnelse({
+                action: 'select-option',
+                option: valgmuligheter[0],
+            });
         }
         skalAutomatiskUtfylle.current = false;
     }, [genererteBrevbegrunnelser, grupperteBegrunnelser]);
@@ -111,18 +109,25 @@ const BegrunnelserMultiselect = ({ vedtaksperiodetype }: IProps) => {
 
     return (
         <FamilieReactSelect
-            id={`${id}`}
+            id={`${vedtaksperiodeMedBegrunnelser.id}`}
             value={standardbegrunnelser}
             propSelectStyles={propSelectStyles}
             placeholder={'Velg begrunnelse(r)'}
+            isLoading={
+                oppdaterVedtaksperioderMedFriteksterMutation?.status === 'pending' ||
+                oppdaterStandardbegrunnelserMutation?.status === 'pending' ||
+                genererteBrevbegrunnelserIsPending
+            }
             isDisabled={
                 skalIkkeEditeres ||
                 oppdaterVedtaksperioderMedFriteksterMutation?.status === 'pending' ||
-                oppdaterStandardbegrunnelserMutation?.status === 'pending'
+                oppdaterStandardbegrunnelserMutation?.status === 'pending' ||
+                genererteBrevbegrunnelserIsPending
             }
             feil={
                 oppdaterVedtaksperioderMedFriteksterMutation?.error?.message ??
-                oppdaterStandardbegrunnelserMutation?.error?.message
+                oppdaterStandardbegrunnelserMutation?.error?.message ??
+                genererteBrevbegrunnelserError?.message
             }
             label="Velg standardtekst i brev"
             creatable={false}
@@ -159,6 +164,4 @@ const BegrunnelserMultiselect = ({ vedtaksperiodetype }: IProps) => {
             options={grupperteBegrunnelser}
         />
     );
-};
-
-export default BegrunnelserMultiselect;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
@@ -1,22 +1,13 @@
 import type { PropsWithChildren } from 'react';
 
+import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
+import { hentVedtaksperiodeTittel, Vedtaksperiodetype } from '@typer/vedtaksperiode';
+import { dagensDato, isoDatoPeriodeTilFormatertString, isoStringTilDateMedFallback, tidenesEnde } from '@utils/dato';
+import { formaterBeløp, summer } from '@utils/formatter';
 import { endOfMonth, isAfter } from 'date-fns';
 import styled from 'styled-components';
 
 import { BodyShort, Label, ExpansionCard } from '@navikt/ds-react';
-
-import {
-    hentVedtaksperiodeTittel,
-    Vedtaksperiodetype,
-    type IVedtaksperiodeMedBegrunnelser,
-} from '../../../../../../typer/vedtaksperiode';
-import {
-    dagensDato,
-    isoDatoPeriodeTilFormatertString,
-    isoStringTilDateMedFallback,
-    tidenesEnde,
-} from '../../../../../../utils/dato';
-import { formaterBeløp, summer } from '../../../../../../utils/formatter';
 
 const StyledExpansionCard = styled(ExpansionCard)`
     margin-bottom: 1rem;
@@ -38,25 +29,17 @@ const StyledExpansionContent = styled(ExpansionCard.Content)`
     overflow: visible;
 `;
 
-interface EkspanderbarVedtaksperiodeProps extends PropsWithChildren {
-    vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
-    åpen: boolean;
-    onClick?: () => void;
-}
-
 const slutterSenereEnnInneværendeMåned = (tom?: string) =>
     isAfter(isoStringTilDateMedFallback({ isoString: tom, fallbackDate: tidenesEnde }), endOfMonth(dagensDato));
 
-const EkspanderbarVedtaksperiode = ({
-    vedtaksperiodeMedBegrunnelser,
-    åpen,
-    onClick,
-    children,
-}: EkspanderbarVedtaksperiodeProps) => {
+export function EkspanderbarVedtaksperiode({ children }: PropsWithChildren) {
+    const { vedtaksperiodeMedBegrunnelser, erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
+
     const periode = {
         fom: vedtaksperiodeMedBegrunnelser.fom,
         tom: vedtaksperiodeMedBegrunnelser.tom,
     };
+
     const skalViseSum =
         (vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.UTBETALING ||
             vedtaksperiodeMedBegrunnelser.type ===
@@ -72,7 +55,12 @@ const EkspanderbarVedtaksperiode = ({
     const tittel = hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser);
 
     return (
-        <StyledExpansionCard open={åpen} onToggle={onClick} size="small" aria-label="Begrunnelser">
+        <StyledExpansionCard
+            open={erPanelEkspandert}
+            onToggle={() => onPanelClose(true)}
+            size="small"
+            aria-label="Begrunnelser"
+        >
             <StyledExpansionHeader>
                 <StyledExpansionTitle>
                     {periode.fom && (
@@ -90,6 +78,4 @@ const EkspanderbarVedtaksperiode = ({
             <StyledExpansionContent>{children}</StyledExpansionContent>
         </StyledExpansionCard>
     );
-};
-
-export default EkspanderbarVedtaksperiode;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/FritekstBegrunnelser.tsx
@@ -68,10 +68,7 @@ const ItalicText = styled(BodyLong)`
     font-style: italic;
 `;
 
-const FritekstBegrunnelser = () => {
-    const behandling = useBehandling();
-    const erLesevisning = useErLesevisning();
-
+export function FritekstBegrunnelser() {
     const {
         skjema,
         leggTilFritekst,
@@ -81,6 +78,9 @@ const FritekstBegrunnelser = () => {
         putVedtaksperiodeMedFritekster,
         vedtaksperiodeMedBegrunnelser,
     } = useVedtaksperiodeContext();
+
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
 
     const erMaksAntallKulepunkter = skjema.felter.fritekster.verdi.length >= maksAntallKulepunkter;
 
@@ -238,6 +238,4 @@ const FritekstBegrunnelser = () => {
             )}
         </FritekstContainer>
     );
-};
-
-export default FritekstBegrunnelser;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
@@ -50,7 +50,7 @@ export function GenererteBrevbegrunnelser() {
         <VStack gap={'space-0'}>
             <Label>Begrunnelse(r)</Label>
             <ul>
-                {(genererteBrevbegrunnelser ?? []).map((begrunnelse, index) => (
+                {genererteBrevbegrunnelser.map((begrunnelse, index) => (
                     <li key={`begrunnelse-${index}`}>
                         <BodyShort>{begrunnelse}</BodyShort>
                     </li>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
@@ -1,0 +1,61 @@
+import { useHentGenererteBrevbegrunnelser } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
+
+import { BodyShort, ErrorMessage, HStack, Label, Loader, VStack } from '@navikt/ds-react';
+
+export function GenererteBrevbegrunnelser() {
+    const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
+
+    const {
+        data: genererteBrevbegrunnelser,
+        isPending: genererteBrevbegrunnelserIsPending,
+        error: genererteBrevbegrunnelserError,
+    } = useHentGenererteBrevbegrunnelser(vedtaksperiodeMedBegrunnelser.id);
+
+    if (genererteBrevbegrunnelserIsPending) {
+        return (
+            <VStack gap={'space-4'}>
+                <Label>Begrunnelse(r)</Label>
+                <HStack gap={'space-6'}>
+                    <Loader size={'xsmall'} />
+                    <BodyShort textColor={'subtle'} size={'small'}>
+                        Laster begrunnelse(r)...
+                    </BodyShort>
+                </HStack>
+            </VStack>
+        );
+    }
+
+    if (genererteBrevbegrunnelserError) {
+        return (
+            <VStack gap={'space-4'}>
+                <Label>Begrunnelse(r)</Label>
+                <ErrorMessage size={'small'}>{genererteBrevbegrunnelserError.message}</ErrorMessage>
+            </VStack>
+        );
+    }
+
+    if (genererteBrevbegrunnelser.length === 0) {
+        return (
+            <VStack gap={'space-4'}>
+                <Label>Begrunnelse(r)</Label>
+                <BodyShort textColor={'subtle'} size={'small'}>
+                    Ingen begrunnelse(r).
+                </BodyShort>
+            </VStack>
+        );
+    }
+
+    return (
+        <VStack gap={'space-0'}>
+            <Label>Begrunnelse(r)</Label>
+            <ul>
+                {(genererteBrevbegrunnelser ?? []).map((begrunnelse, index) => (
+                    <li key={`begrunnelse-${index}`}>
+                        <BodyShort>{begrunnelse}</BodyShort>
+                    </li>
+                ))}
+            </ul>
+        </VStack>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Utbetalingsresultat.tsx
@@ -1,41 +1,19 @@
-import styled from 'styled-components';
+import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
+import { formaterIdent, formaterBeløp, sorterUtbetaling } from '@utils/formatter';
 
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, HStack, Label, VStack } from '@navikt/ds-react';
 
-import type { IUtbetalingsperiodeDetalj } from '../../../../../../typer/vedtaksperiode';
-import { formaterIdent, formaterBeløp, sorterUtbetaling } from '../../../../../../utils/formatter';
-
-interface IProps {
-    utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
-}
-
-const UtbetalingsperiodeDetalj = styled.div`
-    display: flex;
-    flex-direction: row;
-
-    p + p {
-        margin-left: 1.5rem;
-    }
-`;
-
-const Utbetalingsresultat = ({ utbetalingsperiodeDetaljer }: IProps) => {
-    if (utbetalingsperiodeDetaljer.length === 0) return null;
-
+export function Utbetalingsresultat() {
+    const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
     return (
-        <div style={{ marginBottom: '1rem' }}>
+        <VStack gap={'space-4'}>
             <Label>Resultat</Label>
-
-            {utbetalingsperiodeDetaljer
-                .sort(sorterUtbetaling)
-                .map((detalj: IUtbetalingsperiodeDetalj, index: number) => (
-                    <UtbetalingsperiodeDetalj key={`${index}_${detalj.person.fødselsdato}`}>
-                        <BodyShort title={detalj.person.navn}>{formaterIdent(detalj.person.personIdent)}</BodyShort>
-
-                        <BodyShort>{formaterBeløp(detalj.utbetaltPerMnd)}</BodyShort>
-                    </UtbetalingsperiodeDetalj>
-                ))}
-        </div>
+            {vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.sort(sorterUtbetaling).map((detalj, index) => (
+                <HStack key={`${index}_${detalj.person.fødselsdato}`} gap={'space-28'}>
+                    <BodyShort title={detalj.person.navn}>{formaterIdent(detalj.person.personIdent)}</BodyShort>
+                    <BodyShort>{formaterBeløp(detalj.utbetaltPerMnd)}</BodyShort>
+                </HStack>
+            ))}
+        </VStack>
     );
-};
-
-export default Utbetalingsresultat;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
@@ -1,25 +1,17 @@
-import { BodyShort, ErrorMessage, Label } from '@navikt/ds-react';
+import { GenererteBrevbegrunnelser } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser';
+import { Standardbegrunnelse, VedtakBegrunnelseType } from '@typer/vedtak';
+import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
 
-import BegrunnelserMultiselect from './BegrunnelserMultiselect';
-import EkspanderbarVedtaksperiode from './EkspanderbarVedtaksperiode';
-import FritekstBegrunnelser from './FritekstBegrunnelser';
-import Utbetalingsresultat from './Utbetalingsresultat';
+import { VStack } from '@navikt/ds-react';
+
+import { BegrunnelserMultiselect } from './BegrunnelserMultiselect';
+import { EkspanderbarVedtaksperiode } from './EkspanderbarVedtaksperiode';
+import { FritekstBegrunnelser } from './FritekstBegrunnelser';
+import { Utbetalingsresultat } from './Utbetalingsresultat';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
-import { useHentGenererteBrevbegrunnelser } from '../../../../../../hooks/useHentGenererteBrevbegrunnelser';
-import { Standardbegrunnelse, VedtakBegrunnelseType } from '../../../../../../typer/vedtak';
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
-import { Vedtaksperiodetype } from '../../../../../../typer/vedtaksperiode';
 
-interface IProps {
-    vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
-}
-
-const Vedtaksperiode = ({ vedtaksperiodeMedBegrunnelser }: IProps) => {
-    const { erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
-
-    const { data: genererteBrevbegrunnelser, error: genererteBrevbegrunnelserError } = useHentGenererteBrevbegrunnelser(
-        { vedtaksperiodeId: vedtaksperiodeMedBegrunnelser.id }
-    );
+export function Vedtaksperiode() {
+    const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
 
     const ugyldigeReduksjonsteksterForÅTriggeFritekst = [
         Standardbegrunnelse.REDUKSJON_SATSENDRING,
@@ -53,36 +45,17 @@ const Vedtaksperiode = ({ vedtaksperiodeMedBegrunnelser }: IProps) => {
         ).length > 0;
 
     return (
-        <EkspanderbarVedtaksperiode
-            vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
-            åpen={erPanelEkspandert}
-            onClick={() => onPanelClose(true)}
-        >
-            <Utbetalingsresultat
-                utbetalingsperiodeDetaljer={vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer}
-            />
-            {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && (
-                <BegrunnelserMultiselect vedtaksperiodetype={vedtaksperiodeMedBegrunnelser.type} />
-            )}
-            {genererteBrevbegrunnelserError ? (
-                <ErrorMessage>{genererteBrevbegrunnelserError.message}</ErrorMessage>
-            ) : (
-                genererteBrevbegrunnelser &&
-                genererteBrevbegrunnelser.length > 0 && (
-                    <>
-                        <Label>Begrunnelse(r)</Label>
-                        <ul>
-                            {genererteBrevbegrunnelser.map((begrunnelse: string, index: number) => (
-                                <li key={`begrunnelse-${index}`}>
-                                    <BodyShort children={begrunnelse} />
-                                </li>
-                            ))}
-                        </ul>
-                    </>
-                )
-            )}
-            {visFritekster() && <FritekstBegrunnelser />}
+        <EkspanderbarVedtaksperiode>
+            <VStack gap={'space-20'}>
+                {vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.length !== 0 && <Utbetalingsresultat />}
+                {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && <BegrunnelserMultiselect />}
+                <GenererteBrevbegrunnelser />
+                {visFritekster() && (
+                    <div>
+                        <FritekstBegrunnelser />
+                    </div>
+                )}
+            </VStack>
         </EkspanderbarVedtaksperiode>
     );
-};
-export default Vedtaksperiode;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
@@ -87,6 +87,7 @@ export function VedtaksperiodeProvider({ vedtaksperiodeMedBegrunnelser, children
                     HentVedtaksperioderQueryKeyFactory.behandling(behandling.behandlingId),
                     vedtaksperioderMedBegrunnelser
                 );
+                onPanelClose(false);
             },
         }
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
@@ -1,32 +1,33 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
+import { useOppdaterStandardbegrunnelser } from '@hooks/useOppdaterStandardbegrunnelser';
+import { useOppdaterVedtaksperiodeMedFritekster } from '@hooks/useOppdaterVedtaksperiodeMedFritekster';
 import { useQueryClient } from '@tanstack/react-query';
+import { Behandlingstype } from '@typer/behandling';
+import type { OptionType } from '@typer/common';
+import type { VedtakBegrunnelse } from '@typer/vedtak';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+import type { IIsoDatoPeriode } from '@utils/dato';
+import type { IFritekstFelt } from '@utils/fritekstfelter';
+import { genererIdBasertPåAndreFritekstKulepunkter, lagInitiellFritekst } from '@utils/fritekstfelter';
 import deepEqual from 'deep-equal';
 
 import type { ActionMeta, GroupBase } from '@navikt/familie-form-elements';
-import type { FeltState, ISkjema } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
+import type { FeltState, ISkjema } from '@navikt/familie-skjema';
 
 import { grupperBegrunnelser } from './utils';
-import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '../../../../../../hooks/useHentGenererteBrevbegrunnelser';
-import { HentVedtaksperioderQueryKeyFactory } from '../../../../../../hooks/useHentVedtaksperioder';
-import { useOppdaterStandardbegrunnelser } from '../../../../../../hooks/useOppdaterStandardbegrunnelser';
-import { useOppdaterVedtaksperiodeMedFritekster } from '../../../../../../hooks/useOppdaterVedtaksperiodeMedFritekster';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import { Behandlingstype } from '../../../../../../typer/behandling';
-import type { OptionType } from '../../../../../../typer/common';
-import type { VedtakBegrunnelse } from '../../../../../../typer/vedtak';
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
-import type { IIsoDatoPeriode } from '../../../../../../utils/dato';
-import type { IFritekstFelt } from '../../../../../../utils/fritekstfelter';
-import { genererIdBasertPåAndreFritekstKulepunkter, lagInitiellFritekst } from '../../../../../../utils/fritekstfelter';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
 import { useAlleBegrunnelserContext } from '../AlleBegrunnelserContext';
 
-interface IProps extends PropsWithChildren {
+const maksAntallKulepunkter = 3;
+const makslengdeFritekst = 350;
+
+interface Props extends PropsWithChildren {
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
-    åpenBehandling: IBehandling;
 }
 
 interface BegrunnelserSkjema {
@@ -37,7 +38,6 @@ interface BegrunnelserSkjema {
 interface VedtaksperiodeContextValue {
     erPanelEkspandert: boolean;
     grupperteBegrunnelser: GroupBase<OptionType>[];
-    id: number;
     leggTilFritekst: () => void;
     maksAntallKulepunkter: number;
     makslengdeFritekst: number;
@@ -46,30 +46,29 @@ interface VedtaksperiodeContextValue {
     putVedtaksperiodeMedFritekster: () => void;
     skjema: ISkjema<BegrunnelserSkjema, IVedtaksperiodeMedBegrunnelser[]>;
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
-    åpenBehandling: IBehandling;
 }
 
 const VedtaksperiodeContext = createContext<VedtaksperiodeContextValue | undefined>(undefined);
 
-export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegrunnelser, children }: IProps) => {
+export function VedtaksperiodeProvider({ vedtaksperiodeMedBegrunnelser, children }: Props) {
     const { alleBegrunnelser } = useAlleBegrunnelserContext();
+
+    const behandling = useBehandling();
     const queryClient = useQueryClient();
 
-    const behandlingId = useBehandlingContext().behandling.behandlingId;
-
     const [erPanelEkspandert, settErPanelEkspandert] = useState(
-        åpenBehandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING &&
+        behandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING &&
             vedtaksperiodeMedBegrunnelser.begrunnelser.length === 0 &&
             vedtaksperiodeMedBegrunnelser.fritekster.length === 0
     );
 
     const { mutate: oppdaterStandardbegrunnelser } = useOppdaterStandardbegrunnelser(vedtaksperiodeMedBegrunnelser.id, {
-        onSuccess: vedtaksperioderMedBegrunnelser => {
-            queryClient.invalidateQueries({
+        onSuccess: async vedtaksperioderMedBegrunnelser => {
+            await queryClient.invalidateQueries({
                 queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(vedtaksperiodeMedBegrunnelser.id),
             });
             queryClient.setQueryData(
-                HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
+                HentVedtaksperioderQueryKeyFactory.behandling(behandling.behandlingId),
                 vedtaksperioderMedBegrunnelser
             );
         },
@@ -78,23 +77,19 @@ export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegru
     const { mutate: oppdaterVedtaksperiodeMedFritekster } = useOppdaterVedtaksperiodeMedFritekster(
         vedtaksperiodeMedBegrunnelser.id,
         {
-            onSuccess: vedtaksperioderMedBegrunnelser => {
-                queryClient.invalidateQueries({
+            onSuccess: async vedtaksperioderMedBegrunnelser => {
+                await queryClient.invalidateQueries({
                     queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(
                         vedtaksperiodeMedBegrunnelser.id
                     ),
                 });
                 queryClient.setQueryData(
-                    HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
+                    HentVedtaksperioderQueryKeyFactory.behandling(behandling.behandlingId),
                     vedtaksperioderMedBegrunnelser
                 );
-                onPanelClose(false);
             },
         }
     );
-
-    const maksAntallKulepunkter = 3;
-    const makslengdeFritekst = 350;
 
     const periode = useFelt<IIsoDatoPeriode>({
         verdi: {
@@ -222,7 +217,6 @@ export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegru
             value={{
                 erPanelEkspandert,
                 grupperteBegrunnelser: grupperBegrunnelser(vedtaksperiodeMedBegrunnelser, alleBegrunnelser),
-                id: vedtaksperiodeMedBegrunnelser.id,
                 vedtaksperiodeMedBegrunnelser,
                 leggTilFritekst,
                 maksAntallKulepunkter,
@@ -231,19 +225,17 @@ export const VedtaksperiodeProvider = ({ åpenBehandling, vedtaksperiodeMedBegru
                 onPanelClose,
                 putVedtaksperiodeMedFritekster,
                 skjema,
-                åpenBehandling,
             }}
         >
             {children}
         </VedtaksperiodeContext.Provider>
     );
-};
+}
 
-export const useVedtaksperiodeContext = () => {
+export function useVedtaksperiodeContext() {
     const context = useContext(VedtaksperiodeContext);
-
     if (context === undefined) {
         throw new Error('useVedtaksperiodeContext må brukes inne i en VedtaksperiodeProvider');
     }
     return context;
-};
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -1,34 +1,29 @@
 import { Fragment } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
+import { partition } from '@utils/commons';
 import styled from 'styled-components';
 
 import { Heading } from '@navikt/ds-react';
 
 import { filtrerOgSorterPerioderMedBegrunnelseBehov } from './utils';
-import Vedtaksperiode from './Vedtaksperiode';
+import { Vedtaksperiode } from './Vedtaksperiode';
 import { VedtaksperiodeProvider } from './VedtaksperiodeContext';
 import { useVedtaksperioderContext } from './VedtaksperioderContext';
-import type { IBehandling } from '../../../../../../typer/behandling';
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
-import { Vedtaksperiodetype } from '../../../../../../typer/vedtaksperiode';
-import { partition } from '../../../../../../utils/commons';
 
 const StyledHeading = styled(Heading)`
     display: flex;
     margin-top: 1rem;
 `;
 
-interface VedtaksperioderProps {
-    åpenBehandling: IBehandling;
-}
-
-const Vedtaksperioder = ({ åpenBehandling }: VedtaksperioderProps) => {
+export function Vedtaksperioder() {
     const { vedtaksperioder } = useVedtaksperioderContext();
 
-    const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(
-        vedtaksperioder,
-        åpenBehandling.status
-    );
+    const behandling = useBehandling();
+
+    const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(vedtaksperioder, behandling.status);
 
     const avslagOgResterende = partition(
         vedtaksperiode =>
@@ -41,27 +36,23 @@ const Vedtaksperioder = ({ åpenBehandling }: VedtaksperioderProps) => {
             <GrupperteVedtaksperioder
                 vedtaksperioderMedBegrunnelser={avslagOgResterende[1]}
                 overskrift={'Begrunnelser i vedtaksbrev'}
-                åpenBehandling={åpenBehandling}
             />
             <GrupperteVedtaksperioder
                 vedtaksperioderMedBegrunnelser={avslagOgResterende[0]}
                 overskrift={'Generelle avslagsbegrunnelser'}
-                åpenBehandling={åpenBehandling}
             />
         </>
     ) : (
         <Fragment />
     );
-};
+}
 
 const GrupperteVedtaksperioder = ({
     vedtaksperioderMedBegrunnelser,
     overskrift,
-    åpenBehandling,
 }: {
     vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     overskrift: string;
-    åpenBehandling: IBehandling;
 }) => {
     if (vedtaksperioderMedBegrunnelser.length === 0) {
         return <></>;
@@ -72,17 +63,14 @@ const GrupperteVedtaksperioder = ({
             <StyledHeading level="2" size="small" spacing>
                 {overskrift}
             </StyledHeading>
-            {vedtaksperioderMedBegrunnelser.map((vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser) => (
+            {vedtaksperioderMedBegrunnelser.map(vedtaksperiodeMedBegrunnelser => (
                 <VedtaksperiodeProvider
                     key={vedtaksperiodeMedBegrunnelser.id}
-                    åpenBehandling={åpenBehandling}
                     vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
                 >
-                    <Vedtaksperiode vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser} />
+                    <Vedtaksperiode />
                 </VedtaksperiodeProvider>
             ))}
         </>
     );
 };
-
-export default Vedtaksperioder;


### PR DESCRIPTION
### 📮 Favro
NAV-27893

### 💰 Hva skal gjøres, og hvorfor?
Forbedrer tilstandshåndtering rundt henting av vedtaksperiode genererte begrunnelser. Gjør også listen stabil ved å sortere den slik at `useEffect` hooks som lytter på listen ikke blir trigget hvis rekkefølgen endrer seg. Rydder også generelt bare opp i koden en del. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ingen tidligere tester, legger dem ikke til nå. 

### 👀 Screen shots
Før:

https://github.com/user-attachments/assets/048bf831-4914-4e41-8089-60c02545b1d1

Etter:

https://github.com/user-attachments/assets/6b677149-cef5-4cfa-ad72-5a0ef3abc1ba

