### PR TITLE
Legger til egen toggle for oppretting av fagsak med type skjermet barn

### DIFF
--- a/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
+++ b/src/frontend/komponenter/Modal/fagsak/felt/FagsaktypeFelt.tsx
@@ -56,7 +56,7 @@ export function FagsaktypeFelt({ readOnly }: Props) {
             if (option.value === FagsakType.SKJERMET_BARN) {
                 const aktuellGruppe = erProd() ? SKJERMET_BARN_GRUPPE.PROD : SKJERMET_BARN_GRUPPE.DEV;
                 const harTilgang = saksbehandler.groups.some(group => group === aktuellGruppe);
-                return harTilgang && toggles[FeatureToggle.tillattBehandlingAvSkjermetBarn];
+                return harTilgang && toggles[FeatureToggle.tillattOpprettingAvSkjermetBarnFagsak];
             }
             return true;
         })

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -10,7 +10,7 @@ export enum FeatureToggle {
 
     // Release
     selvstendigRettInfobrev = 'familie-ba-sak.selvstendig-rett-infobrev',
-    tillattBehandlingAvSkjermetBarn = 'familie-ba-sak.tillatt-behandling-av-kode6-kode19',
+    tillattOpprettingAvSkjermetBarnFagsak = 'familie-ba-sak.tillatt-oppretting-av-skjermet-barn-fagsak',
     skalViseVarsellampeForManueltLagtTilBarn = 'familie-ba-sak.skal-vise-varsellampe-for-manuelt-lagt-til-barn',
     skalBrukeNyttSkjemaForEndretUtbetalingAndel = 'familie-ba-sak.endret-utbetaling-andel-skjema-rhf',
     skalKunneBehandleBaInstitusjonFagsaker = 'familie-klage.skal-kunne-behandle-ba-institusjon-fagsaker',


### PR DESCRIPTION
### 📮 Favro: NAV-29315

### 💰 Hva skal gjøres, og hvorfor?
Legger til en egen [toggle](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ba-sak.tillatt-oppretting-av-skjermet-barn-fagsak) for oppretting av fagsak med type skjermet barn, ettersom den forrige også blokkerte automatisk journalføring