### PR TITLE
NAV-29193: "Kopier vilkår"-knapp synlighetstilpasninger

### DIFF
--- a/src/frontend/testutils/testdata/personTestdata.ts
+++ b/src/frontend/testutils/testdata/personTestdata.ts
@@ -37,6 +37,7 @@ export function lagGrunnlagPerson(person: Partial<IGrunnlagPerson> = {}): IGrunn
         erManueltLagtTilISøknad: false,
         harFalskIdentitet: false,
         skjermesForBruker: false,
+        erNyttBarn: false,
         ...person,
     };
 }

--- a/src/frontend/typer/behandling.test.ts
+++ b/src/frontend/typer/behandling.test.ts
@@ -1,5 +1,6 @@
 import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
 import { lagGrunnlagPerson } from '@testutils/testdata/personTestdata';
+import { BehandlingKategori } from '@typer/behandlingstema';
 import { PersonType } from '@typer/person';
 import { Målform } from '@typer/søknad';
 import { describe, expect } from 'vitest';
@@ -7,6 +8,7 @@ import { describe, expect } from 'vitest';
 import {
     Behandlingstype,
     BehandlingÅrsak,
+    erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna,
     kanLeggeTilUtvidetVilkår,
     MIDLERTIDIG_BEHANDLENDE_ENHET_ID,
     sjekkErBehandleneEnhetMidlertidig,
@@ -146,6 +148,194 @@ describe('behandling', () => {
 
             // Assert
             expect(målform).toBe(Målform.NB);
+        });
+    });
+
+    describe('erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna', () => {
+        test('skal returnere true for eøs førstegangsbehandling', () => {
+            // Arrange
+            const behandling = lagBehandling({
+                kategori: BehandlingKategori.EØS,
+                type: Behandlingstype.FØRSTEGANGSBEHANDLING,
+                årsak: BehandlingÅrsak.SØKNAD,
+                personer: [
+                    lagGrunnlagPerson({
+                        personIdent: '12345678901',
+                        navn: 'Søker Søkeresen',
+                        fødselsdato: '1990-01-01',
+                        type: PersonType.SØKER,
+                        erNyttBarn: false,
+                    }),
+                    lagGrunnlagPerson({
+                        personIdent: '12345678902',
+                        navn: 'Barn Barnesen',
+                        fødselsdato: '2026-01-01',
+                        type: PersonType.BARN,
+                        erNyttBarn: true,
+                    }),
+                ],
+            });
+
+            // Act
+            const erRiktigBehandling = erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna(behandling);
+
+            // Assert
+            expect(erRiktigBehandling).toBe(true);
+        });
+
+        test('skal returnere true for eøs revurdering søknad med minst ett nytt barn', () => {
+            // Arrange
+            const behandling = lagBehandling({
+                kategori: BehandlingKategori.EØS,
+                type: Behandlingstype.REVURDERING,
+                årsak: BehandlingÅrsak.SØKNAD,
+                personer: [
+                    lagGrunnlagPerson({
+                        personIdent: '12345678901',
+                        navn: 'Søker Søkeresen',
+                        fødselsdato: '1990-01-01',
+                        type: PersonType.SØKER,
+                        erNyttBarn: false,
+                    }),
+                    lagGrunnlagPerson({
+                        personIdent: '12345678902',
+                        navn: 'Barn Barnesen',
+                        fødselsdato: '2026-01-01',
+                        type: PersonType.BARN,
+                        erNyttBarn: true,
+                    }),
+                ],
+            });
+
+            // Act
+            const erRiktigBehandling = erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna(behandling);
+
+            // Assert
+            expect(erRiktigBehandling).toBe(true);
+        });
+
+        test('skal returnere false for nasjonal førstegangsbehandling', () => {
+            // Arrange
+            const behandling = lagBehandling({
+                kategori: BehandlingKategori.NASJONAL,
+                type: Behandlingstype.FØRSTEGANGSBEHANDLING,
+                årsak: BehandlingÅrsak.SØKNAD,
+                personer: [
+                    lagGrunnlagPerson({
+                        personIdent: '12345678901',
+                        navn: 'Søker Søkeresen',
+                        fødselsdato: '1990-01-01',
+                        type: PersonType.SØKER,
+                        erNyttBarn: false,
+                    }),
+                    lagGrunnlagPerson({
+                        personIdent: '12345678902',
+                        navn: 'Barn Barnesen',
+                        fødselsdato: '2026-01-01',
+                        type: PersonType.BARN,
+                        erNyttBarn: true,
+                    }),
+                ],
+            });
+
+            // Act
+            const erRiktigBehandling = erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna(behandling);
+
+            // Assert
+            expect(erRiktigBehandling).toBe(false);
+        });
+
+        test('skal returnere false for eøs revurdering søknad uten nytt barn', () => {
+            // Arrange
+            const behandling = lagBehandling({
+                kategori: BehandlingKategori.EØS,
+                type: Behandlingstype.REVURDERING,
+                årsak: BehandlingÅrsak.SØKNAD,
+                personer: [
+                    lagGrunnlagPerson({
+                        personIdent: '12345678901',
+                        navn: 'Søker Søkeresen',
+                        fødselsdato: '1990-01-01',
+                        type: PersonType.SØKER,
+                        erNyttBarn: false,
+                    }),
+                    lagGrunnlagPerson({
+                        personIdent: '12345678902',
+                        navn: 'Barn Barnesen',
+                        fødselsdato: '2020-01-01',
+                        type: PersonType.BARN,
+                        erNyttBarn: false,
+                    }),
+                ],
+            });
+
+            // Act
+            const erRiktigBehandling = erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna(behandling);
+
+            // Assert
+            expect(erRiktigBehandling).toBe(false);
+        });
+
+        test('skal returnere false for eøs revurdering med annen årsak enn søknad selv med nytt barn', () => {
+            // Arrange
+            const behandling = lagBehandling({
+                kategori: BehandlingKategori.EØS,
+                type: Behandlingstype.REVURDERING,
+                årsak: BehandlingÅrsak.NYE_OPPLYSNINGER,
+                personer: [
+                    lagGrunnlagPerson({
+                        personIdent: '12345678901',
+                        navn: 'Søker Søkeresen',
+                        fødselsdato: '1990-01-01',
+                        type: PersonType.SØKER,
+                        erNyttBarn: false,
+                    }),
+                    lagGrunnlagPerson({
+                        personIdent: '12345678902',
+                        navn: 'Barn Barnesen',
+                        fødselsdato: '2026-01-01',
+                        type: PersonType.BARN,
+                        erNyttBarn: true,
+                    }),
+                ],
+            });
+
+            // Act
+            const erRiktigBehandling = erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna(behandling);
+
+            // Assert
+            expect(erRiktigBehandling).toBe(false);
+        });
+
+        test('skal returnere false for nasjonal revurdering søknad med nytt barn', () => {
+            // Arrange
+            const behandling = lagBehandling({
+                kategori: BehandlingKategori.NASJONAL,
+                type: Behandlingstype.REVURDERING,
+                årsak: BehandlingÅrsak.SØKNAD,
+                personer: [
+                    lagGrunnlagPerson({
+                        personIdent: '12345678901',
+                        navn: 'Søker Søkeresen',
+                        fødselsdato: '1990-01-01',
+                        type: PersonType.SØKER,
+                        erNyttBarn: false,
+                    }),
+                    lagGrunnlagPerson({
+                        personIdent: '12345678902',
+                        navn: 'Barn Barnesen',
+                        fødselsdato: '2026-01-01',
+                        type: PersonType.BARN,
+                        erNyttBarn: true,
+                    }),
+                ],
+            });
+
+            // Act
+            const erRiktigBehandling = erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna(behandling);
+
+            // Assert
+            expect(erRiktigBehandling).toBe(false);
         });
     });
 });

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -475,6 +475,6 @@ export function erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna(behandl
     const erFørstegangsbehandling = behandling.type === Behandlingstype.FØRSTEGANGSBEHANDLING;
     const erRevurdering = behandling.type === Behandlingstype.REVURDERING;
     const erSøknad = behandling.årsak === BehandlingÅrsak.SØKNAD;
-    // TODO : Legg inn sjekk om revurdering søknad gjelder nytt barn
-    return erEøs && (erFørstegangsbehandling || (erRevurdering && erSøknad));
+    const harMinstEttNyttBarn = behandling.personer.some(it => it.erNyttBarn);
+    return erEøs && (erFørstegangsbehandling || (erRevurdering && erSøknad && harMinstEttNyttBarn));
 }

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -41,6 +41,7 @@ export interface IGrunnlagPerson {
     erManueltLagtTilISøknad?: boolean;
     harFalskIdentitet: boolean;
     skjermesForBruker?: boolean;
+    erNyttBarn?: boolean;
 }
 
 export interface IPersonInfo {


### PR DESCRIPTION
### 📮 Favro
NAV-29193

### 💰 Hva skal gjøres, og hvorfor?
Tilpasser visning av "kopier vilkår"-knappen slik at den tar hensyn til om hvorvidt revurderingen har minst et nytt barn

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 