### PR TITLE
Fjern logikk for KORREKSJON_VEDTAKSBREV

### DIFF
--- a/src/frontend/hooks/useErLesevisning.test.ts
+++ b/src/frontend/hooks/useErLesevisning.test.ts
@@ -8,7 +8,7 @@ import { useSaksbehandler } from './useSaksbehandler';
 import { lagBehandling } from '../testutils/testdata/behandlingTestdata';
 import { lagFagsak } from '../testutils/testdata/fagsakTestdata';
 import { lagSaksbehandler } from '../testutils/testdata/saksbehandlerTestdata';
-import { BehandlingStatus, BehandlingSteg, BehandlingÅrsak } from '../typer/behandling';
+import { BehandlingStatus, BehandlingSteg } from '../typer/behandling';
 import { harTilgangTilEnhet } from '../typer/enhet';
 import { FagsakStatus } from '../typer/fagsak';
 import { MIDLERTIDIG_BEHANDLENDE_ENHET_ID } from '../utils/behandling';
@@ -107,15 +107,6 @@ describe('useErLesevisning', () => {
     it('returnerer false når saksbehandler mangler enhetstilgang men er superbruker', () => {
         mockHarTilgangTilEnhet.mockReturnValue(false);
         mockUseSaksbehandler.mockReturnValue(lagSaksbehandler({ harSuperbrukertilgang: true }));
-
-        const { result } = renderHook(() => useErLesevisning());
-
-        expect(result.current).toBe(false);
-    });
-
-    it('returnerer false når saksbehandler mangler enhetstilgang men årsak er KORREKSJON_VEDTAKSBREV', () => {
-        mockHarTilgangTilEnhet.mockReturnValue(false);
-        mockUseBehandling.mockReturnValue(lagBehandling({ årsak: BehandlingÅrsak.KORREKSJON_VEDTAKSBREV }));
 
         const { result } = renderHook(() => useErLesevisning());
 

--- a/src/frontend/hooks/useErLesevisning.ts
+++ b/src/frontend/hooks/useErLesevisning.ts
@@ -7,7 +7,7 @@ import { useBehandling } from './useBehandling';
 import { useFagsak } from './useFagsak';
 import { useSaksbehandler } from './useSaksbehandler';
 
-const ÅRSAKER_ÅPEN_FOR_ALLE = new Set([BehandlingÅrsak.TEKNISK_ENDRING, BehandlingÅrsak.KORREKSJON_VEDTAKSBREV]);
+const ÅRSAKER_ÅPEN_FOR_ALLE = new Set([BehandlingÅrsak.TEKNISK_ENDRING]);
 
 interface Parameters {
     sjekkTilgangTilEnhet?: boolean;

--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilBarnPåBehandling/LeggTilBarnPåBehandling.tsx
@@ -7,7 +7,6 @@ import { ActionMenu } from '@navikt/ds-react';
 const relevanteBehandlingsårsaker = [
     BehandlingÅrsak.NYE_OPPLYSNINGER,
     BehandlingÅrsak.KLAGE,
-    BehandlingÅrsak.KORREKSJON_VEDTAKSBREV,
     BehandlingÅrsak.TEKNISK_ENDRING,
     BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
     Behandlingstype.MIGRERING_FRA_INFOTRYGD,

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg.tsx
@@ -46,8 +46,7 @@ const forrigeBehandlingVarTekniskEndringMedOpphør = (minimalFagsak?: IMinimalFa
 const hentTilgjengeligeBehandlingsårsaker = (
     erMigreringFraInfotrygd: boolean,
     kanOpprettMigreringsbehandlingMedHelmanuellMigrering: boolean,
-    kanOppretteMigreringsbehandlingMedEndreMigreringsdato: boolean,
-    kanManueltKorrigereMedVedtaksbrev: boolean
+    kanOppretteMigreringsbehandlingMedEndreMigreringsdato: boolean
 ): BehandlingÅrsak[] =>
     erMigreringFraInfotrygd
         ? Object.values(BehandlingÅrsak).filter(
@@ -67,7 +66,7 @@ const hentTilgjengeligeBehandlingsårsaker = (
                   årsak !== BehandlingÅrsak.OMREGNING_6ÅR &&
                   årsak !== BehandlingÅrsak.OMREGNING_18ÅR &&
                   årsak !== BehandlingÅrsak.OMREGNING_SMÅBARNSTILLEGG &&
-                  (årsak !== BehandlingÅrsak.KORREKSJON_VEDTAKSBREV || kanManueltKorrigereMedVedtaksbrev) &&
+                  årsak !== BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
                   årsak !== BehandlingÅrsak.ENDRE_MIGRERINGSDATO &&
                   årsak !== BehandlingÅrsak.HELMANUELL_MIGRERING &&
                   årsak !== BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING &&
@@ -113,7 +112,6 @@ const OpprettBehandlingValg = ({
         : minimalFagsak.behandlinger.filter(behandling => !erBehandlingHenlagt(behandling.resultat)).length > 0 &&
           kanOppretteBehandling;
     const kanOppretteTekniskEndring = kanOppretteBehandling && saksbehandler.harSuperbrukertilgang;
-    const kanManueltKorrigereMedVedtaksbrev = saksbehandler.harSuperbrukertilgang ?? false;
     const kanOppretteTilbakekreving = !manuellJournalfør;
     const kanOppretteMigreringFraInfotrygd = !manuellJournalfør && kanOppretteBehandling;
     const erMigreringFraInfotrygd =
@@ -221,8 +219,7 @@ const OpprettBehandlingValg = ({
                     {hentTilgjengeligeBehandlingsårsaker(
                         erMigreringFraInfotrygd,
                         kanOpprettMigreringsbehandlingMedHelmanuellMigrering,
-                        kanOppretteMigreringsbehandlingMedEndreMigreringsdato,
-                        kanManueltKorrigereMedVedtaksbrev
+                        kanOppretteMigreringsbehandlingMedEndreMigreringsdato
                     ).map(årsak => {
                         return (
                             <option key={årsak} aria-selected={behandlingsårsak.verdi === årsak} value={årsak}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtak.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/Vedtak.tsx
@@ -44,7 +44,6 @@ function kanSendeInnVedtak(vedtaksperioderMedBegrunnelser: IVedtaksperiodeMedBeg
     return (
         minstEnPeriodeharBegrunnelseEllerFritekst ||
         behandling.årsak === BehandlingÅrsak.TEKNISK_ENDRING ||
-        behandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
         behandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
         behandling.årsak === BehandlingÅrsak.IVERKSETTE_KA_VEDTAK ||
         behandling.årsak === BehandlingÅrsak.FALSK_IDENTITET ||

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -61,8 +61,6 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
             return 'Behandlingen er avsluttet. Du kan se vedtaksbrevet ved å trykke på "Vis vedtaksbrev".';
         } else if (årsak === BehandlingÅrsak.DØDSFALL_BRUKER) {
             return 'Vedtak om opphør på grunn av dødsfall er automatisk generert.';
-        } else if (årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV) {
-            return 'Behandling bruker manuelt skrevet vedtaksbrev. Forhåndsvis for å se brevet.';
         } else return '';
     };
 
@@ -140,7 +138,6 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
                     åpenBehandling={åpenBehandling}
                 />
                 {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
-                åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
                 åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (
                     <Box marginBlock={'space-32 space-16'}>
                         <InfoCard data-color="info">

--- a/src/frontend/typer/behandling.test.ts
+++ b/src/frontend/typer/behandling.test.ts
@@ -58,17 +58,6 @@ describe('behandling', () => {
             expect(result).toBe(true);
         });
 
-        test('returnerer true når årsak er KORREKSJON_VEDTAKSBREV', () => {
-            // Arrange
-            const behandling = lagBehandling({ årsak: BehandlingÅrsak.KORREKSJON_VEDTAKSBREV });
-
-            // Act
-            const result = kanLeggeTilUtvidetVilkår(behandling);
-
-            // Assert
-            expect(result).toBe(true);
-        });
-
         test('returnerer true når årsak er TEKNISK_ENDRING', () => {
             // Arrange
             const behandling = lagBehandling({ årsak: BehandlingÅrsak.TEKNISK_ENDRING });

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -457,7 +457,6 @@ export function sjekkErBehandleneEnhetMidlertidig(behandling: IBehandling) {
 export function kanLeggeTilUtvidetVilkår(behandling: IBehandling) {
     return (
         behandling.type === Behandlingstype.MIGRERING_FRA_INFOTRYGD ||
-        behandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
         behandling.årsak === BehandlingÅrsak.TEKNISK_ENDRING ||
         behandling.årsak === BehandlingÅrsak.KLAGE ||
         behandling.årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO ||


### PR DESCRIPTION
### 📮 Favro:
Nav-29782

### 💰 Hva skal gjøres, og hvorfor?
Funksjonen for å korrigere vedtak med egen brevmal (`KORREKSJON_VEDTAKSBREV`) er ikke i bruk lenger. Fjerner UI-logikk knyttet til den; speiler fjerningen på backend.

- Fjerner KORREKSJON_VEDTAKSBREV-håndtering i `useErLesevisning`, `OpprettBehandlingValg`, `LeggTilBarnPåBehandling`, `Vedtak` og `VedtaksbrevBygger`.
- Rydder `behandling`-typer og berørte tester.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
- Backend speiler fjerningen i egen PR.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Ingen ny visuell flate – kun fjerning av logikk for en funksjon som ikke lenger er i bruk.
