### PR TITLE
NAV-29011: Refaktorerer tilgangssjekk til react-query.

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -4,8 +4,10 @@ import './index.css';
 import { AppProvider } from '@context/AppContext';
 import { AuthContextProvider } from '@context/AuthContext';
 import { HttpContextProvider } from '@context/HttpContext';
+import { ManglerTilgangModalProvider } from '@context/ManglerTilgangModalContext';
 import { ModalProvider } from '@context/ModalContext';
 import { SaksbehandlerProvider } from '@context/SaksbehandlerContext';
+import { TekniskFeilModalProvider } from '@context/TekniskFeilModalContext';
 import { ToastProvider } from '@context/ToastContext';
 import { FeatureTogglesProvider } from '@context/TogglesContext';
 import { useStartUmami } from '@hooks/useStartUmami';
@@ -29,26 +31,30 @@ export function App() {
 
     return (
         <ErrorBoundary>
-            <QueryClientProvider client={queryClient}>
-                {!erProd() && <ReactQueryDevtools position={'right'} initialIsOpen={false} />}
-                <SaksbehandlerProvider>
-                    <ErrorBoundaryMedSaksbehandler>
-                        <AuthContextProvider>
-                            <HttpContextProvider>
-                                <FeatureTogglesProvider>
-                                    <AppProvider>
-                                        <ModalProvider>
-                                            <ToastProvider>
-                                                <Container />
-                                            </ToastProvider>
-                                        </ModalProvider>
-                                    </AppProvider>
-                                </FeatureTogglesProvider>
-                            </HttpContextProvider>
-                        </AuthContextProvider>
-                    </ErrorBoundaryMedSaksbehandler>
-                </SaksbehandlerProvider>
-            </QueryClientProvider>
+            <TekniskFeilModalProvider>
+                <ManglerTilgangModalProvider>
+                    <QueryClientProvider client={queryClient}>
+                        {!erProd() && <ReactQueryDevtools position={'right'} initialIsOpen={false} />}
+                        <SaksbehandlerProvider>
+                            <ErrorBoundaryMedSaksbehandler>
+                                <AuthContextProvider>
+                                    <HttpContextProvider>
+                                        <FeatureTogglesProvider>
+                                            <AppProvider>
+                                                <ModalProvider>
+                                                    <ToastProvider>
+                                                        <Container />
+                                                    </ToastProvider>
+                                                </ModalProvider>
+                                            </AppProvider>
+                                        </FeatureTogglesProvider>
+                                    </HttpContextProvider>
+                                </AuthContextProvider>
+                            </ErrorBoundaryMedSaksbehandler>
+                        </SaksbehandlerProvider>
+                    </QueryClientProvider>
+                </ManglerTilgangModalProvider>
+            </TekniskFeilModalProvider>
         </ErrorBoundary>
     );
 }

--- a/src/frontend/api/sjekkSaksbehandlertilgangTilIdent.ts
+++ b/src/frontend/api/sjekkSaksbehandlertilgangTilIdent.ts
@@ -1,0 +1,24 @@
+import type { Adressebeskyttelsegradering } from '@typer/person';
+
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface Tilgangsresultat {
+    saksbehandlerHarTilgang: boolean;
+    adressebeskyttelsegradering: Adressebeskyttelsegradering;
+}
+
+interface Payload {
+    brukerIdent: string;
+}
+
+export async function sjekkSaksbehandlertilgangTilIdent(request: FamilieRequest, payload: Payload) {
+    const ressurs = await request<Payload, Tilgangsresultat>({
+        method: 'POST',
+        url: '/familie-ba-sak/api/tilgang',
+        data: payload,
+        påvirkerSystemLaster: false,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -8,7 +8,6 @@ import type { AxiosRequestConfig } from 'axios';
 import { BodyShort, Button, HStack } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import StatusIkon, { Status } from '../ikoner/StatusIkon';
 
@@ -49,7 +48,6 @@ const tilgangModal = (data: IRestTilgang, lukkModal: () => void) => ({
 
 interface AppContextValue {
     appInfoModal: IModal;
-    sjekkTilgang: (brukerIdent: string, visSystemetLaster?: boolean) => Promise<boolean>;
     hentPerson: (brukerIdent: string) => Promise<Ressurs<IPersonInfo>>;
 }
 
@@ -87,27 +85,10 @@ const AppProvider = (props: PropsWithChildren) => {
         });
     };
 
-    const sjekkTilgang = async (brukerIdent: string, visSystemetLaster = true): Promise<boolean> => {
-        return request<{ brukerIdent: string }, IRestTilgang>({
-            method: 'POST',
-            url: '/familie-ba-sak/api/tilgang',
-            data: { brukerIdent },
-            påvirkerSystemLaster: visSystemetLaster,
-        }).then((ressurs: Ressurs<IRestTilgang>) => {
-            if (ressurs.status === RessursStatus.SUKSESS) {
-                settAppInfoModal(tilgangModal(ressurs.data, lukkModal));
-                return ressurs.data.saksbehandlerHarTilgang;
-            } else {
-                return false;
-            }
-        });
-    };
-
     return (
         <AppContext.Provider
             value={{
                 appInfoModal,
-                sjekkTilgang,
                 hentPerson,
             }}
         >

--- a/src/frontend/context/ManglerTilgangModalContext.tsx
+++ b/src/frontend/context/ManglerTilgangModalContext.tsx
@@ -1,0 +1,69 @@
+import { type PropsWithChildren, useCallback, useState } from 'react';
+import { createContext, useContext } from 'react';
+
+import type { Adressebeskyttelsegradering } from '@typer/person';
+import { adressebeskyttelsestyper } from '@typer/person';
+
+import { XMarkOctagonFillIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, ErrorMessage, HStack, Modal, VStack } from '@navikt/ds-react';
+
+interface ManglerTilgang {
+    readonly begrunnelse: string;
+    readonly adressebeskyttelsegradering?: Adressebeskyttelsegradering;
+}
+
+const DEFAULT_BEGRUNNELSE = 'Du har ikke tilgang til å gjennomføre denne handlingen.';
+
+interface Context {
+    visManglerTilgangModal: (manglerTilgang?: Partial<ManglerTilgang>) => void;
+}
+
+const ManglerTilgangModalContext = createContext<Context | undefined>(undefined);
+
+export function ManglerTilgangModalProvider({ children }: PropsWithChildren) {
+    const [manglerTilgang, settManglerTilgang] = useState<ManglerTilgang | undefined>(undefined);
+
+    const visManglerTilgangModal = useCallback((manglerTilgang: Partial<ManglerTilgang> = {}) => {
+        settManglerTilgang({ begrunnelse: DEFAULT_BEGRUNNELSE, ...manglerTilgang });
+    }, []);
+
+    const lukk = useCallback(() => {
+        settManglerTilgang(undefined);
+    }, []);
+
+    return (
+        <ManglerTilgangModalContext.Provider value={{ visManglerTilgangModal }}>
+            {children}
+            {manglerTilgang && (
+                <Modal open={true} portal={true} header={{ heading: 'Mangler tilgang' }} onClose={lukk} width={'35rem'}>
+                    <Modal.Body>
+                        <VStack gap={'space-24'} marginBlock={'space-8 space-0'}>
+                            <BodyShort>{manglerTilgang.begrunnelse}</BodyShort>
+                            {manglerTilgang.adressebeskyttelsegradering && (
+                                <HStack gap={'space-4'} align={'center'}>
+                                    <XMarkOctagonFillIcon color={'var(--ax-text-danger-subtle)'} fontSize={'1.2rem'} />
+                                    <ErrorMessage>
+                                        {`Ident har diskresjonskode ${adressebeskyttelsestyper[manglerTilgang.adressebeskyttelsegradering] ?? manglerTilgang.adressebeskyttelsegradering}.`}
+                                    </ErrorMessage>
+                                </HStack>
+                            )}
+                        </VStack>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button variant={'primary'} size={'small'} onClick={lukk}>
+                            Lukk
+                        </Button>
+                    </Modal.Footer>
+                </Modal>
+            )}
+        </ManglerTilgangModalContext.Provider>
+    );
+}
+
+export function useVisManglerTilgangModal() {
+    const context = useContext(ManglerTilgangModalContext);
+    if (context === undefined) {
+        throw new Error('useVisManglerTilgangModal må brukes innenfor en ManglerTilgangModalProvider');
+    }
+    return context.visManglerTilgangModal;
+}

--- a/src/frontend/context/TekniskFeilModalContext.tsx
+++ b/src/frontend/context/TekniskFeilModalContext.tsx
@@ -1,0 +1,92 @@
+import { createContext, type PropsWithChildren, useCallback, useContext, useState } from 'react';
+
+import { XMarkOctagonFillIcon } from '@navikt/aksel-icons';
+import { BodyLong, Button, ErrorMessage, HStack, Modal, VStack } from '@navikt/ds-react';
+
+function finnFeilmeldingstekst(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') {
+        return error.message;
+    }
+    return 'En ukjent feil oppstod.';
+}
+
+export interface TekniskFeil {
+    readonly id: string;
+    readonly tekst: string;
+}
+
+interface Context {
+    visTekniskFeilModal: (error: unknown) => void;
+}
+
+const TekniskFeilModalContext = createContext<Context | undefined>(undefined);
+
+interface Props extends PropsWithChildren {
+    initielleTekniskeFeil?: TekniskFeil[];
+}
+
+export function TekniskFeilModalProvider({ initielleTekniskeFeil = [], children }: Props) {
+    const [tekniskeFeil, settTekniskeFeil] = useState<TekniskFeil[]>(initielleTekniskeFeil);
+
+    const visTekniskFeilModal = useCallback((error: unknown) => {
+        const nyTekniskFeil = { id: crypto.randomUUID(), tekst: finnFeilmeldingstekst(error) };
+        settTekniskeFeil(prev => [...prev, nyTekniskFeil]);
+        console.error(error);
+    }, []);
+
+    const lukk = useCallback(() => {
+        settTekniskeFeil([]);
+    }, []);
+
+    return (
+        <TekniskFeilModalContext.Provider value={{ visTekniskFeilModal }}>
+            {children}
+            {tekniskeFeil.length > 0 && (
+                <Modal open={true} portal={true} header={{ heading: 'Teknisk feil' }} onClose={lukk} width={'35rem'}>
+                    <Modal.Body>
+                        <VStack gap={'space-32'}>
+                            <BodyLong>
+                                {tekniskeFeil.length === 1
+                                    ? 'Det har oppstått en teknisk feil i vedtaksløsningen. Prøv igjen senere eller kontakt brukerstøtte hvis problemet vedvarer.'
+                                    : 'Det har oppstått tekniske feil i vedtaksløsningen. Prøv igjen senere eller kontakt brukerstøtte hvis problemet vedvarer.'}
+                            </BodyLong>
+                            <VStack gap={'space-8'}>
+                                {tekniskeFeil.map((tf, index) => (
+                                    <HStack key={tf.id} gap={'space-4'} align={'center'}>
+                                        <XMarkOctagonFillIcon
+                                            color={'var(--ax-text-danger-subtle)'}
+                                            fontSize={'1.2rem'}
+                                        />
+                                        <ErrorMessage>
+                                            {tekniskeFeil.length > 1 && `${index + 1}. `}
+                                            {tf.tekst}
+                                        </ErrorMessage>
+                                    </HStack>
+                                ))}
+                            </VStack>
+                        </VStack>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button variant={'primary'} size={'small'} onClick={lukk}>
+                            Lukk
+                        </Button>
+                    </Modal.Footer>
+                </Modal>
+            )}
+        </TekniskFeilModalContext.Provider>
+    );
+}
+
+export function useVisTekniskFeilModal() {
+    const context = useContext(TekniskFeilModalContext);
+    if (context === undefined) {
+        throw new Error('useVisTekniskFeilModal må brukes innenfor en TekniskFeilModalProvider.');
+    }
+    return context.visTekniskFeilModal;
+}

--- a/src/frontend/hooks/useSjekkSaksbehandlertilgangTilIdent.ts
+++ b/src/frontend/hooks/useSjekkSaksbehandlertilgangTilIdent.ts
@@ -1,0 +1,22 @@
+import { sjekkSaksbehandlertilgangTilIdent, type Tilgangsresultat } from '@api/sjekkSaksbehandlertilgangTilIdent';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+interface Parameters {
+    brukerIdent: string;
+}
+
+type Options = Omit<UseMutationOptions<Tilgangsresultat, DefaultError, Parameters>, 'mutationFn'>;
+
+export function useSjekkSaksbehandlertilgangTilIdent(options?: Options) {
+    const { request } = useHttp();
+    return useMutation({
+        mutationFn: (parameters: Parameters) => {
+            const { brukerIdent } = parameters;
+            const payload = { brukerIdent };
+            return sjekkSaksbehandlertilgangTilIdent(request, payload);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgaveDirektelenke.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 
-import { useAppContext } from '@context/AppContext';
-import { useToastContext } from '@context/ToastContext';
-import { AlertType, ToastTyper } from '@komponenter/Toast/typer';
+import { useVisManglerTilgangModal } from '@context/ManglerTilgangModalContext';
+import { useVisTekniskFeilModal } from '@context/TekniskFeilModalContext';
+import { useSjekkSaksbehandlertilgangTilIdent } from '@hooks/useSjekkSaksbehandlertilgangTilIdent';
 import type { IOppgave } from '@typer/oppgave';
 import { oppgaveTypeFilter, OppgavetypeFilter } from '@typer/oppgave';
 import { hentFnrFraOppgaveIdenter } from '@utils/oppgave';
@@ -12,24 +12,35 @@ import { Button } from '@navikt/ds-react';
 
 import { useOppgavebenkContext } from './OppgavebenkContext';
 
-interface IOppgaveDirektelenke {
+interface Props {
     oppgave: IOppgave;
 }
 
-export function OppgaveDirektelenke({ oppgave }: IOppgaveDirektelenke) {
-    const { settToast } = useToastContext();
+export function OppgaveDirektelenke({ oppgave }: Props) {
     const { gåTilFagsakEllerVisFeilmelding } = useOppgavebenkContext();
-    const { sjekkTilgang } = useAppContext();
-    const [laster, settLaster] = useState<boolean>(false);
-    const navigate = useNavigate();
-    const oppgavetype = oppgaveTypeFilter[oppgave.oppgavetype as OppgavetypeFilter]?.id;
 
-    async function visTilgangsmodalEllerSendVidere(oppgave: IOppgave) {
+    const visTekniskFeilModal = useVisTekniskFeilModal();
+    const visManglerTilgangModal = useVisManglerTilgangModal();
+
+    const navigate = useNavigate();
+
+    const [laster, settLaster] = useState(false);
+
+    const { mutateAsync: sjekkSaksbehandlertilgangTilIdent } = useSjekkSaksbehandlertilgangTilIdent();
+
+    async function navigerTilJournalføring() {
         settLaster(true);
-        const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
-        if (brukerident) {
-            if (await sjekkTilgang(brukerident, false)) {
-                navigate(`/oppgaver/journalfor/${oppgave.id}`);
+        const brukerIdent = hentFnrFraOppgaveIdenter(oppgave.identer);
+        if (brukerIdent) {
+            try {
+                const tilgangsreusltat = await sjekkSaksbehandlertilgangTilIdent({ brukerIdent });
+                if (tilgangsreusltat.saksbehandlerHarTilgang) {
+                    navigate(`/oppgaver/journalfor/${oppgave.id}`);
+                } else {
+                    visManglerTilgangModal(tilgangsreusltat);
+                }
+            } catch (error) {
+                visTekniskFeilModal(error);
             }
         } else {
             navigate(`/oppgaver/journalfor/${oppgave.id}`);
@@ -37,43 +48,39 @@ export function OppgaveDirektelenke({ oppgave }: IOppgaveDirektelenke) {
         settLaster(false);
     }
 
-    async function sjekkTilgangOgGåTilBehandling(oppgave: IOppgave) {
+    async function navigerTilFagsak() {
         settLaster(true);
-        const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
-        if (brukerident) {
-            if (await sjekkTilgang(brukerident, false)) {
-                await gåTilFagsakEllerVisFeilmelding(brukerident);
+        const brukerIdent = hentFnrFraOppgaveIdenter(oppgave.identer);
+        if (brukerIdent) {
+            try {
+                const tilgangsreusltat = await sjekkSaksbehandlertilgangTilIdent({ brukerIdent });
+                if (tilgangsreusltat.saksbehandlerHarTilgang) {
+                    await gåTilFagsakEllerVisFeilmelding(brukerIdent);
+                } else {
+                    visManglerTilgangModal(tilgangsreusltat);
+                }
+            } catch (error) {
+                visTekniskFeilModal(error);
             }
         } else {
-            settToast(ToastTyper.MANGLER_TILGANG, {
-                alertType: AlertType.WARNING,
-                tekst: 'Mangler tilgang',
-            });
+            visManglerTilgangModal();
         }
         settLaster(false);
     }
 
+    const oppgavetype = oppgaveTypeFilter[oppgave.oppgavetype as OppgavetypeFilter]?.id;
+
     switch (oppgavetype) {
         case OppgavetypeFilter.JFR:
             return (
-                <Button
-                    variant={'tertiary'}
-                    size={'small'}
-                    onClick={() => visTilgangsmodalEllerSendVidere(oppgave)}
-                    loading={laster}
-                >
+                <Button variant={'tertiary'} size={'small'} onClick={navigerTilJournalføring} loading={laster}>
                     Se oppgave
                 </Button>
             );
         case OppgavetypeFilter.BEH_SED:
             if (oppgavetype === OppgavetypeFilter.BEH_SED) {
                 return (
-                    <Button
-                        variant={'tertiary'}
-                        size={'small'}
-                        onClick={() => visTilgangsmodalEllerSendVidere(oppgave)}
-                        loading={laster}
-                    >
+                    <Button variant={'tertiary'} size={'small'} onClick={navigerTilJournalføring} loading={laster}>
                         Gå til oppgave
                     </Button>
                 );
@@ -86,12 +93,7 @@ export function OppgaveDirektelenke({ oppgave }: IOppgaveDirektelenke) {
         case OppgavetypeFilter.VURD_LIVS:
         case OppgavetypeFilter.FREM:
             return (
-                <Button
-                    variant={'tertiary'}
-                    size={'small'}
-                    onClick={() => sjekkTilgangOgGåTilBehandling(oppgave)}
-                    loading={laster}
-                >
+                <Button variant={'tertiary'} size={'small'} onClick={navigerTilFagsak} loading={laster}>
                     Gå til fagsak
                 </Button>
             );

--- a/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
+++ b/src/frontend/sider/Oppgavebenk/OppgavelisteSaksbehandler.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 
-import { useAppContext } from '@context/AppContext';
+import { useVisManglerTilgangModal } from '@context/ManglerTilgangModalContext';
+import { useVisTekniskFeilModal } from '@context/TekniskFeilModalContext';
+import { useSjekkSaksbehandlertilgangTilIdent } from '@hooks/useSjekkSaksbehandlertilgangTilIdent';
 import type { IOppgave } from '@typer/oppgave';
 import { OppgavetypeFilter } from '@typer/oppgave';
 import type { Saksbehandler } from '@typer/saksbehandler';
@@ -10,14 +12,19 @@ import { BodyShort, Button, HGrid } from '@navikt/ds-react';
 
 import { useOppgavebenkContext } from './OppgavebenkContext';
 
-interface IOppgavelisteSaksbehandler {
+interface Props {
     oppgave: IOppgave;
     saksbehandler: Saksbehandler;
 }
 
-export function OppgavelisteSaksbehandler({ oppgave, saksbehandler }: IOppgavelisteSaksbehandler) {
+export function OppgavelisteSaksbehandler({ oppgave, saksbehandler }: Props) {
     const { fordelOppgave, tilbakestillFordelingPåOppgave } = useOppgavebenkContext();
-    const { sjekkTilgang } = useAppContext();
+
+    const visTekniskFeilModal = useVisTekniskFeilModal();
+    const visManglerTilgangModal = useVisManglerTilgangModal();
+
+    const { mutateAsync: sjekkSaksbehandlertilgangTilIdent } = useSjekkSaksbehandlertilgangTilIdent({});
+
     const oppgaveRef = useRef<IOppgave | null>(null);
 
     useEffect(() => {
@@ -45,8 +52,19 @@ export function OppgavelisteSaksbehandler({ oppgave, saksbehandler }: IOppgaveli
     }
 
     async function onFordelOppgave() {
-        const brukerident = hentFnrFraOppgaveIdenter(oppgave.identer);
-        if (!brukerident || (brukerident && (await sjekkTilgang(brukerident)))) {
+        const brukerIdent = hentFnrFraOppgaveIdenter(oppgave.identer);
+        if (brukerIdent) {
+            try {
+                const tilgangsreusltat = await sjekkSaksbehandlertilgangTilIdent({ brukerIdent });
+                if (tilgangsreusltat.saksbehandlerHarTilgang) {
+                    fordelOppgave(oppgave, saksbehandler.navIdent);
+                } else {
+                    visManglerTilgangModal(tilgangsreusltat);
+                }
+            } catch (error) {
+                visTekniskFeilModal(error);
+            }
+        } else {
             fordelOppgave(oppgave, saksbehandler.navIdent);
         }
     }

--- a/src/frontend/testutils/testrender.tsx
+++ b/src/frontend/testutils/testrender.tsx
@@ -3,8 +3,10 @@ import type { ReactNode, PropsWithChildren } from 'react';
 import { AppProvider } from '@context/AppContext';
 import { AuthContextProvider } from '@context/AuthContext';
 import { HttpContextProvider } from '@context/HttpContext';
+import { ManglerTilgangModalProvider } from '@context/ManglerTilgangModalContext';
 import { ModalProvider } from '@context/ModalContext';
 import { SaksbehandlerProvider } from '@context/SaksbehandlerContext';
+import { TekniskFeilModalProvider } from '@context/TekniskFeilModalContext';
 import { ToastProvider } from '@context/ToastContext';
 import { FeatureTogglesProvider } from '@context/TogglesContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -44,23 +46,27 @@ export function TestProviders({
     children,
 }: Props) {
     return (
-        <QueryClientProvider client={queryClient}>
-            <SaksbehandlerProvider saksbehandler={saksbehandler}>
-                <AuthContextProvider>
-                    <HttpContextProvider fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}>
-                        <FeatureTogglesProvider featureToggles={featureToggles}>
-                            <AppProvider>
-                                <ModalProvider>
-                                    <ToastProvider>
-                                        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-                                    </ToastProvider>
-                                </ModalProvider>
-                            </AppProvider>
-                        </FeatureTogglesProvider>
-                    </HttpContextProvider>
-                </AuthContextProvider>
-            </SaksbehandlerProvider>
-        </QueryClientProvider>
+        <TekniskFeilModalProvider>
+            <ManglerTilgangModalProvider>
+                <QueryClientProvider client={queryClient}>
+                    <SaksbehandlerProvider saksbehandler={saksbehandler}>
+                        <AuthContextProvider>
+                            <HttpContextProvider fjernRessursSomLasterTimeout={fjernRessursSomLasterTimeout}>
+                                <FeatureTogglesProvider featureToggles={featureToggles}>
+                                    <AppProvider>
+                                        <ModalProvider>
+                                            <ToastProvider>
+                                                <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+                                            </ToastProvider>
+                                        </ModalProvider>
+                                    </AppProvider>
+                                </FeatureTogglesProvider>
+                            </HttpContextProvider>
+                        </AuthContextProvider>
+                    </SaksbehandlerProvider>
+                </QueryClientProvider>
+            </ManglerTilgangModalProvider>
+        </TekniskFeilModalProvider>
     );
 }
 


### PR DESCRIPTION
### 📮 Favro
NAV-29011

### 💰 Hva skal gjøres, og hvorfor?
- Refaktorerer tilgangssjekk til react-query.
- Lager en global modal for tekniske feil og eksponere en metode for å vise modalen.
- Lager en global modal for manglende tilgang og eksponere en metode for å vise modalen.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Modal for mangler tilgang:
<img width="537" height="315" alt="image" src="https://github.com/user-attachments/assets/168409ac-8512-4881-b2f4-33c833e61d17" />

Modal for teknisk feil:
<img width="537" height="315" alt="image" src="https://github.com/user-attachments/assets/223b33b3-c76e-4eda-9c1d-14d3fb7d0f3c" />
