### PR TITLE
NAV-29193: Legger til funksjonalitet for å generere vilkår for barna

### DIFF
--- a/src/frontend/api/utfyllVilkårForBarnaAutomatisk.ts
+++ b/src/frontend/api/utfyllVilkårForBarnaAutomatisk.ts
@@ -1,0 +1,13 @@
+import type { IBehandling } from '@typer/behandling';
+
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function utfyllVilkårForBarnaAutomatisk(request: FamilieRequest, behandlingId: number) {
+    const ressurs = await request<null, IBehandling>({
+        method: 'POST',
+        url: `/familie-ba-sak/api/vilkaarsvurdering/${behandlingId}/automatisk-fyll-ut-barnas-vilkaar`,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useUtfyllVilkårForBarnaAutomatisk.ts
+++ b/src/frontend/hooks/useUtfyllVilkårForBarnaAutomatisk.ts
@@ -1,0 +1,22 @@
+import { utfyllVilkårForBarnaAutomatisk } from '@api/utfyllVilkårForBarnaAutomatisk';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+import { useHttp } from '@navikt/familie-http';
+
+interface Parameters {
+    behandlingId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, Parameters>, 'mutationFn'>;
+
+export function useUtfyllVilkårForBarnaAutomatisk(options?: Options) {
+    const { request } = useHttp();
+    return useMutation<IBehandling, Error, Parameters>({
+        mutationFn: (parameters: Parameters): Promise<IBehandling> => {
+            const { behandlingId } = parameters;
+            return utfyllVilkårForBarnaAutomatisk(request, behandlingId);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/UtfyllVilkårForBarnaAutomatisk.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/UtfyllVilkårForBarnaAutomatisk.tsx
@@ -1,0 +1,47 @@
+import { useFeatureToggles } from '@hooks/useFeatureToggles';
+import { useUtfyllVilkårForBarnaAutomatisk } from '@hooks/useUtfyllVilkårForBarnaAutomatisk';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
+import { FeatureToggle } from '@typer/featureToggles';
+
+import { Button, LocalAlert, VStack } from '@navikt/ds-react';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+export function UtfyllVilkårForBarnaAutomatisk() {
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const toggles = useFeatureToggles();
+
+    const {
+        mutate: utfyllVilkårForBarnaAutomatisk,
+        isPending: utfyllVilkårForBarnaAutomatiskIsPending,
+        error: utfyllVilkårForBarnaAutomatiskError,
+    } = useUtfyllVilkårForBarnaAutomatisk({
+        onSuccess: behandling => settÅpenBehandling(byggSuksessRessurs(behandling)),
+    });
+
+    if (!toggles[FeatureToggle.kanGenerereBarnasVilkar]) {
+        return null;
+    }
+
+    return (
+        <VStack gap={'space-8'} marginBlock={'space-48 space-0'} width={'fit-content'}>
+            {utfyllVilkårForBarnaAutomatiskError && (
+                <LocalAlert status={'error'} size={'small'}>
+                    <LocalAlert.Header>
+                        <LocalAlert.Title>
+                            {utfyllVilkårForBarnaAutomatiskError?.message ?? 'En ukjent feil oppstod.'}
+                        </LocalAlert.Title>
+                    </LocalAlert.Header>
+                </LocalAlert>
+            )}
+            <div>
+                <Button
+                    variant={'primary'}
+                    onClick={() => utfyllVilkårForBarnaAutomatisk({ behandlingId: behandling.behandlingId })}
+                    loading={utfyllVilkårForBarnaAutomatiskIsPending}
+                >
+                    Fyll ut vilkår for barna automatisk
+                </Button>
+            </div>
+        </VStack>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/VilkårsvurderingSkjemaNormal.tsx
@@ -4,7 +4,13 @@ import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFeatureToggles } from '@hooks/useFeatureToggles';
 import { Skjermstørrelse, useSkjermstørrelse } from '@hooks/useSkjermstørrelse';
 import { PersonInformasjon } from '@komponenter/PersonInformasjon/PersonInformasjon';
-import { BehandlingSteg, type IBehandling, kanLeggeTilUtvidetVilkår } from '@typer/behandling';
+import { UtfyllVilkårForBarnaAutomatisk } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Skjema/UtfyllVilkårForBarnaAutomatisk';
+import {
+    BehandlingSteg,
+    erRiktigBehandlingForAutomatiskUtfyllingAvVilkårForBarna,
+    type IBehandling,
+    kanLeggeTilUtvidetVilkår,
+} from '@typer/behandling';
 import { FeatureToggle } from '@typer/featureToggles';
 import { PersonType } from '@typer/person';
 import { annenVurderingConfig, harPersonIkkeVurdertVilkår, vilkårConfig, VilkårType } from '@typer/vilkår';
@@ -86,6 +92,7 @@ export function VilkårsvurderingSkjemaNormal({ visFeilmeldinger }: Props) {
                 </LocalAlert>
             )}
             {vilkårsvurdering.map((personResultat, index) => {
+                const erSøker = personResultat.person.type === PersonType.SØKER;
                 const andreVurderinger = personResultat.andreVurderinger;
                 const harUtvidet = personResultat.vilkårResultater.find(
                     vilkårResultat => vilkårResultat.verdi.vilkårType === VilkårType.UTVIDET_BARNETRYGD
@@ -93,10 +100,10 @@ export function VilkårsvurderingSkjemaNormal({ visFeilmeldinger }: Props) {
                 const personSkalSkjermesForBruker = personResultat.person.skjermesForBruker;
 
                 const skalKunneLeggeTilUtvidetBarnetrygdVilkår =
-                    !erLesevisning &&
-                    personResultat.person.type === PersonType.SØKER &&
-                    !harUtvidet &&
-                    kanLeggeTilUtvidetVilkår(behandling);
+                    !erLesevisning && erSøker && !harUtvidet && kanLeggeTilUtvidetVilkår(behandling);
+
+                const skalViseUtfyllVilkårForBarnaAutomatisk =
+                    erSøker && erRiktigBehandlingForAutomatiskUtfyllingAvVilkårForBarna(behandling);
 
                 return (
                     <EkspanderVilkårsvurderingProvider
@@ -215,6 +222,9 @@ export function VilkårsvurderingSkjemaNormal({ visFeilmeldinger }: Props) {
                                                                 visFeilmeldinger={visFeilmeldinger}
                                                             />
                                                         ))}
+                                                {skalViseUtfyllVilkårForBarnaAutomatisk && (
+                                                    <UtfyllVilkårForBarnaAutomatisk />
+                                                )}
                                             </Box>
                                         </Activity>
                                     </>

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -1,7 +1,7 @@
 import type { IRestBrevmottaker } from '@komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import type { IsoDatoString } from '@utils/dato';
 
-import type { BehandlingKategori, BehandlingUnderkategori } from './behandlingstema';
+import { BehandlingKategori, type BehandlingUnderkategori } from './behandlingstema';
 import type { IPersonMedAndelerTilkjentYtelse } from './beregning';
 import type { INøkkelPar } from './common';
 import type { IRestFeilutbetaltValuta } from './eøs-feilutbetalt-valuta';
@@ -476,4 +476,13 @@ export function kanLeggeTilUtvidetVilkår(behandling: IBehandling) {
 export function utledSøkersMålform(behandling: IBehandling) {
     const søker = behandling.personer.find(person => person.type === PersonType.SØKER);
     return søker?.målform ?? Målform.NB;
+}
+
+export function erRiktigBehandlingForAutomatiskUtfyllingAvVilkårForBarna(behandling: IBehandling) {
+    const erEøs = behandling.kategori === BehandlingKategori.EØS;
+    const erFørstegangsbehandling = behandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING;
+    const erRevurdering = behandling.type === Behandlingstype.REVURDERING;
+    const erSøknad = behandling.årsak === BehandlingÅrsak.SØKNAD;
+    // TODO : Legg inn sjekk om revurdering søknad gjelder nytt barn
+    return erEøs && (erFørstegangsbehandling || (erRevurdering && erSøknad));
 }

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -15,4 +15,5 @@ export enum FeatureToggle {
     skalBrukeNyttSkjemaForEndretUtbetalingAndel = 'familie-ba-sak.endret-utbetaling-andel-skjema-rhf',
     skalKunneBehandleBaInstitusjonFagsaker = 'familie-klage.skal-kunne-behandle-ba-institusjon-fagsaker',
     preutfyllingLovligOpphold = 'familie-ba-sak.preutfylling-lovlig-opphold',
+    kanGenerereBarnasVilkar = 'familie-ba-sak.kan-generere-barnas-vilkar',
 }


### PR DESCRIPTION
### 📮 Favro:
NAV-29193

### 💰 Hva skal gjøres, og hvorfor?
Legger til funksjonalitet for å fylle ut vilkår for barna automatisk.

Mangler logikk for å sjekke om revurdering gjelder nytt barn, men det kommer i en senere PR. Må trolig ha noen endringer i backend først. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Designet kan endres på senere. Usikker på hvor det blir best å ha knappen og feilmeldingen. Kanskje knappen burde ligge ved siden av "vis/skjul vilkårsvurdering"-knappen? 

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
<img width="1163" height="735" alt="image" src="https://github.com/user-attachments/assets/5ad6fc86-8d69-404f-82ea-881b920f5c0f" />