### PR TITLE
Legg til Lås opp fagsak modal

### DIFF
--- a/src/frontend/api/låsOppFagsak.ts
+++ b/src/frontend/api/låsOppFagsak.ts
@@ -1,0 +1,19 @@
+import type { IMinimalFagsak } from '@typer/fagsak';
+
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface LåsOppFagsakPayload {
+    begrunnelse: string;
+}
+
+export async function låsOppFagsak(request: FamilieRequest, fagsakId: number, payload: LåsOppFagsakPayload) {
+    const ressurs = await request<LåsOppFagsakPayload, IMinimalFagsak>({
+        data: payload,
+        method: 'PATCH',
+        url: `/familie-ba-sak/api/fagsaker/${fagsakId}/laas-opp`,
+        påvirkerSystemLaster: false,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/context/ModalContext.tsx
+++ b/src/frontend/context/ModalContext.tsx
@@ -23,6 +23,7 @@ export enum ModalType {
     FEILMELDING = 'FEILMELDING',
     KORRIGER_ETTERBETALING = 'KORRIGER_ETTERBETALING',
     FORHÅNDSVIS_OPPRETTING_AV_PDF = 'FORHÅNDSVIS_OPPRETTING_AV_PDF',
+    LAAS_OPP_FAGSAK = 'LAAS_OPP_FAGSAK',
 }
 
 export interface Args {
@@ -76,6 +77,11 @@ const initialState: State = {
         tittel: 'Korriger etterbetaling',
         åpen: false,
         bredde: '35rem',
+    },
+    [ModalType.LAAS_OPP_FAGSAK]: {
+        tittel: 'Lås opp fagsak',
+        åpen: false,
+        bredde: '37rem',
     },
 };
 

--- a/src/frontend/hooks/useLåsOppFagsak.ts
+++ b/src/frontend/hooks/useLåsOppFagsak.ts
@@ -1,8 +1,9 @@
-import { låsOppFagsak, type LåsOppFagsakPayload } from '@api/låsOppFagsak';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IMinimalFagsak } from '@typer/fagsak';
 
 import { useHttp } from '@navikt/familie-http';
+
+import { låsOppFagsak, type LåsOppFagsakPayload } from '../api/låsOppFagsak';
+import type { IMinimalFagsak } from '../typer/fagsak';
 
 interface Parameters extends LåsOppFagsakPayload {
     fagsakId: number;

--- a/src/frontend/hooks/useLåsOppFagsak.ts
+++ b/src/frontend/hooks/useLåsOppFagsak.ts
@@ -1,0 +1,22 @@
+import { låsOppFagsak, type LåsOppFagsakPayload } from '@api/låsOppFagsak';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IMinimalFagsak } from '@typer/fagsak';
+
+import { useHttp } from '@navikt/familie-http';
+
+interface Parameters extends LåsOppFagsakPayload {
+    fagsakId: number;
+}
+
+type Options = Omit<UseMutationOptions<IMinimalFagsak, DefaultError, Parameters>, 'mutationFn'>;
+
+export function useLåsOppFagsak(options?: Options) {
+    const { request } = useHttp();
+    return useMutation({
+        mutationFn: (parameters: Parameters) => {
+            const { fagsakId, begrunnelse } = parameters;
+            return låsOppFagsak(request, fagsakId, { begrunnelse });
+        },
+        ...options,
+    });
+}

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.test.tsx
@@ -12,7 +12,6 @@ import { lagPerson } from '../../testutils/testdata/personTestdata';
 import { lagSaksbehandler } from '../../testutils/testdata/saksbehandlerTestdata';
 import { render, TestProviders } from '../../testutils/testrender';
 import type { IMinimalFagsak } from '../../typer/fagsak';
-import { FagsakStatus } from '../../typer/fagsak';
 import type { IPersonInfo } from '../../typer/person';
 import type { Saksbehandler } from '../../typer/saksbehandler';
 
@@ -100,15 +99,6 @@ describe('Fagsaklinje', () => {
 
         expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Dokumenter' })).toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: 'Meny' })).not.toBeInTheDocument();
-    });
-
-    test('skal ikke vise meny hvis fagsaken er låst', async () => {
-        const { screen } = render(<Fagsaklinje />, {
-            wrapper: props => <Wrapper {...props} fagsak={lagFagsak({ status: FagsakStatus.LÅST })} />,
-        });
-
-        expect(screen.getByRole('button', { name: 'Saksoversikt' })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Meny' })).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
+++ b/src/frontend/komponenter/Saklinje/Fagsaklinje.tsx
@@ -6,7 +6,6 @@ import { Box, Button, HStack } from '@navikt/ds-react';
 import { Fagsakmeny } from './Meny/Fagsakmeny';
 import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 import { useFagsakContext } from '../../sider/Fagsak/FagsakContext';
-import { FagsakStatus } from '../../typer/fagsak';
 
 function lagAktivFaneStyle(fanenavn: string, pathname: string) {
     const urlSplit = pathname.split('/');
@@ -54,7 +53,7 @@ export function Fagsaklinje() {
                         Dokumenter
                     </Button>
                 </HStack>
-                {saksbehandler.harSkrivetilgang && fagsak.status !== FagsakStatus.LÅST && <Fagsakmeny />}
+                {saksbehandler.harSkrivetilgang && <Fagsakmeny />}
             </HStack>
         </Box>
     );

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
@@ -6,13 +6,20 @@ import { ActionMenu, Button } from '@navikt/ds-react';
 import Styles from './Fagsakmeny.module.css';
 import { LeggTilBrevmottakerModalFagsak } from './LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModalFagsak';
 import { LeggTilEllerFjernBrevmottakerePåFagsak } from './LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåFagsak';
+import { LåsOppFagsak } from './LåsOppFagsak/LåsOppFagsak';
+import { LåsOppFagsakModal } from './LåsOppFagsak/LåsOppFagsakModal';
 import { OpprettBehandling } from './OpprettBehandling/OpprettBehandling';
 import { OpprettBehandlingModal } from './OpprettBehandling/OpprettBehandlingModal';
 import { TilbakekrevingsbehandlingOpprettetModal } from './OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal';
 import { OpprettFagsak } from './OpprettFagsak/OpprettFagsak';
 import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
+import { useFagsakContext } from '../../../sider/Fagsak/FagsakContext';
+import { FagsakStatus } from '../../../typer/fagsak';
 
 export function Fagsakmeny() {
+    const { fagsak } = useFagsakContext();
+    const fagsakErLåst = fagsak.status === FagsakStatus.LÅST;
+
     const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
     const [visTilbakekrevingsbehandlingOpprettetModal, settVisTilbakekrevingsbehandlingOpprettetModal] =
         useState(false);
@@ -34,6 +41,7 @@ export function Fagsakmeny() {
             {visLeggTilBrevmottakerModal && (
                 <LeggTilBrevmottakerModalFagsak lukkModal={() => settVisLeggTilBrevmottakerModal(false)} />
             )}
+            <LåsOppFagsakModal />
             <ActionMenu>
                 <ActionMenu.Trigger>
                     <Button variant={'secondary'} size={'small'} iconPosition={'right'} icon={<ChevronDownIcon />}>
@@ -42,12 +50,17 @@ export function Fagsakmeny() {
                 </ActionMenu.Trigger>
                 <ActionMenu.Content>
                     <ActionMenu.Group className={Styles.group} aria-label={'Fagsak'}>
-                        <OpprettBehandling åpneModal={() => settVisOpprettBehandlingModal(true)} />
-                        <OpprettFagsak />
-                        <LeggTilEllerFjernBrevmottakerePåFagsak
-                            åpneModal={() => settVisLeggTilBrevmottakerModal(true)}
-                        />
-                        <SendInformasjonsbrev />
+                        {!fagsakErLåst && (
+                            <>
+                                <OpprettBehandling åpneModal={() => settVisOpprettBehandlingModal(true)} />
+                                <OpprettFagsak />
+                                <LeggTilEllerFjernBrevmottakerePåFagsak
+                                    åpneModal={() => settVisLeggTilBrevmottakerModal(true)}
+                                />
+                                <SendInformasjonsbrev />
+                            </>
+                        )}
+                        {fagsakErLåst && <LåsOppFagsak />}
                     </ActionMenu.Group>
                 </ActionMenu.Content>
             </ActionMenu>

--- a/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Fagsakmeny.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 
+import { useFagsak } from '@hooks/useFagsak';
+import { FagsakStatus } from '@typer/fagsak';
+
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { ActionMenu, Button } from '@navikt/ds-react';
 
@@ -13,11 +16,9 @@ import { OpprettBehandlingModal } from './OpprettBehandling/OpprettBehandlingMod
 import { TilbakekrevingsbehandlingOpprettetModal } from './OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal';
 import { OpprettFagsak } from './OpprettFagsak/OpprettFagsak';
 import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbrev';
-import { useFagsakContext } from '../../../sider/Fagsak/FagsakContext';
-import { FagsakStatus } from '../../../typer/fagsak';
 
 export function Fagsakmeny() {
-    const { fagsak } = useFagsakContext();
+    const fagsak = useFagsak();
     const fagsakErLåst = fagsak.status === FagsakStatus.LÅST;
 
     const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsak.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsak.tsx
@@ -1,0 +1,10 @@
+import { ModalType } from '@context/ModalContext';
+import { useModal } from '@hooks/useModal';
+
+import { ActionMenu } from '@navikt/ds-react';
+
+export function LåsOppFagsak() {
+    const { åpneModal } = useModal(ModalType.LAAS_OPP_FAGSAK);
+
+    return <ActionMenu.Item onSelect={() => åpneModal()}>Lås opp fagsak</ActionMenu.Item>;
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
@@ -1,0 +1,111 @@
+import { ModalType } from '@context/ModalContext';
+import { useModal } from '@hooks/useModal';
+import { FormProvider, useController, useFormContext } from 'react-hook-form';
+
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { Button, Fieldset, InfoCard, Modal, Textarea, VStack } from '@navikt/ds-react';
+
+import {
+    LAAS_OPP_FAGSAK_FORM_ID,
+    LåsOppFagsakFormFields,
+    type LåsOppFagsakFormValues,
+    LåsOppFagsakServerErrors,
+    useLåsOppFagsakForm,
+} from './useLåsOppFagsakForm';
+
+export function LåsOppFagsakModal() {
+    const { erModalÅpen, tittel, lukkModal, bredde } = useModal(ModalType.LAAS_OPP_FAGSAK);
+    return (
+        <Modal
+            open={erModalÅpen}
+            width={bredde}
+            onClose={lukkModal}
+            header={{ heading: tittel, size: 'medium' }}
+            portal={true}
+        >
+            {erModalÅpen && <Innhold />}
+        </Modal>
+    );
+}
+
+function Innhold() {
+    const { lukkModal } = useModal(ModalType.LAAS_OPP_FAGSAK);
+    const { form, onSubmit } = useLåsOppFagsakForm();
+
+    const {
+        handleSubmit,
+        formState: { errors },
+    } = form;
+
+    const submitError = LåsOppFagsakServerErrors.onSubmitError.lookup(errors);
+
+    return (
+        <>
+            <Modal.Body>
+                <VStack gap={'space-16'}>
+                    <InfoCard data-color="info">
+                        <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
+                            Skriv en begrunnelse som forklarer hvorfor fagsaken låses opp. Merk at fagsaken vil låses
+                            ned igjen etter en periode dersom det ikke opprettes en ny behandling.
+                        </InfoCard.Message>
+                    </InfoCard>
+                    <FormProvider {...form}>
+                        <form id={LAAS_OPP_FAGSAK_FORM_ID} onSubmit={handleSubmit(onSubmit)}>
+                            <Fieldset legend={'Lås opp fagsak'} hideLegend={true} error={submitError}>
+                                <BegrunnelseFelt />
+                            </Fieldset>
+                        </form>
+                    </FormProvider>
+                </VStack>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button
+                    form={LAAS_OPP_FAGSAK_FORM_ID}
+                    variant={'primary'}
+                    size={'small'}
+                    type={'submit'}
+                    loading={form.formState.isSubmitting}
+                >
+                    Bekreft
+                </Button>
+                <Button
+                    variant={'tertiary'}
+                    size={'small'}
+                    onClick={() => lukkModal()}
+                    disabled={form.formState.isSubmitting}
+                >
+                    Avbryt
+                </Button>
+            </Modal.Footer>
+        </>
+    );
+}
+
+function BegrunnelseFelt() {
+    const { control } = useFormContext<LåsOppFagsakFormValues>();
+
+    const { field, fieldState, formState } = useController({
+        name: LåsOppFagsakFormFields.BEGRUNNELSE,
+        control,
+        rules: {
+            validate: verdi => {
+                if (verdi.trim().length < 5) {
+                    return 'Skriv en begrunnelse med minst 5 tegn.';
+                }
+            },
+        },
+    });
+
+    return (
+        <Textarea
+            label={'Begrunnelse'}
+            maxLength={4000}
+            value={field.value}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={fieldState.error?.message}
+            readOnly={formState.isSubmitting}
+            disabled={formState.isSubmitting}
+        />
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
@@ -89,8 +89,12 @@ function BegrunnelseFelt() {
         control,
         rules: {
             validate: verdi => {
-                if (verdi.trim().length < 5) {
+                const trimmed = verdi.trim();
+                if (trimmed.length < 5) {
                     return 'Skriv en begrunnelse med minst 5 tegn.';
+                }
+                if (trimmed.length > 4000) {
+                    return 'Begrunnelsen kan ikke være lengre enn 4000 tegn.';
                 }
             },
         },
@@ -104,7 +108,6 @@ function BegrunnelseFelt() {
             onBlur={field.onBlur}
             onChange={field.onChange}
             error={fieldState.error?.message}
-            readOnly={formState.isSubmitting}
             disabled={formState.isSubmitting}
         />
     );

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/LåsOppFagsakModal.tsx
@@ -9,7 +9,6 @@ import {
     LAAS_OPP_FAGSAK_FORM_ID,
     LåsOppFagsakFormFields,
     type LåsOppFagsakFormValues,
-    LåsOppFagsakServerErrors,
     useLåsOppFagsakForm,
 } from './useLåsOppFagsakForm';
 
@@ -34,11 +33,8 @@ function Innhold() {
 
     const {
         handleSubmit,
-        formState: { errors },
+        formState: { isSubmitting, errors },
     } = form;
-
-    const submitError = LåsOppFagsakServerErrors.onSubmitError.lookup(errors);
-
     return (
         <>
             <Modal.Body>
@@ -51,7 +47,7 @@ function Innhold() {
                     </InfoCard>
                     <FormProvider {...form}>
                         <form id={LAAS_OPP_FAGSAK_FORM_ID} onSubmit={handleSubmit(onSubmit)}>
-                            <Fieldset legend={'Lås opp fagsak'} hideLegend={true} error={submitError}>
+                            <Fieldset legend={'Lås opp fagsak'} hideLegend={true} error={errors?.root?.message}>
                                 <BegrunnelseFelt />
                             </Fieldset>
                         </form>
@@ -64,16 +60,11 @@ function Innhold() {
                     variant={'primary'}
                     size={'small'}
                     type={'submit'}
-                    loading={form.formState.isSubmitting}
+                    loading={isSubmitting}
                 >
                     Bekreft
                 </Button>
-                <Button
-                    variant={'tertiary'}
-                    size={'small'}
-                    onClick={() => lukkModal()}
-                    disabled={form.formState.isSubmitting}
-                >
+                <Button variant={'tertiary'} size={'small'} onClick={() => lukkModal()} disabled={isSubmitting}>
                     Avbryt
                 </Button>
             </Modal.Footer>
@@ -84,7 +75,11 @@ function Innhold() {
 function BegrunnelseFelt() {
     const { control } = useFormContext<LåsOppFagsakFormValues>();
 
-    const { field, fieldState, formState } = useController({
+    const {
+        field: { value, onBlur, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
         name: LåsOppFagsakFormFields.BEGRUNNELSE,
         control,
         rules: {
@@ -104,11 +99,11 @@ function BegrunnelseFelt() {
         <Textarea
             label={'Begrunnelse'}
             maxLength={4000}
-            value={field.value}
-            onBlur={field.onBlur}
-            onChange={field.onChange}
-            error={fieldState.error?.message}
-            disabled={formState.isSubmitting}
+            value={value}
+            onBlur={onBlur}
+            onChange={onChange}
+            error={error?.message}
+            disabled={isSubmitting}
         />
     );
 }

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
@@ -1,0 +1,58 @@
+import { ModalType } from '@context/ModalContext';
+import { useLåsOppFagsak } from '@hooks/useLåsOppFagsak';
+import { useModal } from '@hooks/useModal';
+import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
+import { type FieldErrors, useForm } from 'react-hook-form';
+
+export const LåsOppFagsakServerErrors: Record<
+    'onSubmitError',
+    {
+        id: `root.${string}`;
+        lookup: (errors: FieldErrors<LåsOppFagsakFormValues>) => string | undefined;
+    }
+> = {
+    onSubmitError: {
+        id: 'root.onSubmitError',
+        lookup: errors => errors?.root?.onSubmitError?.message,
+    },
+};
+
+export enum LåsOppFagsakFormFields {
+    BEGRUNNELSE = 'begrunnelse',
+}
+
+export interface LåsOppFagsakFormValues {
+    [LåsOppFagsakFormFields.BEGRUNNELSE]: string;
+}
+
+export const LAAS_OPP_FAGSAK_FORM_ID = 'laas_opp_fagsak_modal_form';
+
+export function useLåsOppFagsakForm() {
+    const { fagsak } = useFagsakContext();
+    const { lukkModal } = useModal(ModalType.LAAS_OPP_FAGSAK);
+    const { mutateAsync } = useLåsOppFagsak();
+
+    const form = useForm<LåsOppFagsakFormValues>({
+        defaultValues: {
+            [LåsOppFagsakFormFields.BEGRUNNELSE]: '',
+        },
+    });
+
+    const { setError } = form;
+
+    async function onSubmit(values: LåsOppFagsakFormValues) {
+        const { begrunnelse } = values;
+        return mutateAsync({ fagsakId: fagsak.id, begrunnelse: begrunnelse.trim() })
+            .then(() => {
+                lukkModal();
+                window.location.reload();
+            })
+            .catch(error =>
+                setError(LåsOppFagsakServerErrors.onSubmitError.id, {
+                    message: error.message ?? 'En feil oppstod.',
+                })
+            );
+    }
+
+    return { form, onSubmit };
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
@@ -1,24 +1,10 @@
 import { ModalType } from '@context/ModalContext';
+import { useFagsak } from '@hooks/useFagsak';
+import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
 import { useLåsOppFagsak } from '@hooks/useLåsOppFagsak';
 import { useModal } from '@hooks/useModal';
-import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
 import { useQueryClient } from '@tanstack/react-query';
-import { type FieldErrors, useForm } from 'react-hook-form';
-
-import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
-
-export const LåsOppFagsakServerErrors: Record<
-    'onSubmitError',
-    {
-        id: `root.${string}`;
-        lookup: (errors: FieldErrors<LåsOppFagsakFormValues>) => string | undefined;
-    }
-> = {
-    onSubmitError: {
-        id: 'root.onSubmitError',
-        lookup: errors => errors?.root?.onSubmitError?.message,
-    },
-};
+import { useForm } from 'react-hook-form';
 
 export enum LåsOppFagsakFormFields {
     BEGRUNNELSE = 'begrunnelse',
@@ -31,7 +17,7 @@ export interface LåsOppFagsakFormValues {
 export const LAAS_OPP_FAGSAK_FORM_ID = 'laas_opp_fagsak_modal_form';
 
 export function useLåsOppFagsakForm() {
-    const { fagsak } = useFagsakContext();
+    const fagsak = useFagsak();
     const { lukkModal } = useModal(ModalType.LAAS_OPP_FAGSAK);
     const { mutateAsync } = useLåsOppFagsak();
     const queryClient = useQueryClient();
@@ -47,14 +33,14 @@ export function useLåsOppFagsakForm() {
     async function onSubmit(values: LåsOppFagsakFormValues) {
         const { begrunnelse } = values;
         return mutateAsync({ fagsakId: fagsak.id, begrunnelse: begrunnelse.trim() })
-            .then(() => {
-                lukkModal();
-                queryClient.invalidateQueries({
+            .then(async () => {
+                await queryClient.invalidateQueries({
                     queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
                 });
+                lukkModal();
             })
             .catch(error =>
-                setError(LåsOppFagsakServerErrors.onSubmitError.id, {
+                setError('root', {
                     message: error.message ?? 'En feil oppstod.',
                 })
             );

--- a/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LåsOppFagsak/useLåsOppFagsakForm.ts
@@ -2,7 +2,10 @@ import { ModalType } from '@context/ModalContext';
 import { useLåsOppFagsak } from '@hooks/useLåsOppFagsak';
 import { useModal } from '@hooks/useModal';
 import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
+import { useQueryClient } from '@tanstack/react-query';
 import { type FieldErrors, useForm } from 'react-hook-form';
+
+import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
 
 export const LåsOppFagsakServerErrors: Record<
     'onSubmitError',
@@ -31,6 +34,7 @@ export function useLåsOppFagsakForm() {
     const { fagsak } = useFagsakContext();
     const { lukkModal } = useModal(ModalType.LAAS_OPP_FAGSAK);
     const { mutateAsync } = useLåsOppFagsak();
+    const queryClient = useQueryClient();
 
     const form = useForm<LåsOppFagsakFormValues>({
         defaultValues: {
@@ -45,7 +49,9 @@ export function useLåsOppFagsakForm() {
         return mutateAsync({ fagsakId: fagsak.id, begrunnelse: begrunnelse.trim() })
             .then(() => {
                 lukkModal();
-                window.location.reload();
+                queryClient.invalidateQueries({
+                    queryKey: HentFagsakQueryKeyFactory.fagsak(fagsak.id),
+                });
             })
             .catch(error =>
                 setError(LåsOppFagsakServerErrors.onSubmitError.id, {


### PR DESCRIPTION
### 📮 Favro: Nav-29111
Backend PR: https://github.com/navikt/familie-ba-sak/pull/6268

### 💰 Hva skal gjøres, og hvorfor?

Nå som vi oppretter funksjonalitet for å låse fagsak, så må vi også ha funksjonalitet for å låse dem opp.
Fagsak skal låses opp gjennom automatiske behandlinger (f.eks fødsel) og manuelt.
I denne pullrequesten legger jeg til manuell løype for å låse opp fagsak.

- Legger til ny modal for å låse opp fagsak. Denne vises bare hvis fagsak er låst. Det gjøres også et kall mot backend ved bekreftelse.

https://github.com/user-attachments/assets/3d6416b1-fe05-4009-98b9-534698833f32


