### PR TITLE
NAV-29352: Forbedrer sync mellom saksbehandler og sentry

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -10,7 +10,7 @@ import { TekniskFeilModalProvider } from '@context/TekniskFeilModalContext';
 import { ToastProvider } from '@context/ToastContext';
 import { FeatureTogglesProvider } from '@context/TogglesContext';
 import { useStartUmami } from '@hooks/useStartUmami';
-import { ErrorBoundary, ErrorBoundaryMedSaksbehandler } from '@komponenter/ErrorBoundary/ErrorBoundary';
+import { ErrorBoundary } from '@komponenter/ErrorBoundary/ErrorBoundary';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { erProd } from '@utils/miljø';
@@ -35,19 +35,17 @@ export function App() {
                     <QueryClientProvider client={queryClient}>
                         {!erProd() && <ReactQueryDevtools position={'right'} initialIsOpen={false} />}
                         <SaksbehandlerProvider>
-                            <ErrorBoundaryMedSaksbehandler>
-                                <AuthContextProvider>
-                                    <HttpContextProvider>
-                                        <FeatureTogglesProvider>
-                                            <ModalProvider>
-                                                <ToastProvider>
-                                                    <Container />
-                                                </ToastProvider>
-                                            </ModalProvider>
-                                        </FeatureTogglesProvider>
-                                    </HttpContextProvider>
-                                </AuthContextProvider>
-                            </ErrorBoundaryMedSaksbehandler>
+                            <AuthContextProvider>
+                                <HttpContextProvider>
+                                    <FeatureTogglesProvider>
+                                        <ModalProvider>
+                                            <ToastProvider>
+                                                <Container />
+                                            </ToastProvider>
+                                        </ModalProvider>
+                                    </FeatureTogglesProvider>
+                                </HttpContextProvider>
+                            </AuthContextProvider>
                         </SaksbehandlerProvider>
                     </QueryClientProvider>
                 </ManglerTilgangModalProvider>

--- a/src/frontend/context/SaksbehandlerContext.test.tsx
+++ b/src/frontend/context/SaksbehandlerContext.test.tsx
@@ -1,11 +1,11 @@
+import { useHentSaksbehandler } from '@hooks/useHentSaksbehandler';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import { lagSaksbehandler } from '@testutils/testdata/saksbehandlerTestdata';
+import type { Saksbehandler } from '@typer/saksbehandler';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { SaksbehandlerProvider, useSaksbehandlerContext } from './SaksbehandlerContext';
-import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
-import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
-import type { Saksbehandler } from '../typer/saksbehandler';
 
 vi.mock('../hooks/useHentSaksbehandler', () => ({
     useHentSaksbehandler: vi.fn(),

--- a/src/frontend/context/SaksbehandlerContext.tsx
+++ b/src/frontend/context/SaksbehandlerContext.tsx
@@ -1,11 +1,13 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext } from 'react';
 
+import { useHentSaksbehandler } from '@hooks/useHentSaksbehandler';
+import { useSyncSentryUser } from '@hooks/useSyncSentryUser';
+import type { Saksbehandler } from '@typer/saksbehandler';
+
 import { Box, GlobalAlert } from '@navikt/ds-react';
 
-import { useHentSaksbehandler } from '../hooks/useHentSaksbehandler';
 import SystemetLaster from '../komponenter/SystemetLaster/SystemetLaster';
-import type { Saksbehandler } from '../typer/saksbehandler';
 
 interface Context {
     saksbehandler: Saksbehandler;
@@ -19,6 +21,8 @@ interface Props extends PropsWithChildren {
 
 export function SaksbehandlerProvider({ saksbehandler, children }: Props) {
     const { data, isPending, error } = useHentSaksbehandler({ initialData: saksbehandler });
+
+    useSyncSentryUser({ saksbehandler: data });
 
     if (isPending) {
         return <SystemetLaster />;

--- a/src/frontend/hooks/useSyncSentryUser.ts
+++ b/src/frontend/hooks/useSyncSentryUser.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+import * as Sentry from '@sentry/browser';
+import type { Saksbehandler } from '@typer/saksbehandler';
+
+interface Props {
+    saksbehandler?: Saksbehandler;
+}
+
+export function useSyncSentryUser({ saksbehandler }: Props) {
+    useEffect(() => {
+        if (!Sentry.isEnabled()) {
+            return;
+        }
+
+        if (!saksbehandler) {
+            Sentry.setUser(null);
+            return;
+        }
+
+        Sentry.setUser({
+            username: saksbehandler.displayName,
+            email: saksbehandler.email,
+        });
+
+        return () => {
+            Sentry.setUser(null);
+        };
+    }, [saksbehandler]);
+}

--- a/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/frontend/komponenter/ErrorBoundary/ErrorBoundary.tsx
@@ -5,20 +5,13 @@ import * as Sentry from '@sentry/browser';
 import { XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button, ErrorMessage, Heading, HStack, VStack } from '@navikt/ds-react';
 
-import { useSaksbehandler } from '../../hooks/useSaksbehandler';
-import type { Saksbehandler } from '../../typer/saksbehandler';
-
-interface Props extends PropsWithChildren {
-    saksbehandler?: Saksbehandler;
-}
-
 interface State {
     hasError: boolean;
     error?: Error;
 }
 
-export class ErrorBoundary extends Component<Props, State> {
-    public constructor(props: Props) {
+export class ErrorBoundary extends Component<PropsWithChildren, State> {
+    public constructor(props: PropsWithChildren) {
         super(props);
         this.state = { hasError: false };
         this.visSentryDialog = this.visSentryDialog.bind(this);
@@ -32,36 +25,32 @@ export class ErrorBoundary extends Component<Props, State> {
     public componentDidCatch(error: any, info: any): void {
         console.error(error, info);
         if (Sentry.isEnabled()) {
-            Sentry.setUser({
-                username: this.props.saksbehandler?.displayName ?? 'Ukjent navn',
-                email: this.props.saksbehandler?.email ?? 'Ukjent e-post',
-            });
             Sentry.withScope(scope => {
-                Object.keys(info).forEach(key => {
-                    scope.setExtra(key, info[key]);
-                    Sentry.captureException(error);
-                });
+                scope.setExtras(info);
+                Sentry.captureException(error);
             });
         }
     }
 
     private visSentryDialog() {
-        if (Sentry.isEnabled()) {
-            Sentry.showReportDialog({
-                title: 'En feil har oppstått i vedtaksløsningen',
-                subtitle: '',
-                subtitle2: 'Teamet har fått beskjed. Dersom du ønsker å hjelpe oss, si litt om hva som skjedde.',
-                user: {
-                    name: this.props.saksbehandler?.displayName ?? 'Ukjent navn',
-                    email: this.props.saksbehandler?.email ?? 'Ukjent e-post',
-                },
-                labelName: 'NAVN',
-                labelComments: 'HVA SKJEDDE?',
-                labelClose: 'Lukk',
-                labelSubmit: 'Send inn rapport',
-                successMessage: 'Rapport er innsendt',
-            });
+        if (!Sentry.isEnabled()) {
+            return;
         }
+        const user = Sentry.getCurrentScope().getUser();
+        Sentry.showReportDialog({
+            title: 'En feil har oppstått i vedtaksløsningen',
+            subtitle: '',
+            subtitle2: 'Teamet har fått beskjed. Dersom du ønsker å hjelpe oss, si litt om hva som skjedde.',
+            user: {
+                name: user?.username ?? 'Ukjent navn',
+                email: user?.email ?? 'Ukjent e-post',
+            },
+            labelName: 'NAVN',
+            labelComments: 'HVA SKJEDDE?',
+            labelClose: 'Lukk',
+            labelSubmit: 'Send inn rapport',
+            successMessage: 'Rapport er innsendt',
+        });
     }
 
     render(): ReactNode {
@@ -99,9 +88,4 @@ export class ErrorBoundary extends Component<Props, State> {
         }
         return this.props.children;
     }
-}
-
-export function ErrorBoundaryMedSaksbehandler({ children }: PropsWithChildren) {
-    const saksbehandler = useSaksbehandler();
-    return <ErrorBoundary saksbehandler={saksbehandler}>{children}</ErrorBoundary>;
 }


### PR DESCRIPTION
### 📮 Favro
NAV-29352

### 💰 Hva skal gjøres, og hvorfor?
Forbedrer sync mellom saksbehandler og Sentry sin user. Burde ikke sette Sentry user for hver feil, men heller når man har tilgang til en saksbehandler. Lager dermed en egen hook for å synce saksbehandler og Sentry. Endrer også måten man henter ut Sentry sin user i ErrorBoundary. Siden vi henter user fra Sentry trenger vi ikke ErrorBoundaryMedSaksbehandler lengre.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 