### PR TITLE
NAV-29213 Endre rekkefølge på kall i onSuccess

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -190,6 +190,13 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
 
     const { mutate: opprettBehandling } = useOpprettBehandling({
         onSuccess: async behandling => {
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
+                }),
+                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
+            ]);
+
             lukkModal();
             nullstillSkjema();
             settSubmitRessurs(byggSuksessRessurs(behandling));
@@ -203,13 +210,6 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
             } else {
                 navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
             }
-
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
-                }),
-                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
-            ]);
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
@@ -218,10 +218,10 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
 
     const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
         onSuccess: async behandling => {
+            await queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
             lukkModal();
             nullstillSkjema();
             settSubmitRessurs(byggSuksessRessurs(behandling));
-            await queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
@@ -230,12 +230,13 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
 
     const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
         onSuccess: async behandling => {
-            nullstillSkjemaStatus();
-            onTilbakekrevingsbehandlingOpprettet();
-            settSubmitRessurs(byggSuksessRessurs(behandling));
             await queryClient.invalidateQueries({
                 queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
             });
+
+            nullstillSkjemaStatus();
+            onTilbakekrevingsbehandlingOpprettet();
+            settSubmitRessurs(byggSuksessRessurs(behandling));
         },
         onError: error => {
             settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));


### PR DESCRIPTION
### 📮 Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29213

### 💰 Hva skal gjøres, og hvorfor?
Flytt `await`-kall med `invalidateQueries` til før de andre kallene i `onSuccess` for å sikre at det kjøres før de andre kallene.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_ ingen funksjonelle endringer


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_ Nei
