### PR TITLE
NAV-29213 Ta i bruk react-query i OpprettBehandling

### DIFF
--- a/src/frontend/api/opprettBehandling.ts
+++ b/src/frontend/api/opprettBehandling.ts
@@ -1,15 +1,9 @@
+import { apiClient } from '@api/client/apiClient';
 import { type IBehandling, type NyBehandling } from '@typer/behandling';
 
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
-
-import { RessursResolver } from '../utils/ressursResolver';
-
-export async function opprettBehandling(request: FamilieRequest, payload: NyBehandling) {
-    const ressurs = await request<NyBehandling, IBehandling>({
+export async function opprettBehandling(payload: NyBehandling) {
+    return apiClient.post<NyBehandling, IBehandling>({
         data: payload,
-        method: 'POST',
         url: `/familie-ba-sak/api/behandlinger`,
-        påvirkerSystemLaster: true,
     });
-    return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/api/opprettBehandling.ts
+++ b/src/frontend/api/opprettBehandling.ts
@@ -1,29 +1,11 @@
-import type { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
-import { type IBehandling } from '@typer/behandling';
-import type { BehandlingKategori } from '@typer/behandlingstema';
-import { type BehandlingUnderkategori } from '@typer/behandlingstema';
-import type { IsoDatoString } from '@utils/dato';
+import { type IBehandling, type NyBehandling } from '@typer/behandling';
 
 import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
 
 import { RessursResolver } from '../utils/ressursResolver';
 
-export interface OpprettBehandlingPayload {
-    kategori: BehandlingKategori | null;
-    underkategori: BehandlingUnderkategori | null;
-    behandlingType: Behandlingstype;
-    journalpostID?: string;
-    behandlingÅrsak?: BehandlingÅrsak;
-    skalBehandlesAutomatisk?: boolean;
-    navIdent?: string;
-    barnasIdenter?: string[];
-    nyMigreringsdato?: IsoDatoString;
-    søknadMottattDato?: IsoDatoString;
-    fagsakId: number;
-}
-
-export async function opprettBehandling(request: FamilieRequest, payload: OpprettBehandlingPayload) {
-    const ressurs = await request<OpprettBehandlingPayload, IBehandling>({
+export async function opprettBehandling(request: FamilieRequest, payload: NyBehandling) {
+    const ressurs = await request<NyBehandling, IBehandling>({
         data: payload,
         method: 'POST',
         url: `/familie-ba-sak/api/behandlinger`,

--- a/src/frontend/api/opprettBehandling.ts
+++ b/src/frontend/api/opprettBehandling.ts
@@ -1,0 +1,33 @@
+import type { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { type IBehandling } from '@typer/behandling';
+import type { BehandlingKategori } from '@typer/behandlingstema';
+import { type BehandlingUnderkategori } from '@typer/behandlingstema';
+import type { IsoDatoString } from '@utils/dato';
+
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface OpprettBehandlingPayload {
+    kategori: BehandlingKategori | null;
+    underkategori: BehandlingUnderkategori | null;
+    behandlingType: Behandlingstype;
+    journalpostID?: string;
+    behandlingÅrsak?: BehandlingÅrsak;
+    skalBehandlesAutomatisk?: boolean;
+    navIdent?: string;
+    barnasIdenter?: string[];
+    nyMigreringsdato?: IsoDatoString;
+    søknadMottattDato?: IsoDatoString;
+    fagsakId: number;
+}
+
+export async function opprettBehandling(request: FamilieRequest, payload: OpprettBehandlingPayload) {
+    const ressurs = await request<OpprettBehandlingPayload, IBehandling>({
+        data: payload,
+        method: 'POST',
+        url: `/familie-ba-sak/api/behandlinger`,
+        påvirkerSystemLaster: true,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/api/opprettKlagebehandling.ts
+++ b/src/frontend/api/opprettKlagebehandling.ts
@@ -1,0 +1,24 @@
+import type { IBehandling } from '@typer/behandling';
+import type { IsoDatoString } from '@utils/dato';
+
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export interface OpprettKlagebehandlingPayload {
+    klageMottattDato: IsoDatoString;
+}
+
+export async function opprettKlagebehandling(
+    request: FamilieRequest,
+    payload: OpprettKlagebehandlingPayload,
+    fagsakId: number
+) {
+    const ressurs = await request<OpprettKlagebehandlingPayload, IBehandling>({
+        data: payload,
+        method: 'POST',
+        url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
+        påvirkerSystemLaster: true,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/api/opprettKlagebehandling.ts
+++ b/src/frontend/api/opprettKlagebehandling.ts
@@ -1,24 +1,14 @@
+import { apiClient } from '@api/client/apiClient';
 import type { IBehandling } from '@typer/behandling';
 import type { IsoDatoString } from '@utils/dato';
-
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
-
-import { RessursResolver } from '../utils/ressursResolver';
 
 export interface OpprettKlagebehandlingPayload {
     klageMottattDato: IsoDatoString;
 }
 
-export async function opprettKlagebehandling(
-    request: FamilieRequest,
-    payload: OpprettKlagebehandlingPayload,
-    fagsakId: number
-) {
-    const ressurs = await request<OpprettKlagebehandlingPayload, IBehandling>({
+export async function opprettKlagebehandling(payload: OpprettKlagebehandlingPayload, fagsakId: number) {
+    return apiClient.post<OpprettKlagebehandlingPayload, IBehandling>({
         data: payload,
-        method: 'POST',
         url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
-        påvirkerSystemLaster: true,
     });
-    return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/api/opprettTilbakekreving.ts
+++ b/src/frontend/api/opprettTilbakekreving.ts
@@ -1,13 +1,8 @@
+import { apiClient } from '@api/client/apiClient';
 import type { IBehandling } from '@typer/behandling';
 
-import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
-
-import { RessursResolver } from '../utils/ressursResolver';
-
-export async function opprettTilbakekreving(request: FamilieRequest, fagsakId: number) {
-    const ressurs = await request<null, IBehandling>({
-        method: 'GET',
+export async function opprettTilbakekreving(fagsakId: number) {
+    return apiClient.get<void, IBehandling>({
         url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,
     });
-    return RessursResolver.resolveToPromise(ressurs);
 }

--- a/src/frontend/api/opprettTilbakekreving.ts
+++ b/src/frontend/api/opprettTilbakekreving.ts
@@ -1,0 +1,13 @@
+import type { IBehandling } from '@typer/behandling';
+
+import type { FamilieRequest } from '@navikt/familie-http/dist/HttpProvider';
+
+import { RessursResolver } from '../utils/ressursResolver';
+
+export async function opprettTilbakekreving(request: FamilieRequest, fagsakId: number) {
+    const ressurs = await request<null, IBehandling>({
+        method: 'GET',
+        url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,
+    });
+    return RessursResolver.resolveToPromise(ressurs);
+}

--- a/src/frontend/hooks/useOpprettBehandling.ts
+++ b/src/frontend/hooks/useOpprettBehandling.ts
@@ -2,17 +2,11 @@ import { opprettBehandling } from '@api/opprettBehandling';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import type { IBehandling, NyBehandling } from '@typer/behandling';
 
-import { useHttp } from '@navikt/familie-http';
-
 type Options = Omit<UseMutationOptions<IBehandling, DefaultError, NyBehandling>, 'mutationFn'>;
 
 export function useOpprettBehandling(options?: Options) {
-    const { request } = useHttp();
-
     return useMutation<IBehandling, Error, NyBehandling>({
-        mutationFn: (payload: NyBehandling): Promise<IBehandling> => {
-            return opprettBehandling(request, payload);
-        },
+        mutationFn: (payload: NyBehandling): Promise<IBehandling> => opprettBehandling(payload),
         ...options,
     });
 }

--- a/src/frontend/hooks/useOpprettBehandling.ts
+++ b/src/frontend/hooks/useOpprettBehandling.ts
@@ -1,16 +1,16 @@
-import { opprettBehandling, type OpprettBehandlingPayload } from '@api/opprettBehandling';
+import { opprettBehandling } from '@api/opprettBehandling';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
+import type { IBehandling, NyBehandling } from '@typer/behandling';
 
 import { useHttp } from '@navikt/familie-http';
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettBehandlingPayload>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, NyBehandling>, 'mutationFn'>;
 
 export function useOpprettBehandling(options?: Options) {
     const { request } = useHttp();
 
-    return useMutation<IBehandling, Error, OpprettBehandlingPayload>({
-        mutationFn: (payload: OpprettBehandlingPayload): Promise<IBehandling> => {
+    return useMutation<IBehandling, Error, NyBehandling>({
+        mutationFn: (payload: NyBehandling): Promise<IBehandling> => {
             return opprettBehandling(request, payload);
         },
         ...options,

--- a/src/frontend/hooks/useOpprettBehandling.ts
+++ b/src/frontend/hooks/useOpprettBehandling.ts
@@ -1,0 +1,18 @@
+import { opprettBehandling, type OpprettBehandlingPayload } from '@api/opprettBehandling';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+import { useHttp } from '@navikt/familie-http';
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettBehandlingPayload>, 'mutationFn'>;
+
+export function useOpprettBehandling(options?: Options) {
+    const { request } = useHttp();
+
+    return useMutation<IBehandling, Error, OpprettBehandlingPayload>({
+        mutationFn: (payload: OpprettBehandlingPayload): Promise<IBehandling> => {
+            return opprettBehandling(request, payload);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useOpprettKlagebehandling.ts
+++ b/src/frontend/hooks/useOpprettKlagebehandling.ts
@@ -2,8 +2,6 @@ import { opprettKlagebehandling, type OpprettKlagebehandlingPayload } from '@api
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import type { IBehandling } from '@typer/behandling';
 
-import { useHttp } from '@navikt/familie-http';
-
 interface OpprettKlagebehandlingParameters extends OpprettKlagebehandlingPayload {
     fagsakId: number;
 }
@@ -11,14 +9,9 @@ interface OpprettKlagebehandlingParameters extends OpprettKlagebehandlingPayload
 type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettKlagebehandlingParameters>, 'mutationFn'>;
 
 export function useOpprettKlagebehandling(options?: Options) {
-    const { request } = useHttp();
-
     return useMutation<IBehandling, Error, OpprettKlagebehandlingParameters>({
-        mutationFn: (parameters: OpprettKlagebehandlingParameters): Promise<IBehandling> => {
-            const { klageMottattDato, fagsakId } = parameters;
-            const payload = { klageMottattDato };
-            return opprettKlagebehandling(request, payload, fagsakId);
-        },
+        mutationFn: ({ klageMottattDato, fagsakId }: OpprettKlagebehandlingParameters): Promise<IBehandling> =>
+            opprettKlagebehandling({ klageMottattDato }, fagsakId),
         ...options,
     });
 }

--- a/src/frontend/hooks/useOpprettKlagebehandling.ts
+++ b/src/frontend/hooks/useOpprettKlagebehandling.ts
@@ -1,0 +1,24 @@
+import { opprettKlagebehandling, type OpprettKlagebehandlingPayload } from '@api/opprettKlagebehandling';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+import { useHttp } from '@navikt/familie-http';
+
+interface OpprettKlagebehandlingParameters extends OpprettKlagebehandlingPayload {
+    fagsakId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettKlagebehandlingParameters>, 'mutationFn'>;
+
+export function useOpprettKlagebehandling(options?: Options) {
+    const { request } = useHttp();
+
+    return useMutation<IBehandling, Error, OpprettKlagebehandlingParameters>({
+        mutationFn: (parameters: OpprettKlagebehandlingParameters): Promise<IBehandling> => {
+            const { klageMottattDato, fagsakId } = parameters;
+            const payload = { klageMottattDato };
+            return opprettKlagebehandling(request, payload, fagsakId);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useOpprettTilbakekreving.ts
+++ b/src/frontend/hooks/useOpprettTilbakekreving.ts
@@ -2,8 +2,6 @@ import { opprettTilbakekreving } from '@api/opprettTilbakekreving';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import type { IBehandling } from '@typer/behandling';
 
-import { useHttp } from '@navikt/familie-http';
-
 interface OpprettTilbakekrevingParameters {
     fagsakId: number;
 }
@@ -11,12 +9,9 @@ interface OpprettTilbakekrevingParameters {
 type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettTilbakekrevingParameters>, 'mutationFn'>;
 
 export function useOpprettTilbakekreving(options?: Options) {
-    const { request } = useHttp();
-
     return useMutation<IBehandling, Error, OpprettTilbakekrevingParameters>({
-        mutationFn: (parameters: OpprettTilbakekrevingParameters): Promise<IBehandling> => {
-            return opprettTilbakekreving(request, parameters.fagsakId);
-        },
+        mutationFn: ({ fagsakId }: OpprettTilbakekrevingParameters): Promise<IBehandling> =>
+            opprettTilbakekreving(fagsakId),
         ...options,
     });
 }

--- a/src/frontend/hooks/useOpprettTilbakekreving.ts
+++ b/src/frontend/hooks/useOpprettTilbakekreving.ts
@@ -1,0 +1,22 @@
+import { opprettTilbakekreving } from '@api/opprettTilbakekreving';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+import { useHttp } from '@navikt/familie-http';
+
+interface OpprettTilbakekrevingParameters {
+    fagsakId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettTilbakekrevingParameters>, 'mutationFn'>;
+
+export function useOpprettTilbakekreving(options?: Options) {
+    const { request } = useHttp();
+
+    return useMutation<IBehandling, Error, OpprettTilbakekrevingParameters>({
+        mutationFn: (parameters: OpprettTilbakekrevingParameters): Promise<IBehandling> => {
+            return opprettTilbakekreving(request, parameters.fagsakId);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -1,3 +1,7 @@
+import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { dagensDato } from '@utils/dato';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import { isBefore, subDays } from 'date-fns';
 
 import { Box, Button, Fieldset, LocalAlert, Modal, Textarea, VStack } from '@navikt/ds-react';
@@ -6,10 +10,6 @@ import { RessursStatus } from '@navikt/familie-typer';
 
 import OpprettBehandlingValg from './OpprettBehandlingValg';
 import useOpprettBehandling from './useOpprettBehandling';
-import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
-import { Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
-import { dagensDato } from '../../../../utils/dato';
-import { hentFrontendFeilmelding } from '../../../../utils/ressursUtils';
 import Datovelger from '../../../Datovelger/Datovelger';
 
 interface Props {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -9,7 +9,7 @@ import { Valideringsstatus } from '@navikt/familie-skjema';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import OpprettBehandlingValg from './OpprettBehandlingValg';
-import useOpprettBehandling from './useOpprettBehandling';
+import { useOpprettBehandlingSkjema } from './useOpprettBehandlingSkjema';
 import Datovelger from '../../../Datovelger/Datovelger';
 
 interface Props {
@@ -21,14 +21,7 @@ export function OpprettBehandlingModal({ lukkModal, onTilbakekrevingsbehandlingO
     const { fagsak } = useFagsakContext();
 
     const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus, bruker, maksdatoForMigrering } =
-        useOpprettBehandling(
-            fagsak.id,
-            () => lukkModal(),
-            () => {
-                lukkModal();
-                onTilbakekrevingsbehandlingOpprettet();
-            }
-        );
+        useOpprettBehandlingSkjema({ fagsakId: fagsak.id, lukkModal, onTilbakekrevingsbehandlingOpprettet });
 
     const lukkOpprettBehandlingModal = () => {
         nullstillSkjemaStatus();

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -1,14 +1,9 @@
 import type { ChangeEvent } from 'react';
 
-import { Select, UNSAFE_Combobox } from '@navikt/ds-react';
-import type { ISkjema } from '@navikt/familie-skjema';
-
-import { OpprettBehandlingBehandlingstemaSelect } from './OpprettBehandlingBehandlingstemaSelect';
-import type { IOpprettBehandlingSkjemaFelter } from './useOpprettBehandling';
-import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
-import type { VisningBehandling } from '../../../../sider/Fagsak/Saksoversikt/visningBehandling';
-import type { ManuellJournalføringSkjemaFelter } from '../../../../sider/ManuellJournalføring/ManuellJournalføringContext';
-import type { IBehandling } from '../../../../typer/behandling';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import type { VisningBehandling } from '@sider/Fagsak/Saksoversikt/visningBehandling';
+import type { ManuellJournalføringSkjemaFelter } from '@sider/ManuellJournalføring/ManuellJournalføringContext';
+import type { IBehandling } from '@typer/behandling';
 import {
     BehandlingResultat,
     BehandlingStatus,
@@ -16,16 +11,22 @@ import {
     behandlingÅrsak,
     BehandlingÅrsak,
     erBehandlingHenlagt,
-} from '../../../../typer/behandling';
-import type { ComboboxOption } from '../../../../typer/common';
-import { FagsakStatus, type IMinimalFagsak } from '../../../../typer/fagsak';
-import { Klagebehandlingstype } from '../../../../typer/klage';
-import type { IPersonInfo } from '../../../../typer/person';
-import { ForelderBarnRelasjonRolle } from '../../../../typer/person';
-import { Tilbakekrevingsbehandlingstype } from '../../../../typer/tilbakekrevingsbehandling';
-import { hentAktivBehandlingPåMinimalFagsak, hentSisteIkkeHenlagteBehandling } from '../../../../utils/fagsak';
-import { hentAlder } from '../../../../utils/formatter';
-import { onOptionSelected } from '../../../../utils/skjema';
+} from '@typer/behandling';
+import type { ComboboxOption } from '@typer/common';
+import { FagsakStatus, type IMinimalFagsak } from '@typer/fagsak';
+import { Klagebehandlingstype } from '@typer/klage';
+import type { IPersonInfo } from '@typer/person';
+import { ForelderBarnRelasjonRolle } from '@typer/person';
+import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import { hentAktivBehandlingPåMinimalFagsak, hentSisteIkkeHenlagteBehandling } from '@utils/fagsak';
+import { hentAlder } from '@utils/formatter';
+import { onOptionSelected } from '@utils/skjema';
+
+import { Select, UNSAFE_Combobox } from '@navikt/ds-react';
+import type { ISkjema } from '@navikt/familie-skjema';
+
+import { OpprettBehandlingBehandlingstemaSelect } from './OpprettBehandlingBehandlingstemaSelect';
+import type { IOpprettBehandlingSkjemaFelter } from './useOpprettBehandlingSkjema';
 
 const erOpprettBehandlingSkjema = (
     skjema: ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling> | ISkjema<ManuellJournalføringSkjemaFelter, string>

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/TilbakekrevingsbehandlingOpprettetModal.tsx
@@ -1,8 +1,7 @@
+import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
 import { useNavigate } from 'react-router';
 
 import { BodyLong, Button, Modal } from '@navikt/ds-react';
-
-import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
 
 interface Props {
     lukkModal: () => void;

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling.ts
@@ -1,29 +1,28 @@
 import { useEffect } from 'react';
 
+import { HentBarnetrygdbehandlingerQueryKeyFactory } from '@hooks/useHentBarnetrygdbehandlinger';
+import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
+import { HentKlagebehandlingerQueryKeyFactory } from '@hooks/useHentKlagebehandlinger';
+import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '@hooks/useHentTilbakekrevingsbehandlinger';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { useBrukerContext } from '@sider/Fagsak/BrukerContext';
+import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
 import { useQueryClient } from '@tanstack/react-query';
+import type { IBehandling, IRestNyBehandling } from '@typer/behandling';
+import { BehandlingSteg, Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import type { IBehandlingstema } from '@typer/behandlingstema';
+import { behandlingstemaer } from '@typer/behandlingstema';
+import type { OptionType } from '@typer/common';
+import { FagsakType } from '@typer/fagsak';
+import { Klagebehandlingstype } from '@typer/klage';
+import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import type { IsoDatoString } from '@utils/dato';
+import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '@utils/dato';
 import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
-
-import { HentBarnetrygdbehandlingerQueryKeyFactory } from '../../../../hooks/useHentBarnetrygdbehandlinger';
-import { HentFagsakQueryKeyFactory } from '../../../../hooks/useHentFagsak';
-import { HentKlagebehandlingerQueryKeyFactory } from '../../../../hooks/useHentKlagebehandlinger';
-import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '../../../../hooks/useHentTilbakekrevingsbehandlinger';
-import { useSaksbehandler } from '../../../../hooks/useSaksbehandler';
-import { useBrukerContext } from '../../../../sider/Fagsak/BrukerContext';
-import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
-import type { IBehandling, IRestNyBehandling } from '../../../../typer/behandling';
-import { BehandlingSteg, Behandlingstype, BehandlingÅrsak } from '../../../../typer/behandling';
-import type { IBehandlingstema } from '../../../../typer/behandlingstema';
-import { behandlingstemaer } from '../../../../typer/behandlingstema';
-import type { OptionType } from '../../../../typer/common';
-import { FagsakType } from '../../../../typer/fagsak';
-import { Klagebehandlingstype } from '../../../../typer/klage';
-import { Tilbakekrevingsbehandlingstype } from '../../../../typer/tilbakekrevingsbehandling';
-import type { IsoDatoString } from '../../../../utils/dato';
-import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '../../../../utils/dato';
 
 export interface IOpprettBehandlingSkjemaBase {
     behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | '';

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -190,18 +190,11 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
 
     const { mutate: opprettBehandling } = useOpprettBehandling({
         onSuccess: async behandling => {
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
-                }),
-                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
-            ]);
-
             lukkModal();
             nullstillSkjema();
             settSubmitRessurs(byggSuksessRessurs(behandling));
 
-            if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
+            if (behandling.årsak === BehandlingÅrsak.SØKNAD) {
                 navigate(
                     behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON
                         ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
@@ -210,6 +203,13 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
             } else {
                 navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
             }
+
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
+                }),
+                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
+            ]);
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
@@ -218,10 +218,10 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
 
     const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
         onSuccess: async behandling => {
-            await queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
             lukkModal();
             nullstillSkjema();
             settSubmitRessurs(byggSuksessRessurs(behandling));
+            await queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
@@ -230,12 +230,12 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
 
     const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
         onSuccess: async behandling => {
-            await queryClient.invalidateQueries({
-                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
-            });
             nullstillSkjemaStatus();
             onTilbakekrevingsbehandlingOpprettet();
             settSubmitRessurs(byggSuksessRessurs(behandling));
+            await queryClient.invalidateQueries({
+                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
+            });
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -24,7 +24,12 @@ import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import { byggTomRessurs } from '@navikt/familie-typer';
+import {
+    byggFunksjonellFeilRessurs,
+    byggHenterRessurs,
+    byggSuksessRessurs,
+    byggTomRessurs,
+} from '@navikt/familie-typer';
 
 export interface IOpprettBehandlingSkjemaBase {
     behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | '';
@@ -53,44 +58,6 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
     const saksbehandler = useSaksbehandler();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
-
-    const { mutate: opprettBehandling } = useOpprettBehandling({
-        onSuccess: behandling => {
-            queryClient.invalidateQueries({ queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId) });
-            queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) });
-
-            lukkModal();
-            nullstillSkjema();
-
-            if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
-                navigate(
-                    behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON
-                        ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
-                        : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
-                );
-            } else {
-                navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
-            }
-        },
-    });
-
-    const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
-            lukkModal();
-            nullstillSkjema();
-        },
-    });
-
-    const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
-        onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
-            });
-            nullstillSkjemaStatus();
-            onTilbakekrevingsbehandlingOpprettet();
-        },
-    });
 
     const behandlingstype = useFelt<Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | ''>({
         verdi: '',
@@ -221,6 +188,60 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
         skjemanavn: 'Opprett behandling modal',
     });
 
+    const { mutate: opprettBehandling } = useOpprettBehandling({
+        onSuccess: async behandling => {
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
+                }),
+                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
+            ]);
+
+            lukkModal();
+            nullstillSkjema();
+            settSubmitRessurs(byggSuksessRessurs(behandling));
+
+            if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
+                navigate(
+                    behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON
+                        ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
+                        : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
+                );
+            } else {
+                navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
+            }
+        },
+        onError: error => {
+            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
+        },
+    });
+
+    const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
+        onSuccess: async behandling => {
+            await queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
+            lukkModal();
+            nullstillSkjema();
+            settSubmitRessurs(byggSuksessRessurs(behandling));
+        },
+        onError: error => {
+            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
+        },
+    });
+
+    const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
+        onSuccess: async behandling => {
+            await queryClient.invalidateQueries({
+                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
+            });
+            nullstillSkjemaStatus();
+            onTilbakekrevingsbehandlingOpprettet();
+            settSubmitRessurs(byggSuksessRessurs(behandling));
+        },
+        onError: error => {
+            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
+        },
+    });
+
     useEffect(() => {
         if (behandlingstype.verdi === Behandlingstype.TEKNISK_ENDRING) {
             behandlingsårsak.validerOgSettFelt(BehandlingÅrsak.TEKNISK_ENDRING);
@@ -231,6 +252,7 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
 
     const onBekreft = () => {
         if (kanSendeSkjema()) {
+            settSubmitRessurs(byggHenterRessurs());
             if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
                 opprettTilbakekreving({ fagsakId });
             } else if (behandlingstype.verdi === Klagebehandlingstype.KLAGE) {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -4,11 +4,14 @@ import { HentBarnetrygdbehandlingerQueryKeyFactory } from '@hooks/useHentBarnetr
 import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
 import { HentKlagebehandlingerQueryKeyFactory } from '@hooks/useHentKlagebehandlinger';
 import { HentTilbakekrevingsbehandlingerQueryKeyFactory } from '@hooks/useHentTilbakekrevingsbehandlinger';
+import { useOpprettBehandling } from '@hooks/useOpprettBehandling';
+import { useOpprettKlagebehandling } from '@hooks/useOpprettKlagebehandling';
+import { useOpprettTilbakekreving } from '@hooks/useOpprettTilbakekreving';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { useBrukerContext } from '@sider/Fagsak/BrukerContext';
 import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
 import { useQueryClient } from '@tanstack/react-query';
-import type { IBehandling, IRestNyBehandling } from '@typer/behandling';
+import type { IBehandling } from '@typer/behandling';
 import { BehandlingSteg, Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
 import type { IBehandlingstema } from '@typer/behandlingstema';
 import { behandlingstemaer } from '@typer/behandlingstema';
@@ -16,13 +19,12 @@ import type { OptionType } from '@typer/common';
 import { FagsakType } from '@typer/fagsak';
 import { Klagebehandlingstype } from '@typer/klage';
 import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
-import type { IsoDatoString } from '@utils/dato';
 import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '@utils/dato';
 import { useNavigate } from 'react-router';
 
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import { byggTomRessurs, hentDataFraRessurs, RessursStatus } from '@navikt/familie-typer';
+import { byggTomRessurs } from '@navikt/familie-typer';
 
 export interface IOpprettBehandlingSkjemaBase {
     behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | '';
@@ -38,13 +40,57 @@ export interface IOpprettBehandlingSkjemaFelter extends IOpprettBehandlingSkjema
     valgteBarn: OptionType[];
 }
 
-const useOpprettBehandling = (fagsakId: number, lukkModal: () => void, onOpprettTilbakekrevingSuccess: () => void) => {
+interface Props {
+    fagsakId: number;
+    lukkModal: () => void;
+    onTilbakekrevingsbehandlingOpprettet: () => void;
+}
+
+export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
     const { fagsak } = useFagsakContext();
     const { bruker } = useBrukerContext();
 
     const saksbehandler = useSaksbehandler();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
+
+    const { mutate: opprettBehandling } = useOpprettBehandling({
+        onSuccess: behandling => {
+            queryClient.invalidateQueries({ queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId) });
+            queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) });
+
+            lukkModal();
+            nullstillSkjema();
+
+            if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
+                navigate(
+                    behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON
+                        ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
+                        : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
+                );
+            } else {
+                navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
+            }
+        },
+    });
+
+    const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
+            lukkModal();
+            nullstillSkjema();
+        },
+    });
+
+    const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
+            });
+            nullstillSkjemaStatus();
+            onTilbakekrevingsbehandlingOpprettet();
+        },
+    });
 
     const behandlingstype = useFelt<Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | ''>({
         verdi: '',
@@ -158,7 +204,7 @@ const useOpprettBehandling = (fagsakId: number, lukkModal: () => void, onOpprett
         },
     });
 
-    const { skjema, nullstillSkjema, kanSendeSkjema, onSubmit, settSubmitRessurs, valideringErOk } = useSkjema<
+    const { skjema, nullstillSkjema, kanSendeSkjema, settSubmitRessurs, valideringErOk } = useSkjema<
         IOpprettBehandlingSkjemaFelter,
         IBehandling
     >({
@@ -183,54 +229,21 @@ const useOpprettBehandling = (fagsakId: number, lukkModal: () => void, onOpprett
         }
     }, [behandlingstype.verdi]);
 
-    const opprettTilbakekreving = () => {
-        onSubmit<void>(
-            {
-                method: 'GET',
-                url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,
-            },
-            response => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    queryClient.invalidateQueries({
-                        queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
-                    });
-                    nullstillSkjemaStatus();
-                    onOpprettTilbakekrevingSuccess();
-                }
-            }
-        );
-    };
-
-    const opprettKlagebehandling = () => {
-        onSubmit<{ klageMottattDato: IsoDatoString }>(
-            {
-                method: 'POST',
-                url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
-                data: {
+    const onBekreft = () => {
+        if (kanSendeSkjema()) {
+            if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
+                opprettTilbakekreving({ fagsakId });
+            } else if (behandlingstype.verdi === Klagebehandlingstype.KLAGE) {
+                opprettKlagebehandling({
                     klageMottattDato: dateTilIsoDatoString(klageMottattDato.verdi),
-                },
-                påvirkerSystemLaster: true,
-            },
-            response => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    queryClient.invalidateQueries({
-                        queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId),
-                    });
-                    lukkModal();
-                    nullstillSkjema();
-                }
-            }
-        );
-    };
+                    fagsakId,
+                });
+            } else {
+                const erMigreringFraInfoTrygd = behandlingstype.verdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
+                const erHelmanuellMigrering =
+                    erMigreringFraInfoTrygd && behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
 
-    const opprettBehandling = () => {
-        const erMigreringFraInfoTrygd = behandlingstype.verdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
-        const erHelmanuellMigrering =
-            erMigreringFraInfoTrygd && behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
-
-        onSubmit<IRestNyBehandling>(
-            {
-                data: {
+                const payload = {
                     kategori: behandlingstema.verdi?.kategori ?? null,
                     underkategori: behandlingstema.verdi?.underkategori ?? null,
                     behandlingType: behandlingstype.verdi as Behandlingstype,
@@ -243,47 +256,8 @@ const useOpprettBehandling = (fagsakId: number, lukkModal: () => void, onOpprett
                     barnasIdenter: erHelmanuellMigrering ? valgteBarn.verdi.map(option => option.value) : undefined,
                     fagsakId: fagsakId,
                     begrunnelse: begrunnelse.verdi,
-                },
-                method: 'POST',
-                url: '/familie-ba-sak/api/behandlinger',
-            },
-            response => {
-                if (response.status === RessursStatus.SUKSESS) {
-                    queryClient.invalidateQueries({
-                        queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
-                    });
-
-                    queryClient.invalidateQueries({
-                        queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId),
-                    });
-
-                    lukkModal();
-                    nullstillSkjema();
-
-                    const behandling: IBehandling | undefined = hentDataFraRessurs(response);
-
-                    if (behandling && behandling.årsak === BehandlingÅrsak.SØKNAD) {
-                        navigate(
-                            behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON
-                                ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
-                                : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
-                        );
-                    } else {
-                        navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
-                    }
-                }
-            }
-        );
-    };
-
-    const onBekreft = () => {
-        if (kanSendeSkjema()) {
-            if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
-                opprettTilbakekreving();
-            } else if (behandlingstype.verdi === Klagebehandlingstype.KLAGE) {
-                opprettKlagebehandling();
-            } else {
-                opprettBehandling();
+                };
+                opprettBehandling(payload);
             }
         }
     };
@@ -303,6 +277,4 @@ const useOpprettBehandling = (fagsakId: number, lukkModal: () => void, onOpprett
         maksdatoForMigrering: MAKSDATO_FOR_MIGRERING,
         valideringErOk,
     };
-};
-
-export default useOpprettBehandling;
+}

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -22,7 +22,7 @@ import {
 import { useKlageApi } from '../../api/useKlageApi';
 import useDokument from '../../hooks/useDokument';
 import { useSaksbehandler } from '../../hooks/useSaksbehandler';
-import type { IOpprettBehandlingSkjemaBase } from '../../komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandling';
+import type { IOpprettBehandlingSkjemaBase } from '../../komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
 import { Behandlingstype, BehandlingÅrsak } from '../../typer/behandling';
 import type { IBehandlingstema } from '../../typer/behandlingstema';
 import { behandlingstemaer } from '../../typer/behandlingstema';

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -27,20 +27,6 @@ import type { IRestPersonResultat, IRestStegTilstand } from './vilkår';
 
 export const MIDLERTIDIG_BEHANDLENDE_ENHET_ID = '4863';
 
-export interface IRestNyBehandling {
-    kategori: BehandlingKategori | null;
-    underkategori: BehandlingUnderkategori | null;
-    behandlingType: Behandlingstype;
-    journalpostID?: string;
-    behandlingÅrsak?: BehandlingÅrsak;
-    skalBehandlesAutomatisk?: boolean;
-    navIdent?: string;
-    barnasIdenter?: string[];
-    nyMigreringsdato?: IsoDatoString;
-    søknadMottattDato?: IsoDatoString;
-    fagsakId: number;
-}
-
 export enum HenleggÅrsak {
     SØKNAD_TRUKKET = 'SØKNAD_TRUKKET',
     FEILAKTIG_OPPRETTET = 'FEILAKTIG_OPPRETTET',

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -27,6 +27,20 @@ import type { IRestPersonResultat, IRestStegTilstand } from './vilkår';
 
 export const MIDLERTIDIG_BEHANDLENDE_ENHET_ID = '4863';
 
+export interface NyBehandling {
+    kategori: BehandlingKategori | null;
+    underkategori: BehandlingUnderkategori | null;
+    behandlingType: Behandlingstype;
+    journalpostID?: string;
+    behandlingÅrsak?: BehandlingÅrsak;
+    skalBehandlesAutomatisk?: boolean;
+    navIdent?: string;
+    barnasIdenter?: string[];
+    nyMigreringsdato?: IsoDatoString;
+    søknadMottattDato?: IsoDatoString;
+    fagsakId: number;
+}
+
 export enum HenleggÅrsak {
     SØKNAD_TRUKKET = 'SØKNAD_TRUKKET',
     FEILAKTIG_OPPRETTET = 'FEILAKTIG_OPPRETTET',


### PR DESCRIPTION
### 📮 Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29213

### 💰 Hva skal gjøres, og hvorfor?
- Ta i bruk TanStack Query (React Query) i OpprettBehandling modalen og skjemaet. Første steg i omskrivingen til react-query og react-hook-form.
- Bruk @ -imports.
- Endre navn fra `useOpprettBehandling` til `useOpprettBehandlingSkjema` for tydeliggjøring.

OBS: Denne PR-en er så og si kun omskriving til react-query, ingen forenkling av kode. Det kommer flere PR-er, men tar litt om gangen 🤓

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_ ingen funksjonelle endringer


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_ ingen visuelle endringer
