### PR TITLE
NAV-29334: Fjerner props fra komponenter som brukes av Routes

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRouter.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from 'react';
 
+import { useTrackTidsbrukPåSide } from '@hooks/useTrackTidsbrukPåSide';
+import { TidslinjeProvider } from '@komponenter/Tidslinje/TidslinjeContext';
+import { hentSideHref } from '@utils/miljø';
 import { Route, Routes, useLocation } from 'react-router';
 
 import { useFagsakContext } from '../FagsakContext';
@@ -14,15 +17,12 @@ import { sider } from './Sider/sider';
 import Simulering from './Sider/Simulering/Simulering';
 import { SimuleringProvider } from './Sider/Simulering/SimuleringContext';
 import { FeilutbetaltValutaTabellProvider } from './Sider/Vedtak/FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
+import { RefusjonEøsTabellProvider } from './Sider/Vedtak/RefusjonEøs/RefusjonEøsTabellContext';
 import { SammensattKontrollsakProvider } from './Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext';
 import { Vedtak } from './Sider/Vedtak/Vedtak';
+import { VedtaksperioderProvider } from './Sider/Vedtak/Vedtaksperioder/VedtaksperioderContext';
 import { Vilkårsvurdering } from './Sider/Vilkårsvurdering/Vilkårsvurdering';
 import { VilkårsvurderingProvider } from './Sider/Vilkårsvurdering/VilkårsvurderingContext';
-import { useTrackTidsbrukPåSide } from '../../../hooks/useTrackTidsbrukPåSide';
-import { TidslinjeProvider } from '../../../komponenter/Tidslinje/TidslinjeContext';
-import { hentSideHref } from '../../../utils/miljø';
-import { RefusjonEøsTabellProvider } from './Sider/Vedtak/RefusjonEøs/RefusjonEøsTabellContext';
-import { VedtaksperioderProvider } from './Sider/Vedtak/Vedtaksperioder/VedtaksperioderContext';
 
 export function BehandlingRouter() {
     const { fagsak } = useFagsakContext();
@@ -46,16 +46,16 @@ export function BehandlingRouter() {
             <Route
                 path="/registrer-soknad"
                 element={
-                    <SøknadProvider åpenBehandling={behandling}>
+                    <SøknadProvider>
                         <RegistrerSøknad />
                     </SøknadProvider>
                 }
             />
-            <Route path="/filtreringsregler" element={<Filtreringsregler åpenBehandling={behandling} />} />
+            <Route path="/filtreringsregler" element={<Filtreringsregler />} />
             <Route
                 path="/vilkaarsvurdering"
                 element={
-                    <VilkårsvurderingProvider åpenBehandling={behandling}>
+                    <VilkårsvurderingProvider>
                         <Vilkårsvurdering />
                     </VilkårsvurderingProvider>
                 }
@@ -64,25 +64,25 @@ export function BehandlingRouter() {
                 path="/tilkjent-ytelse"
                 element={
                     <TidslinjeProvider>
-                        <Behandlingsresultat åpenBehandling={behandling} />
+                        <Behandlingsresultat />
                     </TidslinjeProvider>
                 }
             />
             <Route
                 path="/simulering"
                 element={
-                    <SimuleringProvider åpenBehandling={behandling}>
-                        <Simulering åpenBehandling={behandling} />
+                    <SimuleringProvider>
+                        <Simulering />
                     </SimuleringProvider>
                 }
             />
             <Route
                 path="/vedtak"
                 element={
-                    <SimuleringProvider åpenBehandling={behandling}>
+                    <SimuleringProvider>
                         <FeilutbetaltValutaTabellProvider>
                             <RefusjonEøsTabellProvider>
-                                <SammensattKontrollsakProvider åpenBehandling={behandling}>
+                                <SammensattKontrollsakProvider>
                                     <VedtaksperioderProvider>
                                         <Vedtak />
                                     </VedtaksperioderProvider>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Behandlingsresultat.tsx
@@ -47,12 +47,8 @@ const StyledErrorSummary = styled(ErrorSummary)`
     margin-top: 5rem;
 `;
 
-interface IBehandlingsresultatProps {
-    åpenBehandling: IBehandling;
-}
-
-const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => {
-    const { settÅpenBehandling } = useBehandlingContext();
+const Behandlingsresultat = () => {
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const fagsak = useFagsak();
     const navigate = useNavigate();
@@ -63,7 +59,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
         settVisFeilmeldinger,
         hentPersonerMedUgyldigEtterbetalingsperiode,
         personerMedUgyldigEtterbetalingsperiode,
-    } = useBehandlingsresultat(åpenBehandling);
+    } = useBehandlingsresultat(behandling);
 
     const {
         mutate: oppdaterBehandlingsresultat,
@@ -102,11 +98,11 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
         valutakurser,
         erValutakurserGyldige,
         hentValutakurserMedFeil,
-    } = useEøs(åpenBehandling);
+    } = useEøs(behandling);
 
     useEffect(() => {
         hentPersonerMedUgyldigEtterbetalingsperiode();
-    }, [åpenBehandling]);
+    }, [behandling]);
 
     const finnUtbetalingsperiodeForAktivEtikett = (
         utbetalingsperioder: Utbetalingsperiode[]
@@ -123,20 +119,20 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
     };
 
     const grunnlagPersoner = filterOgSorterGrunnlagPersonerMedAndeler(
-        åpenBehandling.personer,
-        åpenBehandling.personerMedAndelerTilkjentYtelse
+        behandling.personer,
+        behandling.personerMedAndelerTilkjentYtelse
     );
 
     const tidslinjePersoner = filterOgSorterAndelPersonerIGrunnlag(
         grunnlagPersoner,
-        åpenBehandling.personerMedAndelerTilkjentYtelse
+        behandling.personerMedAndelerTilkjentYtelse
     );
 
-    const erMigreringFraInfotrygd = åpenBehandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
+    const erMigreringFraInfotrygd = behandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
 
-    const harKompetanser = åpenBehandling.kompetanser?.length > 0;
-    const harUtenlandskeBeløper = åpenBehandling.utenlandskePeriodebeløp?.length > 0;
-    const harValutakurser = åpenBehandling.utenlandskePeriodebeløp?.length > 0;
+    const harKompetanser = behandling.kompetanser?.length > 0;
+    const harUtenlandskeBeløper = behandling.utenlandskePeriodebeløp?.length > 0;
+    const harValutakurser = behandling.utenlandskePeriodebeløp?.length > 0;
 
     const harEøs = harKompetanser || harUtenlandskeBeløper || harValutakurser;
 
@@ -145,14 +141,14 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
             senderInn={oppdaterBehandlingsresultatIsPending}
             tittel="Behandlingsresultat"
             className="behandlingsresultat"
-            forrigeOnClick={() => navigate(`/fagsak/${fagsak.id}/${åpenBehandling.behandlingId}/vilkaarsvurdering`)}
+            forrigeOnClick={() => navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`)}
             nesteOnClick={() => {
                 if (erLesevisning) {
-                    navigate(`/fagsak/${fagsak.id}/${åpenBehandling.behandlingId}/simulering`);
+                    navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/simulering`);
                 } else if (harEøs && !erEøsInformasjonGyldig()) {
                     settVisFeilmeldinger(true);
                 } else {
-                    oppdaterBehandlingsresultat({ behandlingId: åpenBehandling.behandlingId });
+                    oppdaterBehandlingsresultat({ behandlingId: behandling.behandlingId });
                 }
             }}
             maxWidthStyle={'80rem'}
@@ -174,7 +170,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
                     </LocalAlert>
                 </Box>
             )}
-            {erMigreringFraInfotrygd && <MigreringInfoboks behandlingId={åpenBehandling.behandlingId} />}
+            {erMigreringFraInfotrygd && <MigreringInfoboks behandlingId={behandling.behandlingId} />}
             <TilkjentYtelseTidslinje
                 grunnlagPersoner={grunnlagPersoner}
                 tidslinjePersoner={tidslinjePersoner}
@@ -199,21 +195,21 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
             )}
             {aktivEtikett && (
                 <Oppsummeringsboks
-                    utbetalingsperiode={finnUtbetalingsperiodeForAktivEtikett(åpenBehandling.utbetalingsperioder)}
+                    utbetalingsperiode={finnUtbetalingsperiodeForAktivEtikett(behandling.utbetalingsperioder)}
                     aktivEtikett={aktivEtikett}
                     kompetanser={kompetanser}
                     utbetaltAnnetLandBeløp={utbetaltAnnetLandBeløp}
                     valutakurser={valutakurser}
                 />
             )}
-            {åpenBehandling.endretUtbetalingAndeler.length > 0 && (
-                <EndretUtbetalingAndelTabell åpenBehandling={åpenBehandling} />
+            {behandling.endretUtbetalingAndeler.length > 0 && (
+                <EndretUtbetalingAndelTabell åpenBehandling={behandling} />
             )}
             {harKompetanser && (
                 <KompetanseSkjema
                     kompetanser={kompetanser}
                     visFeilmeldinger={visFeilmeldinger}
-                    åpenBehandling={åpenBehandling}
+                    åpenBehandling={behandling}
                 />
             )}
             {harUtenlandskeBeløper && (
@@ -221,7 +217,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
                     utbetaltAnnetLandBeløp={utbetaltAnnetLandBeløp}
                     erUtbetaltAnnetLandBeløpGyldige={erUtbetaltAnnetLandBeløpGyldige}
                     visFeilmeldinger={visFeilmeldinger}
-                    åpenBehandling={åpenBehandling}
+                    åpenBehandling={behandling}
                 />
             )}
             {harValutakurser && (
@@ -229,7 +225,7 @@ const Behandlingsresultat = ({ åpenBehandling }: IBehandlingsresultatProps) => 
                     valutakurser={valutakurser}
                     erValutakurserGyldige={erValutakurserGyldige}
                     visFeilmeldinger={visFeilmeldinger}
-                    åpenBehandling={åpenBehandling}
+                    åpenBehandling={behandling}
                 />
             )}
             {visFeilmeldinger && !erEøsInformasjonGyldig() && (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/FiltreringFødselshendelser/Filtreringsregler.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/FiltreringFødselshendelser/Filtreringsregler.tsx
@@ -1,20 +1,17 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useFagsakId } from '@hooks/useFagsakId';
+import { BehandlingSteg } from '@typer/behandling';
+import { Filtreringsregel, filtreringsregler } from '@typer/fødselshendelser';
 import { useNavigate } from 'react-router';
 
 import { BodyShort, List } from '@navikt/ds-react';
 
-import { useFagsakId } from '../../../../../hooks/useFagsakId';
 import VilkårResultatIkon from '../../../../../ikoner/VilkårResultatIkon';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { BehandlingSteg } from '../../../../../typer/behandling';
-import { Filtreringsregel, filtreringsregler } from '../../../../../typer/fødselshendelser';
 import Skjemasteg from '../Skjemasteg';
 
-interface IProps {
-    åpenBehandling: IBehandling;
-}
-
-const Filtreringsregler = ({ åpenBehandling }: IProps) => {
+const Filtreringsregler = () => {
     const fagsakId = useFagsakId();
+    const behandling = useBehandling();
     const navigate = useNavigate();
 
     return (
@@ -22,7 +19,7 @@ const Filtreringsregler = ({ åpenBehandling }: IProps) => {
             skalViseForrigeKnapp={false}
             tittel={'Filtreringsregler'}
             nesteOnClick={() => {
-                navigate(`/fagsak/${fagsakId}/${åpenBehandling.behandlingId}/vilkaarsvurdering`);
+                navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vilkaarsvurdering`);
             }}
             maxWidthStyle={'80rem'}
             senderInn={false}
@@ -30,7 +27,7 @@ const Filtreringsregler = ({ åpenBehandling }: IProps) => {
         >
             <List>
                 {Object.keys(Filtreringsregel).map(filtreringsregel => {
-                    const fødselshendelsefiltreringResultat = åpenBehandling.fødselshendelsefiltreringResultater.find(
+                    const fødselshendelsefiltreringResultat = behandling.fødselshendelsefiltreringResultater.find(
                         it => it.filtreringsregel === filtreringsregel
                     );
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
@@ -19,10 +19,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 import useDeepEffect from '../../../../../hooks/useDeepEffect';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-interface Props extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
-
 interface SøknadSkjema {
     underkategori: BehandlingUnderkategori;
     barnaMedOpplysninger: IBarnMedOpplysninger[];
@@ -42,8 +38,8 @@ interface SøknadContextValue {
 
 const SøknadContext = createContext<SøknadContextValue | undefined>(undefined);
 
-export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
-    const { settÅpenBehandling, gjelderInstitusjon, gjelderEnsligMindreårig, gjelderSkjermetBarn } =
+export const SøknadProvider = ({ children }: PropsWithChildren) => {
+    const { behandling, settÅpenBehandling, gjelderInstitusjon, gjelderEnsligMindreårig, gjelderSkjermetBarn } =
         useBehandlingContext();
 
     const fagsak = useFagsak();
@@ -59,7 +55,7 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
         felter: {
             underkategori: useFelt<BehandlingUnderkategori>({
                 verdi:
-                    åpenBehandling.underkategori === BehandlingUnderkategori.UTVIDET
+                    behandling.underkategori === BehandlingUnderkategori.UTVIDET
                         ? BehandlingUnderkategori.UTVIDET
                         : BehandlingUnderkategori.ORDINÆR,
             }),
@@ -124,10 +120,10 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
     }, [bruker]);
 
     useDeepEffect(() => {
-        if (åpenBehandling.søknadsgrunnlag) {
+        if (behandling.søknadsgrunnlag) {
             settSøknadErLastetFraBackend(true);
             skjema.felter.barnaMedOpplysninger.validerOgSettFelt(
-                åpenBehandling.søknadsgrunnlag.barnaMedOpplysninger.map(
+                behandling.søknadsgrunnlag.barnaMedOpplysninger.map(
                     (barnMedOpplysninger: IBarnMedOpplysningerBackend) => ({
                         ...barnMedOpplysninger,
                         merket: barnMedOpplysninger.inkludertISøknaden,
@@ -135,20 +131,20 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
                 )
             );
 
-            skjema.felter.målform.validerOgSettFelt(åpenBehandling.søknadsgrunnlag.søkerMedOpplysninger.målform);
-            skjema.felter.underkategori.validerOgSettFelt(åpenBehandling.søknadsgrunnlag.underkategori);
+            skjema.felter.målform.validerOgSettFelt(behandling.søknadsgrunnlag.søkerMedOpplysninger.målform);
+            skjema.felter.underkategori.validerOgSettFelt(behandling.søknadsgrunnlag.underkategori);
             skjema.felter.endringAvOpplysningerBegrunnelse.validerOgSettFelt(
-                åpenBehandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse
+                behandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse
             );
         } else {
             // Ny behandling er lastet som ikke har fullført søknad-steget.
             tilbakestillSøknad();
         }
-    }, [åpenBehandling.behandlingId, åpenBehandling.søknadsgrunnlag]);
+    }, [behandling.behandlingId, behandling.søknadsgrunnlag]);
 
     const nesteAction = (bekreftEndringerViaFrontend: boolean) => {
         if (erLesevisning) {
-            navigate(`/fagsak/${fagsak.id}/${åpenBehandling?.behandlingId}/vilkaarsvurdering`);
+            navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
         } else {
             onSubmit<IRestRegistrerSøknad>(
                 {
@@ -171,12 +167,12 @@ export const SøknadProvider = ({ åpenBehandling, children }: Props) => {
                         },
                         bekreftEndringerViaFrontend,
                     },
-                    url: `/familie-ba-sak/api/behandlinger/${åpenBehandling.behandlingId}/steg/registrer-søknad`,
+                    url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/steg/registrer-søknad`,
                 },
                 (response: Ressurs<IBehandling>) => {
                     if (response.status === RessursStatus.SUKSESS) {
                         settÅpenBehandling(response);
-                        navigate(`/fagsak/${fagsak.id}/${åpenBehandling.behandlingId}/vilkaarsvurdering`);
+                        navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
                     }
                 },
                 (errorResponse: Ressurs<IBehandling>) => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Simulering.tsx
@@ -19,11 +19,7 @@ import SimuleringPanel from './SimuleringPanel';
 import SimuleringTabell from './SimuleringTabell';
 import { TilbakekrevingsvedtakMotregning } from './UlovfestetMotregning/TilbakekrevingsvedtakMotregning';
 
-interface ISimuleringProps {
-    åpenBehandling: IBehandling;
-}
-
-const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
+const Simulering = () => {
     const {
         hentSkjemadata,
         onSubmit,
@@ -40,7 +36,7 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
         behandlingErEndreMigreringsdato,
     } = useSimuleringContext();
 
-    const { settÅpenBehandling } = useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
 
     const fagsakId = useFagsakId();
     const erLesevisning = useErLesevisning();
@@ -52,18 +48,18 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
 
     const nesteOnClick = () => {
         if (erLesevisning) {
-            navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vedtak`);
+            navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vedtak`);
         } else {
             onSubmit<ITilbakekreving | undefined>(
                 {
                     data: hentSkjemadata(),
                     method: 'POST',
-                    url: `/familie-ba-sak/api/behandlinger/${åpenBehandling.behandlingId}/steg/tilbakekreving`,
+                    url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/steg/tilbakekreving`,
                 },
                 (ressurs: Ressurs<IBehandling>) => {
                     if (ressurs.status === RessursStatus.SUKSESS) {
                         settÅpenBehandling(ressurs);
-                        navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/vedtak`);
+                        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/vedtak`);
                     }
                 }
             );
@@ -71,7 +67,7 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
     };
 
     const forrigeOnClick = () => {
-        navigate(`/fagsak/${fagsakId}/${åpenBehandling?.behandlingId}/tilkjent-ytelse`);
+        navigate(`/fagsak/${fagsakId}/${behandling.behandlingId}/tilkjent-ytelse`);
     };
 
     if (
@@ -83,7 +79,7 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
 
     const erAvregning = avregningsperioder.length > 0;
 
-    const tilbakekrevingsvedtakMotregning = åpenBehandling.tilbakekrevingsvedtakMotregning;
+    const tilbakekrevingsvedtakMotregning = behandling.tilbakekrevingsvedtakMotregning;
 
     const heleBeløpetSkalKrevesTilbake = tilbakekrevingsvedtakMotregning?.heleBeløpetSkalKrevesTilbake === true;
 
@@ -176,7 +172,7 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
                         )}
                         {erAvregning && (
                             <TilbakekrevingsvedtakMotregning
-                                åpenBehandling={åpenBehandling}
+                                åpenBehandling={behandling}
                                 tilbakekrevingsvedtakMotregning={tilbakekrevingsvedtakMotregning}
                                 avregningsperioder={avregningsperioder}
                                 harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
@@ -184,9 +180,9 @@ const Simulering = ({ åpenBehandling }: ISimuleringProps) => {
                         )}
                         {skalViseTilbakekrevingSkjema && (
                             <TilbakekrevingSkjema
-                                søkerMålform={hentSøkersMålform(åpenBehandling)}
+                                søkerMålform={hentSøkersMålform(behandling)}
                                 harÅpenTilbakekrevingRessurs={harÅpenTilbakekrevingRessurs}
-                                åpenBehandling={åpenBehandling}
+                                åpenBehandling={behandling}
                             />
                         )}
                     </>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringContext.tsx
@@ -1,6 +1,20 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useFagsakId } from '@hooks/useFagsakId';
+import type { IBehandling } from '@typer/behandling';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { PersonType } from '@typer/person';
+import type {
+    IAvregningsperiode,
+    IOverlappendePeriodeMedAndreFagsaker,
+    ISimuleringDTO,
+    ISimuleringPeriode,
+    ITilbakekreving,
+} from '@typer/simulering';
+import { Tilbakekrevingsvalg } from '@typer/simulering';
+import { isoStringTilDate, isoStringTilDateMedFallback, tidenesMorgen } from '@utils/dato';
 import { isAfter, isBefore } from 'date-fns';
 
 import { type FamilieRequestConfig, useHttp } from '@navikt/familie-http';
@@ -8,24 +22,6 @@ import type { Avhengigheter, FeiloppsummeringFeil, ISkjema } from '@navikt/famil
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
-
-import { useFagsakId } from '../../../../../hooks/useFagsakId';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { Behandlingstype, BehandlingÅrsak } from '../../../../../typer/behandling';
-import { PersonType } from '../../../../../typer/person';
-import type {
-    IAvregningsperiode,
-    IOverlappendePeriodeMedAndreFagsaker,
-    ISimuleringDTO,
-    ISimuleringPeriode,
-    ITilbakekreving,
-} from '../../../../../typer/simulering';
-import { Tilbakekrevingsvalg } from '../../../../../typer/simulering';
-import { isoStringTilDate, isoStringTilDateMedFallback, tidenesMorgen } from '../../../../../utils/dato';
-
-interface IProps extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
 
 interface Tilbakekrevingsskjema {
     tilbakekrevingsvalg: Tilbakekrevingsvalg | undefined;
@@ -58,10 +54,11 @@ interface SimuleringContextValue {
 
 const SimuleringContext = createContext<SimuleringContextValue | undefined>(undefined);
 
-export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
+export const SimuleringProvider = ({ children }: PropsWithChildren) => {
     const { request } = useHttp();
 
     const fagsakId = useFagsakId();
+    const behandling = useBehandling();
 
     const [simuleringsresultat, settSimuleringresultat] = useState<Ressurs<ISimuleringDTO>>({
         status: RessursStatus.HENTER,
@@ -71,8 +68,8 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
         status: RessursStatus.HENTER,
     });
 
-    const vedtak = åpenBehandling.vedtak;
-    const personerMedAndelerTilkjentYtelse = åpenBehandling.personerMedAndelerTilkjentYtelse;
+    const vedtak = behandling.vedtak;
+    const personerMedAndelerTilkjentYtelse = behandling.personerMedAndelerTilkjentYtelse;
     const maksLengdeTekst = 1500;
     const maksgrenseForAvvikIBeløpVedMigrering = 100;
     const mars2023 = '2023-03-01';
@@ -80,7 +77,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
     useEffect(() => {
         request<IBehandling, ISimuleringDTO>({
             method: 'GET',
-            url: `/familie-ba-sak/api/behandlinger/${åpenBehandling.behandlingId}/simulering`,
+            url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/simulering`,
             påvirkerSystemLaster: true,
         }).then(response =>
             response.status === RessursStatus.SUKSESS
@@ -98,7 +95,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
                   })
                 : settSimuleringresultat(response)
         );
-    }, [åpenBehandling]);
+    }, [behandling]);
 
     useEffect(() => {
         if (erFeilutbetaling || avregningsperioder.length > 0) {
@@ -130,7 +127,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
     const erFeilutbetaling = simResultat && simResultat.feilutbetaling > 0;
     const erEtterutbetaling = totalEtterbetalingFørMars2023 > 0;
 
-    const erMigreringFraInfotrygd = åpenBehandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
+    const erMigreringFraInfotrygd = behandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
 
     const erAvvikISimuleringForBehandling = erFeilutbetaling || erEtterutbetaling;
 
@@ -147,7 +144,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
         );
 
     const harMaks1KroneIAvvikPerBarn = (perioderesultater: number[]) => {
-        const antallBarn = åpenBehandling.personer.filter(person => person.type === PersonType.BARN).length;
+        const antallBarn = behandling.personer.filter(person => person.type === PersonType.BARN).length;
         return perioderesultater.every(beløp => Math.abs(beløp) <= antallBarn);
     };
 
@@ -166,10 +163,10 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
 
     const behandlingErMigreringMedManuellePosteringer = erMigreringFraInfotrygd && behandlingHarManuellePosteringer;
 
-    const behandlingErEndreMigreringsdato = åpenBehandling.årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO;
+    const behandlingErEndreMigreringsdato = behandling.årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO;
 
     const tilbakekrevingsvalg = useFelt<Tilbakekrevingsvalg | undefined>({
-        verdi: åpenBehandling.tilbakekreving?.valg,
+        verdi: behandling.tilbakekreving?.valg,
         avhengigheter: {
             erMigreringFraInfotrygdMedAvvik,
             erFeilutbetaling,
@@ -185,7 +182,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
                 : ok(felt),
     });
     const fritekstVarsel = useFelt<string>({
-        verdi: åpenBehandling.tilbakekreving?.varsel ?? '',
+        verdi: behandling.tilbakekreving?.varsel ?? '',
         avhengigheter: {
             tilbakekreving: tilbakekrevingsvalg,
             erFeilutbetaling,
@@ -204,7 +201,7 @@ export const SimuleringProvider = ({ åpenBehandling, children }: IProps) => {
             avhengigheter?.tilbakekreving?.verdi === Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_MED_VARSEL,
     });
     const begrunnelse = useFelt<string>({
-        verdi: åpenBehandling.tilbakekreving?.begrunnelse ?? '',
+        verdi: behandling.tilbakekreving?.begrunnelse ?? '',
         avhengigheter: {
             erFeilutbetaling,
             maksLengdeTekst: maksLengdeTekst,

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/SammensattKontrollsak/SammensattKontrollsakContext.tsx
@@ -1,25 +1,14 @@
 import type { PropsWithChildren, SetStateAction, Dispatch } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useFeatureToggles } from '@hooks/useFeatureToggles';
+import { Behandlingstype, erBehandlingAvslått, erBehandlingFortsattInnvilget } from '@typer/behandling';
+import { FeatureToggle } from '@typer/featureToggles';
+import type { IRestOpprettSammensattKontrollsak, IRestSammensattKontrollsak } from '@typer/sammensatt-kontrollsak';
+
 import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
-
-import { useFeatureToggles } from '../../../../../../hooks/useFeatureToggles';
-import {
-    Behandlingstype,
-    erBehandlingAvslått,
-    erBehandlingFortsattInnvilget,
-    type IBehandling,
-} from '../../../../../../typer/behandling';
-import { FeatureToggle } from '../../../../../../typer/featureToggles';
-import type {
-    IRestOpprettSammensattKontrollsak,
-    IRestSammensattKontrollsak,
-} from '../../../../../../typer/sammensatt-kontrollsak';
-
-interface ISammensattKontrollsakProps extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
 
 interface SammensattKontrollsakContextValue {
     opprettEllerOppdaterSammensattKontrollsak: (fritekst: string) => void;
@@ -33,8 +22,8 @@ interface SammensattKontrollsakContextValue {
 
 const SammensattKontrollsakContext = createContext<SammensattKontrollsakContextValue | undefined>(undefined);
 
-export const SammensattKontrollsakProvider = ({ åpenBehandling, children }: ISammensattKontrollsakProps) => {
-    const { behandlingId, resultat, type } = åpenBehandling;
+export const SammensattKontrollsakProvider = ({ children }: PropsWithChildren) => {
+    const { behandlingId, resultat, type } = useBehandling();
     const { request } = useHttp();
     const toggles = useFeatureToggles();
     const [feilmelding, settFeilmelding] = useState<string | undefined>(undefined);
@@ -43,7 +32,7 @@ export const SammensattKontrollsakProvider = ({ åpenBehandling, children }: ISa
 
     useEffect(() => {
         hentSammensattKontrollsak();
-    }, [åpenBehandling.behandlingId]);
+    }, [behandlingId]);
 
     const skalViseSammensattKontrollsakMenyValg = (): boolean => {
         if (!toggles[FeatureToggle.kanOppretteOgEndreSammensatteKontrollsaker]) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContext.tsx
@@ -1,13 +1,8 @@
 import type { PropsWithChildren, SetStateAction, Dispatch } from 'react';
 import { createContext, useState, useEffect, useContext } from 'react';
 
-import { useHttp } from '@navikt/familie-http';
-import type { FeltState } from '@navikt/familie-skjema';
-import { Valideringsstatus } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-
-import { mapFraRestVilkårsvurderingTilUi } from './utils';
-import type { IBehandling } from '../../../../../typer/behandling';
+import { useBehandling } from '@hooks/useBehandling';
+import type { IBehandling } from '@typer/behandling';
 import type {
     IAnnenVurdering,
     IPersonResultat,
@@ -16,11 +11,14 @@ import type {
     IRestPersonResultat,
     IVilkårResultat,
     VilkårType,
-} from '../../../../../typer/vilkår';
+} from '@typer/vilkår';
 
-interface IProps extends PropsWithChildren {
-    åpenBehandling: IBehandling;
-}
+import { useHttp } from '@navikt/familie-http';
+import type { FeltState } from '@navikt/familie-skjema';
+import { Valideringsstatus } from '@navikt/familie-skjema';
+import type { Ressurs } from '@navikt/familie-typer';
+
+import { mapFraRestVilkårsvurderingTilUi } from './utils';
 
 export enum VilkårSubmit {
     PUT,
@@ -48,28 +46,27 @@ interface VilkårsvurderingContextValue {
 
 const VilkårsvurderingContext = createContext<VilkårsvurderingContextValue | undefined>(undefined);
 
-export const VilkårsvurderingProvider = ({ åpenBehandling, children }: IProps) => {
+export const VilkårsvurderingProvider = ({ children }: PropsWithChildren) => {
     const { request } = useHttp();
+
+    const behandling = useBehandling();
+
     const [vilkårSubmit, settVilkårSubmit] = useState(VilkårSubmit.NONE);
 
     const [vilkårsvurdering, settVilkårsvurdering] = useState<IPersonResultat[]>(
-        åpenBehandling ? mapFraRestVilkårsvurderingTilUi(åpenBehandling.personResultater, åpenBehandling.personer) : []
+        mapFraRestVilkårsvurderingTilUi(behandling.personResultater, behandling.personer)
     );
 
     useEffect(() => {
-        settVilkårsvurdering(
-            åpenBehandling
-                ? mapFraRestVilkårsvurderingTilUi(åpenBehandling.personResultater, åpenBehandling.personer)
-                : []
-        );
-    }, [åpenBehandling]);
+        settVilkårsvurdering(mapFraRestVilkårsvurderingTilUi(behandling.personResultater, behandling.personer));
+    }, [behandling]);
 
     const putVilkår = (vilkårsvurderingForPerson: IPersonResultat, redigerbartVilkår: FeltState<IVilkårResultat>) => {
         settVilkårSubmit(VilkårSubmit.PUT);
 
         return request<IRestPersonResultat, IBehandling>({
             method: 'PUT',
-            url: `/familie-ba-sak/api/vilkaarsvurdering/${åpenBehandling?.behandlingId}/${redigerbartVilkår.verdi.id}`,
+            url: `/familie-ba-sak/api/vilkaarsvurdering/${behandling.behandlingId}/${redigerbartVilkår.verdi.id}`,
             data: {
                 personIdent: vilkårsvurderingForPerson.personIdent,
                 vilkårResultater: [
@@ -104,7 +101,7 @@ export const VilkårsvurderingProvider = ({ åpenBehandling, children }: IProps)
 
         return request<IRestAnnenVurdering, IBehandling>({
             method: 'PUT',
-            url: `/familie-ba-sak/api/vilkaarsvurdering/${åpenBehandling?.behandlingId}/annenvurdering/${redigerbartAnnenVurdering.verdi.id}`,
+            url: `/familie-ba-sak/api/vilkaarsvurdering/${behandling.behandlingId}/annenvurdering/${redigerbartAnnenVurdering.verdi.id}`,
             data: {
                 id: redigerbartAnnenVurdering.verdi.id,
                 begrunnelse: redigerbartAnnenVurdering.verdi.begrunnelse.verdi,
@@ -123,7 +120,7 @@ export const VilkårsvurderingProvider = ({ åpenBehandling, children }: IProps)
 
         return request<string, IBehandling>({
             method: 'DELETE',
-            url: `/familie-ba-sak/api/vilkaarsvurdering/${åpenBehandling?.behandlingId}/${vilkårId}`,
+            url: `/familie-ba-sak/api/vilkaarsvurdering/${behandling.behandlingId}/${vilkårId}`,
             data: personIdent,
         });
     };
@@ -133,7 +130,7 @@ export const VilkårsvurderingProvider = ({ åpenBehandling, children }: IProps)
 
         return request<IRestNyttVilkår, IBehandling>({
             method: 'POST',
-            url: `/familie-ba-sak/api/vilkaarsvurdering/${åpenBehandling?.behandlingId}`,
+            url: `/familie-ba-sak/api/vilkaarsvurdering/${behandling.behandlingId}`,
             data: { personIdent, vilkårType },
         });
     };

--- a/src/frontend/sider/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/sider/Fagsak/FagsakContainer.tsx
@@ -1,4 +1,13 @@
-import { Navigate, Route, Routes } from 'react-router';
+import { useFagsakIdParam } from '@hooks/useFagsakIdParam';
+import { useHentFagsak } from '@hooks/useHentFagsak';
+import { useHentPerson } from '@hooks/useHentPerson';
+import { useScrollTilAnker } from '@hooks/useScrollTilAnker';
+import { useSyncModiaContext } from '@hooks/useSyncModiaContext';
+import { Personlinje } from '@komponenter/Personlinje/Personlinje';
+import { Fagsaklinje } from '@komponenter/Saklinje/Fagsaklinje';
+import { RedirectTilSaksoversikt } from '@sider/Fagsak/Saksoversikt/RedirectTilSaksoversikt';
+import { FagsakType } from '@typer/fagsak';
+import { Route, Routes } from 'react-router';
 
 import { Box, GlobalAlert, HStack, Loader } from '@navikt/ds-react';
 
@@ -13,14 +22,6 @@ import { InfotrygdFagsak } from './Infotrygd/InfotrygdFagsak';
 import { JournalpostListe } from './journalposter/JournalpostListe';
 import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
 import { Saksoversikt } from './Saksoversikt/Saksoversikt';
-import { useFagsakIdParam } from '../../hooks/useFagsakIdParam';
-import { useHentFagsak } from '../../hooks/useHentFagsak';
-import { useHentPerson } from '../../hooks/useHentPerson';
-import { useScrollTilAnker } from '../../hooks/useScrollTilAnker';
-import { useSyncModiaContext } from '../../hooks/useSyncModiaContext';
-import { Personlinje } from '../../komponenter/Personlinje/Personlinje';
-import { Fagsaklinje } from '../../komponenter/Saklinje/Fagsaklinje';
-import { FagsakType } from '../../typer/fagsak';
 
 export function FagsakContainer() {
     const fagsakIdParam = useFagsakIdParam();
@@ -119,7 +120,7 @@ export function FagsakContainer() {
                                 element={
                                     <>
                                         <Fagsaklinje />
-                                        <InfotrygdFagsak minimalFagsak={fagsak} />
+                                        <InfotrygdFagsak />
                                     </>
                                 }
                             />
@@ -131,14 +132,7 @@ export function FagsakContainer() {
                                     </HentOgSettBehandlingProvider>
                                 }
                             />
-                            <Route
-                                path="/"
-                                element={
-                                    <>
-                                        <Navigate to={`/fagsak/${fagsak.id}/saksoversikt`} />
-                                    </>
-                                }
-                            />
+                            <Route path="/" element={<RedirectTilSaksoversikt />} />
                         </Routes>
                     </ManuelleBrevmottakerePåFagsakProvider>
                 </BrukerProvider>

--- a/src/frontend/sider/Fagsak/Infotrygd/InfotrygdFagsak.tsx
+++ b/src/frontend/sider/Fagsak/Infotrygd/InfotrygdFagsak.tsx
@@ -1,14 +1,11 @@
 import type { ReactNode } from 'react';
 
+import { useFagsak } from '@hooks/useFagsak';
+
 import { BodyShort, Box, Heading, HStack, Loader, LocalAlert } from '@navikt/ds-react';
 
 import { useHentInfotrygdSaker } from './useHentInfotrygdSaker';
-import type { IMinimalFagsak } from '../../../typer/fagsak';
 import { Infotrygdtabeller } from '../../Infotrygd/Infotrygdtabeller';
-
-interface InfotrygdFagsakProps {
-    minimalFagsak: IMinimalFagsak;
-}
 
 const InnholdContainer = ({ children }: { children: ReactNode }) => (
     <Box maxWidth="70rem" marginBlock="space-40" marginInline="space-64">
@@ -16,8 +13,10 @@ const InnholdContainer = ({ children }: { children: ReactNode }) => (
     </Box>
 );
 
-export const InfotrygdFagsak = ({ minimalFagsak }: InfotrygdFagsakProps) => {
-    const { data, isPending, error } = useHentInfotrygdSaker(minimalFagsak.søkerFødselsnummer);
+export const InfotrygdFagsak = () => {
+    const fagsak = useFagsak();
+
+    const { data, isPending, error } = useHentInfotrygdSaker(fagsak.søkerFødselsnummer);
 
     if (isPending) {
         return (
@@ -45,11 +44,7 @@ export const InfotrygdFagsak = ({ minimalFagsak }: InfotrygdFagsakProps) => {
     return (
         <InnholdContainer>
             <Heading size="large" level="1" children="Infotrygd" />
-            <Infotrygdtabeller
-                ident={minimalFagsak.søkerFødselsnummer}
-                saker={data.saker}
-                minimalFagsak={minimalFagsak}
-            />
+            <Infotrygdtabeller ident={fagsak.søkerFødselsnummer} saker={data.saker} minimalFagsak={fagsak} />
         </InnholdContainer>
     );
 };

--- a/src/frontend/sider/Fagsak/Saksoversikt/RedirectTilSaksoversikt.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/RedirectTilSaksoversikt.tsx
@@ -1,0 +1,7 @@
+import { useFagsakId } from '@hooks/useFagsakId';
+import { Navigate } from 'react-router';
+
+export function RedirectTilSaksoversikt() {
+    const fagsakId = useFagsakId();
+    return <Navigate to={`/fagsak/${fagsakId}/saksoversikt`} replace={true} />;
+}


### PR DESCRIPTION
### 📮 Favro
NAV-29334

### 💰 Hva skal gjøres, og hvorfor?
Fjerner props fra komponenter som brukes av Routes. Det vil gjøre det lettere å skrive om til `createBrowserRouter` senere. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant.

### 👀 Screen shots
Ingen visuelle endringer. 