### PR TITLE
Fix: gap i saksoversikt mellom heading og utbetalinger

### DIFF
--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -129,7 +129,7 @@ export function Saksoversikt() {
                 <FagsakLenkepanel />
                 {fagsak.status === FagsakStatus.LØPENDE && (
                     <VStack>
-                        <Heading size="medium" level="2" spacing>
+                        <Heading size="medium" level="2">
                             Løpende månedlig utbetaling
                         </Heading>
                         {løpendeMånedligUtbetaling()}

--- a/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Saksoversikt.tsx
@@ -128,12 +128,12 @@ export function Saksoversikt() {
             <VStack gap="space-56">
                 <FagsakLenkepanel />
                 {fagsak.status === FagsakStatus.LØPENDE && (
-                    <>
+                    <VStack>
                         <Heading size="medium" level="2" spacing>
                             Løpende månedlig utbetaling
                         </Heading>
                         {løpendeMånedligUtbetaling()}
-                    </>
+                    </VStack>
                 )}
                 <Behandlinger />
             </VStack>

--- a/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { BodyShort, HStack, VStack } from '@navikt/ds-react';
-import { BorderNeutralStrong, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
+import { BorderNeutralStrong, Space24, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
 
 import { SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import PersonUtbetaling from './PersonUtbetaling';
@@ -11,7 +11,7 @@ import { formaterBeløp, sorterUtbetaling } from '../../../utils/formatter';
 
 const LøpendeUtbetalinger = styled(VStack)`
     max-width: ${SaksoversiktPanelBredde};
-    margin-top: ${Space32};
+    margin-top: ${Space24};
 `;
 
 const Totallinje = styled(HStack)`


### PR DESCRIPTION
Fragment `<>` inni `VStack gap='space-56'` gjorde heading og utbetalingsinnhold til separate flex-children, noe som ga et stort mellomrom. Bytter til `<VStack>` slik at de grupperes som én enhet.

Introdusert i NAV-24909 (`12a7483b`).

FØR:
<img width="1052" height="772" alt="Screenshot 2026-05-21 at 12 19 34" src="https://github.com/user-attachments/assets/76b1501e-d705-4d1c-8c55-e5cf9522c50b" />

ETTER:
<img width="811" height="440" alt="Screenshot 2026-05-21 at 12 18 06" src="https://github.com/user-attachments/assets/e06b1cde-c5d5-4b38-933d-a4f4511d55a8" />
