### PR TITLE
NAV-27893: Refaktorer fritekstbegrunnelser til RHF

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Fritekstbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Fritekstbegrunnelser.tsx
@@ -1,17 +1,16 @@
-import { type ChangeEvent, useId } from 'react';
+import { useId } from 'react';
 
 import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
-import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '@hooks/useHentGenererteBrevbegrunnelser';
-import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
 import { useOppdaterVedtaksperiodeMedBegrunnelserIsPending } from '@hooks/useOppdaterVedtaksperiodeMedBegrunnelserIsPending';
-import { useOppdaterVedtaksperiodeMedFritekster } from '@hooks/useOppdaterVedtaksperiodeMedFritekster';
-import { useQueryClient } from '@tanstack/react-query';
-import { type IBehandling, utledSøkersMålform } from '@typer/behandling';
+import {
+    Field,
+    useFritekstbegrunnelserForm,
+} from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/useFritekstbegrunnelserForm';
+import { utledSøkersMålform } from '@typer/behandling';
 import { målform } from '@typer/søknad';
-import { genererIdBasertPåAndreFritekstKulepunkter, lagInitiellFritekst } from '@utils/fritekstfelter';
-import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import classNames from 'classnames';
+import { FormProvider } from 'react-hook-form';
 
 import { ExternalLinkIcon, PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
 import {
@@ -34,94 +33,51 @@ import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
 
 export const MAKS_LENGDE_FRITEKST = 350;
 const MAKS_ANTALL_KULEPUNKT = 3;
-const KLARSPRÅK_URL = 'https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Spr%C3%A5k.aspx';
+const KLARSPRÅK_URL = 'https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Språk.aspx';
 
 export function Fritekstbegrunnelser() {
-    const { skjema, kanSendeSkjema, onPanelClose, vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
+    const { vedtaksperiodeMedBegrunnelser, onPanelClose } = useVedtaksperiodeContext();
 
-    const queryClient = useQueryClient();
-    const behandling = useBehandling();
     const erLesevisning = useErLesevisning();
     const fieldsetId = useId();
+
     const oppdaterVedtaksperiodeMedBegrunnelserIsPending = useOppdaterVedtaksperiodeMedBegrunnelserIsPending(
         vedtaksperiodeMedBegrunnelser.id
     );
 
     const {
-        mutate: oppdaterVedtaksperiodeMedFritekster,
-        isPending: oppdaterVedtaksperiodeMedFriteksterIsPending,
-        error: oppdaterVedtaksperiodeMedFriteksterError,
-    } = useOppdaterVedtaksperiodeMedFritekster(vedtaksperiodeMedBegrunnelser.id, {
-        onSuccess: async vedtaksperioderMedBegrunnelser => {
-            await queryClient.invalidateQueries({
-                queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(vedtaksperiodeMedBegrunnelser.id),
-            });
-            queryClient.setQueryData(
-                HentVedtaksperioderQueryKeyFactory.behandling(behandling.behandlingId),
-                vedtaksperioderMedBegrunnelser
-            );
-            onPanelClose(false); // TODO : Kan vi fjerne denne? Sjekk med funskjonelle
-        },
-    });
+        form,
+        fields,
+        onSubmit,
+        submittedFieldsRef,
+        leggTilFritekstbegrunnelse,
+        slettFritekstbegrunnelse,
+        validerBegrunnelse,
+    } = useFritekstbegrunnelserForm();
 
-    function onChangeFritekst(event: ChangeEvent<HTMLTextAreaElement>, fritekstId: number) {
-        return skjema.felter.fritekster.validerOgSettFelt([
-            ...skjema.felter.fritekster.verdi.map(mapFritekst => {
-                if (mapFritekst.verdi.id === fritekstId) {
-                    return mapFritekst.valider({
-                        ...mapFritekst,
-                        verdi: {
-                            ...mapFritekst.verdi,
-                            tekst: event.target.value,
-                        },
-                    });
-                } else {
-                    return mapFritekst;
-                }
-            }),
-        ]);
-    }
-
-    function onOppdaterVedtaksperiodeMedFritekster() {
-        if (!kanSendeSkjema()) {
-            return;
-        }
-        const fritekster = skjema.felter.fritekster.verdi.map(fritekst => fritekst.verdi.tekst);
-        oppdaterVedtaksperiodeMedFritekster({ fritekster });
-    }
-
-    function onSlettFritekst(fritekstId: number) {
-        skjema.felter.fritekster.validerOgSettFelt([
-            ...skjema.felter.fritekster.verdi.filter(mapFritekst => mapFritekst.verdi.id !== fritekstId),
-        ]);
-    }
-
-    function onLeggTilFritekst() {
-        skjema.felter.fritekster.validerOgSettFelt([
-            ...skjema.felter.fritekster.verdi,
-            lagInitiellFritekst(
-                '',
-                genererIdBasertPåAndreFritekstKulepunkter(skjema.felter.fritekster),
-                MAKS_LENGDE_FRITEKST
-            ),
-        ]);
-    }
+    const {
+        handleSubmit,
+        register,
+        formState: { isSubmitting, errors },
+        reset,
+    } = form;
 
     function onAvbryt() {
         onPanelClose(false);
+        reset();
     }
 
-    if (!vedtaksperiodeMedBegrunnelser.fritekster.length && !skjema.felter.fritekster.verdi.length) {
+    if (!vedtaksperiodeMedBegrunnelser.fritekster.length && !fields.length) {
         return (
             <>
                 {!erLesevisning && (
                     <VStack gap={'space-8'}>
-                        <FritekstHeader behandling={behandling} />
+                        <FritekstHeader />
                         <div>
                             <Button
                                 variant={'tertiary'}
                                 size={'small'}
-                                onClick={onLeggTilFritekst}
+                                onClick={leggTilFritekstbegrunnelse}
                                 icon={<PlusCircleIcon />}
                                 disabled={oppdaterVedtaksperiodeMedBegrunnelserIsPending}
                             >
@@ -134,114 +90,114 @@ export function Fritekstbegrunnelser() {
         );
     }
 
-    const erMaksAntallKulepunkter = skjema.felter.fritekster.verdi.length >= MAKS_ANTALL_KULEPUNKT;
-
-    return (
-        <VStack gap={'space-8'}>
-            <FritekstHeader behandling={behandling} htmlFor={fieldsetId} />
-            <Fieldset
-                id={fieldsetId}
-                legend={'Fritekst til kulepunkt i brev'}
-                hideLegend={true}
-                error={
-                    (skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)) ??
-                    oppdaterVedtaksperiodeMedFriteksterError?.message
-                }
-            >
-                {erLesevisning ? (
+    if (erLesevisning) {
+        return (
+            <VStack gap={'space-8'}>
+                <FritekstHeader htmlFor={fieldsetId} />
+                <Fieldset id={fieldsetId} legend={'Fritekst til kulepunkt i brev'} hideLegend={true}>
                     <ul>
-                        {skjema.felter.fritekster.verdi.map(fritekst => (
-                            <li>{fritekst.verdi.tekst}</li>
+                        {fields.map(field => (
+                            <li>{field.value}</li>
                         ))}
                     </ul>
-                ) : (
-                    <VStack gap={'space-16'}>
-                        {skjema.felter.fritekster.verdi.map(fritekst => {
-                            const fritekstId = fritekst.verdi.id;
-                            return (
-                                <HGrid columns={'5fr 1fr'} align={'center'}>
-                                    <Textarea
-                                        label={`Kulepunkt ${fritekstId}`}
-                                        value={fritekst.verdi.tekst}
-                                        onChange={event => onChangeFritekst(event, fritekstId)}
-                                        error={skjema.visFeilmeldinger && fritekst.feilmelding}
-                                        maxLength={MAKS_LENGDE_FRITEKST}
-                                        readOnly={
-                                            oppdaterVedtaksperiodeMedFriteksterIsPending ||
-                                            oppdaterVedtaksperiodeMedBegrunnelserIsPending
-                                        }
-                                        /* eslint-disable-next-line jsx-a11y/no-autofocus */
-                                        autoFocus={true}
-                                        hideLabel={true}
-                                        resize={true}
-                                    />
-                                    <Button
-                                        aria-label={'Fjern fritekst'}
-                                        variant={'tertiary'}
-                                        size={'small'}
-                                        onClick={() => onSlettFritekst(fritekstId)}
-                                        icon={<TrashIcon />}
-                                        className={classNames({
-                                            [Styles.slettFritekstKnapp]: !oppdaterVedtaksperiodeMedFriteksterIsPending,
-                                        })}
-                                        disabled={
-                                            oppdaterVedtaksperiodeMedFriteksterIsPending ||
-                                            oppdaterVedtaksperiodeMedBegrunnelserIsPending
-                                        }
-                                    >
-                                        Fjern
-                                    </Button>
-                                </HGrid>
-                            );
-                        })}
-                    </VStack>
-                )}
-            </Fieldset>
-            {!erMaksAntallKulepunkter && !erLesevisning && (
-                <div>
-                    <Button
-                        variant={'tertiary'}
-                        size={'small'}
-                        onClick={onLeggTilFritekst}
-                        icon={<PlusCircleIcon />}
-                        disabled={
-                            oppdaterVedtaksperiodeMedFriteksterIsPending ||
-                            oppdaterVedtaksperiodeMedBegrunnelserIsPending
-                        }
+                </Fieldset>
+            </VStack>
+        );
+    }
+
+    const erMaksAntallKulepunkter = fields.length >= MAKS_ANTALL_KULEPUNKT;
+
+    return (
+        <FormProvider {...form}>
+            <form
+                onSubmit={event => {
+                    submittedFieldsRef.current = new Set(fields.map(field => field.id));
+                    handleSubmit(onSubmit)(event);
+                }}
+            >
+                <VStack gap={'space-8'}>
+                    <FritekstHeader htmlFor={fieldsetId} />
+                    <Fieldset
+                        id={fieldsetId}
+                        legend={'Fritekst til kulepunkt i brev'}
+                        hideLegend={true}
+                        error={errors.root?.message}
                     >
-                        Legg til fritekst
-                    </Button>
-                </div>
-            )}
-            {!erLesevisning && (
-                <HStack align={'center'} justify={'space-between'} paddingBlock={'space-8 space-0'}>
-                    <Button
-                        variant={'primary'}
-                        size={'small'}
-                        onClick={onOppdaterVedtaksperiodeMedFritekster}
-                        loading={oppdaterVedtaksperiodeMedFriteksterIsPending}
-                        disabled={oppdaterVedtaksperiodeMedBegrunnelserIsPending}
-                    >
-                        Lagre
-                    </Button>
-                    <Button
-                        variant={'tertiary'}
-                        size={'small'}
-                        onClick={onAvbryt}
-                        disabled={
-                            oppdaterVedtaksperiodeMedFriteksterIsPending ||
-                            oppdaterVedtaksperiodeMedBegrunnelserIsPending
-                        }
-                    >
-                        Avbryt
-                    </Button>
-                </HStack>
-            )}
-        </VStack>
+                        <VStack gap={'space-16'}>
+                            {fields.map((field, index) => {
+                                return (
+                                    <HGrid columns={'5fr 1fr'} align={'center'} key={field.id}>
+                                        <Textarea
+                                            {...register(`${Field.FRITEKSTBEGRUNNELSER}.${index}.value`, {
+                                                validate: value => validerBegrunnelse(field.id, value),
+                                            })}
+                                            label={`Kulepunkt ${field.id}`}
+                                            maxLength={MAKS_LENGDE_FRITEKST}
+                                            error={errors.fritekstbegrunnelser?.[index]?.value?.message}
+                                            readOnly={isSubmitting || oppdaterVedtaksperiodeMedBegrunnelserIsPending}
+                                            hideLabel={true}
+                                            resize={true}
+                                        />
+                                        <Button
+                                            type={'button'}
+                                            aria-label={'Fjern fritekst'}
+                                            variant={'tertiary'}
+                                            size={'small'}
+                                            onClick={() => slettFritekstbegrunnelse(index)}
+                                            icon={<TrashIcon />}
+                                            className={classNames({ [Styles.slettFritekstKnapp]: !isSubmitting })}
+                                            disabled={isSubmitting || oppdaterVedtaksperiodeMedBegrunnelserIsPending}
+                                        >
+                                            Fjern
+                                        </Button>
+                                    </HGrid>
+                                );
+                            })}
+                        </VStack>
+                    </Fieldset>
+                    {!erMaksAntallKulepunkter && (
+                        <div>
+                            <Button
+                                type={'button'}
+                                variant={'tertiary'}
+                                size={'small'}
+                                onClick={leggTilFritekstbegrunnelse}
+                                icon={<PlusCircleIcon />}
+                                disabled={isSubmitting || oppdaterVedtaksperiodeMedBegrunnelserIsPending}
+                            >
+                                Legg til fritekst
+                            </Button>
+                        </div>
+                    )}
+                    <HStack align={'center'} justify={'space-between'} paddingBlock={'space-8 space-0'}>
+                        <Button
+                            type={'submit'}
+                            variant={'primary'}
+                            size={'small'}
+                            loading={isSubmitting}
+                            disabled={oppdaterVedtaksperiodeMedBegrunnelserIsPending}
+                        >
+                            Lagre
+                        </Button>
+                        <Button
+                            type={'button'}
+                            variant={'tertiary'}
+                            size={'small'}
+                            onClick={onAvbryt}
+                            disabled={isSubmitting || oppdaterVedtaksperiodeMedBegrunnelserIsPending}
+                        >
+                            Avbryt
+                        </Button>
+                    </HStack>
+                </VStack>
+            </form>
+        </FormProvider>
     );
 }
 
-function FritekstHeader({ behandling, htmlFor }: { behandling: IBehandling; htmlFor?: string }) {
+function FritekstHeader({ htmlFor }: { htmlFor?: string }) {
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
     return (
         <HStack gap={'space-8'} align={'center'} justify={'space-between'}>
             <HStack gap={'space-8'} align={'center'} justify={'center'} wrap={false}>
@@ -265,9 +221,11 @@ function FritekstHeader({ behandling, htmlFor }: { behandling: IBehandling; html
                     </BodyLong>
                 </HelpText>
             </HStack>
-            <Tag variant={'outline'} data-color={'neutral'} size={'small'}>
-                Skriv {målform[utledSøkersMålform(behandling)].toLowerCase()}
-            </Tag>
+            {!erLesevisning && (
+                <Tag variant={'outline'} data-color={'neutral'} size={'small'}>
+                    Skriv {målform[utledSøkersMålform(behandling)].toLowerCase()}
+                </Tag>
+            )}
         </HStack>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext.tsx
@@ -1,33 +1,19 @@
 import type { PropsWithChildren } from 'react';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 
 import { useBehandling } from '@hooks/useBehandling';
-import { MAKS_LENGDE_FRITEKST } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Fritekstbegrunnelser';
 import { Behandlingstype } from '@typer/behandling';
 import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
-import type { IIsoDatoPeriode } from '@utils/dato';
-import type { IFritekstFelt } from '@utils/fritekstfelter';
-import { lagInitiellFritekst } from '@utils/fritekstfelter';
-import deepEqual from 'deep-equal';
-
-import { feil, ok, useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
-import type { FeltState, ISkjema } from '@navikt/familie-skjema';
 
 interface Props extends PropsWithChildren {
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
 }
 
-interface BegrunnelserSkjema {
-    periode: IIsoDatoPeriode;
-    fritekster: FeltState<IFritekstFelt>[];
-}
-
 interface VedtaksperiodeContextValue {
     erPanelEkspandert: boolean;
     onPanelClose: (visAlert: boolean) => void;
-    skjema: ISkjema<BegrunnelserSkjema, IVedtaksperiodeMedBegrunnelser[]>;
+    settErSkjemaendringer: (erSkjemaendringer: boolean) => void;
     vedtaksperiodeMedBegrunnelser: IVedtaksperiodeMedBegrunnelser;
-    kanSendeSkjema: () => boolean;
 }
 
 const VedtaksperiodeContext = createContext<VedtaksperiodeContextValue | undefined>(undefined);
@@ -35,72 +21,19 @@ const VedtaksperiodeContext = createContext<VedtaksperiodeContextValue | undefin
 export function VedtaksperiodeProvider({ vedtaksperiodeMedBegrunnelser, children }: Props) {
     const behandling = useBehandling();
 
+    const [erSkjemaendringer, settErSkjemaendringer] = useState(false);
+
     const [erPanelEkspandert, settErPanelEkspandert] = useState(
         behandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING &&
             vedtaksperiodeMedBegrunnelser.begrunnelser.length === 0 &&
             vedtaksperiodeMedBegrunnelser.fritekster.length === 0
     );
 
-    const periode = useFelt<IIsoDatoPeriode>({
-        verdi: {
-            fom: vedtaksperiodeMedBegrunnelser.fom,
-            tom: vedtaksperiodeMedBegrunnelser.tom,
-        },
-    });
-
-    const fritekster = useFelt<FeltState<IFritekstFelt>[]>({
-        verdi: [],
-        valideringsfunksjon: (felt: FeltState<FeltState<IFritekstFelt>[]>) => {
-            return felt.verdi.some(
-                fritekst => fritekst.valideringsstatus === Valideringsstatus.FEIL || fritekst.verdi.tekst.length === 0
-            )
-                ? feil(felt, '')
-                : ok(felt);
-        },
-    });
-
-    const { kanSendeSkjema, settVisfeilmeldinger, skjema } = useSkjema<
-        BegrunnelserSkjema,
-        IVedtaksperiodeMedBegrunnelser[]
-    >({
-        felter: {
-            periode,
-            fritekster,
-        },
-        skjemanavn: 'Begrunnelser for vedtaksperiode',
-    });
-
-    const populerSkjemaFraBackend = () => {
-        settVisfeilmeldinger(false);
-        skjema.felter.periode.validerOgSettFelt({
-            fom: vedtaksperiodeMedBegrunnelser.fom,
-            tom: vedtaksperiodeMedBegrunnelser.tom,
-        });
-
-        skjema.felter.fritekster.validerOgSettFelt(
-            vedtaksperiodeMedBegrunnelser.fritekster.map((fritekst, id) =>
-                lagInitiellFritekst(fritekst, id, MAKS_LENGDE_FRITEKST)
-            )
-        );
-    };
-
-    useEffect(() => {
-        populerSkjemaFraBackend();
-    }, [vedtaksperiodeMedBegrunnelser]);
-
     const onPanelClose = (visAlert: boolean) => {
-        if (
-            erPanelEkspandert &&
-            visAlert &&
-            !deepEqual(
-                skjema.felter.fritekster.verdi.map(fritekst => fritekst.verdi.tekst),
-                vedtaksperiodeMedBegrunnelser.fritekster
-            )
-        ) {
+        if (erPanelEkspandert && visAlert && erSkjemaendringer) {
             alert('Periode har endringer som ikke er lagret!');
         } else {
             settErPanelEkspandert(!erPanelEkspandert);
-            populerSkjemaFraBackend();
         }
     };
 
@@ -108,10 +41,9 @@ export function VedtaksperiodeProvider({ vedtaksperiodeMedBegrunnelser, children
         <VedtaksperiodeContext.Provider
             value={{
                 erPanelEkspandert,
-                vedtaksperiodeMedBegrunnelser,
                 onPanelClose,
-                skjema,
-                kanSendeSkjema,
+                settErSkjemaendringer,
+                vedtaksperiodeMedBegrunnelser,
             }}
         >
             {children}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/useFritekstbegrunnelserForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/useFritekstbegrunnelserForm.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from 'react';
+
+import { useBehandlingId } from '@hooks/useBehandlingId';
+import { useConfirmBrowserRefresh } from '@hooks/useConfirmBrowserRefresh';
+import { HentGenererteBrevbegrunnelserQueryKeyFactory } from '@hooks/useHentGenererteBrevbegrunnelser';
+import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
+import { useOnFormSubmitSuccessful } from '@hooks/useOnFormSubmitSuccessful';
+import { useOppdaterVedtaksperiodeMedFritekster } from '@hooks/useOppdaterVedtaksperiodeMedFritekster';
+import { MAKS_LENGDE_FRITEKST } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Fritekstbegrunnelser';
+import { useVedtaksperiodeContext } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperiodeContext';
+import { useQueryClient } from '@tanstack/react-query';
+import { useFieldArray, useForm } from 'react-hook-form';
+
+const NY_FRITEKSTBEGRUNNELSE = { value: '' };
+
+interface Fritekstbegrunnelse {
+    value: string;
+}
+
+export enum Field {
+    FRITEKSTBEGRUNNELSER = 'fritekstbegrunnelser',
+}
+
+export interface FormValues {
+    [Field.FRITEKSTBEGRUNNELSER]: Fritekstbegrunnelse[];
+}
+
+export function useFritekstbegrunnelserForm() {
+    const { vedtaksperiodeMedBegrunnelser, settErSkjemaendringer } = useVedtaksperiodeContext();
+
+    const queryClient = useQueryClient();
+    const behandlingId = useBehandlingId();
+    const submittedFieldsRef = useRef<Set<string>>(new Set());
+
+    const form = useForm<FormValues>({
+        values: {
+            [Field.FRITEKSTBEGRUNNELSER]: vedtaksperiodeMedBegrunnelser.fritekster.map(fritekst => ({
+                value: fritekst,
+            })),
+        },
+    });
+
+    const {
+        control,
+        setError,
+        clearErrors,
+        formState: { isDirty },
+        reset,
+    } = form;
+
+    const { fields, append, remove } = useFieldArray({
+        control,
+        name: Field.FRITEKSTBEGRUNNELSER,
+    });
+
+    useEffect(() => {
+        settErSkjemaendringer(isDirty);
+    }, [settErSkjemaendringer, isDirty]);
+
+    useConfirmBrowserRefresh({ enabled: isDirty });
+
+    useOnFormSubmitSuccessful(control, () => reset());
+
+    const { mutateAsync: oppdaterVedtaksperiodeMedFritekster } = useOppdaterVedtaksperiodeMedFritekster(
+        vedtaksperiodeMedBegrunnelser.id,
+        {
+            onSuccess: async vedtaksperioderMedBegrunnelser => {
+                await queryClient.invalidateQueries({
+                    queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(
+                        vedtaksperiodeMedBegrunnelser.id
+                    ),
+                });
+                queryClient.setQueryData(
+                    HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
+                    vedtaksperioderMedBegrunnelser
+                );
+            },
+            onError: error => setError('root', { message: error.message ?? 'En ukjent feil oppstod.' }),
+        }
+    );
+
+    function leggTilFritekstbegrunnelse() {
+        clearErrors('root');
+        append(NY_FRITEKSTBEGRUNNELSE);
+    }
+
+    function slettFritekstbegrunnelse(index: number) {
+        clearErrors('root');
+        remove(index);
+    }
+
+    function validerBegrunnelse(fieldId: string, value: string) {
+        if (!submittedFieldsRef.current.has(fieldId)) {
+            return true;
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return 'Friktest må fylles ut eller fjernes.';
+        }
+        if (trimmed.length < 3) {
+            return 'Minst tre tegn er påkrevd.';
+        }
+        if (trimmed.length > MAKS_LENGDE_FRITEKST) {
+            return `Kan ikke overstige ${MAKS_LENGDE_FRITEKST} tegn.`;
+        }
+        return true;
+    }
+
+    function onSubmit({ fritekstbegrunnelser }: FormValues) {
+        const fritekster = fritekstbegrunnelser.map(fritekstbegrunnelse => fritekstbegrunnelse.value);
+        return oppdaterVedtaksperiodeMedFritekster({ fritekster });
+    }
+
+    return {
+        form,
+        fields,
+        onSubmit,
+        submittedFieldsRef,
+        leggTilFritekstbegrunnelse,
+        slettFritekstbegrunnelse,
+        validerBegrunnelse,
+    };
+}


### PR DESCRIPTION
### 📮 Favro
NAV-27893

### 💰 Hva skal gjøres, og hvorfor?
Skriver om fritekstbegrunnelser til RHF. Her slipper vi å bruke en `useEffect` for å populere skjemaet. Den `useEffect` hooken ble kjørt hver gang nettleserfanen fikk fokus. Dermed ble endringer som ikke var lagret tilbakestil til server-staten. Staten ligger nå i `values` i RHF-staten, og håndtere nettlserfanefokus feilfritt. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ingen eksisterende tester.

### 👀 Screen shots
Ingen store visuelle endringer, men slik ser det ut nå:

https://github.com/user-attachments/assets/d9e0cc70-5d06-4b29-9d40-3e8d5264e84d

