### PR TITLE
NAV-29258: Sørger for at ApiClient bruker Error objektet ved feil

### DIFF
--- a/src/frontend/api/client/apiClient.test.ts
+++ b/src/frontend/api/client/apiClient.test.ts
@@ -44,7 +44,7 @@ describe('ApiClient', () => {
                     http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -76,7 +76,7 @@ describe('ApiClient', () => {
                     http.post(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.post({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.post({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -98,7 +98,7 @@ describe('ApiClient', () => {
                     http.put(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.put({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.put({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -120,7 +120,7 @@ describe('ApiClient', () => {
                     http.patch(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
                 );
 
-                await expect(client.patch({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.patch({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -142,7 +142,7 @@ describe('ApiClient', () => {
                     )
                 );
 
-                await expect(client.delete({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+                await expect(client.delete({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
             }
         );
     });
@@ -155,7 +155,7 @@ describe('ApiClient', () => {
                 )
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt (CallId: abc-123)');
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt (CallId: abc-123)');
         });
 
         test('utelater callId fra feilmeldingen når den er null', async () => {
@@ -165,7 +165,7 @@ describe('ApiClient', () => {
                 )
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
         });
 
         test('utelater callId fra feilmeldingen når den mangler i responsen', async () => {
@@ -173,7 +173,7 @@ describe('ApiClient', () => {
                 http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt')))
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toBe('Noe gikk galt');
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
         });
     });
 

--- a/src/frontend/api/client/apiClient.ts
+++ b/src/frontend/api/client/apiClient.ts
@@ -85,16 +85,20 @@ export class ApiClient {
     }
 
     private resolveToPromise<T>(ressurs: Ressurs<T>): Promise<T> {
+        if (!Object.values(RessursStatus).includes(ressurs.status)) {
+            return Promise.reject(new Error(`Ukjent status: ${ressurs.status}`));
+        }
         switch (ressurs.status) {
             case RessursStatus.SUKSESS:
                 return Promise.resolve(ressurs.data);
             case RessursStatus.FEILET:
             case RessursStatus.FUNKSJONELL_FEIL:
             case RessursStatus.IKKE_TILGANG:
+                const frontendFeilmelding = ressurs.frontendFeilmelding?.trim() ?? undefined;
                 const frontendFeilmeldingMedEllerUtenCallId = ressurs.callId
-                    ? `${ressurs.frontendFeilmelding} (CallId: ${ressurs.callId})`
-                    : ressurs.frontendFeilmelding;
-                return Promise.reject(frontendFeilmeldingMedEllerUtenCallId);
+                    ? `${frontendFeilmelding} (CallId: ${ressurs.callId})`
+                    : frontendFeilmelding;
+                return Promise.reject(new Error(frontendFeilmeldingMedEllerUtenCallId));
         }
     }
 }


### PR DESCRIPTION
### 📮 Favro
NAV-29258

### 💰 Hva skal gjøres, og hvorfor?
React-query fungerer bedre med `new Error(...)` over bare en string. Flere plasser bruker vi `error.message` og det vil ikke fungere om man ikke bruker `new Error(...)`

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Oppdaterte eksisterende tester.

### 👀 Screen shots
Ingen visuelle endringer. 