### PR TITLE
NAV-26302: fjern styled-components fra diverse komponenter

### DIFF
--- a/src/frontend/komponenter/FamilieBaseKnapp.module.css
+++ b/src/frontend/komponenter/FamilieBaseKnapp.module.css
@@ -1,0 +1,13 @@
+.familieBaseKnapp {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    outline: inherit;
+
+    :focus {
+        box-shadow: 0 0 0 3px var(--ax-border-focus);
+    }
+}

--- a/src/frontend/komponenter/FamilieBaseKnapp.tsx
+++ b/src/frontend/komponenter/FamilieBaseKnapp.tsx
@@ -1,19 +1,8 @@
-import styled from 'styled-components';
+import type { ButtonHTMLAttributes } from 'react';
 
-import { BorderFocus } from '@navikt/ds-tokens/dist/tokens';
+import styles from './FamilieBaseKnapp.module.css';
 
-const FamilieBaseKnapp = styled.button`
-    background: none;
-    color: inherit;
-    border: none;
-    padding: 0;
-    font: inherit;
-    cursor: pointer;
-    outline: inherit;
-
-    :focus {
-        box-shadow: 0 0 0 3px ${BorderFocus};
-    }
-`;
-
+const FamilieBaseKnapp = ({ children }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button className={styles.familieBaseKnapp}>{children}</button>
+);
 export default FamilieBaseKnapp;

--- a/src/frontend/komponenter/Modal/ModalKnapperad.ts
+++ b/src/frontend/komponenter/Modal/ModalKnapperad.ts
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-export const ModalKnapperad = styled.div`
-    margin-top: 2.5rem;
-    display: flex;
-    justify-content: flex-start;
-    gap: 1rem;
-`;

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.module.css
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.module.css
@@ -1,0 +1,3 @@
+.postInput {
+    height: fit-content;
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -7,6 +7,7 @@ import { Box, Button, Fieldset, HGrid, HStack, InlineMessage, Select, TextField,
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import styles from './BrevmottakerSkjema.module.css';
 import type { BrevmottakerUseSkjema, IRestBrevmottaker, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import { Mottaker, mottakerVisningsnavn, useBrevmottakerSkjema } from './useBrevmottakerSkjema';
 import { ALLE_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '../../../FlaggCombobox';
@@ -116,8 +117,9 @@ const BrevmottakerSkjema = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
                                 </InlineMessage>
                             )}
 
-                            <HGrid gap={'space-16'} columns={'8rem 1fr'}>
+                            <HGrid gap={'space-16'} columns={'10rem 1fr'}>
                                 <TextField
+                                    className={styles.postInput}
                                     {...skjema.felter.postnummer.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                                     readOnly={erLesevisning}
                                     disabled={skjema.felter.land.verdi !== 'NO'}
@@ -127,6 +129,7 @@ const BrevmottakerSkjema = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
                                     }}
                                 />
                                 <TextField
+                                    className={styles.postInput}
                                     {...skjema.felter.poststed.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                                     readOnly={erLesevisning}
                                     disabled={skjema.felter.land.verdi !== 'NO'}

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerSkjema.tsx
@@ -1,40 +1,15 @@
 import type { ChangeEvent } from 'react';
 
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import { useLocation } from 'react-router';
-import styled from 'styled-components';
 
-import { Button, Fieldset, InlineMessage, Select, TextField } from '@navikt/ds-react';
+import { Box, Button, Fieldset, HGrid, HStack, InlineMessage, Select, TextField, VStack } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import type { BrevmottakerUseSkjema, IRestBrevmottaker, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import { Mottaker, mottakerVisningsnavn, useBrevmottakerSkjema } from './useBrevmottakerSkjema';
-import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import { ALLE_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '../../../FlaggCombobox';
-import { ModalKnapperad } from '../../../Modal/ModalKnapperad';
-
-const PostnummerOgStedContainer = styled.div`
-    display: grid;
-    grid-gap: 1rem;
-    grid-template-columns: 8rem 1fr;
-
-    &:has(.aksel-text-field--error) {
-        .aksel-form-field .aksel-form-field__error {
-            height: 3rem;
-            display: initial;
-        }
-    }
-`;
-
-const StyledFieldset = styled(Fieldset)`
-    &.aksel-fieldset > div:not(:first-of-type):not(:empty) {
-        margin-top: var(--ax-space-24);
-    }
-`;
-
-const MottakerSelect = styled(Select)`
-    max-width: 19rem;
-`;
 
 interface Props<T extends SkjemaBrevmottaker | IRestBrevmottaker> {
     lukkModal: () => void;
@@ -62,106 +37,110 @@ const BrevmottakerSkjema = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
 
     return (
         <>
-            <StyledFieldset
+            <Fieldset
                 legend="Skjema for å legge til eller fjerne brevmottaker"
                 hideLegend
                 error={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
             >
-                <MottakerSelect
-                    {...skjema.felter.mottaker.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    readOnly={erLesevisning}
-                    label="Mottaker"
-                    onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
-                        skjema.felter.mottaker.validerOgSettFelt(event.target.value as Mottaker);
-                    }}
-                >
-                    <option value="">Velg</option>
-                    {gyldigeMottakerTyper.map(mottaker => (
-                        <option value={mottaker} key={mottaker}>
-                            {mottakerVisningsnavn[mottaker]}
-                        </option>
-                    ))}
-                </MottakerSelect>
-                <TextField
-                    {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    readOnly={erLesevisning || navnErPreutfylt}
-                    label={'Navn'}
-                    onChange={(event): void => {
-                        skjema.felter.navn.validerOgSettFelt(event.target.value);
-                    }}
-                />
-                <RegionCombobox
-                    label={'Land'}
-                    value={(skjema.felter.land.verdi !== '' ? skjema.felter.land.verdi : undefined) as Regionkode}
-                    options={ALLE_LAND_REGIONKODER.filter(regionkode => {
-                        if (skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE) {
-                            return regionkode !== 'NO' && regionkode !== 'XU';
-                        }
-                        return regionkode !== 'XU';
-                    })}
-                    onChange={value => {
-                        if (value) {
-                            skjema.felter.land.validerOgSettFelt(value);
-                        } else {
-                            skjema.felter.land.nullstill();
-                        }
-                    }}
-                    readOnly={erLesevisning}
-                    error={
-                        skjema.visFeilmeldinger && skjema.felter.land.valideringsstatus === Valideringsstatus.FEIL
-                            ? skjema.felter.land.feilmelding?.toString()
-                            : ''
-                    }
-                    dropdownPlacement={skjema.felter.land.verdi ? 'bottom' : 'top'}
-                />
-                {skjema.felter.land.verdi && (
-                    <>
-                        <TextField
-                            {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                <VStack gap={'space-24'}>
+                    <Box maxWidth={'19rem'}>
+                        <Select
+                            {...skjema.felter.mottaker.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                             readOnly={erLesevisning}
-                            label={'Adresselinje 1'}
-                            onChange={(event): void => {
-                                skjema.felter.adresselinje1.validerOgSettFelt(event.target.value);
+                            label="Mottaker"
+                            onChange={(event: ChangeEvent<HTMLSelectElement>): void => {
+                                skjema.felter.mottaker.validerOgSettFelt(event.target.value as Mottaker);
                             }}
-                        />
-                        <TextField
-                            {...skjema.felter.adresselinje2.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                            readOnly={erLesevisning}
-                            label={'Adresselinje 2 (valgfri)'}
-                            onChange={(event): void => {
-                                skjema.felter.adresselinje2.validerOgSettFelt(event.target.value);
-                            }}
-                        />
-                        {skjema.felter.land.verdi !== 'NO' && (
-                            <InlineMessage status="info">
-                                Ved utenlandsk adresse skal postnummer og poststed legges i adresselinjene.
-                            </InlineMessage>
-                        )}
+                        >
+                            <option value="">Velg</option>
+                            {gyldigeMottakerTyper.map(mottaker => (
+                                <option value={mottaker} key={mottaker}>
+                                    {mottakerVisningsnavn[mottaker]}
+                                </option>
+                            ))}
+                        </Select>
+                    </Box>
+                    <TextField
+                        {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                        readOnly={erLesevisning || navnErPreutfylt}
+                        label={'Navn'}
+                        onChange={(event): void => {
+                            skjema.felter.navn.validerOgSettFelt(event.target.value);
+                        }}
+                    />
+                    <RegionCombobox
+                        label={'Land'}
+                        value={(skjema.felter.land.verdi !== '' ? skjema.felter.land.verdi : undefined) as Regionkode}
+                        options={ALLE_LAND_REGIONKODER.filter(regionkode => {
+                            if (skjema.felter.mottaker.verdi === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE) {
+                                return regionkode !== 'NO' && regionkode !== 'XU';
+                            }
+                            return regionkode !== 'XU';
+                        })}
+                        onChange={value => {
+                            if (value) {
+                                skjema.felter.land.validerOgSettFelt(value);
+                            } else {
+                                skjema.felter.land.nullstill();
+                            }
+                        }}
+                        readOnly={erLesevisning}
+                        error={
+                            skjema.visFeilmeldinger && skjema.felter.land.valideringsstatus === Valideringsstatus.FEIL
+                                ? skjema.felter.land.feilmelding?.toString()
+                                : ''
+                        }
+                        dropdownPlacement={skjema.felter.land.verdi ? 'bottom' : 'top'}
+                    />
+                    {skjema.felter.land.verdi && (
+                        <>
+                            <TextField
+                                {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                                readOnly={erLesevisning}
+                                label={'Adresselinje 1'}
+                                onChange={(event): void => {
+                                    skjema.felter.adresselinje1.validerOgSettFelt(event.target.value);
+                                }}
+                            />
+                            <TextField
+                                {...skjema.felter.adresselinje2.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                                readOnly={erLesevisning}
+                                label={'Adresselinje 2 (valgfri)'}
+                                onChange={(event): void => {
+                                    skjema.felter.adresselinje2.validerOgSettFelt(event.target.value);
+                                }}
+                            />
+                            {skjema.felter.land.verdi !== 'NO' && (
+                                <InlineMessage status="info">
+                                    Ved utenlandsk adresse skal postnummer og poststed legges i adresselinjene.
+                                </InlineMessage>
+                            )}
 
-                        <PostnummerOgStedContainer>
-                            <TextField
-                                {...skjema.felter.postnummer.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                                readOnly={erLesevisning}
-                                disabled={skjema.felter.land.verdi !== 'NO'}
-                                label={'Postnummer'}
-                                onChange={(event): void => {
-                                    skjema.felter.postnummer.validerOgSettFelt(event.target.value);
-                                }}
-                            />
-                            <TextField
-                                {...skjema.felter.poststed.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                                readOnly={erLesevisning}
-                                disabled={skjema.felter.land.verdi !== 'NO'}
-                                label={'Poststed'}
-                                onChange={(event): void => {
-                                    skjema.felter.poststed.validerOgSettFelt(event.target.value);
-                                }}
-                            />
-                        </PostnummerOgStedContainer>
-                    </>
-                )}
-            </StyledFieldset>
-            <ModalKnapperad>
+                            <HGrid gap={'space-16'} columns={'8rem 1fr'}>
+                                <TextField
+                                    {...skjema.felter.postnummer.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                                    readOnly={erLesevisning}
+                                    disabled={skjema.felter.land.verdi !== 'NO'}
+                                    label={'Postnummer'}
+                                    onChange={(event): void => {
+                                        skjema.felter.postnummer.validerOgSettFelt(event.target.value);
+                                    }}
+                                />
+                                <TextField
+                                    {...skjema.felter.poststed.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                                    readOnly={erLesevisning}
+                                    disabled={skjema.felter.land.verdi !== 'NO'}
+                                    label={'Poststed'}
+                                    onChange={(event): void => {
+                                        skjema.felter.poststed.validerOgSettFelt(event.target.value);
+                                    }}
+                                />
+                            </HGrid>
+                        </>
+                    )}
+                </VStack>
+            </Fieldset>
+            <HStack marginBlock={'space-40 space-0'} justify={'start'} gap={'space-16'}>
                 {!erLesevisning && (
                     <>
                         <Button
@@ -176,9 +155,8 @@ const BrevmottakerSkjema = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
                         </Button>
                     </>
                 )}
-
                 {erLesevisning && <Button onClick={lukkModal}>Lukk</Button>}
-            </ModalKnapperad>
+            </HStack>
         </>
     );
 };

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.module.css
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.module.css
@@ -1,0 +1,14 @@
+.definitionList {
+    display: grid;
+    grid-gap: 1rem;
+    grid-template-columns: 10rem 20rem;
+    margin-left: 1rem;
+
+    dt {
+        font-weight: var(--ax-font-weight-bold);
+    }
+
+    dd {
+        margin-left: 0;
+    }
+}

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/BrevmottakerTabell.tsx
@@ -1,38 +1,12 @@
-import styled from 'styled-components';
-
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Button, Heading, InlineMessage } from '@navikt/ds-react';
-import { FontWeightBold } from '@navikt/ds-tokens/dist/tokens';
+import { Box, Button, Heading, HStack, InlineMessage } from '@navikt/ds-react';
 import _CountryData from '@navikt/land-verktoy';
 
+import styles from './BrevmottakerTabell.module.css';
 import type { IRestBrevmottaker, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
 import { mottakerVisningsnavn } from './useBrevmottakerSkjema';
 
 const CountryData = (_CountryData as unknown as { default?: typeof _CountryData }).default ?? _CountryData;
-
-const FlexDiv = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
-const StyledDiv = styled.div`
-    margin-top: 2.5rem;
-`;
-
-const DefinitionList = styled.dl`
-    display: grid;
-    grid-gap: 1rem;
-    grid-template-columns: 10rem 20rem;
-    margin-left: 1rem;
-
-    dt {
-        font-weight: ${FontWeightBold};
-    }
-
-    dd {
-        margin-left: 0;
-    }
-`;
 
 interface Props<T extends SkjemaBrevmottaker | IRestBrevmottaker> {
     mottaker: T;
@@ -48,8 +22,8 @@ const BrevmottakerTabell = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
     const land = CountryData.getCountryInstance('nb').findByValue(mottaker.landkode);
 
     return (
-        <StyledDiv>
-            <FlexDiv>
+        <Box marginBlock={'space-40 space-0'}>
+            <HStack justify={'space-between'}>
                 <Heading size="medium" children={mottakerVisningsnavn[mottaker.type]} />
                 {!erLesevisning && (
                     <Button
@@ -63,8 +37,8 @@ const BrevmottakerTabell = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
                         {'Fjern'}
                     </Button>
                 )}
-            </FlexDiv>
-            <DefinitionList>
+            </HStack>
+            <dl className={styles.definitionList}>
                 <dt>Navn</dt>
                 <dd>{mottaker.navn}</dd>
                 <dt>Land</dt>
@@ -77,14 +51,14 @@ const BrevmottakerTabell = <T extends SkjemaBrevmottaker | IRestBrevmottaker>({
                 <dd>{mottaker.postnummer || '-'}</dd>
                 <dt>Poststed</dt>
                 <dd>{mottaker.poststed || '-'}</dd>
-            </DefinitionList>
+            </dl>
 
             {mottaker.landkode !== 'NO' && (
                 <InlineMessage status={'info'}>
                     Ved utenlandsk adresse skal postnummer og poststed legges i adresselinjene.
                 </InlineMessage>
             )}
-        </StyledDiv>
+        </Box>
     );
 };
 

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilBrevmottakerModal.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import { useLocation } from 'react-router';
-import styled from 'styled-components';
 
 import { InformationSquareIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { Box, Button, Heading, InfoCard, Modal } from '@navikt/ds-react';
@@ -9,16 +8,6 @@ import { Box, Button, Heading, InfoCard, Modal } from '@navikt/ds-react';
 import BrevmottakerSkjema from './BrevmottakerSkjema';
 import BrevmottakerTabell from './BrevmottakerTabell';
 import type { BrevmottakerUseSkjema, IRestBrevmottaker, SkjemaBrevmottaker } from './useBrevmottakerSkjema';
-
-const StyledHeading = styled(Heading)`
-    margin: 1rem 0 0.75rem;
-`;
-const LeggTilKnapp = styled(Button)`
-    margin-top: 1rem;
-`;
-const LukkKnapp = styled(Button)`
-    margin-top: 2.5rem;
-`;
 
 interface Props<T extends SkjemaBrevmottaker | IRestBrevmottaker> {
     lukkModal: () => void;
@@ -84,7 +73,11 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
                 ))}
                 {erSkjemaSynlig ? (
                     <>
-                        {brevmottakere.length === 1 && <StyledHeading size="medium">Ny mottaker</StyledHeading>}
+                        {brevmottakere.length === 1 && (
+                            <Box marginBlock={'space-16 space-12'}>
+                                <Heading size="medium">Ny mottaker</Heading>
+                            </Box>
+                        )}
                         <BrevmottakerSkjema
                             lukkModal={lukkModalOgSkjema}
                             brevmottakere={brevmottakere}
@@ -95,18 +88,20 @@ export const LeggTilBrevmottakerModal = <T extends SkjemaBrevmottaker | IRestBre
                 ) : (
                     <>
                         {brevmottakere.length === 1 && !erLesevisning && (
-                            <LeggTilKnapp
-                                variant="tertiary"
-                                size="small"
-                                icon={<PlusCircleIcon />}
-                                onClick={() => settVisSkjemaNårDetErÉnBrevmottaker(true)}
-                            >
-                                Legg til ny mottaker
-                            </LeggTilKnapp>
+                            <Box marginBlock={'space-16 space-0'}>
+                                <Button
+                                    variant="tertiary"
+                                    size="small"
+                                    icon={<PlusCircleIcon />}
+                                    onClick={() => settVisSkjemaNårDetErÉnBrevmottaker(true)}
+                                >
+                                    Legg til ny mottaker
+                                </Button>
+                            </Box>
                         )}
-                        <div>
-                            <LukkKnapp onClick={lukkModal}>Lukk vindu</LukkKnapp>
-                        </div>
+                        <Box marginBlock={'space-40 space-0'}>
+                            <Button onClick={lukkModal}>Lukk vindu</Button>
+                        </Box>
                     </>
                 )}
             </Modal.Body>

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.module.css
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.module.css
@@ -1,0 +1,3 @@
+.tittel {
+    font-size: 1.2rem;
+}

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentInfoStripe.tsx
@@ -1,40 +1,11 @@
-import styled from 'styled-components';
+import { DokumentIkon } from '@ikoner/DokumentIkon';
+import { EksternLenke } from '@ikoner/EksternLenke';
 
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, Box, HStack, VStack } from '@navikt/ds-react';
 import type { IDokumentInfo } from '@navikt/familie-typer';
 
-import { DokumentIkon } from '../../../ikoner/DokumentIkon';
-import { EksternLenke } from '../../../ikoner/EksternLenke';
+import styles from './DokumentInfoStripe.module.css';
 import FamilieBaseKnapp from '../../../komponenter/FamilieBaseKnapp';
-
-const DokumentInfoStripeContainer = styled.div`
-    display: flex;
-    justify-content: left;
-    align-items: flex-start;
-    width: 100%;
-    height: 100%;
-`;
-
-const DokumentTittelContainer = styled.div`
-    display: flex;
-    justify-content: left;
-    flex-direction: column;
-`;
-
-const DokumentTittelDiv = styled.div`
-    font-size: 1.2rem;
-    margin-bottom: 10px;
-`;
-
-const StyledDokumentIkonDiv = styled.div`
-    margin: 0 16px 0 0;
-    min-width: 48px;
-    min-height: 48px;
-`;
-
-const StyledÅpenDokument = styled(FamilieBaseKnapp)`
-    margin-left: 10px;
-`;
 
 interface IDokumentInfoStripeProps {
     valgt: boolean;
@@ -44,14 +15,14 @@ interface IDokumentInfoStripeProps {
 
 export const DokumentInfoStripe = ({ valgt, journalpostId, dokument }: IDokumentInfoStripeProps) => {
     return (
-        <DokumentInfoStripeContainer>
-            <StyledDokumentIkonDiv>
+        <HStack>
+            <Box minHeight={'48px'} minWidth={'48px'} marginInline={'space-0 space-16'}>
                 <DokumentIkon filled={valgt} width={48} height={48} />
-            </StyledDokumentIkonDiv>
-            <DokumentTittelContainer>
-                <DokumentTittelDiv>
+            </Box>
+            <VStack>
+                <HStack gap={'space-8'} marginBlock={'space-0 space-8'} className={styles.tittel}>
                     {dokument.tittel || 'Ukjent'}
-                    <StyledÅpenDokument
+                    <FamilieBaseKnapp
                         onClick={() => {
                             window.open(
                                 `/familie-ba-sak/api/journalpost/${journalpostId}/dokument/${dokument.dokumentInfoId}`,
@@ -60,12 +31,12 @@ export const DokumentInfoStripe = ({ valgt, journalpostId, dokument }: IDokument
                         }}
                     >
                         <EksternLenke />
-                    </StyledÅpenDokument>
-                </DokumentTittelDiv>
+                    </FamilieBaseKnapp>
+                </HStack>
                 {dokument.logiskeVedlegg.map((it, index) => (
                     <BodyShort key={index}>{it.tittel}</BodyShort>
                 ))}
-            </DokumentTittelContainer>
-        </DokumentInfoStripeContainer>
+            </VStack>
+        </HStack>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
+++ b/src/frontend/sider/ManuellJournalføring/Dokument/DokumentVelger.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react';
 
-import styled from 'styled-components';
-
-import { ExpansionCard } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
+import { Box, ExpansionCard } from '@navikt/ds-react';
 import type { IDokumentInfo } from '@navikt/familie-typer';
+import { RessursStatus } from '@navikt/familie-typer';
 
 import { DokumentInfoStripe } from './DokumentInfoStripe';
 import { EndreDokumentInfoPanel } from './EndreDokumentInfoPanel';
@@ -14,11 +12,6 @@ interface IDokumentVelgerProps {
     dokument: IDokumentInfo;
     visFeilmeldinger: boolean;
 }
-
-const StyledExpansionCard = styled(ExpansionCard)`
-    margin-top: 1rem;
-    width: 100%;
-`;
 
 export const DokumentVelger = ({ dokument, visFeilmeldinger }: IDokumentVelgerProps) => {
     const { dataForManuellJournalføring, valgtDokumentId, velgOgHentDokumentData } = useManuellJournalføringContext();
@@ -37,25 +30,27 @@ export const DokumentVelger = ({ dokument, visFeilmeldinger }: IDokumentVelgerPr
     }, [visFeilmeldinger]);
 
     return (
-        <StyledExpansionCard
-            open={åpen}
-            onToggle={() => {
-                settÅpen(!åpen);
-                if (!valgt && journalpostId && dokument.dokumentInfoId) {
-                    velgOgHentDokumentData(dokument.dokumentInfoId);
-                }
-            }}
-            size="small"
-            aria-label="Dokumentvelger"
-        >
-            <ExpansionCard.Header>
-                <ExpansionCard.Title>
-                    <DokumentInfoStripe valgt={valgt} journalpostId={journalpostId} dokument={dokument} />
-                </ExpansionCard.Title>
-            </ExpansionCard.Header>
-            <ExpansionCard.Content>
-                <EndreDokumentInfoPanel dokument={dokument} visFeilmeldinger={visFeilmeldinger} />
-            </ExpansionCard.Content>
-        </StyledExpansionCard>
+        <Box marginBlock={'space-16 space-0'}>
+            <ExpansionCard
+                open={åpen}
+                onToggle={() => {
+                    settÅpen(!åpen);
+                    if (!valgt && journalpostId && dokument.dokumentInfoId) {
+                        velgOgHentDokumentData(dokument.dokumentInfoId);
+                    }
+                }}
+                size="small"
+                aria-label="Dokumentvelger"
+            >
+                <ExpansionCard.Header>
+                    <ExpansionCard.Title>
+                        <DokumentInfoStripe valgt={valgt} journalpostId={journalpostId} dokument={dokument} />
+                    </ExpansionCard.Title>
+                </ExpansionCard.Header>
+                <ExpansionCard.Content>
+                    <EndreDokumentInfoPanel dokument={dokument} visFeilmeldinger={visFeilmeldinger} />
+                </ExpansionCard.Content>
+            </ExpansionCard>
+        </Box>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
+++ b/src/frontend/sider/ManuellJournalføring/JournalpostSkjema.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 
+import { FagsakType } from '@typer/fagsak';
+import type { OppgavetypeFilter } from '@typer/oppgave';
+import { oppgaveTypeFilter } from '@typer/oppgave';
 import { useNavigate } from 'react-router';
-import styled from 'styled-components';
 
 import { ChevronLeftIcon } from '@navikt/aksel-icons';
-import { Button, ErrorMessage, ErrorSummary, Heading, LocalAlert } from '@navikt/ds-react';
+import { Box, Button, ErrorMessage, ErrorSummary, Heading, LocalAlert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { AvsenderPanel } from './AvsenderPanel';
@@ -14,18 +16,6 @@ import Journalpost from './Journalpost';
 import { KnyttJournalpostTilBehandling } from './KnyttJournalpostTilBehandling';
 import { useManuellJournalføringContext } from './ManuellJournalføringContext';
 import Knapperekke from '../../komponenter/Knapperekke';
-import { FagsakType } from '../../typer/fagsak';
-import type { OppgavetypeFilter } from '../../typer/oppgave';
-import { oppgaveTypeFilter } from '../../typer/oppgave';
-
-const Container = styled.div`
-    padding: 2rem;
-    overflow-y: scroll;
-`;
-
-const StyledSectionDiv = styled.div`
-    margin-top: 2.5rem;
-`;
 
 export const JournalpostSkjema = () => {
     const {
@@ -52,7 +42,7 @@ export const JournalpostSkjema = () => {
     };
 
     return (
-        <Container>
+        <Box padding={'space-32'} overflowY={'scroll'}>
             {dataForManuellJournalføring.status === RessursStatus.SUKSESS && (
                 <Heading spacing size="medium" level="2">
                     {
@@ -63,18 +53,18 @@ export const JournalpostSkjema = () => {
                 </Heading>
             )}
             <Journalpost />
-            <StyledSectionDiv>
+            <Box marginBlock={'space-40 space-0'}>
                 <Heading size={'small'} level={'2'} children={'Dokumenter'} />
                 <Dokumenter />
-            </StyledSectionDiv>
-            <StyledSectionDiv>
+            </Box>
+            <Box marginBlock={'space-40 space-0'}>
                 <Heading size={'small'} level={'2'} children={'Bruker og avsender'} />
                 <BrukerPanel />
                 <br />
                 <AvsenderPanel />
-            </StyledSectionDiv>
+            </Box>
 
-            <StyledSectionDiv>
+            <Box marginBlock={'space-40 space-0'}>
                 {kanKnytteJournalpostTilBehandling() && <KnyttJournalpostTilBehandling />}
                 <br />
                 {(skjema.submitRessurs.status === RessursStatus.FEILET ||
@@ -93,7 +83,7 @@ export const JournalpostSkjema = () => {
                         ))}
                     </ErrorSummary>
                 )}
-            </StyledSectionDiv>
+            </Box>
 
             <Knapperekke>
                 <Button
@@ -129,6 +119,6 @@ export const JournalpostSkjema = () => {
                 )}
             </Knapperekke>
             {valideringsfeilmelding && <ErrorMessage>{valideringsfeilmelding}</ErrorMessage>}
-        </Container>
+        </Box>
     );
 };

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.module.css
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.module.css
@@ -1,0 +1,10 @@
+.toKolonner {
+    display: grid;
+    grid-template-columns: 40rem 1fr;
+    grid-template-rows: 1fr;
+    height: calc(100vh - 6rem);
+}
+
+.withAlert {
+    height: calc(100vh - 11.25rem);
+}

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføring.tsx
@@ -1,20 +1,13 @@
-import styled from 'styled-components';
+import { Personlinje } from '@komponenter/Personlinje/Personlinje';
+import classNames from 'classnames';
 
 import { GlobalAlert } from '@navikt/ds-react';
 import { Journalstatus, RessursStatus } from '@navikt/familie-typer';
 
 import { DokumentPanel } from './Dokument/DokumentPanel';
 import { JournalpostSkjema } from './JournalpostSkjema';
+import styles from './ManuellJournalføring.module.css';
 import { ManuellJournalføringProvider, useManuellJournalføringContext } from './ManuellJournalføringContext';
-import { Personlinje } from '../../komponenter/Personlinje/Personlinje';
-import { fagsakHeaderHøydeRem } from '../../typer/styling';
-
-const ToKolonnerDiv = styled.div<{ $viserAlert?: boolean }>`
-    display: grid;
-    grid-template-columns: 40rem 1fr;
-    grid-template-rows: 1fr;
-    height: calc(100vh - ${props => (props.$viserAlert ? fagsakHeaderHøydeRem + 5.25 : fagsakHeaderHøydeRem)}rem);
-`;
 
 const ManuellJournalføringContent = () => {
     const { dataForManuellJournalføring, minimalFagsak, skjema } = useManuellJournalføringContext();
@@ -41,10 +34,10 @@ const ManuellJournalføringContent = () => {
                         </>
                     )}
 
-                    <ToKolonnerDiv $viserAlert={viserAlert}>
+                    <div className={classNames(styles.toKolonner, { [styles.withAlert]: viserAlert })}>
                         <JournalpostSkjema />
                         <DokumentPanel />
-                    </ToKolonnerDiv>
+                    </div>
                 </>
             );
 


### PR DESCRIPTION
### 📮 Favro: NAV-26302

### 💰 Hva skal gjøres, og hvorfor?
Skriver bort ifra bruk av styled-components for fordel av Aksel primitive eller module.css


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Det burde være så å si ingen visuelle endringer. Gammel versjon er venstre og ny er høyre

Spacing rundt "Ny mottaker" header
<img width="1144" height="504" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/c35a44ed-6d02-4e69-b9e4-5df42057bd96" />

Spacing rundt knappene
<img width="1220" height="208" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/298a9718-16a6-4293-9db2-9e860e42e984" />

spacing i hele modal
<img width="1021" height="780" alt="image" src="https://github.com/user-attachments/assets/8b10a158-76f3-4697-b13c-b8cf3f553f46" />

mottakerliste
<img width="942" height="530" alt="image" src="https://github.com/user-attachments/assets/1a618d1a-165d-4a13-9fc8-933d009602d9" />

manuelljournalføring
<img width="1119" height="596" alt="image" src="https://github.com/user-attachments/assets/a7688d2a-7b11-4657-ae61-7f1d3ff7af4e" />


postnummer sted feilmelding, litt bredere plass for postnummer(lik i ks) for å få plass til feilmelding
<img width="1404" height="468" alt="image" src="https://github.com/user-attachments/assets/936a5733-209f-4ebc-81dc-5d052de2525d" />