### PR TITLE
NAV-29360: Synker fagsakId og behandlingId med Sentry

### DIFF
--- a/src/frontend/hooks/useSyncSentryBehandlingId.ts
+++ b/src/frontend/hooks/useSyncSentryBehandlingId.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import * as Sentry from '@sentry/browser';
+import { erDefinert } from '@utils/commons';
+
+const BEHANDLING_ID_TAG_KEY = 'behandlingId';
+
+export function useSyncSentryBehandlingId(behandlingId?: number) {
+    useEffect(() => {
+        if (!erDefinert(behandlingId)) {
+            Sentry.setTag(BEHANDLING_ID_TAG_KEY, undefined);
+            return;
+        }
+
+        Sentry.setTag(BEHANDLING_ID_TAG_KEY, String(behandlingId));
+
+        return () => {
+            Sentry.setTag(BEHANDLING_ID_TAG_KEY, undefined);
+        };
+    }, [behandlingId]);
+}

--- a/src/frontend/hooks/useSyncSentryFagsakId.ts
+++ b/src/frontend/hooks/useSyncSentryFagsakId.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import * as Sentry from '@sentry/browser';
+import { erDefinert } from '@utils/commons';
+
+const FAGSAK_ID_TAG_KEY = 'fagsakId';
+
+export function useSyncSentryFagsakId(fagsakId?: number) {
+    useEffect(() => {
+        if (!erDefinert(fagsakId)) {
+            Sentry.setTag(FAGSAK_ID_TAG_KEY, undefined);
+            return;
+        }
+
+        Sentry.setTag(FAGSAK_ID_TAG_KEY, String(fagsakId));
+
+        return () => {
+            Sentry.setTag(FAGSAK_ID_TAG_KEY, undefined);
+        };
+    }, [fagsakId]);
+}

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -4,6 +4,7 @@ import { useState, createContext, useContext, useEffect } from 'react';
 import { useFagsak } from '@hooks/useFagsak';
 import { useNavigerAutomatiskTilSideForBehandlingssteg } from '@hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { useSyncSentryBehandlingId } from '@hooks/useSyncSentryBehandlingId';
 import { useTrackTidsbrukPåSide } from '@hooks/useTrackTidsbrukPåSide';
 import type { IBehandling } from '@typer/behandling';
 import { BehandlerRolle, BehandlingStatus, Behandlingstype } from '@typer/behandling';
@@ -39,6 +40,7 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
     const { settBehandlingRessurs } = useHentOgSettBehandlingContext();
 
     useNavigerAutomatiskTilSideForBehandlingssteg({ behandling });
+    useSyncSentryBehandlingId(behandling.behandlingId);
 
     const saksbehandler = useSaksbehandler();
     const fagsak = useFagsak();

--- a/src/frontend/sider/Fagsak/Fagsak.tsx
+++ b/src/frontend/sider/Fagsak/Fagsak.tsx
@@ -3,6 +3,7 @@ import { useHentFagsak } from '@hooks/useHentFagsak';
 import { useHentPerson } from '@hooks/useHentPerson';
 import { useScrollTilAnker } from '@hooks/useScrollTilAnker';
 import { useSyncModiaContext } from '@hooks/useSyncModiaContext';
+import { useSyncSentryFagsakId } from '@hooks/useSyncSentryFagsakId';
 import { NotFound } from '@komponenter/Error/NotFound';
 import { Personlinje } from '@komponenter/Personlinje/Personlinje';
 import { FagsakType } from '@typer/fagsak';
@@ -26,6 +27,7 @@ export function Fagsak() {
 
     useScrollTilAnker();
     useSyncModiaContext(bruker);
+    useSyncSentryFagsakId(fagsak?.id);
 
     if (!fagsakIdParam) {
         return <NotFound />;


### PR DESCRIPTION
### 📮 Favro
NAV-29360

### 💰 Hva skal gjøres, og hvorfor?
Synker fagsakId og behandlingId med Sentry slik at det blir lettere å løse Sentry issues. Gjør det også mulig å søke på fagsakId og behandlingId hvis nødvendig. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant. 

### 👀 Screen shots
Ingen visuelle endringer. 