### PR TITLE
NAV-29440: Rydder opp i sider.ts og venstremenyen

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -20,7 +20,7 @@ import { BehandlingStatus } from '../../../../../typer/behandling';
 import type { ITotrinnskontrollData } from '../../../../../typer/totrinnskontroll';
 import { TotrinnskontrollBeslutning } from '../../../../../typer/totrinnskontroll';
 import { useBehandlingContext } from '../../context/BehandlingContext';
-import type { ITrinn } from '../../Sider/sider';
+import type { Trinn } from '../../Sider/sider';
 import { KontrollertStatus } from '../../Sider/sider';
 import { Tab, useTabContext } from '../TabContextProvider';
 
@@ -43,7 +43,7 @@ export function Totrinnskontroll() {
 
     const nullstillFeilmelding = () => {
         const erFørsteSjekk = Object.entries(forrigeState).some(([sideId, trinn]) => {
-            const oppdatertTrinn: ITrinn = Object.entries(trinnPåBehandling)
+            const oppdatertTrinn: Trinn = Object.entries(trinnPåBehandling)
                 .filter(([oppdatertSideId, _]) => sideId === oppdatertSideId)
                 .map(([_, aTrinn]) => aTrinn)[0];
             return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/sider.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/sider.test.ts
@@ -1,3 +1,6 @@
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { BehandlingÅrsak, BehandlingSteg, BehandlingStegStatus } from '@typer/behandling';
+
 import {
     SideId,
     hentTrinnForBehandling,
@@ -6,8 +9,6 @@ import {
     erViPåUlovligSteg,
     finnSideForBehandlingssteg,
 } from './sider';
-import { lagBehandling } from '../../../../testutils/testdata/behandlingTestdata';
-import { BehandlingÅrsak, BehandlingSteg, BehandlingStegStatus } from '../../../../typer/behandling';
 
 describe('sider.ts', () => {
     describe('siderForBehandling', () => {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
@@ -1,20 +1,19 @@
-import type { FeltState } from '@navikt/familie-skjema';
+import type { IBehandling } from '@typer/behandling';
+import { BehandlingSteg, BehandlingStegStatus, BehandlingÅrsak, hentStegNummer } from '@typer/behandling';
+import { Resultat } from '@typer/vilkår';
 
 import { mapFraRestPersonResultatTilPersonResultat } from './Vilkårsvurdering/utils';
-import type { IBehandling } from '../../../../typer/behandling';
-import { BehandlingSteg, BehandlingStegStatus, BehandlingÅrsak, hentStegNummer } from '../../../../typer/behandling';
-import type { IPersonResultat, IVilkårResultat } from '../../../../typer/vilkår';
-import { Resultat } from '../../../../typer/vilkår';
 
-export interface ISide {
+export interface Side {
+    id: SideId;
     href: string;
     navn: string;
     steg: BehandlingSteg;
-    undersider?: (åpenBehandling: IBehandling) => IUnderside[];
-    visSide?: (åpenBehandling: IBehandling) => boolean;
+    undersider?: (behandling: IBehandling) => Underside[];
+    visSide?: (behandling: IBehandling) => boolean;
 }
 
-export interface IUnderside {
+export interface Underside {
     navn: string;
     ident: string;
     antallAksjonspunkter: () => number;
@@ -22,7 +21,7 @@ export interface IUnderside {
     skjermesForBruker?: boolean;
 }
 
-export interface ITrinn extends ISide {
+export interface Trinn extends Side {
     kontrollert: KontrollertStatus;
 }
 
@@ -42,83 +41,91 @@ export enum SideId {
     VEDTAK = 'VEDTAK',
 }
 
-export const sider: Record<SideId, ISide> = {
+export const sider: Record<SideId, Side> = {
     REGISTRER_INSTITUSJON: {
+        id: SideId.REGISTRER_INSTITUSJON,
         href: 'registrer-institusjon',
         navn: 'Info om institusjon',
         steg: BehandlingSteg.REGISTRERE_INSTITUSJON,
-        visSide: (åpenBehandling: IBehandling) => {
-            return (
-                åpenBehandling.stegTilstand.find(
-                    value => value.behandlingSteg === BehandlingSteg.REGISTRERE_INSTITUSJON
-                ) !== undefined
+        visSide: behandling => {
+            const registrereInstitusjonSteg = behandling.stegTilstand.find(
+                value => value.behandlingSteg === BehandlingSteg.REGISTRERE_INSTITUSJON
             );
+            return registrereInstitusjonSteg !== undefined;
         },
     },
     REGISTRERE_SØKNAD: {
+        id: SideId.REGISTRERE_SØKNAD,
         href: 'registrer-soknad',
         navn: 'Registrer søknad',
         steg: BehandlingSteg.REGISTRERE_SØKNAD,
-        visSide: (åpenBehandling: IBehandling) => {
-            return åpenBehandling.årsak === BehandlingÅrsak.SØKNAD;
+        visSide: behandling => {
+            return behandling.årsak === BehandlingÅrsak.SØKNAD;
         },
     },
     FILTRERING_FØDSELSHENDELSER: {
+        id: SideId.FILTRERING_FØDSELSHENDELSER,
         href: 'filtreringsregler',
         navn: 'Filtreringsregler',
         steg: BehandlingSteg.FILTRERING_FØDSELSHENDELSER,
-        visSide: (åpenBehandling: IBehandling) => {
-            return åpenBehandling.årsak === BehandlingÅrsak.FØDSELSHENDELSE;
+        visSide: behandling => {
+            return behandling.årsak === BehandlingÅrsak.FØDSELSHENDELSE;
         },
     },
     VILKÅRSVURDERING: {
+        id: SideId.VILKÅRSVURDERING,
         href: 'vilkaarsvurdering',
         navn: 'Vilkårsvurdering',
         steg: BehandlingSteg.VILKÅRSVURDERING,
-        undersider: (åpenBehandling: IBehandling) => {
+        undersider: behandling => {
             const personResultater = mapFraRestPersonResultatTilPersonResultat(
-                åpenBehandling.personResultater,
-                åpenBehandling.personer
+                behandling.personResultater,
+                behandling.personer
             );
 
-            return personResultater.map((personResultat: IPersonResultat, index: number): IUnderside => {
+            return personResultater.map((personResultat, index): Underside => {
                 return {
                     navn: personResultat.person.navn,
                     ident: personResultat.person.personIdent,
                     hash: `${index}_${personResultat.person.fødselsdato}`,
                     skjermesForBruker: personResultat.person.skjermesForBruker,
-                    antallAksjonspunkter: () =>
-                        personResultat.vilkårResultater.filter((vilkårResultat: FeltState<IVilkårResultat>) => {
-                            return vilkårResultat.verdi.resultat.verdi === Resultat.IKKE_VURDERT;
-                        }).length,
+                    antallAksjonspunkter: () => {
+                        const vilkårSomErIkkeVurdert = personResultat.vilkårResultater.filter(
+                            vilkårResultat => vilkårResultat.verdi.resultat.verdi === Resultat.IKKE_VURDERT
+                        );
+                        return vilkårSomErIkkeVurdert.length;
+                    },
                 };
             });
         },
     },
     BEHANDLINGRESULTAT: {
+        id: SideId.BEHANDLINGRESULTAT,
         href: 'tilkjent-ytelse',
         navn: 'Behandlingsresultat',
         steg: BehandlingSteg.BEHANDLINGSRESULTAT,
     },
     SIMULERING: {
+        id: SideId.SIMULERING,
         href: 'simulering',
         navn: 'Simulering',
         steg: BehandlingSteg.VURDER_TILBAKEKREVING,
-        visSide: (åpenBehandling: IBehandling) => {
-            return !åpenBehandling.skalBehandlesAutomatisk;
+        visSide: behandling => {
+            return !behandling.skalBehandlesAutomatisk;
         },
     },
     VEDTAK: {
+        id: SideId.VEDTAK,
         href: 'vedtak',
         navn: 'Vedtak',
         steg: BehandlingSteg.SEND_TIL_BESLUTTER,
-        visSide: (åpenBehandling: IBehandling) => {
-            return åpenBehandling.årsak !== BehandlingÅrsak.SATSENDRING;
+        visSide: behandling => {
+            return behandling.årsak !== BehandlingÅrsak.SATSENDRING;
         },
     },
 };
 
-export const erSidenAktiv = (side: ISide, behandling: IBehandling): boolean => {
+export function erSidenAktiv(side: Side, behandling: IBehandling): boolean {
     const steg = finnSteg(behandling);
 
     if (!side.steg && side.steg !== 0) {
@@ -130,12 +137,16 @@ export const erSidenAktiv = (side: ISide, behandling: IBehandling): boolean => {
     }
 
     return hentStegNummer(side.steg) <= hentStegNummer(steg);
-};
+}
 
-export const hentTrinnForBehandling = (åpenBehandling: IBehandling): { [sideId: string]: ISide } => {
-    const visSide = (side: ISide) => {
+export function finnSiderForBehandling(behandling: IBehandling) {
+    return Object.values(sider).filter(side => side.visSide?.(behandling) ?? true);
+}
+
+export function hentTrinnForBehandling(behandling: IBehandling): { [sideId: string]: Side } {
+    const visSide = (side: Side) => {
         if (side.visSide) {
-            return side.visSide(åpenBehandling);
+            return side.visSide(behandling);
         } else {
             return true;
         }
@@ -145,13 +156,13 @@ export const hentTrinnForBehandling = (åpenBehandling: IBehandling): { [sideId:
         .reduce((acc, [sideId, side]) => {
             return { ...acc, [sideId]: side };
         }, {});
-};
+}
 
-export const hentSideFraUrl = (url: string) => {
+export function hentSideFraUrl(url: string) {
     return Object.entries(sider).find(([_, side]) => side.href === url)?.[0] as SideId;
-};
+}
 
-export const finnSideForBehandlingssteg = (behandling: IBehandling): ISide | undefined => {
+export function finnSideForBehandlingssteg(behandling: IBehandling): Side | undefined {
     const steg = finnSteg(behandling);
 
     if (hentStegNummer(steg) >= hentStegNummer(BehandlingSteg.SEND_TIL_BESLUTTER)) {
@@ -167,20 +178,20 @@ export const finnSideForBehandlingssteg = (behandling: IBehandling): ISide | und
     const sideForSteg = Object.entries(sider).find(([_, side]) => side.steg === steg);
 
     return sideForSteg ? sideForSteg[1] : undefined;
-};
+}
 
-export const erViPåUdefinertFagsakSide = (pathname: string) => {
+export function erViPåUdefinertFagsakSide(pathname: string) {
     return (
-        Object.values(sider).filter((side: ISide) => pathname.includes(side.href)).length === 0 &&
+        Object.values(sider).filter((side: Side) => pathname.includes(side.href)).length === 0 &&
         !pathname.includes('saksoversikt') &&
         !pathname.includes('ny-behandling')
     );
-};
+}
 
-export const erViPåUlovligSteg = (pathname: string, behandlingSide?: ISide) => {
+export function erViPåUlovligSteg(pathname: string, behandlingSide?: Side) {
     if (!behandlingSide) return false;
 
-    const ønsketSteg: ISide | undefined = Object.values(sider).find((side: ISide) => pathname.includes(side.href));
+    const ønsketSteg = Object.values(sider).find((side: Side) => pathname.includes(side.href));
 
     if (ønsketSteg) {
         if (hentStegNummer(ønsketSteg?.steg) > hentStegNummer(behandlingSide.steg)) {
@@ -189,23 +200,28 @@ export const erViPåUlovligSteg = (pathname: string, behandlingSide?: ISide) => 
     }
 
     return false;
-};
+}
 
-const finnSteg = (behandling: IBehandling): BehandlingSteg => {
+function finnSteg(behandling: IBehandling): BehandlingSteg {
     const erHenlagt = inneholderSteg(behandling, BehandlingSteg.HENLEGG_BEHANDLING);
-
     if (erHenlagt) {
-        if (inneholderSteg(behandling, BehandlingSteg.SEND_TIL_BESLUTTER)) return BehandlingSteg.SEND_TIL_BESLUTTER;
-        if (inneholderSteg(behandling, BehandlingSteg.VILKÅRSVURDERING)) return BehandlingSteg.VILKÅRSVURDERING;
-        if (inneholderSteg(behandling, BehandlingSteg.FILTRERING_FØDSELSHENDELSER))
+        if (inneholderSteg(behandling, BehandlingSteg.SEND_TIL_BESLUTTER)) {
+            return BehandlingSteg.SEND_TIL_BESLUTTER;
+        }
+        if (inneholderSteg(behandling, BehandlingSteg.VILKÅRSVURDERING)) {
+            return BehandlingSteg.VILKÅRSVURDERING;
+        }
+        if (inneholderSteg(behandling, BehandlingSteg.FILTRERING_FØDSELSHENDELSER)) {
             return BehandlingSteg.FILTRERING_FØDSELSHENDELSER;
+        }
         return BehandlingSteg.REGISTRERE_SØKNAD;
     } else {
         return behandling.steg;
     }
-};
+}
 
-const inneholderSteg = (behandling: IBehandling, behandlingSteg: BehandlingSteg): boolean =>
-    behandling.stegTilstand
+function inneholderSteg(behandling: IBehandling, behandlingSteg: BehandlingSteg): boolean {
+    return behandling.stegTilstand
         .filter(stegTilstand => stegTilstand.behandlingStegStatus !== BehandlingStegStatus.IKKE_UTFØRT)
         .some(stegTilstand => stegTilstand.behandlingSteg === behandlingSteg);
+}

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.module.css
@@ -55,7 +55,7 @@
 }
 
 .lenkeInaktiv {
-    color: var(--ax-text-neutral-subtle);
+    color: var(--ax-text-neutral-decoration);
     pointer-events: none;
 }
 

--- a/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Venstremeny/Venstremeny.tsx
@@ -1,6 +1,9 @@
 import type { MouseEvent } from 'react';
 import { Activity } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useFagsakId } from '@hooks/useFagsakId';
+import { formaterIdent } from '@utils/formatter';
 import classNames from 'classnames';
 import { NavLink } from 'react-router';
 
@@ -9,16 +12,15 @@ import { BodyShort, Box, Button, CopyButton, HStack, Stack, VStack } from '@navi
 
 import { useVenstremeny } from './useVenstremeny';
 import Styles from './Venstremeny.module.css';
-import { useFagsakId } from '../../../../hooks/useFagsakId';
-import { formaterIdent } from '../../../../utils/formatter';
-import { useBehandlingContext } from '../context/BehandlingContext';
-import { erSidenAktiv } from '../Sider/sider';
+import { erSidenAktiv, finnSiderForBehandling } from '../Sider/sider';
 
 export function Venstremeny() {
-    const { behandling, trinnPåBehandling } = useBehandlingContext();
-
     const fagsakId = useFagsakId();
+    const behandling = useBehandling();
+
     const [erÅpen, settErÅpen] = useVenstremeny();
+
+    const sider = finnSiderForBehandling(behandling);
 
     function stansNavigeringDersomSidenIkkeErAktiv(event: MouseEvent, sidenErAktiv: boolean) {
         if (!sidenErAktiv) {
@@ -46,12 +48,12 @@ export function Venstremeny() {
             />
             <Activity mode={erÅpen ? 'visible' : 'hidden'}>
                 <Box as={'nav'} width={'clamp(14rem, 15vw, 25rem)'}>
-                    {Object.entries(trinnPåBehandling).map(([sideId, side], index) => {
+                    {sider.map((side, index) => {
                         const tilPath = `/fagsak/${fagsakId}/${behandling.behandlingId}/${side.href}`;
                         const undersider = side.undersider ? side.undersider(behandling) : [];
                         const sidenErAktiv = erSidenAktiv(side, behandling);
                         return (
-                            <VStack key={sideId}>
+                            <VStack key={side.id}>
                                 <NavLink
                                     to={tilPath}
                                     className={({ isActive }) =>
@@ -70,7 +72,7 @@ export function Venstremeny() {
                                     const antallAksjonspunkter = underside.antallAksjonspunkter();
                                     return (
                                         <NavLink
-                                            key={`${sideId}_${underside.hash}`}
+                                            key={`${side.id}_${underside.hash}`}
                                             to={`${tilPath}#${underside.hash}`}
                                             className={({ isActive }) =>
                                                 classNames(Styles.undersidelenke, {

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -13,7 +13,7 @@ import { useLocation } from 'react-router';
 import { type Ressurs } from '@navikt/familie-typer';
 
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
-import { type ITrinn, type SideId } from '../Sider/sider';
+import { type Trinn, type SideId } from '../Sider/sider';
 import { hentTrinnForBehandling, KontrollertStatus } from '../Sider/sider';
 
 interface Props extends PropsWithChildren {
@@ -23,7 +23,7 @@ interface Props extends PropsWithChildren {
 interface BehandlingContextValue {
     leggTilBesøktSide: (besøktSide: SideId) => void;
     settIkkeKontrollerteSiderTilManglerKontroll: () => void;
-    trinnPåBehandling: { [sideId: string]: ITrinn };
+    trinnPåBehandling: { [sideId: string]: Trinn };
     behandling: IBehandling;
     settÅpenBehandling: (behandling: Ressurs<IBehandling>) => void;
 }
@@ -39,7 +39,7 @@ export const BehandlingProvider = ({ behandling, children }: Props) => {
     const fagsak = useFagsak();
     const location = useLocation();
 
-    const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: ITrinn }>({});
+    const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: Trinn }>({});
 
     useTrackTidsbrukPåSide(fagsak, behandling);
 


### PR DESCRIPTION
### 📮 Favro
NAV-29440

### 💰 Hva skal gjøres, og hvorfor?
Rydder opp i navigasjons-/side-definisjoner for behandling ved å modernisere typene i `sider.ts`, og forenkler venstremenyen ved å bruke felles side-filtrering (i stedet for å iterere via `trinnPåBehandling`).

**Endringer:**
- Omdøper typene (`Side`, `Underside`, `Trinn`) og legger til eksplisitt `id` på sider i `sider.ts`.
- Legger til `finnSiderForBehandling()` og oppdaterer venstremenyen til å bruke denne for å finne synlige sider.
- Oppdaterer imports/typer i kontekst og totrinnskontroll, samt justerer inaktiv lenke-farge i CSS.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Burde ikke være så stor logiske endringer.

### 👀 Screen shots
<img width="231" height="300" alt="image" src="https://github.com/user-attachments/assets/925f59de-fa3b-4fba-a9ac-293947d48b88" />