### PR TITLE
Fiks tidslinje

### DIFF
--- a/src/frontend/komponenter/FamilieBaseKnapp.tsx
+++ b/src/frontend/komponenter/FamilieBaseKnapp.tsx
@@ -1,8 +1,12 @@
 import type { ButtonHTMLAttributes } from 'react';
 
+import classNames from 'classnames';
+
 import styles from './FamilieBaseKnapp.module.css';
 
-const FamilieBaseKnapp = ({ children }: ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button className={styles.familieBaseKnapp}>{children}</button>
+const FamilieBaseKnapp = ({ children, className, ...rest }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button className={classNames(styles.familieBaseKnapp, className)} {...rest}>
+        {children}
+    </button>
 );
 export default FamilieBaseKnapp;


### PR DESCRIPTION
 ### 📮 Favro:  Nav-29451

  ### 💰 Hva skal gjøres, og hvorfor?
  Etter at `FamilieBaseKnapp` ble skrevet om fra `styled.button` til en vanlig
  funksjonskomponent (i NAV-26302), ble alle props bortsett fra `children` forkastet.
  Det gjorde at knappen mistet `onClick`, `disabled`, `aria-label` og `className`.
  Konsekvensen var at man ikke lenger kunne klikke på månedene i tidslinjen på
  behandlingsresultat for å se utbetaling for den måneden (og «åpne dokument»-knappen
  i manuell journalføring sluttet å virke).

  - `FamilieBaseKnapp` videresender nå alle native button-props (`...rest`) til
    `<button>`, slik den opprinnelige `styled.button` gjorde.
  - `className` fra kallstedet flettes sammen med komponentens egen stil via `classNames`,
    så både egen styling og `valgt`-klassen fra `TidslinjeEtikett` beholdes.

<img width="1098" height="776" alt="Screenshot 2026-06-05 at 09 20 55" src="https://github.com/user-attachments/assets/5ecb9dd5-cf24-4b47-a974-bf0df464847e" />
