### PR TITLE
NAV-29258: Forbedrer ApiClient error håndtering ved ikke 2xx responser

### DIFF
--- a/src/frontend/api/client/apiClient.test.ts
+++ b/src/frontend/api/client/apiClient.test.ts
@@ -1,23 +1,39 @@
 import { server } from '@testutils/mocks/node';
+import { AxiosError } from 'axios';
 import { http, HttpResponse } from 'msw';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { ApiClient } from './apiClient';
+import { ApiClient, ApiFeil, RessursStatus } from './apiClient';
 
 const BASE_URL = 'http://localhost:3000';
 
 type TestData = { id: number; name: string };
 
+type FeilStatus = RessursStatus.FEILET | RessursStatus.IKKE_TILGANG | RessursStatus.FUNKSJONELL_FEIL;
+
+const FEIL_STATUSER: FeilStatus[] = [RessursStatus.FEILET, RessursStatus.IKKE_TILGANG, RessursStatus.FUNKSJONELL_FEIL];
+
 function lagSuksessRessurs<T>(data: T) {
-    return { status: 'SUKSESS', data, melding: 'OK' };
+    return { status: RessursStatus.SUKSESS, data, melding: 'OK' };
 }
 
-function lagFeilRessurs(
-    status: 'FEILET' | 'IKKE_TILGANG' | 'FUNKSJONELL_FEIL',
-    frontendFeilmelding: string,
-    callId?: string | null
-) {
+function lagFeilRessurs(status: FeilStatus, frontendFeilmelding: string, callId?: string | null) {
     return { status, melding: 'En feil oppstod', frontendFeilmelding, callId };
+}
+
+/**
+ * Venter på at en forespørsel skal avvises, og returnerer feilen som en ApiFeil
+ * slik at testen kan inspisere feltene (status, ressursStatus, callId, message).
+ * Kaster hvis forespørselen mot formodning lykkes, eller hvis feilen ikke er en ApiFeil.
+ */
+async function fangApiFeil(handling: Promise<unknown>): Promise<ApiFeil> {
+    try {
+        await handling;
+    } catch (error) {
+        expect(error).toBeInstanceOf(ApiFeil);
+        return error as ApiFeil;
+    }
+    throw new Error('Forventet at forespørselen skulle avvises, men den lyktes.');
 }
 
 describe('ApiClient', () => {
@@ -37,16 +53,13 @@ describe('ApiClient', () => {
             expect(result).toEqual(mockData);
         });
 
-        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
-            'avviser forespørselen ved %s-status',
-            async status => {
-                server.use(
-                    http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
-                );
+        test.each(FEIL_STATUSER)('avviser forespørselen ved %s-status', async status => {
+            server.use(
+                http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+            );
 
-                await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
-            }
-        );
+            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
+        });
     });
 
     describe('POST-forespørsler', () => {
@@ -69,16 +82,13 @@ describe('ApiClient', () => {
             expect(result).toEqual(mockData);
         });
 
-        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
-            'avviser forespørselen ved %s-status',
-            async status => {
-                server.use(
-                    http.post(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
-                );
+        test.each(FEIL_STATUSER)('avviser forespørselen ved %s-status', async status => {
+            server.use(
+                http.post(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+            );
 
-                await expect(client.post({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
-            }
-        );
+            await expect(client.post({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
+        });
     });
 
     describe('PUT-forespørsler', () => {
@@ -91,16 +101,13 @@ describe('ApiClient', () => {
             expect(result).toEqual(mockData);
         });
 
-        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
-            'avviser forespørselen ved %s-status',
-            async status => {
-                server.use(
-                    http.put(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
-                );
+        test.each(FEIL_STATUSER)('avviser forespørselen ved %s-status', async status => {
+            server.use(
+                http.put(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+            );
 
-                await expect(client.put({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
-            }
-        );
+            await expect(client.put({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
+        });
     });
 
     describe('PATCH-forespørsler', () => {
@@ -113,16 +120,13 @@ describe('ApiClient', () => {
             expect(result).toEqual(mockData);
         });
 
-        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
-            'avviser forespørselen ved %s-status',
-            async status => {
-                server.use(
-                    http.patch(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
-                );
+        test.each(FEIL_STATUSER)('avviser forespørselen ved %s-status', async status => {
+            server.use(
+                http.patch(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+            );
 
-                await expect(client.patch({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
-            }
-        );
+            await expect(client.patch({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
+        });
     });
 
     describe('DELETE-forespørsler', () => {
@@ -133,47 +137,181 @@ describe('ApiClient', () => {
             expect(result).toBeNull();
         });
 
-        test.each(['FEILET', 'IKKE_TILGANG', 'FUNKSJONELL_FEIL'] as const)(
-            'avviser forespørselen ved %s-status',
-            async status => {
-                server.use(
-                    http.delete(`${BASE_URL}/api/test`, () =>
-                        HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt'))
-                    )
-                );
+        test.each(FEIL_STATUSER)('avviser forespørselen ved %s-status', async status => {
+            server.use(
+                http.delete(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs(status, 'Noe gikk galt')))
+            );
 
-                await expect(client.delete({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
-            }
-        );
+            await expect(client.delete({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
+        });
+    });
+
+    describe('ApiFeil-felter ved feil-Ressurs på HTTP 200', () => {
+        test('setter ressursStatus, status (200) og melding fra Ressurs-objektet', async () => {
+            server.use(
+                http.get(`${BASE_URL}/api/test`, () =>
+                    HttpResponse.json(lagFeilRessurs(RessursStatus.IKKE_TILGANG, 'Ingen tilgang'))
+                )
+            );
+
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Ingen tilgang');
+            // Backend pakker feil i en 200-respons; HTTP-status er derfor 200 selv om dette er en feil.
+            expect(apiFeil.status).toBe(200);
+            expect(apiFeil.ressursStatus).toBe(RessursStatus.IKKE_TILGANG);
+            expect(apiFeil.callId).toBeUndefined();
+        });
+    });
+
+    describe('HTTP-feilstatus med Ressurs-body', () => {
+        test('avviser med ApiFeil som bærer HTTP-status, ressursStatus og callId', async () => {
+            server.use(
+                http.get(`${BASE_URL}/api/test`, () =>
+                    HttpResponse.json(lagFeilRessurs(RessursStatus.IKKE_TILGANG, 'Ingen tilgang', 'abc-123'), {
+                        status: 403,
+                    })
+                )
+            );
+
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Ingen tilgang (CallId: abc-123)');
+            expect(apiFeil.status).toBe(403);
+            expect(apiFeil.ressursStatus).toBe(RessursStatus.IKKE_TILGANG);
+            expect(apiFeil.callId).toBe('abc-123');
+        });
+    });
+
+    describe('HTTP-feilstatus uten Ressurs-body', () => {
+        test('avviser med ApiFeil som bærer HTTP-status og en fallback-melding', async () => {
+            server.use(http.get(`${BASE_URL}/api/test`, () => new HttpResponse(null, { status: 500 })));
+
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            // Faller tilbake på axios sin egen melding når det ikke finnes en Ressurs-body.
+            expect(apiFeil.message).toMatch(/500/);
+            expect(apiFeil.status).toBe(500);
+            expect(apiFeil.ressursStatus).toBeUndefined();
+            expect(apiFeil.callId).toBeUndefined();
+        });
+    });
+
+    describe('Ugyldig respons', () => {
+        test('avviser når responsen mangler status-feltet', async () => {
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.json({ uventet: 'felt' })));
+
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Ugyldig respons fra serveren.');
+            expect(apiFeil.status).toBeUndefined();
+            expect(apiFeil.ressursStatus).toBeUndefined();
+            expect(apiFeil.callId).toBeUndefined();
+        });
+
+        test('avviser når responskroppen er null', async () => {
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(null)));
+
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Ugyldig respons fra serveren.');
+            expect(apiFeil.status).toBeUndefined();
+            expect(apiFeil.ressursStatus).toBeUndefined();
+            expect(apiFeil.callId).toBeUndefined();
+        });
+    });
+
+    describe('Ukjent status', () => {
+        test('avviser når responsen har en status som ikke håndteres', async () => {
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.json({ status: 'TULL', melding: 'Hæ?' })));
+
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Uhåndtert status: TULL');
+            expect(apiFeil.status).toBeUndefined();
+            expect(apiFeil.ressursStatus).toBeUndefined();
+            expect(apiFeil.callId).toBeUndefined();
+        });
     });
 
     describe('Feilmelding med callId', () => {
-        test('inkluderer callId i feilmeldingen når den er satt', async () => {
+        test('inkluderer callId i meldingen og setter callId-feltet', async () => {
             server.use(
                 http.get(`${BASE_URL}/api/test`, () =>
-                    HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt', 'abc-123'))
+                    HttpResponse.json(lagFeilRessurs(RessursStatus.FEILET, 'Noe gikk galt', 'abc-123'))
                 )
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt (CallId: abc-123)');
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Noe gikk galt (CallId: abc-123)');
+            expect(apiFeil.status).toBe(200);
+            expect(apiFeil.ressursStatus).toBe(RessursStatus.FEILET);
+            expect(apiFeil.callId).toBe('abc-123');
         });
 
-        test('utelater callId fra feilmeldingen når den er null', async () => {
+        test('utelater callId fra meldingen når den er null', async () => {
             server.use(
                 http.get(`${BASE_URL}/api/test`, () =>
-                    HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt', null))
+                    HttpResponse.json(lagFeilRessurs(RessursStatus.FEILET, 'Noe gikk galt', null))
                 )
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Noe gikk galt');
+            expect(apiFeil.status).toBe(200);
+            expect(apiFeil.ressursStatus).toBe(RessursStatus.FEILET);
+            expect(apiFeil.callId).toBeNull();
         });
 
-        test('utelater callId fra feilmeldingen når den mangler i responsen', async () => {
+        test('utelater callId fra meldingen når den mangler i responsen', async () => {
             server.use(
-                http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagFeilRessurs('FEILET', 'Noe gikk galt')))
+                http.get(`${BASE_URL}/api/test`, () =>
+                    HttpResponse.json(lagFeilRessurs(RessursStatus.FEILET, 'Noe gikk galt'))
+                )
             );
 
-            await expect(client.get({ url: '/api/test' })).rejects.toThrow('Noe gikk galt');
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            expect(apiFeil.message).toBe('Noe gikk galt');
+            expect(apiFeil.status).toBe(200);
+            expect(apiFeil.ressursStatus).toBe(RessursStatus.FEILET);
+            expect(apiFeil.callId).toBeUndefined();
+        });
+    });
+
+    describe('Timeout', () => {
+        test('avviser med timeout-meldingen når kallet tar for lang tid', async () => {
+            vi.spyOn(client['client'], 'request').mockRejectedValueOnce(
+                new AxiosError(
+                    'Nettverkskallet tok for lang tid. Prøv igjen senere eller kontakt brukerstøtte hvis problemet vedvarer.',
+                    'ECONNABORTED'
+                )
+            );
+
+            const apiFeil = await fangApiFeil(
+                client.request({
+                    method: 'GET',
+                    url: '/api/treg',
+                })
+            );
+
+            expect(apiFeil.message).toMatch(/tok for lang tid/);
+        });
+    });
+
+    describe('Nettverksfeil', () => {
+        test('avviser med en ApiFeil ved nettverksfeil', async () => {
+            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.error()));
+
+            const apiFeil = await fangApiFeil(client.request({ method: 'GET', url: '/api/test' }));
+
+            // Meldingen kommer fra axios (f.eks. "Network Error"); innholdet er miljøavhengig.
+            expect(apiFeil.message).toBeTruthy();
+            expect(apiFeil.status).toBeUndefined();
+            expect(apiFeil.ressursStatus).toBeUndefined();
+            expect(apiFeil.callId).toBeUndefined();
         });
     });
 
@@ -191,18 +329,18 @@ describe('ApiClient', () => {
             server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.json(lagSuksessRessurs(mockData))));
 
             client.addResponseInterceptor({ onFulfilled });
-            await client.get<void, TestData>({ url: '/api/test' });
+            await client.request<void, TestData>({ method: 'GET', url: '/api/test' });
 
             expect(onFulfilled).toHaveBeenCalledOnce();
         });
 
         test('kjører onRejected-interceptoren ved nettverksfeil', async () => {
-            const onRejected = vi.fn(error => Promise.reject(error));
+            const onRejected = vi.fn((error: AxiosError) => Promise.reject(error));
 
             server.use(http.get(`${BASE_URL}/api/network-error`, () => HttpResponse.error()));
 
             client.addResponseInterceptor({ onRejected });
-            await expect(client.get({ url: '/api/network-error' })).rejects.toThrow();
+            await expect(client.request({ method: 'GET', url: '/api/network-error' })).rejects.toThrow();
 
             expect(onRejected).toHaveBeenCalledOnce();
         });
@@ -222,16 +360,8 @@ describe('ApiClient', () => {
             const id = client.addResponseInterceptor({ onFulfilled });
             client.removeResponseInterceptor(id);
 
-            await client.get<void, TestData>({ url: '/api/test' });
+            await client.request<void, TestData>({ method: 'GET', url: '/api/test' });
             expect(onFulfilled).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('Nettverksfeil', () => {
-        test('avviser ved nettverksfeil', async () => {
-            server.use(http.get(`${BASE_URL}/api/test`, () => HttpResponse.error()));
-
-            await expect(client.get({ url: '/api/test' })).rejects.toThrow();
         });
     });
 });

--- a/src/frontend/api/client/apiClient.ts
+++ b/src/frontend/api/client/apiClient.ts
@@ -1,21 +1,14 @@
 import axios, { type AxiosError, type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
 
-const DEFAULT_TIME_OUT = 30_000;
-const DEFAULT_TIME_OUT_MESSAGE =
-    'Nettverkskallet tok for lang tid. Prøv igjen senere eller kontakt brukerstøtte hvis problemet vedvarer.';
-
-type OnFulfilled = <T>(
-    response: AxiosResponse<Ressurs<T>>
-) => AxiosResponse<Ressurs<T>> | Promise<AxiosResponse<Ressurs<T>>>;
-
-type OnRejected = (error: AxiosError) => unknown;
+type OnFulfilled = (response: AxiosResponse) => AxiosResponse | Promise<AxiosResponse>;
+type OnRejected = (error: AxiosError) => unknown | Promise<unknown>;
 
 interface Interceptor {
     onFulfilled?: OnFulfilled;
     onRejected?: OnRejected;
 }
 
-enum RessursStatus {
+export enum RessursStatus {
     SUKSESS = 'SUKSESS',
     FEILET = 'FEILET',
     IKKE_TILGANG = 'IKKE_TILGANG',
@@ -40,20 +33,74 @@ type Ressurs<T> =
           callId?: string | null;
       };
 
+const DEFAULT_TIME_OUT = 60_000;
+const DEFAULT_TIME_OUT_MESSAGE =
+    'Nettverkskallet tok for lang tid. Prøv igjen senere eller kontakt brukerstøtte hvis problemet vedvarer.';
+const DEFAULT_FEILMELDING = 'En ukjent feil oppstod';
+
+export class ApiFeil extends Error {
+    private constructor(
+        message: string,
+        /**
+         * HTTP-statuskoden fra responsen. Kan være 2xx (typisk 200) selv om
+         * dette er en feil: backend pakker svar i et Ressurs-objekt og kan
+         * returnere en feil-status (f.eks. IKKE_TILGANG) med HTTP 200.
+         * Bruk `ressursStatus` for å skille på selve feiltypen.
+         */
+        readonly status?: number,
+        readonly ressursStatus?: RessursStatus,
+        readonly callId?: string | null
+    ) {
+        super(message);
+        this.name = 'ApiFeil';
+    }
+
+    static fraAxiosError<R>(error: AxiosError<Ressurs<R>>): ApiFeil {
+        const ressurs = error.response?.data;
+        const feilmelding = ressurs?.frontendFeilmelding?.trim() || error.message || DEFAULT_FEILMELDING;
+        return new ApiFeil(
+            ApiFeil.padCallId(feilmelding, ressurs?.callId),
+            error.response?.status,
+            ressurs?.status,
+            ressurs?.callId
+        );
+    }
+
+    static fraRessurs(ressurs: Ressurs<unknown>, status?: number): ApiFeil {
+        const feilmelding = ressurs.frontendFeilmelding?.trim() || DEFAULT_FEILMELDING;
+        return new ApiFeil(ApiFeil.padCallId(feilmelding, ressurs.callId), status, ressurs.status, ressurs.callId);
+    }
+
+    static fraFeilmelding(feilmelding: string): ApiFeil {
+        return new ApiFeil(feilmelding);
+    }
+
+    private static padCallId(feilmelding: string, callId?: string | null): string {
+        return callId ? `${feilmelding} (CallId: ${callId})`.trim() : feilmelding;
+    }
+}
+
 export class ApiClient {
     private readonly client: AxiosInstance;
 
-    constructor(baseURL: string = window.location.origin) {
+    constructor(baseURL: string = typeof window !== 'undefined' ? window.location.origin : '') {
         this.client = axios.create({ baseURL });
     }
 
-    private async request<T, R>(config: AxiosRequestConfig<T>): Promise<R> {
-        const response = await this.client.request<T, AxiosResponse<Ressurs<R>>>({
-            timeout: DEFAULT_TIME_OUT,
-            timeoutErrorMessage: DEFAULT_TIME_OUT_MESSAGE,
-            ...config,
-        });
-        return this.resolveToPromise(response.data);
+    async request<T, R>(config: AxiosRequestConfig<T>): Promise<R> {
+        try {
+            const response = await this.client.request<Ressurs<R>>({
+                timeout: DEFAULT_TIME_OUT,
+                timeoutErrorMessage: DEFAULT_TIME_OUT_MESSAGE,
+                ...config,
+            });
+            return this.resolveRessurs(response);
+        } catch (error) {
+            if (axios.isAxiosError<Ressurs<R>>(error)) {
+                return Promise.reject(ApiFeil.fraAxiosError(error));
+            }
+            return Promise.reject(ApiFeil.fraFeilmelding(error instanceof Error ? error.message : DEFAULT_FEILMELDING));
+        }
     }
 
     async get<T, R>(config: Omit<AxiosRequestConfig<T>, 'method'>): Promise<R> {
@@ -84,9 +131,10 @@ export class ApiClient {
         this.client.interceptors.response.eject(id);
     }
 
-    private resolveToPromise<T>(ressurs: Ressurs<T>): Promise<T> {
-        if (!Object.values(RessursStatus).includes(ressurs.status)) {
-            return Promise.reject(new Error(`Ukjent status: ${ressurs.status}`));
+    private resolveRessurs<T>(response: AxiosResponse<Ressurs<T>>): Promise<T> {
+        const ressurs = response.data;
+        if (!ressurs || typeof ressurs !== 'object' || !('status' in ressurs)) {
+            return Promise.reject(ApiFeil.fraFeilmelding('Ugyldig respons fra serveren.'));
         }
         switch (ressurs.status) {
             case RessursStatus.SUKSESS:
@@ -94,11 +142,9 @@ export class ApiClient {
             case RessursStatus.FEILET:
             case RessursStatus.FUNKSJONELL_FEIL:
             case RessursStatus.IKKE_TILGANG:
-                const frontendFeilmelding = ressurs.frontendFeilmelding?.trim() ?? undefined;
-                const frontendFeilmeldingMedEllerUtenCallId = ressurs.callId
-                    ? `${frontendFeilmelding} (CallId: ${ressurs.callId})`
-                    : frontendFeilmelding;
-                return Promise.reject(new Error(frontendFeilmeldingMedEllerUtenCallId));
+                return Promise.reject(ApiFeil.fraRessurs(ressurs, response.status));
+            default:
+                return Promise.reject(ApiFeil.fraFeilmelding(`Uhåndtert status: ${(ressurs as Ressurs<T>).status}`));
         }
     }
 }


### PR DESCRIPTION
### 📮 Favro
NAV-29258

### 💰 Hva skal gjøres, og hvorfor?
- Forbedrer `ApiClient` error håndtering ved ikke 2xx responser ved å innføre en try-catch block slik at ikke 2xx responser blir håndtert av catch-blokken.
- Introduserer `ApiFeil` klassen for å bevare metadata om feilen. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer.