### PR TITLE
NAV-27893: Rydder opp i kode relatert til vedtaksperiode

### DIFF
--- a/src/frontend/api/hentAlleBegrunnelser.ts
+++ b/src/frontend/api/hentAlleBegrunnelser.ts
@@ -1,7 +1,7 @@
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+import type { AlleBegrunnelser } from '@typer/vilkår';
+import { RessursResolver } from '@utils/ressursResolver';
 
-import type { AlleBegrunnelser } from '../typer/vilkår';
-import { RessursResolver } from '../utils/ressursResolver';
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
 
 export async function hentAlleBegrunnelser(request: FamilieRequest): Promise<AlleBegrunnelser> {
     const ressurs = await request<void, AlleBegrunnelser>({

--- a/src/frontend/api/hentVedtaksperioder.ts
+++ b/src/frontend/api/hentVedtaksperioder.ts
@@ -1,7 +1,7 @@
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
+import { RessursResolver } from '@utils/ressursResolver';
 
-import type { IVedtaksperiodeMedBegrunnelser } from '../typer/vedtaksperiode';
-import { RessursResolver } from '../utils/ressursResolver';
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
 
 export async function hentVedtaksperioder(
     request: FamilieRequest,

--- a/src/frontend/hooks/useHentAlleBegrunnelser.ts
+++ b/src/frontend/hooks/useHentAlleBegrunnelser.ts
@@ -1,8 +1,7 @@
+import { hentAlleBegrunnelser } from '@api/hentAlleBegrunnelser';
 import { useQuery } from '@tanstack/react-query';
 
 import { useHttp } from '@navikt/familie-http';
-
-import { hentAlleBegrunnelser } from '../api/hentAlleBegrunnelser';
 
 export const HentAlleBegrunnelserQueryKeyFactory = {
     alleBegrunnelser: () => ['alleBegrunnelser'],

--- a/src/frontend/hooks/useHentGenererteBrevbegrunnelser.ts
+++ b/src/frontend/hooks/useHentGenererteBrevbegrunnelser.ts
@@ -7,14 +7,13 @@ export const HentGenererteBrevbegrunnelserQueryKeyFactory = {
     vedtaksperiode: (vedtaksperiodeId: number) => ['genererteBrevbegrunnelser', vedtaksperiodeId],
 };
 
-type Options = Omit<UseQueryOptions<string[], DefaultError, string[]>, 'queryKey' | 'queryFn' | 'select'>;
+type Options = Omit<UseQueryOptions<string[], DefaultError, string[]>, 'queryKey' | 'queryFn'>;
 
 export function useHentGenererteBrevbegrunnelser(vedtaksperiodeId: number, options?: Options) {
     const { request } = useHttp();
     return useQuery({
         queryKey: HentGenererteBrevbegrunnelserQueryKeyFactory.vedtaksperiode(vedtaksperiodeId),
         queryFn: () => hentGenererteBrevbegrunnelser(request, vedtaksperiodeId),
-        select: data => data.toSorted(),
         ...options,
     });
 }

--- a/src/frontend/hooks/useHentVedtaksperioder.ts
+++ b/src/frontend/hooks/useHentVedtaksperioder.ts
@@ -1,8 +1,7 @@
+import { hentVedtaksperioder } from '@api/hentVedtaksperioder';
 import { useQuery } from '@tanstack/react-query';
 
 import { useHttp } from '@navikt/familie-http';
-
-import { hentVedtaksperioder } from '../api/hentVedtaksperioder';
 
 export const HentVedtaksperioderQueryKeyFactory = {
     behandling: (behandlingId: number) => ['vedtaksperioder', behandlingId],

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/AlleBegrunnelserContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/AlleBegrunnelserContext.tsx
@@ -1,10 +1,10 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext } from 'react';
 
-import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
+import { useHentAlleBegrunnelser } from '@hooks/useHentAlleBegrunnelser';
+import type { AlleBegrunnelser } from '@typer/vilkår';
 
-import { useHentAlleBegrunnelser } from '../../../../../hooks/useHentAlleBegrunnelser';
-import type { AlleBegrunnelser } from '../../../../../typer/vilkår';
+import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
 
 interface AlleBegrunnelserContext {
     alleBegrunnelser: AlleBegrunnelser;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/EkspanderbarVedtaksperiode.tsx
@@ -5,77 +5,51 @@ import { hentVedtaksperiodeTittel, Vedtaksperiodetype } from '@typer/vedtaksperi
 import { dagensDato, isoDatoPeriodeTilFormatertString, isoStringTilDateMedFallback, tidenesEnde } from '@utils/dato';
 import { formaterBeløp, summer } from '@utils/formatter';
 import { endOfMonth, isAfter } from 'date-fns';
-import styled from 'styled-components';
 
-import { BodyShort, Label, ExpansionCard } from '@navikt/ds-react';
+import { BodyShort, Label, ExpansionCard, HGrid } from '@navikt/ds-react';
 
-const StyledExpansionCard = styled(ExpansionCard)`
-    margin-bottom: 1rem;
-`;
+const VEDTAKSPERIODETYPE_SOM_SKAL_VISE_SUM = [
+    Vedtaksperiodetype.UTBETALING,
+    Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING,
+];
 
-const StyledExpansionHeader = styled(ExpansionCard.Header)`
-    align-items: center;
-`;
-
-const StyledExpansionTitle = styled(ExpansionCard.Title)`
-    display: grid;
-    grid-template-columns: minmax(6rem, 12rem) minmax(6rem, 15rem) auto;
-    grid-gap: 0.5rem;
-
-    margin-left: 0;
-`;
-
-const StyledExpansionContent = styled(ExpansionCard.Content)`
-    overflow: visible;
-`;
-
-const slutterSenereEnnInneværendeMåned = (tom?: string) =>
-    isAfter(isoStringTilDateMedFallback({ isoString: tom, fallbackDate: tidenesEnde }), endOfMonth(dagensDato));
+function slutterSenereEnnInneværendeMåned(tom?: string) {
+    return isAfter(isoStringTilDateMedFallback({ isoString: tom, fallbackDate: tidenesEnde }), endOfMonth(dagensDato));
+}
 
 export function EkspanderbarVedtaksperiode({ children }: PropsWithChildren) {
     const { vedtaksperiodeMedBegrunnelser, erPanelEkspandert, onPanelClose } = useVedtaksperiodeContext();
 
-    const periode = {
-        fom: vedtaksperiodeMedBegrunnelser.fom,
-        tom: vedtaksperiodeMedBegrunnelser.tom,
-    };
+    const { type, utbetalingsperiodeDetaljer, fom, tom } = vedtaksperiodeMedBegrunnelser;
 
-    const skalViseSum =
-        (vedtaksperiodeMedBegrunnelser.type === Vedtaksperiodetype.UTBETALING ||
-            vedtaksperiodeMedBegrunnelser.type ===
-                Vedtaksperiodetype.UTBETALING_MED_REDUKSJON_FRA_SIST_IVERKSATTE_BEHANDLING) &&
-        vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.length > 0;
-
-    const sum = summer(
-        vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.map(
-            utbetalingsperiodeDetalj => utbetalingsperiodeDetalj.utbetaltPerMnd
-        )
-    );
-
+    const skalVedtaksperiodetypeViseSum = VEDTAKSPERIODETYPE_SOM_SKAL_VISE_SUM.includes(type);
+    const harUtbetalingsperiodeDetaljer = utbetalingsperiodeDetaljer.length > 0;
+    const skalViseSum = skalVedtaksperiodetypeViseSum && harUtbetalingsperiodeDetaljer;
+    const sum = summer(utbetalingsperiodeDetaljer.map(detalj => detalj.utbetaltPerMnd));
     const tittel = hentVedtaksperiodeTittel(vedtaksperiodeMedBegrunnelser);
 
+    const periode = isoDatoPeriodeTilFormatertString({
+        fom: fom,
+        tom: slutterSenereEnnInneværendeMåned(tom) ? '' : tom,
+    });
+
     return (
-        <StyledExpansionCard
+        <ExpansionCard
+            aria-label={`Begrunnelse - Periode ${fom}_${tom}`}
+            size={'small'}
             open={erPanelEkspandert}
             onToggle={() => onPanelClose(true)}
-            size="small"
-            aria-label="Begrunnelser"
         >
-            <StyledExpansionHeader>
-                <StyledExpansionTitle>
-                    {periode.fom && (
-                        <Label>
-                            {isoDatoPeriodeTilFormatertString({
-                                fom: periode.fom,
-                                tom: slutterSenereEnnInneværendeMåned(periode.tom) ? '' : periode.tom,
-                            })}
-                        </Label>
-                    )}
-                    <BodyShort>{tittel}</BodyShort>
-                    {skalViseSum && <BodyShort>{formaterBeløp(sum)}</BodyShort>}
-                </StyledExpansionTitle>
-            </StyledExpansionHeader>
-            <StyledExpansionContent>{children}</StyledExpansionContent>
-        </StyledExpansionCard>
+            <ExpansionCard.Header>
+                <ExpansionCard.Title>
+                    <HGrid columns={'minmax(6rem, 12rem) minmax(6rem, 15rem) auto'} gap={'space-8'}>
+                        {fom && <Label>{periode}</Label>}
+                        <BodyShort>{tittel}</BodyShort>
+                        {skalViseSum && <BodyShort>{formaterBeløp(sum)}</BodyShort>}
+                    </HGrid>
+                </ExpansionCard.Title>
+            </ExpansionCard.Header>
+            <ExpansionCard.Content>{children}</ExpansionCard.Content>
+        </ExpansionCard>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser.tsx
@@ -50,11 +50,13 @@ export function GenererteBrevbegrunnelser() {
         <VStack gap={'space-0'}>
             <Label>Begrunnelse(r)</Label>
             <ul>
-                {genererteBrevbegrunnelser.map((begrunnelse, index) => (
-                    <li key={`begrunnelse-${index}`}>
-                        <BodyShort>{begrunnelse}</BodyShort>
-                    </li>
-                ))}
+                {genererteBrevbegrunnelser
+                    .toSorted((b1, b2) => b1.localeCompare(b2))
+                    .map((begrunnelse, index) => (
+                        <li key={`begrunnelse-${index}`}>
+                            <BodyShort>{begrunnelse}</BodyShort>
+                        </li>
+                    ))}
             </ul>
         </VStack>
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperioder.tsx
@@ -1,76 +1,73 @@
-import { Fragment } from 'react';
-
 import { useBehandling } from '@hooks/useBehandling';
 import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
 import { partition } from '@utils/commons';
-import styled from 'styled-components';
 
-import { Heading } from '@navikt/ds-react';
+import { Heading, VStack } from '@navikt/ds-react';
 
 import { filtrerOgSorterPerioderMedBegrunnelseBehov } from './utils';
 import { Vedtaksperiode } from './Vedtaksperiode';
 import { VedtaksperiodeProvider } from './VedtaksperiodeContext';
 import { useVedtaksperioderContext } from './VedtaksperioderContext';
 
-const StyledHeading = styled(Heading)`
-    display: flex;
-    margin-top: 1rem;
-`;
-
 export function Vedtaksperioder() {
     const { vedtaksperioder } = useVedtaksperioderContext();
 
     const behandling = useBehandling();
 
-    const vedtaksperioderSomSkalvises = filtrerOgSorterPerioderMedBegrunnelseBehov(vedtaksperioder, behandling.status);
+    const vedtaksperioderSomSkalVises = filtrerOgSorterPerioderMedBegrunnelseBehov(vedtaksperioder, behandling.status);
 
-    const avslagOgResterende = partition(
-        vedtaksperiode =>
-            vedtaksperiode.type === Vedtaksperiodetype.AVSLAG && !vedtaksperiode.fom && !vedtaksperiode.tom,
-        vedtaksperioderSomSkalvises
-    );
+    const [avslagsbegrunnelser, begrunnelser] = partition(vedtaksperiode => {
+        const erAvslag = vedtaksperiode.type === Vedtaksperiodetype.AVSLAG;
+        const harIngenFom = !vedtaksperiode.fom;
+        const harIngenTom = !vedtaksperiode.tom;
+        return erAvslag && harIngenFom && harIngenTom;
+    }, vedtaksperioderSomSkalVises);
 
-    return vedtaksperioderSomSkalvises.length > 0 ? (
-        <>
+    if (vedtaksperioderSomSkalVises.length <= 0) {
+        return null;
+    }
+
+    return (
+        <VStack gap={'space-32'} marginBlock={'space-32'}>
             <GrupperteVedtaksperioder
-                vedtaksperioderMedBegrunnelser={avslagOgResterende[1]}
+                vedtaksperioderMedBegrunnelser={begrunnelser}
                 overskrift={'Begrunnelser i vedtaksbrev'}
             />
             <GrupperteVedtaksperioder
-                vedtaksperioderMedBegrunnelser={avslagOgResterende[0]}
+                vedtaksperioderMedBegrunnelser={avslagsbegrunnelser}
                 overskrift={'Generelle avslagsbegrunnelser'}
             />
-        </>
-    ) : (
-        <Fragment />
+        </VStack>
     );
 }
 
-const GrupperteVedtaksperioder = ({
+function GrupperteVedtaksperioder({
     vedtaksperioderMedBegrunnelser,
     overskrift,
 }: {
     vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBegrunnelser[];
     overskrift: string;
-}) => {
+}) {
     if (vedtaksperioderMedBegrunnelser.length === 0) {
-        return <></>;
+        return null;
     }
 
     return (
-        <>
-            <StyledHeading level="2" size="small" spacing>
+        <VStack gap={'space-0'}>
+            <Heading level={'2'} size={'small'} spacing={true}>
                 {overskrift}
-            </StyledHeading>
-            {vedtaksperioderMedBegrunnelser.map(vedtaksperiodeMedBegrunnelser => (
-                <VedtaksperiodeProvider
-                    key={vedtaksperiodeMedBegrunnelser.id}
-                    vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
-                >
-                    <Vedtaksperiode />
-                </VedtaksperiodeProvider>
-            ))}
-        </>
+            </Heading>
+            <VStack gap={'space-20'}>
+                {vedtaksperioderMedBegrunnelser.map(vedtaksperiodeMedBegrunnelser => (
+                    <VedtaksperiodeProvider
+                        key={vedtaksperiodeMedBegrunnelser.id}
+                        vedtaksperiodeMedBegrunnelser={vedtaksperiodeMedBegrunnelser}
+                    >
+                        <Vedtaksperiode />
+                    </VedtaksperiodeProvider>
+                ))}
+            </VStack>
+        </VStack>
     );
-};
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperioderContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/VedtaksperioderContext.tsx
@@ -1,11 +1,11 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext } from 'react';
 
-import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
+import { useBehandlingId } from '@hooks/useBehandlingId';
+import { useHentVedtaksperioder } from '@hooks/useHentVedtaksperioder';
+import type { IVedtaksperiodeMedBegrunnelser } from '@typer/vedtaksperiode';
 
-import { useHentVedtaksperioder } from '../../../../../../hooks/useHentVedtaksperioder';
-import type { IVedtaksperiodeMedBegrunnelser } from '../../../../../../typer/vedtaksperiode';
-import { useBehandlingContext } from '../../../context/BehandlingContext';
+import { BodyShort, Box, ErrorMessage, Loader, LocalAlert, Stack } from '@navikt/ds-react';
 
 interface VedtaksperioderContext {
     vedtaksperioder: IVedtaksperiodeMedBegrunnelser[];
@@ -18,8 +18,8 @@ interface Props extends PropsWithChildren {
 }
 
 export function VedtaksperioderProvider({ children }: Props) {
-    const { behandling } = useBehandlingContext();
-    const behandlingId = behandling.behandlingId;
+    const behandlingId = useBehandlingId();
+
     const { data, isPending, error } = useHentVedtaksperioder(behandlingId);
 
     if (isPending) {


### PR DESCRIPTION
### 📮 Favro
NAV-27893

### 💰 Hva skal gjøres, og hvorfor?
- Rydder opp i imports.
- Erstatter styled-components med Aksel komponenter.
- Lar sortering av begrunnelser skje i UI istendefor i cache.
- Gjør eksisterende logikk mer lesbar. 
- Samsvarer kode mellom ba-sak-frontend og ks-sak-frontend.  

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Bare refaktorere eksisterende logikk, skal ikke være logiske endringer. 

### 👀 Screen shots
Før:
<img width="720" height="757" alt="image" src="https://github.com/user-attachments/assets/b192e68e-23e2-42a6-b83d-9c59ee278461" />

Etter:
<img width="720" height="784" alt="image" src="https://github.com/user-attachments/assets/43339c32-8835-47e2-b9cf-4d372da5c9f9" />

