### PR TITLE
NAV-29767: Vis "SED er sendt til" på svartidsbrev

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/Brevskjema.tsx
@@ -378,34 +378,30 @@ const Brevskjema = ({ onSubmitSuccess, bruker }: IProps) => {
                                 className={styles.textField}
                             />
                         )}
-                    {skjema.felter.brevmal.verdi &&
-                        [
-                            Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS,
-                            Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER,
-                        ].includes(skjema.felter.brevmal.verdi) && (
-                            <>
-                                <RegionCombobox
-                                    label={'SED er sendt til'}
-                                    value={(skjema.felter.mottakerlandSed?.verdi ?? []) as Regionkode[]}
-                                    options={EØS_LAND_REGIONKODER}
-                                    onChange={value => {
-                                        if (value) {
-                                            skjema.felter.mottakerlandSed.validerOgSettFelt(value);
-                                        } else {
-                                            skjema.felter.mottakerlandSed.nullstill();
-                                        }
-                                    }}
-                                    readOnly={false}
-                                    error={
-                                        skjema.visFeilmeldinger &&
-                                        skjema.felter.mottakerlandSed.valideringsstatus === Valideringsstatus.FEIL
-                                            ? skjema.felter.mottakerlandSed?.feilmelding?.toString()
-                                            : ''
+                    {skjema.felter.mottakerlandSed.erSynlig && (
+                        <>
+                            <RegionCombobox
+                                label={'SED er sendt til'}
+                                value={(skjema.felter.mottakerlandSed?.verdi ?? []) as Regionkode[]}
+                                options={EØS_LAND_REGIONKODER}
+                                onChange={value => {
+                                    if (value) {
+                                        skjema.felter.mottakerlandSed.validerOgSettFelt(value);
+                                    } else {
+                                        skjema.felter.mottakerlandSed.nullstill();
                                     }
-                                    isMulti={true}
-                                />
-                            </>
-                        )}
+                                }}
+                                readOnly={false}
+                                error={
+                                    skjema.visFeilmeldinger &&
+                                    skjema.felter.mottakerlandSed.valideringsstatus === Valideringsstatus.FEIL
+                                        ? skjema.felter.mottakerlandSed?.feilmelding?.toString()
+                                        : ''
+                                }
+                                isMulti={true}
+                            />
+                        </>
+                    )}
                 </VStack>
             </Fieldset>
             <Knapperekke>

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
@@ -213,11 +213,16 @@ export const useBrevModul = () => {
 
     const mottakerlandSed = useFelt<string[]>({
         verdi: [],
-        valideringsfunksjon: (felt: FeltState<string[]>) => {
+        valideringsfunksjon: (felt: FeltState<string[]>, avhengigheter?: Avhengigheter) => {
+            // På svartidsbrev er det valgfritt å oppgi land SED er sendt til.
+            if (avhengigheter?.brevmal.verdi === Brevmal.SVARTIDSBREV) {
+                return ok(felt);
+            }
             return felt.verdi.length ? ok(felt) : feil(felt, 'Velg land SED er sendt/skal sendes til');
         },
         skalFeltetVises: (avhengigheter: Avhengigheter) => {
             return [
+                Brevmal.SVARTIDSBREV,
                 Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS,
                 Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER,
             ].includes(avhengigheter?.brevmal.verdi);

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Brev/useBrevModul.ts
@@ -221,8 +221,11 @@ export const useBrevModul = () => {
             return felt.verdi.length ? ok(felt) : feil(felt, 'Velg land SED er sendt/skal sendes til');
         },
         skalFeltetVises: (avhengigheter: Avhengigheter) => {
+            // På svartidsbrev vises feltet kun for EØS-behandlinger.
+            if (avhengigheter?.brevmal.verdi === Brevmal.SVARTIDSBREV) {
+                return behandlingKategori === BehandlingKategori.EØS;
+            }
             return [
-                Brevmal.SVARTIDSBREV,
                 Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS,
                 Brevmal.VARSEL_OM_ÅRLIG_REVURDERING_EØS_MED_INNHENTING_AV_OPPLYSNINGER,
             ].includes(avhengigheter?.brevmal.verdi);


### PR DESCRIPTION
### 📮 Favro:
Nav-29767 – Legge inn "SED er sendt til" i brevmeny på svartidsbrev til søknad EØS

### 💰 Hva skal gjøres, og hvorfor?
Saksbehandler skal kunne opplyse søker om at vi innhenter opplysninger fra annet EØS-land allerede i søknadsprosessen. Viser derfor "SED er sendt til" i brevmenyen også for svartidsbrev (tidligere kun varsel om årlig revurdering EØS).

- **`useBrevModul`:** legger `SVARTIDSBREV` til i `skalFeltetVises` for `mottakerlandSed`, og gjør valideringen valgfri for svartidsbrev (fortsatt påkrevd for varsel om årlig revurdering EØS).
- **`Brevskjema`:** rendrer `RegionCombobox` styrt av `mottakerlandSed.erSynlig` (én kilde til sannhet via `skalFeltetVises`), på linje med øvrige felter.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
- Feltet vises på alle svartidsbrev (også nasjonale) – utfylling er valgfri, etter avklaring.
- Selve teksten i brevet kommer fra en ny delmal i Sanity (se backend-PR). Feltet blir synlig i UI så snart dette deployes – koordiner med Sanity-publisering så saksbehandler ikke fyller ut et felt som (enda) ikke gir tekst.
- Backend-PR: navikt/familie-ba-sak#6351

Bilder:
<img width="347" height="394" alt="Screenshot 2026-06-28 at 17 57 55" src="https://github.com/user-attachments/assets/bdaabbd7-478e-4692-ac55-5c65623dfab2" />
<img width="764" height="279" alt="Screenshot 2026-06-28 at 17 58 01" src="https://github.com/user-attachments/assets/5a1d670d-7d2f-4960-b2c8-4d6fe280a063" />

Testet OK i preprod.
