### PR TITLE
NAV-29011: Flytter toast-state til ToastContext

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -6,6 +6,7 @@ import { AuthContextProvider } from '@context/AuthContext';
 import { HttpContextProvider } from '@context/HttpContext';
 import { ModalProvider } from '@context/ModalContext';
 import { SaksbehandlerProvider } from '@context/SaksbehandlerContext';
+import { ToastProvider } from '@context/ToastContext';
 import { FeatureTogglesProvider } from '@context/TogglesContext';
 import { useStartUmami } from '@hooks/useStartUmami';
 import { ErrorBoundary, ErrorBoundaryMedSaksbehandler } from '@komponenter/ErrorBoundary/ErrorBoundary';
@@ -37,7 +38,9 @@ export function App() {
                                 <FeatureTogglesProvider>
                                     <AppProvider>
                                         <ModalProvider>
-                                            <Container />
+                                            <ToastProvider>
+                                                <Container />
+                                            </ToastProvider>
                                         </ModalProvider>
                                     </AppProvider>
                                 </FeatureTogglesProvider>

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -1,14 +1,6 @@
-import {
-    type Dispatch,
-    type JSX,
-    type PropsWithChildren,
-    type ReactNode,
-    type SetStateAction,
-    useContext,
-} from 'react';
+import { type JSX, type PropsWithChildren, type ReactNode, useContext } from 'react';
 import { createContext, useState } from 'react';
 
-import type { IToast, ToastTyper } from '@komponenter/Toast/typer';
 import type { IPersonInfo, IRestTilgang } from '@typer/person';
 import { adressebeskyttelsestyper } from '@typer/person';
 import type { AxiosRequestConfig } from 'axios';
@@ -57,10 +49,7 @@ const tilgangModal = (data: IRestTilgang, lukkModal: () => void) => ({
 
 interface AppContextValue {
     appInfoModal: IModal;
-    settToast: (toastId: ToastTyper, toast: IToast) => void;
-    settToasts: Dispatch<SetStateAction<{ [toastId: string]: IToast }>>;
     sjekkTilgang: (brukerIdent: string, visSystemetLaster?: boolean) => Promise<boolean>;
-    toasts: { [toastId: string]: IToast };
     hentPerson: (brukerIdent: string) => Promise<Ressurs<IPersonInfo>>;
 }
 
@@ -70,7 +59,6 @@ const AppProvider = (props: PropsWithChildren) => {
     const { request } = useHttp();
 
     const [appInfoModal, settAppInfoModal] = useState<IModal>(initalState);
-    const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
 
     const lukkModal = () => {
         settAppInfoModal(initalState);
@@ -119,14 +107,7 @@ const AppProvider = (props: PropsWithChildren) => {
         <AppContext.Provider
             value={{
                 appInfoModal,
-                settToast: (toastId: ToastTyper, toast: IToast) =>
-                    settToasts({
-                        ...toasts,
-                        [toastId]: toast,
-                    }),
-                settToasts,
                 sjekkTilgang,
-                toasts,
                 hentPerson,
             }}
         >

--- a/src/frontend/context/ToastContext.test.tsx
+++ b/src/frontend/context/ToastContext.test.tsx
@@ -1,0 +1,78 @@
+import type { PropsWithChildren } from 'react';
+
+import { AlertType, type IToast, ToastTyper } from '@komponenter/Toast/typer';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { ToastProvider, useToastContext } from './ToastContext';
+
+const wrapper = ({ children }: PropsWithChildren) => <ToastProvider>{children}</ToastProvider>;
+
+describe('ToastContext', () => {
+    test('kaster feil når useToastContext brukes utenfor ToastProvider', () => {
+        // Act & assert
+        expect(() => renderHook(() => useToastContext())).toThrowError(
+            'useToastContext må brukes innenfor en ToastProvider.'
+        );
+    });
+
+    test('gir tilgang til toasts som er tom ved oppstart', () => {
+        // Act
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        // Assert
+        expect(result.current.toasts).toEqual({});
+    });
+
+    test('settToast legger til en toast i toasts', () => {
+        // Arrange
+        const toast: IToast = { tekst: 'Noe gikk galt', alertType: AlertType.ERROR };
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        // Act
+        act(() => {
+            result.current.settToast(ToastTyper.FANT_IKKE_FAGSAK, toast);
+        });
+
+        // Assert
+        expect(result.current.toasts).toEqual({ [ToastTyper.FANT_IKKE_FAGSAK]: toast });
+    });
+
+    test('settToast bevarer eksisterende toasts når en ny legges til', () => {
+        // Arrange
+        const toast1: IToast = { tekst: 'Noe gikk galt', alertType: AlertType.ERROR };
+        const toast2: IToast = { tekst: 'Ingen tilgang!', alertType: AlertType.ERROR };
+
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        act(() => {
+            result.current.settToast(ToastTyper.FANT_IKKE_FAGSAK, toast1);
+        });
+
+        // Act
+        act(() => {
+            result.current.settToast(ToastTyper.MANGLER_TILGANG, toast2);
+        });
+
+        // Assert
+        expect(result.current.toasts).toEqual({
+            [ToastTyper.FANT_IKKE_FAGSAK]: toast1,
+            [ToastTyper.MANGLER_TILGANG]: toast2,
+        });
+    });
+
+    test('settToasts kan overskrive hele toasts-tilstanden direkte', () => {
+        // Arrange
+        const toast: IToast = { tekst: 'Noe gikk galt', alertType: AlertType.ERROR };
+        const nyeToasts = { [ToastTyper.FANT_IKKE_FAGSAK]: toast };
+        const { result } = renderHook(() => useToastContext(), { wrapper });
+
+        // Act
+        act(() => {
+            result.current.settToasts(nyeToasts);
+        });
+
+        // Assert
+        expect(result.current.toasts).toEqual(nyeToasts);
+    });
+});

--- a/src/frontend/context/ToastContext.tsx
+++ b/src/frontend/context/ToastContext.tsx
@@ -1,0 +1,32 @@
+import { type Dispatch, type PropsWithChildren, type SetStateAction, useMemo, useState } from 'react';
+import { createContext, useContext } from 'react';
+
+import type { IToast, ToastTyper } from '@komponenter/Toast/typer';
+
+interface ToastContext {
+    settToast: (toastId: ToastTyper, toast: IToast) => void;
+    settToasts: Dispatch<SetStateAction<{ [toastId: string]: IToast }>>;
+    toasts: { [toastId: string]: IToast };
+}
+
+const ToastContext = createContext<ToastContext | undefined>(undefined);
+
+export function ToastProvider({ children }: PropsWithChildren) {
+    const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
+
+    function settToast(toastId: ToastTyper, toast: IToast) {
+        settToasts(prev => ({ ...prev, [toastId]: toast }));
+    }
+
+    const value = useMemo(() => ({ settToast, settToasts, toasts }), [toasts]);
+
+    return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+}
+
+export function useToastContext() {
+    const context = useContext(ToastContext);
+    if (context === undefined) {
+        throw new Error('useToastContext må brukes innenfor en ToastProvider.');
+    }
+    return context;
+}

--- a/src/frontend/hooks/useSettAktivBrukerIModiaContext.ts
+++ b/src/frontend/hooks/useSettAktivBrukerIModiaContext.ts
@@ -1,14 +1,13 @@
+import { settAktivBrukerIModiaContext } from '@api/settAktivBrukerIModiaContext';
+import { useToastContext } from '@context/ToastContext';
+import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
 import { useMutation } from '@tanstack/react-query';
 
 import { useHttp } from '@navikt/familie-http';
 
-import { settAktivBrukerIModiaContext } from '../api/settAktivBrukerIModiaContext';
-import { useAppContext } from '../context/AppContext';
-import { AlertType, ToastTyper } from '../komponenter/Toast/typer';
-
 export function useSettAktivBrukerIModiaContext() {
     const { request } = useHttp();
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     return useMutation({
         mutationFn: (personIdent: string) => settAktivBrukerIModiaContext(request, personIdent),
         onError: () => {

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useLagreOgFjernMottakerPåBehandling.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useLagreOgFjernMottakerPåBehandling.ts
@@ -1,12 +1,13 @@
+import { useToastContext } from '@context/ToastContext';
+import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
+import type { IBehandling } from '@typer/behandling';
+
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import { byggHenterRessurs, RessursStatus } from '@navikt/familie-typer';
 
 import type { BrevmottakerUseSkjema, IRestBrevmottaker } from './useBrevmottakerSkjema';
-import { useAppContext } from '../../../../context/AppContext';
-import { useBehandlingContext } from '../../../../sider/Fagsak/Behandling/context/BehandlingContext';
-import type { IBehandling } from '../../../../typer/behandling';
-import { AlertType, ToastTyper } from '../../../Toast/typer';
 
 interface Props {
     behandlingId: number;
@@ -14,7 +15,7 @@ interface Props {
 
 export const useLagreEllerFjernMottakerPåBehandling = ({ behandlingId }: Props) => {
     const { settÅpenBehandling } = useBehandlingContext();
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     const { request } = useHttp();
 
     const lagreMottaker = (verdierFraBrevmottakerUseSkjema: BrevmottakerUseSkjema) => {

--- a/src/frontend/komponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Toast/Toast.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useRef } from 'react';
 
+import { useToastContext } from '@context/ToastContext';
+
 import { LocalAlert } from '@navikt/ds-react';
 
 import styles from './Toast.module.css';
 import type { IToast } from './typer';
-import { useAppContext } from '../../context/AppContext';
 
 const Toast = ({ toastId, toast }: { toastId: string; toast: IToast }) => {
-    const { toasts, settToasts } = useAppContext();
+    const { toasts, settToasts } = useToastContext();
     const toastRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {

--- a/src/frontend/komponenter/Toast/Toasts.tsx
+++ b/src/frontend/komponenter/Toast/Toasts.tsx
@@ -1,9 +1,10 @@
+import { useToastContext } from '@context/ToastContext';
+
 import Toast from './Toast';
 import styles from './Toasts.module.css';
-import { useAppContext } from '../../context/AppContext';
 
 const Toasts = () => {
-    const { toasts } = useAppContext();
+    const { toasts } = useToastContext();
 
     return (
         <div className={styles.container}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Oppsummeringsboks.tsx
@@ -1,6 +1,6 @@
 import { type PropsWithChildren, useEffect, useState } from 'react';
 
-import { useAppContext } from '@context/AppContext';
+import { useToastContext } from '@context/ToastContext';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { FalskIdentitet } from '@komponenter/FalskIdentitet/FalskIdentitet';
 import { Skillelinje } from '@komponenter/PersonInformasjon/PersonInformasjon';
@@ -110,7 +110,7 @@ const Oppsummeringsboks = ({
 }: IProps) => {
     const { request } = useHttp();
     const { behandling, settÅpenBehandling } = useBehandlingContext();
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     const { settAktivEtikett } = useTidslinjeContext();
 
     const erLesevisning = useErLesevisning();

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/useKorrigerEtterbetalingForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/KorrigerEtterbetaling/useKorrigerEtterbetalingForm.ts
@@ -1,15 +1,15 @@
+import { ModalType } from '@context/ModalContext';
+import { useToastContext } from '@context/ToastContext';
+import { useAngreKorrigertEtterbetaling } from '@hooks/useAngreKorrigertEtterbetaling';
+import { useKorrigerEtterbetaling } from '@hooks/useKorrigerEtterbetaling';
+import { useModal } from '@hooks/useModal';
+import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
+import type { OptionType } from '@typer/common';
+import { KorrigertEtterbetalingÅrsak } from '@typer/vedtak';
 import { useForm } from 'react-hook-form';
 
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useAppContext } from '../../../../../../context/AppContext';
-import { ModalType } from '../../../../../../context/ModalContext';
-import { useAngreKorrigertEtterbetaling } from '../../../../../../hooks/useAngreKorrigertEtterbetaling';
-import { useKorrigerEtterbetaling } from '../../../../../../hooks/useKorrigerEtterbetaling';
-import { useModal } from '../../../../../../hooks/useModal';
-import { AlertType, ToastTyper } from '../../../../../../komponenter/Toast/typer';
-import type { OptionType } from '../../../../../../typer/common';
-import { KorrigertEtterbetalingÅrsak } from '../../../../../../typer/vedtak';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
 
 interface KorrigerEtterbetalingFormValues {
@@ -45,7 +45,7 @@ export function useKorrigerEtterbetalingForm() {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
     const korrigertEtterbetaling = behandling.korrigertEtterbetaling;
 
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
 
     const { mutateAsync: korrigerEtterbetalingAsync } = useKorrigerEtterbetaling();
 

--- a/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { useAppContext } from '@context/AppContext';
+import { useToastContext } from '@context/ToastContext';
 import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
 import type { IOppgave } from '@typer/oppgave';
 import { oppgaveTypeFilter, OppgavetypeFilter } from '@typer/oppgave';
@@ -16,7 +17,7 @@ interface IOppgaveDirektelenke {
 }
 
 export function OppgaveDirektelenke({ oppgave }: IOppgaveDirektelenke) {
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     const { gåTilFagsakEllerVisFeilmelding } = useOppgavebenkContext();
     const { sjekkTilgang } = useAppContext();
     const [laster, settLaster] = useState<boolean>(false);

--- a/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavebenkContext.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 import { useFagsakApi } from '@api/useFagsakApi';
-import { useAppContext } from '@context/AppContext';
+import { useToastContext } from '@context/ToastContext';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
 import type { IMinimalFagsak } from '@typer/fagsak';
@@ -52,7 +52,7 @@ interface OppgavebenkContextValue {
 const OppgavebenkContext = createContext<OppgavebenkContextValue | undefined>(undefined);
 
 export const OppgavebenkProvider = (props: PropsWithChildren) => {
-    const { settToast } = useAppContext();
+    const { settToast } = useToastContext();
     const saksbehandler = useSaksbehandler();
     const navigate = useNavigate();
     const { request } = useHttp();

--- a/src/frontend/testutils/testrender.tsx
+++ b/src/frontend/testutils/testrender.tsx
@@ -1,20 +1,21 @@
 import type { ReactNode, PropsWithChildren } from 'react';
 
+import { AppProvider } from '@context/AppContext';
+import { AuthContextProvider } from '@context/AuthContext';
+import { HttpContextProvider } from '@context/HttpContext';
+import { ModalProvider } from '@context/ModalContext';
+import { SaksbehandlerProvider } from '@context/SaksbehandlerContext';
+import { ToastProvider } from '@context/ToastContext';
+import { FeatureTogglesProvider } from '@context/TogglesContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as rtlRender, type RenderOptions, screen as rtlScreen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { FeatureToggles } from '@typer/featureToggles';
+import type { Saksbehandler } from '@typer/saksbehandler';
 import { MemoryRouter } from 'react-router';
 
-import { AppProvider } from '../context/AppContext';
-import { AuthContextProvider } from '../context/AuthContext';
-import { ModalProvider } from '../context/ModalContext';
-import { lagSaksbehandler } from './testdata/saksbehandlerTestdata';
-import { HttpContextProvider } from '../context/HttpContext';
-import { SaksbehandlerProvider } from '../context/SaksbehandlerContext';
-import { FeatureTogglesProvider } from '../context/TogglesContext';
-import type { FeatureToggles } from '../typer/featureToggles';
-import type { Saksbehandler } from '../typer/saksbehandler';
 import { skruPåAlleToggles } from './mocks/handlers/featureToggleHandlers';
+import { lagSaksbehandler } from './testdata/saksbehandlerTestdata';
 
 function lagQueryClient() {
     return new QueryClient({
@@ -50,7 +51,9 @@ export function TestProviders({
                         <FeatureTogglesProvider featureToggles={featureToggles}>
                             <AppProvider>
                                 <ModalProvider>
-                                    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+                                    <ToastProvider>
+                                        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+                                    </ToastProvider>
                                 </ModalProvider>
                             </AppProvider>
                         </FeatureTogglesProvider>


### PR DESCRIPTION
### 📮 Favro
NAV-29011

### 💰 Hva skal gjøres, og hvorfor?
Flytter toast-staten fra AppContext til en egen ToastContext.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 