### PR TITLE
NAV-29193: Fikser bug i ekspanderingslogikk

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
@@ -1,8 +1,7 @@
 import { NotFound } from '@komponenter/Error/NotFound';
 import { TidslinjeProvider } from '@komponenter/Tidslinje/TidslinjeContext';
 import { VedtakContainer } from '@sider/Fagsak/Behandling/Sider/Vedtak/VedtakContainer';
-import { EkspanderbareVilkårResultatRaderProvider } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext';
-import { EkspanderbareVilkårsvurderingPanelerProvider } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext';
+import { VilkårsvurderingContainer } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContainer';
 import type { RouteObject } from 'react-router';
 
 import Behandlingsresultat from './Sider/Behandlingsresultat/Behandlingsresultat';
@@ -13,8 +12,6 @@ import { SøknadProvider } from './Sider/RegistrerSøknad/SøknadContext';
 import Simulering from './Sider/Simulering/Simulering';
 import { SimuleringProvider } from './Sider/Simulering/SimuleringContext';
 import { Vedtak } from './Sider/Vedtak/Vedtak';
-import { Vilkårsvurdering } from './Sider/Vilkårsvurdering/Vilkårsvurdering';
-import { VilkårsvurderingProvider } from './Sider/Vilkårsvurdering/VilkårsvurderingContext';
 
 export const behandlingRoutes: RouteObject[] = [
     {
@@ -35,15 +32,7 @@ export const behandlingRoutes: RouteObject[] = [
     },
     {
         path: 'vilkaarsvurdering',
-        element: (
-            <VilkårsvurderingProvider>
-                <EkspanderbareVilkårsvurderingPanelerProvider>
-                    <EkspanderbareVilkårResultatRaderProvider>
-                        <Vilkårsvurdering />
-                    </EkspanderbareVilkårResultatRaderProvider>
-                </EkspanderbareVilkårsvurderingPanelerProvider>
-            </VilkårsvurderingProvider>
-        ),
+        element: <VilkårsvurderingContainer />,
     },
     {
         path: 'tilkjent-ytelse',

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext.tsx
@@ -3,17 +3,17 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useMemo
 import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFeatureToggles } from '@hooks/useFeatureToggles';
-import { erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna } from '@typer/behandling';
-import { FeatureToggle } from '@typer/featureToggles';
+import { erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna, type IBehandling } from '@typer/behandling';
+import { FeatureToggle, type FeatureToggles } from '@typer/featureToggles';
 import { Resultat, VilkårType } from '@typer/vilkår';
 
 const RELEVANTE_VILKÅR_TYPER_FOR_KOPIERTE_VILKÅR = [VilkårType.BOR_MED_SØKER, VilkårType.BOSATT_I_RIKET];
 
-function useInitielleEkspanderteIder(): Set<number> {
-    const behandling = useBehandling();
-    const erLesevisning = useErLesevisning();
-    const toggles = useFeatureToggles();
-
+function finnInitielleEkspanderteIder(
+    behandling: IBehandling,
+    erLesevisning: boolean,
+    toggles: FeatureToggles
+): Set<number> {
     const vilkårResultater = behandling.personResultater.flatMap(it => it.vilkårResultater);
 
     if (erLesevisning) {
@@ -48,11 +48,20 @@ interface EkspanderbareVilkårResultatRaderContext {
 const Context = createContext<EkspanderbareVilkårResultatRaderContext | undefined>(undefined);
 
 export function EkspanderbareVilkårResultatRaderProvider({ children }: PropsWithChildren) {
-    const initielleEkspanderteIdenter = useInitielleEkspanderteIder();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+    const toggles = useFeatureToggles();
 
-    const [ekspanderteIder, settEkspanderteIder] = useState(initielleEkspanderteIdenter);
+    const [ekspanderteIder, settEkspanderteIder] = useState(() =>
+        finnInitielleEkspanderteIder(behandling, erLesevisning, toggles)
+    );
 
-    const erRadEkspandert = useCallback((id: number) => ekspanderteIder.has(id), [ekspanderteIder]);
+    const erRadEkspandert = useCallback(
+        (id: number) => {
+            return ekspanderteIder.has(id);
+        },
+        [ekspanderteIder]
+    );
 
     const ekspanderRad = useCallback((id: number, isDirty: boolean = false) => {
         if (isDirty) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext.tsx
@@ -3,17 +3,17 @@ import { createContext, type PropsWithChildren, useCallback, useContext, useMemo
 import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFeatureToggles } from '@hooks/useFeatureToggles';
-import { erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna } from '@typer/behandling';
-import { FeatureToggle } from '@typer/featureToggles';
+import { erRiktigBehandlingForKopieringAvVilkårFraSøkerTilBarna, type IBehandling } from '@typer/behandling';
+import { FeatureToggle, type FeatureToggles } from '@typer/featureToggles';
 import { Resultat, VilkårType } from '@typer/vilkår';
 
 const RELEVANTE_VILKÅR_TYPER_FOR_KOPIERTE_VILKÅR = [VilkårType.BOR_MED_SØKER, VilkårType.BOSATT_I_RIKET];
 
-function useInitielleEkspanderteIdenter(): Set<string> {
-    const behandling = useBehandling();
-    const erLesevisning = useErLesevisning();
-    const toggles = useFeatureToggles();
-
+function finnInitielleEkspanderteIdenter(
+    behandling: IBehandling,
+    erLesevisning: boolean,
+    toggles: FeatureToggles
+): Set<string> {
     if (erLesevisning) {
         return new Set(behandling.personResultater.map(pr => pr.personIdent));
     }
@@ -53,9 +53,13 @@ interface EkspanderbareVilkårsvurderingPanelerContext {
 const Context = createContext<EkspanderbareVilkårsvurderingPanelerContext | undefined>(undefined);
 
 export function EkspanderbareVilkårsvurderingPanelerProvider({ children }: PropsWithChildren) {
-    const initielleEkspanderteIdenter = useInitielleEkspanderteIdenter();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+    const toggles = useFeatureToggles();
 
-    const [ekspanderteIdenter, settEkspanderteIdenter] = useState<Set<string>>(initielleEkspanderteIdenter);
+    const [ekspanderteIdenter, settEkspanderteIdenter] = useState(() =>
+        finnInitielleEkspanderteIdenter(behandling, erLesevisning, toggles)
+    );
 
     const erPanelEkspandert = useCallback((ident: string) => ekspanderteIdenter.has(ident), [ekspanderteIdenter]);
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/GeneriskVilkår/VilkårTabellRad.tsx
@@ -55,6 +55,7 @@ export function VilkårTabellRad({
 
     return (
         <Table.ExpandableRow
+            key={`${vilkårResultat.verdi.id}-${erRadEkspandert ? 'ekspandert' : 'lukket'}`} // Pga. React.Activity ikke fungerer så bra med Aksel, se https://github.com/navikt/aksel/issues/5017
             open={erRadEkspandert}
             togglePlacement={'right'}
             onOpenChange={() => toggleForm(true)}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContainer.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContainer.tsx
@@ -1,0 +1,16 @@
+import { EkspanderbareVilkårResultatRaderProvider } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårResultatRaderContext';
+import { EkspanderbareVilkårsvurderingPanelerProvider } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/EkspanderbareVilkårsvurderingPanelerContext';
+import { Vilkårsvurdering } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/Vilkårsvurdering';
+import { VilkårsvurderingProvider } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContext';
+
+export function VilkårsvurderingContainer() {
+    return (
+        <VilkårsvurderingProvider>
+            <EkspanderbareVilkårsvurderingPanelerProvider>
+                <EkspanderbareVilkårResultatRaderProvider>
+                    <Vilkårsvurdering />
+                </EkspanderbareVilkårResultatRaderProvider>
+            </EkspanderbareVilkårsvurderingPanelerProvider>
+        </VilkårsvurderingProvider>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/HentOgSettBehandlingContext.tsx
@@ -44,7 +44,7 @@ export function HentOgSettBehandlingProvider({ children }: PropsWithChildren) {
         navigate(`/fagsak/${fagsak.id}`);
     }
 
-    const settBehandlingRessurs = async (behandling: Ressurs<IBehandling>) => {
+    const settBehandlingRessurs = (behandling: Ressurs<IBehandling>) => {
         if (behandling.status === RessursStatus.SUKSESS) {
             queryClient.invalidateQueries({
                 queryKey: HentHistorikkinnslagQueryKeyFactory.historikkinnslag(behandling.data.behandlingId),


### PR DESCRIPTION
### 📮 Favro
NAV-29193

### 💰 Hva skal gjøres, og hvorfor?
Denne PR-en retter en bug i ekspanderings-/kollaps-logikken i vilkårsvurderingen, og rydder samtidig opp i hvordan kontekst-providers komposeres og initialiseres i UI-laget.

**Endringer:**
- Introduserer `VilkårsvurderingContainer` og bruker den i routing for å samle providers på ett sted.
- Legger til en `key` på `Table.ExpandableRow` for å få ønsket remount/oppførsel ved åpne/lukke (workaround mot Aksel/React.Activity-problematikk).
- Refaktorerer initiering av ekspanderte paneler/rader og justerer invalidation-logikk i behandling-context.
- Fjerner `await` i `settBehandlingRessurs` da den i praksisk ikke gjorde noe da ingen `await`ed metoden. Det sørger for at `settÅpenBehandling` som blir kalt før man navigere til vilkårsvurderingen blir ferdig før navigeringen er ferdig. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.


### 👀 Screen shots
Ingen visuelle endringer. 