### PR TITLE
Treghet i klage stanser saksbehandling

### DIFF
--- a/src/frontend/api/hentKlagebehandlinger.ts
+++ b/src/frontend/api/hentKlagebehandlinger.ts
@@ -1,6 +1,7 @@
+import type { IKlagebehandling } from '@typer/klage';
+
 import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
 
-import type { IKlagebehandling } from '../typer/klage';
 import { RessursResolver } from '../utils/ressursResolver';
 
 export async function hentKlagebehandlinger(request: FamilieRequest, fagsakId: number): Promise<IKlagebehandling[]> {
@@ -8,6 +9,7 @@ export async function hentKlagebehandlinger(request: FamilieRequest, fagsakId: n
         method: 'GET',
         url: `/familie-ba-sak/api/fagsaker/${fagsakId}/hent-klagebehandlinger`,
         påvirkerSystemLaster: true,
+        timeout: 10000,
     });
     return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/api/hentTilbakekrevingsbehandlinger.ts
+++ b/src/frontend/api/hentTilbakekrevingsbehandlinger.ts
@@ -1,6 +1,7 @@
+import type { ITilbakekrevingsbehandling } from '@typer/tilbakekrevingsbehandling';
+
 import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
 
-import type { ITilbakekrevingsbehandling } from '../typer/tilbakekrevingsbehandling';
 import { RessursResolver } from '../utils/ressursResolver';
 
 export async function hentTilbakekrevingsbehandlinger(
@@ -11,6 +12,7 @@ export async function hentTilbakekrevingsbehandlinger(
         method: 'GET',
         url: `/familie-ba-sak/api/tilbakekreving/fagsak/${fagsakId}`,
         påvirkerSystemLaster: true,
+        timeout: 10000,
     });
     return RessursResolver.resolveToPromise(ressurs);
 }


### PR DESCRIPTION
### 📮 Favro: Nav-29168

### 💰 Hva skal gjøres, og hvorfor?
Når vi er i saksoversikten hentes behandlinger fra klage.
Dette kallet låser hele siden, man får ikke gjort noe før klagene er henta.

I ekstremt mange tilfeller er det slik at saksbehandler ikke trenger klagene.
Jeg har derfor gjort litt om på det slik at man kan fortsatt navigere seg rundt i saksoversikten mens man henter inn klage.

FØR:

https://github.com/user-attachments/assets/86e62862-c0ca-43cd-9fca-ba2f08bbc82b


ETTER:


https://github.com/user-attachments/assets/f56a3270-ee5b-4911-bad0-19b0d8fd7110



