### PR TITLE
NAV-29440: Kontrollerte sider for totrinnskontroll

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Behandling.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Behandling.tsx
@@ -1,45 +1,22 @@
-import { useEffect } from 'react';
-
 import { useBehandlingIdParam } from '@hooks/useBehandlingIdParam';
 import { NotFound } from '@komponenter/Error/NotFound';
 import { Behandlingslinje } from '@komponenter/Saklinje/Behandlingslinje';
 import { HenleggBehandlingModal } from '@komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingModal';
 import { HenleggBehandlingVeivalgModal } from '@komponenter/Saklinje/Meny/HenleggBehandling/HenleggBehandlingVeivalgModal';
-import { type SideId, sider } from '@sider/Fagsak/Behandling/Sider/sider';
-import { hentSideHref } from '@utils/miljø';
-import { Outlet, useLocation } from 'react-router';
+import { KontrollsiderProvider } from '@sider/Fagsak/Behandling/KontrollsiderContext';
+import { Outlet } from 'react-router';
 
 import { Box, GlobalAlert, HStack, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import Styles from './Behandling.module.css';
-import { BehandlingProvider, useBehandlingContext } from './context/BehandlingContext';
+import { BehandlingProvider } from './context/BehandlingContext';
 import { useHentOgSettBehandlingContext } from './context/HentOgSettBehandlingContext';
 import { Høyremeny } from './Høyremeny/Høyremeny';
 import { TabContextProvider } from './Høyremeny/TabContextProvider';
 import { TotrinnskontrollModalContextProvider } from './Høyremeny/Totrinnskontroll/TotrinnskontrollModalContextProvider';
 import { KorrigerEtterbetalingModal } from './Sider/Vedtak/KorrigerEtterbetaling/KorrigerEtterbetalingModal';
 import { Venstremeny } from './Venstremeny/Venstremeny';
-
-/**
- * Dette er gjort fordi useEffecten her må kjøre etter at useEffectene i BehandlingProvider er kjørt. Ellers visker
- * den tilstand og viser masse "undefined" i GUI. Dette skjer spesielt hvis man er inne på vedtakssiden f.eks. og
- * refresher siden. Burde skrive en bedre logikk.
- */
-export function OutletContainer() {
-    const { leggTilBesøktSide } = useBehandlingContext();
-    const location = useLocation();
-
-    const sidevisning = hentSideHref(location.pathname);
-
-    useEffect(() => {
-        if (sidevisning) {
-            leggTilBesøktSide(Object.entries(sider).find(([_, side]) => side.href === sidevisning)?.[0] as SideId);
-        }
-    }, [sidevisning]);
-
-    return <Outlet />;
-}
 
 export function Behandling() {
     const { behandlingRessurs } = useHentOgSettBehandlingContext();
@@ -52,29 +29,32 @@ export function Behandling() {
 
     switch (behandlingRessurs.status) {
         case RessursStatus.SUKSESS:
+            const behandling = behandlingRessurs.data;
             return (
-                <BehandlingProvider behandling={behandlingRessurs.data}>
-                    <HenleggBehandlingModal />
-                    <HenleggBehandlingVeivalgModal />
-                    <KorrigerEtterbetalingModal />
-                    <VStack className={Styles.skrollbarStack}>
-                        <Behandlingslinje />
-                        <HStack className={Styles.skrollbarStack}>
-                            <Box className={Styles.venstreKolonne}>
-                                <Venstremeny />
-                            </Box>
-                            <Box className={Styles.midtreKolonne}>
-                                <OutletContainer />
-                            </Box>
-                            <Box className={Styles.høyreKolonne}>
-                                <TotrinnskontrollModalContextProvider>
-                                    <TabContextProvider>
-                                        <Høyremeny />
-                                    </TabContextProvider>
-                                </TotrinnskontrollModalContextProvider>
-                            </Box>
-                        </HStack>
-                    </VStack>
+                <BehandlingProvider key={behandling.behandlingId} behandling={behandling}>
+                    <KontrollsiderProvider>
+                        <HenleggBehandlingModal />
+                        <HenleggBehandlingVeivalgModal />
+                        <KorrigerEtterbetalingModal />
+                        <VStack className={Styles.skrollbarStack}>
+                            <Behandlingslinje />
+                            <HStack className={Styles.skrollbarStack}>
+                                <Box className={Styles.venstreKolonne}>
+                                    <Venstremeny />
+                                </Box>
+                                <Box className={Styles.midtreKolonne}>
+                                    <Outlet />
+                                </Box>
+                                <Box className={Styles.høyreKolonne}>
+                                    <TotrinnskontrollModalContextProvider>
+                                        <TabContextProvider>
+                                            <Høyremeny />
+                                        </TabContextProvider>
+                                    </TotrinnskontrollModalContextProvider>
+                                </Box>
+                            </HStack>
+                        </VStack>
+                    </KontrollsiderProvider>
                 </BehandlingProvider>
             );
         case RessursStatus.IKKE_TILGANG:

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 
 import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
+import { useKontrollsiderContext } from '@sider/Fagsak/Behandling/KontrollsiderContext';
 import { useQueryClient } from '@tanstack/react-query';
 import type { IBehandling } from '@typer/behandling';
 import { BehandlingStatus } from '@typer/behandling';
@@ -22,7 +23,6 @@ import {
 import { useTotrinnskontrollModalContext } from './TotrinnskontrollModalContextProvider';
 import { Totrinnskontrollskjema } from './Totrinnskontrollskjema';
 import { useBehandlingContext } from '../../context/BehandlingContext';
-import type { Trinn } from '../../Sider/sider';
 import { KontrollertStatus } from '../../Sider/sider';
 import { Tab, useTabContext } from '../TabContextProvider';
 
@@ -32,8 +32,8 @@ const Container = styled.div`
 `;
 
 export function Totrinnskontroll() {
-    const { behandling, trinnPåBehandling, settIkkeKontrollerteSiderTilManglerKontroll, settÅpenBehandling } =
-        useBehandlingContext();
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const { kontrollsider, settIkkeKontrollerteSiderTilManglerKontroll } = useKontrollsiderContext();
     const { settTab } = useTabContext();
     const { åpneModal } = useTotrinnskontrollModalContext();
 
@@ -42,34 +42,31 @@ export function Totrinnskontroll() {
 
     const [innsendtVedtak, settInnsendtVedtak] = useState<Ressurs<IBehandling>>(byggTomRessurs());
 
-    const [forrigeState, settForrigeState] = useState(trinnPåBehandling);
+    const [forrigeKontrollsider, settForrigeKontrollsider] = useState(kontrollsider);
 
     const nullstillFeilmelding = () => {
-        const erFørsteSjekk = Object.entries(forrigeState).some(([sideId, trinn]) => {
-            const oppdatertTrinn: Trinn = Object.entries(trinnPåBehandling)
-                .filter(([oppdatertSideId, _]) => sideId === oppdatertSideId)
-                .map(([_, aTrinn]) => aTrinn)[0];
+        const harMinstEnSideBlittKontrollert = forrigeKontrollsider.some(forrigeSide => {
+            const nåværendeSide = kontrollsider.find(side => side.id === forrigeSide.id);
             return (
-                (trinn.kontrollert === KontrollertStatus.IKKE_KONTROLLERT ||
-                    trinn.kontrollert === KontrollertStatus.MANGLER_KONTROLL) &&
-                oppdatertTrinn.kontrollert === KontrollertStatus.KONTROLLERT
+                forrigeSide.kontrollertStatus !== KontrollertStatus.KONTROLLERT &&
+                nåværendeSide?.kontrollertStatus === KontrollertStatus.KONTROLLERT
             );
         });
-        if (erFørsteSjekk) {
+        if (harMinstEnSideBlittKontrollert) {
             settInnsendtVedtak(byggTomRessurs());
         }
-        settForrigeState(trinnPåBehandling);
+        settForrigeKontrollsider(kontrollsider);
     };
 
     useEffect(() => {
         nullstillFeilmelding();
-    }, [trinnPåBehandling]);
+    }, [kontrollsider]);
 
     const sendInnVedtak = (beslutning: TotrinnskontrollBeslutning, begrunnelse: string, egetVedtak: boolean) => {
-        if (
-            !egetVedtak &&
-            Object.values(trinnPåBehandling).some(trinn => trinn.kontrollert !== KontrollertStatus.KONTROLLERT)
-        ) {
+        const harSideSomIkkeErKontrollert = kontrollsider.some(
+            side => side.kontrollertStatus !== KontrollertStatus.KONTROLLERT
+        );
+        if (!egetVedtak && harSideSomIkkeErKontrollert) {
             settIkkeKontrollerteSiderTilManglerKontroll();
             settInnsendtVedtak(byggFunksjonellFeilRessurs('Du må kontrollere alle steg i løsningen.'));
             return;
@@ -87,9 +84,7 @@ export function Totrinnskontroll() {
                 data: {
                     beslutning,
                     begrunnelse,
-                    kontrollerteSider: Object.entries(trinnPåBehandling).map(([_, side]) => {
-                        return side.navn;
-                    }),
+                    kontrollerteSider: kontrollsider.map(side => side.navn),
                 },
                 url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/steg/iverksett-vedtak`,
             })

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
 
+import { useBehandling } from '@hooks/useBehandling';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { useKontrollsiderContext } from '@sider/Fagsak/Behandling/KontrollsiderContext';
+import type { IBehandling } from '@typer/behandling';
+import { TotrinnskontrollBeslutning } from '@typer/totrinnskontroll';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import styled from 'styled-components';
 
 import {
@@ -18,15 +25,9 @@ import {
 import type { Ressurs } from '@navikt/familie-typer';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useSaksbehandler } from '../../../../../hooks/useSaksbehandler';
 import ØyeGrå from '../../../../../ikoner/ØyeGrå';
 import ØyeGrønn from '../../../../../ikoner/ØyeGrønn';
 import ØyeRød from '../../../../../ikoner/ØyeRød';
-import type { IBehandling } from '../../../../../typer/behandling';
-import { TotrinnskontrollBeslutning } from '../../../../../typer/totrinnskontroll';
-import { Datoformat, isoStringTilFormatertString } from '../../../../../utils/dato';
-import { hentFrontendFeilmelding } from '../../../../../utils/ressursUtils';
-import { useBehandlingContext } from '../../context/BehandlingContext';
 import { KontrollertStatus } from '../../Sider/sider';
 
 interface Props {
@@ -35,8 +36,10 @@ interface Props {
 }
 
 export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props) {
-    const { behandling, trinnPåBehandling } = useBehandlingContext();
     const saksbehandler = useSaksbehandler();
+    const behandling = useBehandling();
+
+    const { kontrollsider } = useKontrollsiderContext();
 
     const [beslutning, settBeslutning] = useState<TotrinnskontrollBeslutning>(TotrinnskontrollBeslutning.IKKE_VURDERT);
     const [begrunnelse, settBegrunnelse] = useState<string>('');
@@ -82,11 +85,12 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
                     ) : (
                         <>
                             <Label spacing>Kontrollerte trinn</Label>
-                            {Object.entries(trinnPåBehandling).map(([_, trinn], index) => {
+                            {kontrollsider.map((side, index) => {
                                 return (
                                     <TrinnStatus
-                                        kontrollertStatus={trinn.kontrollert}
-                                        navn={`${index + 1}. ${trinn.navn}`}
+                                        key={side.id}
+                                        kontrollertStatus={side.kontrollertStatus}
+                                        navn={`${index + 1}. ${side.navn}`}
                                     />
                                 );
                             })}

--- a/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.test.tsx
@@ -1,0 +1,320 @@
+import type { PropsWithChildren } from 'react';
+
+import { KontrollertStatus, SideId, type Kontrollside } from '@sider/Fagsak/Behandling/Sider/sider';
+import { renderHook, act } from '@testing-library/react';
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { lagSaksbehandler } from '@testutils/testdata/saksbehandlerTestdata';
+import { BehandlerRolle, BehandlingStatus, BehandlingÅrsak } from '@typer/behandling';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+import { KontrollsiderProvider, useKontrollsiderContext } from './KontrollsiderContext';
+
+const { useLocationMock, useBehandlingMock, useSaksbehandlerMock } = vi.hoisted(() => ({
+    useLocationMock: vi.fn(),
+    useBehandlingMock: vi.fn(),
+    useSaksbehandlerMock: vi.fn(),
+}));
+
+vi.mock('@hooks/useBehandling', () => ({ useBehandling: useBehandlingMock }));
+vi.mock('@hooks/useSaksbehandler', () => ({ useSaksbehandler: useSaksbehandlerMock }));
+vi.mock('react-router', () => ({ useLocation: useLocationMock }));
+
+function lagPathname(href: string) {
+    return `/fagsak/123/321/${href}`;
+}
+
+function statusForSide(sider: Kontrollside[], id: SideId) {
+    return sider.find(side => side.id === id)?.kontrollertStatus;
+}
+
+function renderHookWithProvider() {
+    return renderHook(() => useKontrollsiderContext(), {
+        wrapper: ({ children }: PropsWithChildren) => <KontrollsiderProvider>{children}</KontrollsiderProvider>,
+    });
+}
+
+const defaultLocation = { pathname: lagPathname('vilkaarsvurdering') };
+
+const defaultBehandling = lagBehandling({
+    status: BehandlingStatus.FATTER_VEDTAK,
+    endretAv: 'saksbehandler@nav.no',
+    årsak: BehandlingÅrsak.SØKNAD,
+    skalBehandlesAutomatisk: false,
+});
+
+const defaultSaksbehandler = lagSaksbehandler({
+    rolle: BehandlerRolle.BESLUTTER,
+    email: 'beslutter@nav.no',
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    useLocationMock.mockReturnValue(defaultLocation);
+    useBehandlingMock.mockReturnValue(defaultBehandling);
+    useSaksbehandlerMock.mockReturnValue(defaultSaksbehandler);
+});
+
+describe('KontrollbareSiderProvider', () => {
+    describe('Initialisering av kontrollbare sider', () => {
+        test('inneholder sidene som vises for behandlingen', () => {
+            const { result } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.map(side => side.id)).toEqual([
+                SideId.REGISTRERE_SØKNAD,
+                SideId.VILKÅRSVURDERING,
+                SideId.BEHANDLINGRESULTAT,
+                SideId.SIMULERING,
+                SideId.VEDTAK,
+            ]);
+        });
+
+        test('markerer den åpne siden som kontrollert ved mount', () => {
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('lar øvrige sider være ikke kontrollert ved mount', () => {
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.IKKE_KONTROLLERT);
+        });
+    });
+
+    describe('Tilgang til å kontrollere sider', () => {
+        test('markerer ikke åpen side når saksbehandler ikke er beslutter', () => {
+            useSaksbehandlerMock.mockReturnValue(lagSaksbehandler({ rolle: BehandlerRolle.SAKSBEHANDLER }));
+
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('markerer ikke åpen side når behandlingen ikke er til fatte vedtak', () => {
+            useBehandlingMock.mockReturnValue(lagBehandling({ status: BehandlingStatus.UTREDES }));
+
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('markerer ikke åpen side når beslutter selv endret behandlingen', () => {
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, endretAv: 'beslutter@nav.no' })
+            );
+
+            const { result } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('markerer ikke besøkte sider når man ikke kan beslutte vedtak', () => {
+            useSaksbehandlerMock.mockReturnValue(lagSaksbehandler({ rolle: BehandlerRolle.SAKSBEHANDLER }));
+
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('vedtak') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.IKKE_KONTROLLERT);
+        });
+    });
+
+    describe('Markering av besøkte sider som kontrollert', () => {
+        test('markerer en side som kontrollert når man navigerer til den', () => {
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('vedtak') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.KONTROLLERT);
+        });
+
+        test('beholder tidligere besøkte sider som kontrollert ved videre navigering', () => {
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('tilkjent-ytelse') });
+            rerender();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('vedtak') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.KONTROLLERT);
+        });
+
+        test('markerer ingen side når gjeldende href ikke matcher noen side', () => {
+            const { result, rerender } = renderHookWithProvider();
+            useLocationMock.mockReturnValue({ pathname: lagPathname('finnes-ikke') });
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.IKKE_KONTROLLERT);
+        });
+    });
+
+    describe('Markering av sider som mangler kontroll', () => {
+        test('setter ikke-kontrollerte sider til mangler kontroll', () => {
+            const { result } = renderHookWithProvider();
+
+            act(() => result.current.settIkkeKontrollerteSiderTilManglerKontroll());
+
+            expect(statusForSide(result.current.kontrollsider, SideId.BEHANDLINGRESULTAT)).toBe(
+                KontrollertStatus.MANGLER_KONTROLL
+            );
+            expect(statusForSide(result.current.kontrollsider, SideId.VEDTAK)).toBe(KontrollertStatus.MANGLER_KONTROLL);
+        });
+
+        test('lar kontrollerte sider være uendret', () => {
+            const { result } = renderHookWithProvider();
+
+            act(() => result.current.settIkkeKontrollerteSiderTilManglerKontroll());
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('gjør ingenting når man ikke kan beslutte vedtak', () => {
+            useSaksbehandlerMock.mockReturnValue(lagSaksbehandler({ rolle: BehandlerRolle.SAKSBEHANDLER }));
+
+            const { result } = renderHookWithProvider();
+
+            act(() => result.current.settIkkeKontrollerteSiderTilManglerKontroll());
+
+            result.current.kontrollsider.forEach(side =>
+                expect(side.kontrollertStatus).toBe(KontrollertStatus.IKKE_KONTROLLERT)
+            );
+        });
+    });
+
+    describe('Synkronisering når sidelisten endres', () => {
+        test('legger til nye sider som ikke kontrollert', () => {
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, skalBehandlesAutomatisk: true })
+            );
+
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.SIMULERING)).toBeUndefined();
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, skalBehandlesAutomatisk: false })
+            );
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.SIMULERING)).toBe(
+                KontrollertStatus.IKKE_KONTROLLERT
+            );
+        });
+
+        test('fjerner sider som ikke lenger vises', () => {
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.map(side => side.id)).toContain(SideId.SIMULERING);
+            expect(result.current.kontrollsider).toHaveLength(5);
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, skalBehandlesAutomatisk: true })
+            );
+            rerender();
+
+            expect(result.current.kontrollsider.map(side => side.id)).not.toContain(SideId.SIMULERING);
+            expect(result.current.kontrollsider).toHaveLength(4);
+        });
+
+        test('bevarer kontrollert-status for sider som fortsatt vises', () => {
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    endretAv: 'saksbehandler@nav.no',
+                    skalBehandlesAutomatisk: true,
+                })
+            );
+
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, skalBehandlesAutomatisk: false })
+            );
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('bytter ut sider når årsak endrer hvilke som vises, ved samme antall', () => {
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.map(side => side.id)).toContain(SideId.REGISTRERE_SØKNAD);
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    årsak: BehandlingÅrsak.FØDSELSHENDELSE,
+                })
+            );
+            rerender();
+
+            const ider = result.current.kontrollsider.map(side => side.id);
+            expect(ider).not.toContain(SideId.REGISTRERE_SØKNAD);
+            expect(ider).toContain(SideId.FILTRERING_FØDSELSHENDELSER);
+            expect(statusForSide(result.current.kontrollsider, SideId.VILKÅRSVURDERING)).toBe(
+                KontrollertStatus.KONTROLLERT
+            );
+        });
+
+        test('markerer en nylig tillagt side som kontrollert dersom den er den åpne siden', () => {
+            useLocationMock.mockReturnValue({ pathname: lagPathname('simulering') });
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({ status: BehandlingStatus.FATTER_VEDTAK, skalBehandlesAutomatisk: true })
+            );
+
+            const { result, rerender } = renderHookWithProvider();
+
+            expect(result.current.kontrollsider.find(side => side.id === SideId.SIMULERING)).toBeUndefined();
+
+            useBehandlingMock.mockReturnValue(
+                lagBehandling({
+                    status: BehandlingStatus.FATTER_VEDTAK,
+                    endretAv: 'saksbehandler@nav.no',
+                    skalBehandlesAutomatisk: false,
+                })
+            );
+            rerender();
+
+            expect(statusForSide(result.current.kontrollsider, SideId.SIMULERING)).toBe(KontrollertStatus.KONTROLLERT);
+        });
+    });
+
+    describe('Bruk av context utenfor provider', () => {
+        test('kaster feil når context brukes utenfor en provider', () => {
+            const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            expect(() => renderHook(() => useKontrollsiderContext())).toThrow(
+                'useKontrollsiderContext må brukes innenfor en KontrollsiderProvider.'
+            );
+
+            consoleError.mockRestore();
+        });
+    });
+});

--- a/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/KontrollsiderContext.tsx
@@ -1,0 +1,89 @@
+import { createContext, type PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
+
+import { useBehandling } from '@hooks/useBehandling';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import {
+    finnSiderForBehandling,
+    type Kontrollside,
+    KontrollertStatus,
+    type SideId,
+} from '@sider/Fagsak/Behandling/Sider/sider';
+import { BehandlerRolle, BehandlingStatus } from '@typer/behandling';
+import { hentSideHref } from '@utils/miljø';
+import { useLocation } from 'react-router';
+
+interface KontrollsiderContext {
+    kontrollsider: Kontrollside[];
+    settIkkeKontrollerteSiderTilManglerKontroll: () => void;
+}
+
+const Context = createContext<KontrollsiderContext | undefined>(undefined);
+
+export function KontrollsiderProvider({ children }: PropsWithChildren) {
+    const location = useLocation();
+    const saksbehandler = useSaksbehandler();
+    const behandling = useBehandling();
+
+    const [kontrollerteStatuser, setKontrollerteStatuser] = useState<Partial<Record<SideId, KontrollertStatus>>>({});
+
+    // Forhindrer ny liste ved hver render, viktig pga. equality-check.
+    const sider = useMemo(() => finnSiderForBehandling(behandling), [behandling]);
+
+    const erPåFatterVedtak = behandling.status === BehandlingStatus.FATTER_VEDTAK;
+    const erBeslutter = saksbehandler.rolle === BehandlerRolle.BESLUTTER;
+    const erIkkeSaksbehandlerPåBehandlingen = saksbehandler.email !== behandling.endretAv; // TODO : Er dette egentlig korrekt?
+    const kanBeslutteVedtak = erPåFatterVedtak && erBeslutter && erIkkeSaksbehandlerPåBehandlingen;
+
+    const sideHref = hentSideHref(location.pathname);
+    const åpenSideId = sider.find(side => side.href === sideHref)?.id;
+
+    const besøkteSideErIkkeKontrollert =
+        åpenSideId !== undefined && kontrollerteStatuser[åpenSideId] !== KontrollertStatus.KONTROLLERT;
+
+    if (kanBeslutteVedtak && besøkteSideErIkkeKontrollert) {
+        setKontrollerteStatuser(prev => ({
+            ...prev,
+            [åpenSideId]: KontrollertStatus.KONTROLLERT,
+        }));
+    }
+
+    const kontrollsider = useMemo(
+        () =>
+            sider.map(side => ({
+                ...side,
+                kontrollertStatus: kontrollerteStatuser[side.id] ?? KontrollertStatus.IKKE_KONTROLLERT,
+            })),
+        [sider, kontrollerteStatuser]
+    );
+
+    const settIkkeKontrollerteSiderTilManglerKontroll = useCallback(() => {
+        if (!kanBeslutteVedtak) {
+            return;
+        }
+        setKontrollerteStatuser(forrige => {
+            const nyeStatuser = { ...forrige };
+            sider.forEach(side => {
+                const status = nyeStatuser[side.id] ?? KontrollertStatus.IKKE_KONTROLLERT;
+                if (status === KontrollertStatus.IKKE_KONTROLLERT) {
+                    nyeStatuser[side.id] = KontrollertStatus.MANGLER_KONTROLL;
+                }
+            });
+            return nyeStatuser;
+        });
+    }, [kanBeslutteVedtak, sider]);
+
+    const value = useMemo(
+        () => ({ kontrollsider, settIkkeKontrollerteSiderTilManglerKontroll }),
+        [kontrollsider, settIkkeKontrollerteSiderTilManglerKontroll]
+    );
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+}
+
+export function useKontrollsiderContext() {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useKontrollsiderContext må brukes innenfor en KontrollsiderProvider.');
+    }
+    return context;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/sider.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/sider.test.ts
@@ -1,18 +1,30 @@
 import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
-import { BehandlingÅrsak, BehandlingSteg, BehandlingStegStatus } from '@typer/behandling';
+import { BehandlingSteg, BehandlingStegStatus, BehandlingÅrsak } from '@typer/behandling';
 
 import {
-    SideId,
-    hentTrinnForBehandling,
-    sider,
     erViPåUdefinertFagsakSide,
     erViPåUlovligSteg,
     finnSideForBehandlingssteg,
+    finnSiderForBehandling,
+    SideId,
+    sider,
 } from './sider';
 
-describe('sider.ts', () => {
-    describe('siderForBehandling', () => {
-        test('REGISTRERE_MOTTAKER returneres når behandling.stegTilstand inneholder steget REGISTRERE_INSTITUSJON_OG_VERGE', () => {
+describe('Sider', () => {
+    describe('FinnSiderForBehandling', () => {
+        test('skal returnere forventede sider for en ordinær søknadsbehandling', () => {
+            const sideIder = finnSiderForBehandling(lagBehandling()).map(side => side.id);
+
+            expect(sideIder).toEqual([
+                SideId.REGISTRERE_SØKNAD,
+                SideId.VILKÅRSVURDERING,
+                SideId.BEHANDLINGRESULTAT,
+                SideId.SIMULERING,
+                SideId.VEDTAK,
+            ]);
+        });
+
+        test('skal vise info om institusjon når stegtilstanden inneholder REGISTRERE_INSTITUSJON', () => {
             const behandling = lagBehandling({
                 stegTilstand: [
                     {
@@ -21,34 +33,73 @@ describe('sider.ts', () => {
                     },
                 ],
             });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).toContain(SideId.REGISTRER_INSTITUSJON);
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).toContain(SideId.REGISTRER_INSTITUSJON);
         });
-        test('REGISTRERE_SØKNAD returneres ved årsak SØKNAD', () => {
+
+        test('skal ikke vise info om institusjon når stegtilstanden ikke inneholder REGISTRERE_INSTITUSJON', () => {
+            const behandling = lagBehandling({
+                stegTilstand: [
+                    {
+                        behandlingSteg: BehandlingSteg.REGISTRERE_SØKNAD,
+                        behandlingStegStatus: BehandlingStegStatus.IKKE_UTFØRT,
+                    },
+                ],
+            });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).not.toContain(SideId.REGISTRER_INSTITUSJON);
+        });
+
+        test('skal vise registrer søknad når årsaken er søknad', () => {
             const behandling = lagBehandling({ årsak: BehandlingÅrsak.SØKNAD });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).toContain(SideId.REGISTRERE_SØKNAD);
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).toContain(SideId.REGISTRERE_SØKNAD);
         });
-        test('FILTRERING_FØDSELSHENDELSER returneres ved årsak FØDSELSHENDELSE', () => {
+
+        test('skal ikke vise registrer søknad når årsaken ikke er søknad', () => {
             const behandling = lagBehandling({ årsak: BehandlingÅrsak.FØDSELSHENDELSE });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).toContain(SideId.FILTRERING_FØDSELSHENDELSER);
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).not.toContain(SideId.REGISTRERE_SØKNAD);
         });
-        test('SIMULERING returneres ikke ved automatisk behandling', () => {
-            const behandling = lagBehandling({ skalBehandlesAutomatisk: true });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).not.toContain(SideId.SIMULERING);
-        });
-        test('VEDTAK returneres ikke ved årsak SATSENDRING', () => {
-            const behandling = lagBehandling({ årsak: BehandlingÅrsak.SATSENDRING });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).not.toContain(SideId.VEDTAK);
-        });
-        test('Standard revurdering uten søknad viser alle sider bortsett fra FILTRERING_FØDSELSHENDELSER og REGISTRERE_SØKNAD', () => {
-            const behandling = lagBehandling({ årsak: BehandlingÅrsak.NYE_OPPLYSNINGER });
-            expect(Object.keys(hentTrinnForBehandling(behandling))).toEqual(
-                Object.values(SideId).filter(
-                    side =>
-                        side !== SideId.FILTRERING_FØDSELSHENDELSER &&
-                        side !== SideId.REGISTRERE_SØKNAD &&
-                        side !== SideId.REGISTRER_INSTITUSJON
-                )
+
+        test('skal vise filtreringsregler når årsaken er fødselshendelse', () => {
+            const behandling = lagBehandling({ årsak: BehandlingÅrsak.FØDSELSHENDELSE });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).toContain(
+                SideId.FILTRERING_FØDSELSHENDELSER
             );
+        });
+
+        test('skal ikke vise filtreringsregler når årsaken ikke er fødselshendelse', () => {
+            const behandling = lagBehandling({ årsak: BehandlingÅrsak.SØKNAD });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).not.toContain(
+                SideId.FILTRERING_FØDSELSHENDELSER
+            );
+        });
+
+        test('skal vise simulering når behandlingen ikke skal behandles automatisk', () => {
+            const behandling = lagBehandling({ skalBehandlesAutomatisk: false });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).toContain(SideId.SIMULERING);
+        });
+
+        test('skal ikke vise simulering når behandlingen skal behandles automatisk', () => {
+            const behandling = lagBehandling({ skalBehandlesAutomatisk: true });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).not.toContain(SideId.SIMULERING);
+        });
+
+        test('skal vise vedtak når årsaken ikke er satsendring', () => {
+            const behandling = lagBehandling({ årsak: BehandlingÅrsak.SØKNAD });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).toContain(SideId.VEDTAK);
+        });
+
+        test('skal ikke vise vedtak når årsaken er satsendring', () => {
+            const behandling = lagBehandling({ årsak: BehandlingÅrsak.SATSENDRING });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).not.toContain(SideId.VEDTAK);
         });
     });
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/sider.ts
@@ -21,8 +21,10 @@ export interface Underside {
     skjermesForBruker?: boolean;
 }
 
-export interface Trinn extends Side {
-    kontrollert: KontrollertStatus;
+export interface Kontrollside {
+    id: SideId;
+    navn: string;
+    kontrollertStatus: KontrollertStatus;
 }
 
 export enum KontrollertStatus {
@@ -141,21 +143,6 @@ export function erSidenAktiv(side: Side, behandling: IBehandling): boolean {
 
 export function finnSiderForBehandling(behandling: IBehandling) {
     return Object.values(sider).filter(side => side.visSide?.(behandling) ?? true);
-}
-
-export function hentTrinnForBehandling(behandling: IBehandling): { [sideId: string]: Side } {
-    const visSide = (side: Side) => {
-        if (side.visSide) {
-            return side.visSide(behandling);
-        } else {
-            return true;
-        }
-    };
-    return Object.entries(sider)
-        .filter(([_, side]) => visSide(side))
-        .reduce((acc, [sideId, side]) => {
-            return { ...acc, [sideId]: side };
-        }, {});
 }
 
 export function hentSideFraUrl(url: string) {

--- a/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/context/BehandlingContext.tsx
@@ -1,120 +1,45 @@
 import type { PropsWithChildren } from 'react';
-import { useState, createContext, useContext, useEffect } from 'react';
+import { createContext, useContext } from 'react';
 
 import { useFagsak } from '@hooks/useFagsak';
 import { useNavigerAutomatiskTilSideForBehandlingssteg } from '@hooks/useNavigerAutomatiskTilSideForBehandlingssteg';
-import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { useTrackTidsbrukPåSide } from '@hooks/useTrackTidsbrukPåSide';
 import type { IBehandling } from '@typer/behandling';
-import { BehandlerRolle, BehandlingStatus } from '@typer/behandling';
-import { hentSideHref } from '@utils/miljø';
-import { useLocation } from 'react-router';
 
 import { type Ressurs } from '@navikt/familie-typer';
 
 import { useHentOgSettBehandlingContext } from './HentOgSettBehandlingContext';
-import { type Trinn, type SideId } from '../Sider/sider';
-import { hentTrinnForBehandling, KontrollertStatus } from '../Sider/sider';
 
 interface Props extends PropsWithChildren {
     behandling: IBehandling;
 }
 
 interface BehandlingContextValue {
-    leggTilBesøktSide: (besøktSide: SideId) => void;
-    settIkkeKontrollerteSiderTilManglerKontroll: () => void;
-    trinnPåBehandling: { [sideId: string]: Trinn };
     behandling: IBehandling;
     settÅpenBehandling: (behandling: Ressurs<IBehandling>) => void;
 }
 
 const BehandlingContext = createContext<BehandlingContextValue | undefined>(undefined);
 
-export const BehandlingProvider = ({ behandling, children }: Props) => {
+export function BehandlingProvider({ behandling, children }: Props) {
+    const fagsak = useFagsak();
+
     const { settBehandlingRessurs } = useHentOgSettBehandlingContext();
 
     useNavigerAutomatiskTilSideForBehandlingssteg({ behandling });
-
-    const saksbehandler = useSaksbehandler();
-    const fagsak = useFagsak();
-    const location = useLocation();
-
-    const [trinnPåBehandling, settTrinnPåBehandling] = useState<{ [sideId: string]: Trinn }>({});
-
     useTrackTidsbrukPåSide(fagsak, behandling);
 
-    useEffect(() => {
-        const siderPåBehandling = hentTrinnForBehandling(behandling);
-
-        const sideHref = hentSideHref(location.pathname);
-        settTrinnPåBehandling(
-            Object.entries(siderPåBehandling).reduce((acc, [sideId, side]) => {
-                return {
-                    ...acc,
-                    [sideId]: {
-                        ...side,
-                        kontrollert:
-                            sideHref === side.href ? KontrollertStatus.KONTROLLERT : KontrollertStatus.IKKE_KONTROLLERT,
-                    },
-                };
-            }, {})
-        );
-    }, [behandling.behandlingId]);
-
-    const leggTilBesøktSide = (besøktSide: SideId) => {
-        if (kanBeslutteVedtak) {
-            settTrinnPåBehandling({
-                ...trinnPåBehandling,
-                [besøktSide]: {
-                    ...trinnPåBehandling[besøktSide],
-                    kontrollert: KontrollertStatus.KONTROLLERT,
-                },
-            });
-        }
-    };
-
-    const settIkkeKontrollerteSiderTilManglerKontroll = () => {
-        settTrinnPåBehandling(
-            Object.entries(trinnPåBehandling).reduce((acc, [sideId, trinn]) => {
-                if (trinn.kontrollert === KontrollertStatus.IKKE_KONTROLLERT) {
-                    return {
-                        ...acc,
-                        [sideId]: {
-                            ...trinn,
-                            kontrollert: KontrollertStatus.MANGLER_KONTROLL,
-                        },
-                    };
-                } else return acc;
-            }, trinnPåBehandling)
-        );
-    };
-
-    const kanBeslutteVedtak =
-        behandling.status === BehandlingStatus.FATTER_VEDTAK &&
-        BehandlerRolle.BESLUTTER === saksbehandler.rolle &&
-        saksbehandler.email !== behandling.endretAv;
-
     return (
-        <BehandlingContext.Provider
-            value={{
-                leggTilBesøktSide,
-                settIkkeKontrollerteSiderTilManglerKontroll,
-                trinnPåBehandling,
-                behandling: behandling,
-                settÅpenBehandling: settBehandlingRessurs,
-            }}
-        >
+        <BehandlingContext.Provider value={{ behandling, settÅpenBehandling: settBehandlingRessurs }}>
             {children}
         </BehandlingContext.Provider>
     );
-};
+}
 
-export const useBehandlingContext = () => {
+export function useBehandlingContext() {
     const context = useContext(BehandlingContext);
-
     if (context === undefined) {
-        throw new Error('useBehandlingContext må brukes innenfor en BehandlingProvider');
+        throw new Error('useBehandlingContext må brukes innenfor en BehandlingProvider.');
     }
-
     return context;
-};
+}


### PR DESCRIPTION
### 📮 Favro
NAV-29440

### 💰 Hva skal gjøres, og hvorfor?
Introduserer et eget context for “kontrollerte sider” som brukes i totrinnskontroll, og flytter ansvar for markering av kontrollerte/manglende kontroll fra `BehandlingContext` til ny `KontrollsiderContext`.

**Endringer:**
- Ny `KontrollsiderProvider` som utleder/lagrer kontrollstatus per side basert på behandling, brukerrolle og nåværende URL.
- Oppdatert totrinnskontroll-komponentene til å bruke `kontrollsider` i stedet for tidligere `trinnPåBehandling`.
- Ryddet `BehandlingContext` for tidligere trinn-/kontroll-logikk, og lagt til tester for kontrollside-context.


### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots
Ingen visuelle endringer. 