### PR TITLE
NAV-27893: Forbedrer feilhåndtering av fritekstfeilmelding.

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/BegrunnelserMultiselect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { type Ref, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import { useBehandlingId } from '@hooks/useBehandlingId';
 import { useErLesevisning } from '@hooks/useErLesevisning';
@@ -25,6 +25,9 @@ import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
 import { useAlleBegrunnelserContext } from '../AlleBegrunnelserContext';
 import Styles from './BegrunnelserMultiselect.module.css';
 
+const FRITEKST_FEILMELDING =
+    'Fritekst kan kun brukes i kombinasjon med en eller flere begrunnelser. Legg til en ny begrunnelse eller fjern friteksten(e).';
+
 const enkeltverdierSomKanSettesAutomatisk = [
     'Standardbegrunnelse$INNVILGET_SATSENDRING',
     Standardbegrunnelse.REDUKSJON_SATSENDRING,
@@ -32,8 +35,18 @@ const enkeltverdierSomKanSettesAutomatisk = [
     Standardbegrunnelse.REDUKSJON_UNDER_18_ÅR,
 ];
 
-export function BegrunnelserMultiselect() {
+export interface StandardbegrunnelserHandlinger {
+    tilbakestillKombinertFritekstfeilmelding: () => void;
+}
+
+interface Props {
+    imperativeRef: Ref<StandardbegrunnelserHandlinger>;
+    onSubmitSuccessful: () => void;
+}
+
+export function BegrunnelserMultiselect({ imperativeRef, onSubmitSuccessful }: Props) {
     const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
+
     const { alleBegrunnelser } = useAlleBegrunnelserContext();
 
     const queryClient = useQueryClient();
@@ -42,6 +55,12 @@ export function BegrunnelserMultiselect() {
     const oppdaterVedtaksperioderMedFriteksterIsPending = useOppdaterVedtaksperiodeMedFriteksterIsPending(
         vedtaksperiodeMedBegrunnelser.id
     );
+
+    const [felmelding, settFelmelding] = useState<string | undefined>(undefined);
+
+    useImperativeHandle(imperativeRef, () => ({
+        tilbakestillKombinertFritekstfeilmelding: () => settFelmelding(undefined),
+    }));
 
     const {
         data: genererteBrevbegrunnelser,
@@ -62,6 +81,7 @@ export function BegrunnelserMultiselect() {
                 HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
                 vedtaksperioderMedBegrunnelser
             );
+            onSubmitSuccessful();
         },
     });
 
@@ -92,6 +112,7 @@ export function BegrunnelserMultiselect() {
         switch (action.action) {
             case 'select-option':
                 if (action.option) {
+                    settFelmelding(undefined);
                     oppdaterVedtaksperiodeMedBegrunnelser({
                         standardbegrunnelser: [
                             ...vedtaksperiodeMedBegrunnelser.begrunnelser.map(
@@ -105,21 +126,28 @@ export function BegrunnelserMultiselect() {
             case 'pop-value':
             case 'remove-value':
                 if (action.removedValue) {
-                    oppdaterVedtaksperiodeMedBegrunnelser({
-                        standardbegrunnelser: [
-                            ...vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
-                                persistertBegrunnelse =>
-                                    persistertBegrunnelse.standardbegrunnelse !==
-                                    (action.removedValue?.value as VedtakBegrunnelse)
-                            ),
-                        ].map(begrunnelse => begrunnelse.standardbegrunnelse),
-                    });
+                    const standardbegrunnelser = [
+                        ...vedtaksperiodeMedBegrunnelser.begrunnelser.filter(
+                            persistertBegrunnelse =>
+                                persistertBegrunnelse.standardbegrunnelse !==
+                                (action.removedValue?.value as VedtakBegrunnelse)
+                        ),
+                    ].map(begrunnelse => begrunnelse.standardbegrunnelse);
+                    if (standardbegrunnelser.length === 0 && vedtaksperiodeMedBegrunnelser.fritekster.length > 0) {
+                        settFelmelding(FRITEKST_FEILMELDING);
+                    } else {
+                        oppdaterVedtaksperiodeMedBegrunnelser({ standardbegrunnelser });
+                        settFelmelding(undefined);
+                    }
                 }
                 break;
             case 'clear':
-                oppdaterVedtaksperiodeMedBegrunnelser({
-                    standardbegrunnelser: [],
-                });
+                if (vedtaksperiodeMedBegrunnelser.fritekster.length > 0) {
+                    settFelmelding(FRITEKST_FEILMELDING);
+                } else {
+                    oppdaterVedtaksperiodeMedBegrunnelser({ standardbegrunnelser: [] });
+                    settFelmelding(undefined);
+                }
                 break;
             default:
                 throw new Error('Ukjent action ved onChange på vedtakbegrunnelser');
@@ -174,7 +202,11 @@ export function BegrunnelserMultiselect() {
                 oppdaterVedtaksperiodeMedBegrunnelserIsPending ||
                 genererteBrevbegrunnelserIsPending
             }
-            feil={oppdaterVedtaksperiodeMedBegrunnelserError?.message ?? genererteBrevbegrunnelserError?.message}
+            feil={
+                felmelding ??
+                oppdaterVedtaksperiodeMedBegrunnelserError?.message ??
+                genererteBrevbegrunnelserError?.message
+            }
             creatable={false}
             erLesevisning={skalIkkeEditeres}
             isMulti={true}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Fritekstbegrunnelser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Fritekstbegrunnelser.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { type Ref, useId, useImperativeHandle } from 'react';
 
 import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
@@ -35,7 +35,16 @@ export const MAKS_LENGDE_FRITEKST = 350;
 const MAKS_ANTALL_KULEPUNKT = 3;
 const KLARSPRÅK_URL = 'https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Språk.aspx';
 
-export function Fritekstbegrunnelser() {
+export interface FritekstbegrunnelserHandlinger {
+    tilbakestillKombinertFritekstfeilmelding: () => void;
+}
+
+interface Props {
+    imperativeRef: Ref<FritekstbegrunnelserHandlinger>;
+    onSubmitSuccessful: () => void;
+}
+
+export function Fritekstbegrunnelser({ imperativeRef, onSubmitSuccessful }: Props) {
     const { vedtaksperiodeMedBegrunnelser, onPanelClose } = useVedtaksperiodeContext();
 
     const erLesevisning = useErLesevisning();
@@ -53,14 +62,19 @@ export function Fritekstbegrunnelser() {
         leggTilFritekstbegrunnelse,
         slettFritekstbegrunnelse,
         validerBegrunnelse,
-    } = useFritekstbegrunnelserForm();
+    } = useFritekstbegrunnelserForm({ onSubmitSuccessful });
 
     const {
         handleSubmit,
         register,
         formState: { isSubmitting, errors },
         reset,
+        clearErrors,
     } = form;
+
+    useImperativeHandle(imperativeRef, () => ({
+        tilbakestillKombinertFritekstfeilmelding: () => clearErrors('root.kombinerteBegrunnelserFeilmelding'),
+    }));
 
     function onAvbryt() {
         onPanelClose(false);
@@ -121,7 +135,7 @@ export function Fritekstbegrunnelser() {
                         id={fieldsetId}
                         legend={'Fritekst til kulepunkt i brev'}
                         hideLegend={true}
-                        error={errors.root?.message}
+                        error={errors.root?.message ?? errors.root?.kombinerteBegrunnelserFeilmelding?.message}
                     >
                         <VStack gap={'space-16'}>
                             {fields.map((field, index) => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/Vedtaksperiode.tsx
@@ -1,24 +1,43 @@
+import { useRef } from 'react';
+
 import { GenererteBrevbegrunnelser } from '@sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/GenererteBrevbegrunnelser';
 import { skalViseFritekstbegrunnelser, Vedtaksperiodetype } from '@typer/vedtaksperiode';
 
 import { VStack } from '@navikt/ds-react';
 
-import { BegrunnelserMultiselect } from './BegrunnelserMultiselect';
+import { BegrunnelserMultiselect, type StandardbegrunnelserHandlinger } from './BegrunnelserMultiselect';
 import { EkspanderbarVedtaksperiode } from './EkspanderbarVedtaksperiode';
-import { Fritekstbegrunnelser } from './Fritekstbegrunnelser';
+import { Fritekstbegrunnelser, type FritekstbegrunnelserHandlinger } from './Fritekstbegrunnelser';
 import { Utbetalingsresultat } from './Utbetalingsresultat';
 import { useVedtaksperiodeContext } from './VedtaksperiodeContext';
 
 export function Vedtaksperiode() {
     const { vedtaksperiodeMedBegrunnelser } = useVedtaksperiodeContext();
 
+    const imperativeBegrunnelserMultiselectRef = useRef<StandardbegrunnelserHandlinger>(null);
+    const imperativeFritekstbegrunnelserRef = useRef<FritekstbegrunnelserHandlinger>(null);
+
     return (
         <EkspanderbarVedtaksperiode>
             <VStack gap={'space-20'}>
                 {vedtaksperiodeMedBegrunnelser.utbetalingsperiodeDetaljer.length !== 0 && <Utbetalingsresultat />}
-                {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && <BegrunnelserMultiselect />}
+                {vedtaksperiodeMedBegrunnelser.type !== Vedtaksperiodetype.AVSLAG && (
+                    <BegrunnelserMultiselect
+                        imperativeRef={imperativeBegrunnelserMultiselectRef}
+                        onSubmitSuccessful={() => {
+                            imperativeFritekstbegrunnelserRef.current?.tilbakestillKombinertFritekstfeilmelding();
+                        }}
+                    />
+                )}
                 <GenererteBrevbegrunnelser />
-                {skalViseFritekstbegrunnelser(vedtaksperiodeMedBegrunnelser) && <Fritekstbegrunnelser />}
+                {skalViseFritekstbegrunnelser(vedtaksperiodeMedBegrunnelser) && (
+                    <Fritekstbegrunnelser
+                        imperativeRef={imperativeFritekstbegrunnelserRef}
+                        onSubmitSuccessful={() => {
+                            imperativeBegrunnelserMultiselectRef.current?.tilbakestillKombinertFritekstfeilmelding();
+                        }}
+                    />
+                )}
             </VStack>
         </EkspanderbarVedtaksperiode>
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/useFritekstbegrunnelserForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtaksperioder/useFritekstbegrunnelserForm.ts
@@ -13,6 +13,9 @@ import { useFieldArray, useForm } from 'react-hook-form';
 
 const NY_FRITEKSTBEGRUNNELSE = { value: '' };
 
+const FRITEKST_FEILMELDING =
+    'Fritekst kan kun brukes i kombinasjon med en eller flere begrunnelser. Legg til en ny begrunnelse eller fjern friteksten(e).';
+
 interface Fritekstbegrunnelse {
     value: string;
 }
@@ -25,7 +28,11 @@ export interface FormValues {
     [Field.FRITEKSTBEGRUNNELSER]: Fritekstbegrunnelse[];
 }
 
-export function useFritekstbegrunnelserForm() {
+interface Props {
+    onSubmitSuccessful: () => void;
+}
+
+export function useFritekstbegrunnelserForm({ onSubmitSuccessful }: Props) {
     const { vedtaksperiodeMedBegrunnelser, settErSkjemaendringer } = useVedtaksperiodeContext();
 
     const queryClient = useQueryClient();
@@ -74,6 +81,7 @@ export function useFritekstbegrunnelserForm() {
                     HentVedtaksperioderQueryKeyFactory.behandling(behandlingId),
                     vedtaksperioderMedBegrunnelser
                 );
+                onSubmitSuccessful();
             },
             onError: error => setError('root', { message: error.message ?? 'En ukjent feil oppstod.' }),
         }
@@ -107,6 +115,10 @@ export function useFritekstbegrunnelserForm() {
     }
 
     function onSubmit({ fritekstbegrunnelser }: FormValues) {
+        if (vedtaksperiodeMedBegrunnelser.begrunnelser.length === 0) {
+            setError('root.kombinerteBegrunnelserFeilmelding', { message: FRITEKST_FEILMELDING });
+            return;
+        }
         const fritekster = fritekstbegrunnelser.map(fritekstbegrunnelse => fritekstbegrunnelse.value);
         return oppdaterVedtaksperiodeMedFritekster({ fritekster });
     }


### PR DESCRIPTION
### 📮 Favro
NAV-27893

### 💰 Hva skal gjøres, og hvorfor?
- Viser feilmelding hvis man prøver å legge til fritekst(er) uten å ha tidligere begrunnelser.
- Viser feilmelding hvis man prøver å fjerne alle/siste begrunnelser og har fritekst(er) samtidig. 
- Legger til logikk for å tilbakestille feilmeldingen i `<BegrunnelseMultiselect />` fra `<Fritekstbegrunnelser />` komponenten.
- Legger til logikk for å tilbakestille feilmeldingen i `<Fritekstbegrunnelser />` fra `<BegrunnelseMultiselect />` komponenten.

Tidligere kom feilmeldingen i backend. Nå viser vi en feilmelding i frontend før vi sender en HTTP request til backend. Dette vil forhindre støy i logger.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ingen eksisterende tester.

### 👀 Screen shots
Ingen visuelle endringer. 