### PR TITLE
NAV-29258: Ny ApiClient

### DIFF
--- a/src/frontend/Container.tsx
+++ b/src/frontend/Container.tsx
@@ -1,7 +1,9 @@
 import { useAuthContext } from '@context/AuthContext';
+import { useVisSystemetLaster } from '@hooks/useVisSystemetLaster';
 import { HeaderMedSøk } from '@komponenter/HeaderMedSøk/HeaderMedSøk';
 import { FeilmeldingModal } from '@komponenter/Modal/fagsak/FeilmeldingModal';
 import { OpprettFagsakModal } from '@komponenter/Modal/fagsak/OpprettFagsakModal';
+import { UgyldigSesjon } from '@komponenter/Modal/SesjonUtløpt';
 import { ForhåndsvisOpprettingAvPdfModal } from '@komponenter/PdfVisningModal/ForhåndsvisOpprettingAvPdfModal';
 import { FagsakContainer } from '@sider/Fagsak/FagsakContainer';
 import { Infotrygd } from '@sider/Infotrygd/Infotrygd';
@@ -10,42 +12,37 @@ import { Samhandler } from '@sider/Samhandler/Samhandler';
 import classNames from 'classnames';
 import { BrowserRouter as Router, Navigate, Route, Routes } from 'react-router';
 
-import { useHttp } from '@navikt/familie-http';
-
 import Styles from './Container.module.css';
-import UgyldigSesjon from './komponenter/Modal/SesjonUtløpt';
 import SystemetLaster from './komponenter/SystemetLaster/SystemetLaster';
 import Toasts from './komponenter/Toast/Toasts';
 import ManuellJournalføring from './sider/ManuellJournalføring/ManuellJournalføring';
 
 export function Container() {
     const { autentisert } = useAuthContext();
-    const { systemetLaster } = useHttp();
+    const visSystemetLaster = useVisSystemetLaster();
+
+    if (!autentisert) {
+        return <UgyldigSesjon />;
+    }
 
     return (
         <Router>
-            {autentisert ? (
-                <>
-                    {systemetLaster() && <SystemetLaster />}
-                    <Toasts />
-                    <main className={classNames(Styles.main, { [Styles.systemLaster]: systemetLaster() })}>
-                        <OpprettFagsakModal />
-                        <FeilmeldingModal />
-                        <ForhåndsvisOpprettingAvPdfModal />
-                        <HeaderMedSøk />
-                        <Routes>
-                            <Route path="/fagsak/:fagsakId/*" element={<FagsakContainer />} />
-                            <Route path="/oppgaver/journalfor/:oppgaveId" element={<ManuellJournalføring />} />
-                            <Route path="/infotrygd" element={<Infotrygd />} />
-                            <Route path="/samhandler" element={<Samhandler />} />
-                            <Route path="/oppgaver" element={<Oppgavebenk />} />
-                            <Route path="/" element={<Navigate to="/oppgaver" />} />
-                        </Routes>
-                    </main>
-                </>
-            ) : (
-                <UgyldigSesjon />
-            )}
+            {visSystemetLaster && <SystemetLaster />}
+            <Toasts />
+            <main className={classNames(Styles.main, { [Styles.systemLaster]: visSystemetLaster })}>
+                <OpprettFagsakModal />
+                <FeilmeldingModal />
+                <ForhåndsvisOpprettingAvPdfModal />
+                <HeaderMedSøk />
+                <Routes>
+                    <Route path="/fagsak/:fagsakId/*" element={<FagsakContainer />} />
+                    <Route path="/oppgaver/journalfor/:oppgaveId" element={<ManuellJournalføring />} />
+                    <Route path="/infotrygd" element={<Infotrygd />} />
+                    <Route path="/samhandler" element={<Samhandler />} />
+                    <Route path="/oppgaver" element={<Oppgavebenk />} />
+                    <Route path="/" element={<Navigate to="/oppgaver" />} />
+                </Routes>
+            </main>
         </Router>
     );
 }

--- a/src/frontend/api/client/apiClient.test.ts
+++ b/src/frontend/api/client/apiClient.test.ts
@@ -1,0 +1,237 @@
+import { server } from '@testutils/mocks/node';
+import { http, HttpResponse } from 'msw';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ApiClient } from './apiClient';
+
+const BASE_URL = 'http://localhost:3000';
+
+type TestData = { id: number; name: string };
+
+function lagSuksessRessurs<T>(data: T) {
+    return { status: 'SUKSESS', data, melding: 'OK' };
+}
+
+function lagFeilRessurs(
+    status: 'FEILET' | 'IKKE_TILGANG' | 'FUNKSJONELL_FEIL',
+    frontendFeilmelding: string,
+    callId?: string | null
+) {
+    return { status, melding: 'En feil oppstod', frontendFeilmelding, callId };
+}
+
+describe('ApiClient', () => {
+    let client: ApiClient;
+
+    beforeEach(() => {
+        client = new ApiClient(BASE_URL);
+    });
+
+    describe('GET-forespørsler', () => {
+        test('returnerer data ved vellykket SUKSESS-respons', async () => {
+            const mockData: TestData = { id: 1, name: 'Test' };
+
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagSuksessRessurs(mockData))));
+
+            const result = await client.get<void, TestData>({ url: '/api/test' });
+            expect(result).toEqual(mockData);
+        });
+
+        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
+            'avviser forespørselen ved %s-status',
+            async status => {
+                server.use(
+                    http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+                );
+
+                await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            }
+        );
+    });
+
+    describe('POST-forespørsler', () => {
+        test('sender forespørsel med riktig body og returnerer data', async () => {
+            const requestBody = { name: 'Ny ressurs' };
+            const mockData: TestData = { id: 2, name: 'Ny ressurs' };
+
+            server.use(
+                http.post(`${BASE_URL}/api/test`, async ({ request }) => {
+                    const body = await request.json();
+                    expect(body).toEqual(requestBody);
+                    return HttpResponse.json(lagSuksessRessurs(mockData));
+                })
+            );
+
+            const result = await client.post<typeof requestBody, TestData>({
+                url: '/api/test',
+                data: requestBody,
+            });
+            expect(result).toEqual(mockData);
+        });
+
+        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
+            'avviser forespørselen ved %s-status',
+            async status => {
+                server.use(
+                    http.post(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+                );
+
+                await expect(client.post({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            }
+        );
+    });
+
+    describe('PUT-forespørsler', () => {
+        test('oppdaterer ressurs og returnerer data ved vellykket respons', async () => {
+            const mockData: TestData = { id: 1, name: 'Oppdatert navn' };
+
+            server.use(http.put(`${BASE_URL}/api/test/1`, () => HttpResponse.json(lagSuksessRessurs(mockData))));
+
+            const result = await client.put<void, TestData>({ url: '/api/test/1' });
+            expect(result).toEqual(mockData);
+        });
+
+        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
+            'avviser forespørselen ved %s-status',
+            async status => {
+                server.use(
+                    http.put(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+                );
+
+                await expect(client.put({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            }
+        );
+    });
+
+    describe('PATCH-forespørsler', () => {
+        test('endrer deler av en ressurs og returnerer data ved vellykket respons', async () => {
+            const mockData: TestData = { id: 1, name: 'Delvis oppdatert' };
+
+            server.use(http.patch(`${BASE_URL}/api/test/1`, () => HttpResponse.json(lagSuksessRessurs(mockData))));
+
+            const result = await client.patch<void, TestData>({ url: '/api/test/1' });
+            expect(result).toEqual(mockData);
+        });
+
+        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
+            'avviser forespørselen ved %s-status',
+            async status => {
+                server.use(
+                    http.patch(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+                );
+
+                await expect(client.patch({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            }
+        );
+    });
+
+    describe('DELETE-forespørsler', () => {
+        test('sletter en ressurs og returnerer data ved vellykket respons', async () => {
+            server.use(http.delete(`${BASE_URL}/api/test/1`, () => HttpResponse.json(lagSuksessRessurs(null))));
+
+            const result = await client.delete<void, null>({ url: '/api/test/1' });
+            expect(result).toBeNull();
+        });
+
+        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
+            'avviser forespørselen ved %s-status',
+            async status => {
+                server.use(
+                    http.delete(`${BASE_URL}/api/test`, () =>
+                        HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt'))
+                    )
+                );
+
+                await expect(client.delete({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            }
+        );
+    });
+
+    describe('Feilmelding med callId', () => {
+        test('inkluderer callId i feilmeldingen når den er satt', async () => {
+            server.use(
+                http.get(`${BASE_URL}/api/test`, () =>
+                    HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt', 'abc-123'))
+                )
+            );
+
+            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt (CallId: abc-123)');
+        });
+
+        test('utelater callId fra feilmeldingen når den er null', async () => {
+            server.use(
+                http.get(`${BASE_URL}/api/test`, () =>
+                    HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt', null))
+                )
+            );
+
+            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+        });
+
+        test('utelater callId fra feilmeldingen når den mangler i responsen', async () => {
+            server.use(
+                http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt')))
+            );
+
+            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+        });
+    });
+
+    describe('Interceptorer', () => {
+        test('addResponseInterceptor returnerer en numerisk id', () => {
+            const id = client.addResponseInterceptor({ onFulfilled: vi.fn(r => r) });
+
+            expect(typeof id).toBe('number');
+        });
+
+        test('kjører onFulfilled-interceptoren ved vellykket respons', async () => {
+            const mockData: TestData = { id: 1, name: 'Test' };
+            const onFulfilled = vi.fn(response => response);
+
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagSuksessRessurs(mockData))));
+
+            client.addResponseInterceptor({ onFulfilled });
+            await client.get<void, TestData>({ url: '/api/test' });
+
+            expect(onFulfilled).toHaveBeenCalledOnce();
+        });
+
+        test('kjører onRejected-interceptoren ved nettverksfeil', async () => {
+            const onRejected = vi.fn(error => Promise.reject(error));
+
+            server.use(http.get(`${BASE_URL}/api/network-error`, () => HttpResponse.error()));
+
+            client.addResponseInterceptor({ onRejected });
+            await expect(client.get({ url: '/api/network-error' })).rejects.toThrow();
+
+            expect(onRejected).toHaveBeenCalledOnce();
+        });
+
+        test('removeResponseInterceptor kaster ikke feil', () => {
+            const id = client.addResponseInterceptor({ onFulfilled: vi.fn(r => r) });
+
+            expect(() => client.removeResponseInterceptor(id)).not.toThrow();
+        });
+
+        test('fjernet interceptor kjøres ikke på påfølgende forespørsler', async () => {
+            const mockData: TestData = { id: 1, name: 'Test' };
+            const onFulfilled = vi.fn(response => response);
+
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagSuksessRessurs(mockData))));
+
+            const id = client.addResponseInterceptor({ onFulfilled });
+            client.removeResponseInterceptor(id);
+
+            await client.get<void, TestData>({ url: '/api/test' });
+            expect(onFulfilled).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Nettverksfeil', () => {
+        test('avviser ved nettverksfeil', async () => {
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.error()));
+
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow();
+        });
+    });
+});

--- a/src/frontend/api/client/apiClient.ts
+++ b/src/frontend/api/client/apiClient.ts
@@ -1,0 +1,102 @@
+import axios, { type AxiosError, type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
+
+const DEFAULT_TIME_OUT = 30_000;
+const DEFAULT_TIME_OUT_MESSAGE =
+    'Nettverkskallet tok for lang tid. Prøv igjen senere eller kontakt brukerstøtte hvis problemet vedvarer.';
+
+type OnFulfilled = <T>(
+    response: AxiosResponse<Ressurs<T>>
+) => AxiosResponse<Ressurs<T>> | Promise<AxiosResponse<Ressurs<T>>>;
+
+type OnRejected = (error: AxiosError) => unknown;
+
+interface Interceptor {
+    onFulfilled?: OnFulfilled;
+    onRejected?: OnRejected;
+}
+
+enum RessursStatus {
+    SUKSESS = 'SUKSESS',
+    FEILET = 'FEILET',
+    IKKE_TILGANG = 'IKKE_TILGANG',
+    FUNKSJONELL_FEIL = 'FUNKSJONELL_FEIL',
+}
+
+type Ressurs<T> =
+    | {
+          status: RessursStatus.SUKSESS;
+          data: T;
+          melding: string;
+          frontendFeilmelding?: string | null;
+          stacktrace?: string | null;
+          callId?: string | null;
+      }
+    | {
+          status: RessursStatus.FEILET | RessursStatus.IKKE_TILGANG | RessursStatus.FUNKSJONELL_FEIL;
+          data?: undefined;
+          melding: string;
+          frontendFeilmelding?: string | null;
+          stacktrace?: string | null;
+          callId?: string | null;
+      };
+
+export class ApiClient {
+    private readonly client: AxiosInstance;
+
+    constructor(baseURL: string = window.location.origin) {
+        this.client = axios.create({ baseURL });
+    }
+
+    private async request<T, R>(config: AxiosRequestConfig<T>): Promise<R> {
+        const response = await this.client.request<T, AxiosResponse<Ressurs<R>>>({
+            timeout: DEFAULT_TIME_OUT,
+            timeoutErrorMessage: DEFAULT_TIME_OUT_MESSAGE,
+            ...config,
+        });
+        return this.resolveToPromise(response.data);
+    }
+
+    async get<T, R>(config: Omit<AxiosRequestConfig<T>, 'method'>): Promise<R> {
+        return this.request({ method: 'GET', ...config });
+    }
+
+    async put<T, R>(config: Omit<AxiosRequestConfig<T>, 'method'>): Promise<R> {
+        return this.request({ method: 'PUT', ...config });
+    }
+
+    async post<T, R>(config: Omit<AxiosRequestConfig<T>, 'method'>): Promise<R> {
+        return this.request({ method: 'POST', ...config });
+    }
+
+    async delete<T, R>(config: Omit<AxiosRequestConfig<T>, 'method'>): Promise<R> {
+        return this.request({ method: 'DELETE', ...config });
+    }
+
+    async patch<T, R>(config: Omit<AxiosRequestConfig<T>, 'method'>): Promise<R> {
+        return this.request({ method: 'PATCH', ...config });
+    }
+
+    addResponseInterceptor({ onFulfilled, onRejected }: Interceptor): number {
+        return this.client.interceptors.response.use(onFulfilled, onRejected);
+    }
+
+    removeResponseInterceptor(id: number): void {
+        this.client.interceptors.response.eject(id);
+    }
+
+    private resolveToPromise<T>(ressurs: Ressurs<T>): Promise<T> {
+        switch (ressurs.status) {
+            case RessursStatus.SUKSESS:
+                return Promise.resolve(ressurs.data);
+            case RessursStatus.FEILET:
+            case RessursStatus.FUNKSJONELL_FEIL:
+            case RessursStatus.IKKE_TILGANG:
+                const frontendFeilmeldingMedEllerUtenCallId = ressurs.callId
+                    ? `${ressurs.frontendFeilmelding} (CallId: ${ressurs.callId})`
+                    : ressurs.frontendFeilmelding;
+                return Promise.reject(frontendFeilmeldingMedEllerUtenCallId);
+        }
+    }
+}
+
+export const apiClient = new ApiClient();

--- a/src/frontend/api/hentFagsak.ts
+++ b/src/frontend/api/hentFagsak.ts
@@ -1,13 +1,8 @@
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+import { apiClient } from '@api/client/apiClient';
+import type { IMinimalFagsak } from '@typer/fagsak';
 
-import type { IMinimalFagsak } from '../typer/fagsak';
-import { RessursResolver } from '../utils/ressursResolver';
-
-export async function hentFagsak(request: FamilieRequest, fagsakId: number) {
-    const ressurs = await request<void, IMinimalFagsak>({
-        method: 'GET',
+export async function hentFagsak(fagsakId: number) {
+    return apiClient.get<void, IMinimalFagsak>({
         url: `/familie-ba-sak/api/fagsaker/minimal/${fagsakId}`,
-        påvirkerSystemLaster: true,
     });
-    return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/context/AuthContext.tsx
+++ b/src/frontend/context/AuthContext.tsx
@@ -1,5 +1,6 @@
-import type { PropsWithChildren } from 'react';
-import { useContext, createContext, useState } from 'react';
+import { type PropsWithChildren, useEffect, useContext, createContext, useState } from 'react';
+
+import { apiClient } from '@api/client/apiClient';
 
 interface Context {
     autentisert: boolean;
@@ -10,6 +11,20 @@ const AuthContext = createContext<Context | undefined>(undefined);
 
 export function AuthContextProvider({ children }: PropsWithChildren) {
     const [autentisert, settAutentisert] = useState(true);
+
+    useEffect(() => {
+        const interceptorId = apiClient.addResponseInterceptor({
+            onRejected: error => {
+                if (error.response?.status === 401) {
+                    settAutentisert(false);
+                }
+                return Promise.reject(error);
+            },
+        });
+        return () => {
+            apiClient.removeResponseInterceptor(interceptorId);
+        };
+    }, []);
 
     return <AuthContext.Provider value={{ autentisert, settAutentisert }}>{children}</AuthContext.Provider>;
 }

--- a/src/frontend/hooks/meta/metaKey.ts
+++ b/src/frontend/hooks/meta/metaKey.ts
@@ -1,0 +1,3 @@
+export enum MetaKey {
+    VIS_SYSTEMET_LASTER = 'visSystemetLaster',
+}

--- a/src/frontend/hooks/useHentFagsak.ts
+++ b/src/frontend/hooks/useHentFagsak.ts
@@ -1,10 +1,9 @@
 import { hentFagsak } from '@api/hentFagsak';
+import { MetaKey } from '@hooks/meta/metaKey';
 import { useSkalObfuskereData } from '@hooks/useSkalObfuskereData';
 import { useQuery } from '@tanstack/react-query';
 import type { IMinimalFagsak } from '@typer/fagsak';
 import { PersonType } from '@typer/person';
-
-import { useHttp } from '@navikt/familie-http';
 
 // TODO : Refactor so it does not mutate fagsak object, but return a new object instead
 function obfuskerFagsak(fagsak: IMinimalFagsak) {
@@ -27,15 +26,14 @@ export const HentFagsakQueryKeyFactory = {
 };
 
 export function useHentFagsak(fagsakId: number | undefined) {
-    const { request } = useHttp();
     const skalObfuskereData = useSkalObfuskereData();
     return useQuery({
         queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId),
         queryFn: () => {
             if (fagsakId === undefined) {
-                return Promise.reject(new Error('Kan ikke hente fagsak uten fagsakId.'));
+                throw new Error('Kan ikke hente fagsak uten fagsakId.');
             }
-            return hentFagsak(request, fagsakId);
+            return hentFagsak(fagsakId);
         },
         select: fagsak => {
             if (skalObfuskereData) {
@@ -44,5 +42,6 @@ export function useHentFagsak(fagsakId: number | undefined) {
             return fagsak;
         },
         enabled: fagsakId !== undefined,
+        meta: { [MetaKey.VIS_SYSTEMET_LASTER]: true },
     });
 }

--- a/src/frontend/hooks/useVisSystemetLaster.ts
+++ b/src/frontend/hooks/useVisSystemetLaster.ts
@@ -1,0 +1,18 @@
+import { MetaKey } from '@hooks/meta/metaKey';
+import { useIsFetching, useIsMutating } from '@tanstack/react-query';
+
+import { useHttp } from '@navikt/familie-http';
+
+export function useVisSystemetLaster() {
+    const { systemetLaster } = useHttp();
+
+    const isFetching = useIsFetching({
+        predicate: query => query.meta?.[MetaKey.VIS_SYSTEMET_LASTER] === true,
+    });
+
+    const isMutating = useIsMutating({
+        predicate: query => query.meta?.[MetaKey.VIS_SYSTEMET_LASTER] === true,
+    });
+
+    return systemetLaster() || isFetching > 0 || isMutating > 0;
+}

--- a/src/frontend/komponenter/Modal/SesjonUtløpt.tsx
+++ b/src/frontend/komponenter/Modal/SesjonUtløpt.tsx
@@ -1,13 +1,19 @@
-import { BodyShort, Modal } from '@navikt/ds-react';
+import { BodyShort, Box, Modal } from '@navikt/ds-react';
 
-const UgyldigSesjon = () => {
+export function UgyldigSesjon() {
     return (
-        <Modal header={{ heading: 'Ugyldig sesjon', size: 'small', closeButton: false }} width={'small'}>
+        <Modal
+            open={true}
+            portal={true}
+            header={{ heading: 'Ugyldig sesjon', closeButton: false }}
+            width={'medium'}
+            onClose={() => {}}
+        >
             <Modal.Body>
-                <BodyShort>Prøv å last siden på nytt</BodyShort>
+                <Box marginBlock={'space-24'}>
+                    <BodyShort>Prøv å last siden inn på nytt.</BodyShort>
+                </Box>
             </Modal.Body>
         </Modal>
     );
-};
-
-export default UgyldigSesjon;
+}

--- a/src/frontend/sentry.ts
+++ b/src/frontend/sentry.ts
@@ -1,3 +1,4 @@
+import { apiClient } from '@api/client/apiClient';
 import * as Sentry from '@sentry/browser';
 
 const environment = window.location.hostname;
@@ -9,6 +10,21 @@ export function initSentry() {
             environment,
             integrations: [Sentry.browserTracingIntegration()],
             tracesSampleRate: 0.2,
+        });
+
+        apiClient.addResponseInterceptor({
+            onRejected: error => {
+                Sentry.captureException(error, {
+                    extra: {
+                        response: {
+                            callId: error.response?.headers['nav-call-id'],
+                            status: error.response?.status,
+                            statusText: error.response?.statusText,
+                        },
+                    },
+                });
+                return Promise.reject(error);
+            },
         });
     } catch (e) {
         console.error('Sentry feilet ved initialisering', e);


### PR DESCRIPTION
### 📮 Favro:
NAV-29258

### 💰 Hva skal gjøres, og hvorfor?
- Definerer en egen `ApiClient` og tar den i bruk i endepunktet for å hente fagsaker.
- Definere en interceptor for å sjekke feil for status 401 og setter autentisert til false (likt med familie-felles-frontend).
- Definere en interceptor for å logge feil til Sentry (likt med familie-felles-frontend).
- Bruker `useIsFetching` og `useIsMutating` med en predicate på `MetaKey.VIS_SYSTEMET_LASTER` for å bedømme om man skal vise `<SystemetLaster />`. Lager en egen hook `useVisSystemetLaster.ts` som håndterer logikken rundt det. 
- Legger til `MetaKey.VIS_SYSTEMET_LASTER` nøkkelen på `useHentFagsak.ts` hooken. 
- Rydder litt opp i `<UgylidgSesjon />` modalen. 
- Fjerner `useHttp` og tilhørende `request` fra `useHentFagsak.ts` og `hentFagsak.ts`
- Legger til en timeout på 30 sekunder og en default feilmelding som sier at det er nettverksproblemer.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 