### PR TITLE
Vis varsel dersom bruker har ukjent adresse

### DIFF
--- a/src/frontend/hooks/useHentDistribusjonskanal.ts
+++ b/src/frontend/hooks/useHentDistribusjonskanal.ts
@@ -1,9 +1,9 @@
 import { hentDistribusjonskanal } from '@api/hentDistribusjonskanal';
 import { MetaKey } from '@hooks/meta/metaKey';
-import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import type { Distribusjonskanal } from '@typer/dokument';
 
-type Options = Omit<UseQueryOptions<Distribusjonskanal, DefaultError>, 'queryKey' | 'queryFn'>;
+type Options = Omit<UseQueryOptions<Distribusjonskanal>, 'queryKey' | 'queryFn' | 'enabled'>;
 
 export const HentDistribusjonskanalQueryKeyFactory = {
     distribusjonskanal: (personIdent: string | undefined) => ['hentDistribusjonskanal', personIdent],
@@ -19,6 +19,7 @@ export function useHentDistribusjonskanal(personIdent: string | undefined, optio
             return hentDistribusjonskanal(personIdent);
         },
         meta: { [MetaKey.VIS_SYSTEMET_LASTER]: true },
+        enabled: personIdent !== undefined,
         ...options,
     });
 }

--- a/src/frontend/hooks/useHentDistribusjonskanal.ts
+++ b/src/frontend/hooks/useHentDistribusjonskanal.ts
@@ -1,17 +1,24 @@
 import { hentDistribusjonskanal } from '@api/hentDistribusjonskanal';
+import { MetaKey } from '@hooks/meta/metaKey';
 import { type DefaultError, useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import type { Distribusjonskanal } from '@typer/dokument';
 
 type Options = Omit<UseQueryOptions<Distribusjonskanal, DefaultError>, 'queryKey' | 'queryFn'>;
 
 export const HentDistribusjonskanalQueryKeyFactory = {
-    distribusjonskanal: (personIdent: string) => ['hentDistribusjonskanal', personIdent],
+    distribusjonskanal: (personIdent: string | undefined) => ['hentDistribusjonskanal', personIdent],
 };
 
-export function useHentDistribusjonskanal(personIdent: string, options?: Options) {
+export function useHentDistribusjonskanal(personIdent: string | undefined, options?: Options) {
     return useQuery({
         queryKey: HentDistribusjonskanalQueryKeyFactory.distribusjonskanal(personIdent),
-        queryFn: () => hentDistribusjonskanal(personIdent),
+        queryFn: () => {
+            if (personIdent === undefined) {
+                throw new Error('Kan ikke hente distribusjonskanal uten personIdent.');
+            }
+            return hentDistribusjonskanal(personIdent);
+        },
+        meta: { [MetaKey.VIS_SYSTEMET_LASTER]: true },
         ...options,
     });
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UkjentAdresseAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UkjentAdresseAlert.tsx
@@ -1,0 +1,31 @@
+import { Distribusjonskanal } from '@typer/dokument';
+
+import { Box, LocalAlert } from '@navikt/ds-react';
+
+interface Props {
+    distribusjonskanal: Distribusjonskanal;
+}
+
+export function UkjentAdresseAlert({ distribusjonskanal }: Props) {
+    switch (distribusjonskanal) {
+        case Distribusjonskanal.INGEN_DISTRIBUSJON:
+        case Distribusjonskanal.UKJENT:
+            return (
+                <Box marginBlock={'space-16'}>
+                    <LocalAlert status="warning">
+                        <LocalAlert.Header>
+                            <LocalAlert.Title>
+                                Søker mottar ikke digitale brev og har ingen kjent adresse.
+                            </LocalAlert.Title>
+                        </LocalAlert.Header>
+                        <LocalAlert.Content>
+                            Legg til adresse i "Legg til brevmottaker". Hvis adresse ikke blir lagt til blir ikke brevet
+                            sendt.
+                        </LocalAlert.Content>
+                    </LocalAlert>
+                </Box>
+            );
+        default:
+            return null;
+    }
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UkjentAdresseAlert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/UkjentAdresseAlert.tsx
@@ -1,12 +1,24 @@
+import { useDistribusjonskanalContext } from '@sider/Fagsak/DistribusjonskanalProvider';
 import { Distribusjonskanal } from '@typer/dokument';
 
 import { Box, LocalAlert } from '@navikt/ds-react';
 
-interface Props {
-    distribusjonskanal: Distribusjonskanal;
-}
+export function UkjentAdresseAlert() {
+    const { distribusjonskanal, distribusjonskanalError } = useDistribusjonskanalContext();
 
-export function UkjentAdresseAlert({ distribusjonskanal }: Props) {
+    if (distribusjonskanalError) {
+        return (
+            <Box marginBlock={'space-16'}>
+                <LocalAlert status="warning">
+                    <LocalAlert.Header>
+                        <LocalAlert.Title>Klarte ikke laste inn distribusjonskanal.</LocalAlert.Title>
+                    </LocalAlert.Header>
+                    <LocalAlert.Content>{distribusjonskanalError.message}</LocalAlert.Content>
+                </LocalAlert>
+            </Box>
+        );
+    }
+
     switch (distribusjonskanal) {
         case Distribusjonskanal.INGEN_DISTRIBUSJON:
         case Distribusjonskanal.UKJENT:

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -1,6 +1,8 @@
 import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useHentDistribusjonskanal } from '@hooks/useHentDistribusjonskanal';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '@komponenter/Brevmottaker/BrevmottakereAlert';
+import { Mottaker } from '@komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
 import {
     BehandlerRolle,
     BehandlingResultat,
@@ -22,6 +24,7 @@ import { RefusjonEøsTabell } from './RefusjonEøs/RefusjonEøsTabell';
 import { useRefusjonEøsTabellContext } from './RefusjonEøs/RefusjonEøsTabellContext';
 import { SammensattKontrollsak } from './SammensattKontrollsak/SammensattKontrollsak';
 import { useSammensattKontrollsakContext } from './SammensattKontrollsak/SammensattKontrollsakContext';
+import { UkjentAdresseAlert } from './UkjentAdresseAlert';
 import { TilbakekrevingsvedtakMotregning } from './UlovfestetMotregning/TilbakekrevingsvedtakMotregning';
 import { Vedtaksperioder } from './Vedtaksperioder/Vedtaksperioder';
 import useDokument from '../../../../../hooks/useDokument';
@@ -46,6 +49,12 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
 
     const saksbehandler = useSaksbehandler();
     const erLesevisning = useErLesevisning();
+
+    const { data: distribusjonskanal } = useHentDistribusjonskanal(bruker.personIdent);
+
+    const brukerHarUtenlandskAdresse = åpenBehandling.brevmottakere.some(
+        mottaker => mottaker.type === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
+    );
 
     const automatiskBehandlingMedFortsattInnvilgetSomResultat =
         åpenBehandling.resultat === BehandlingResultat.FORTSATT_INNVILGET && åpenBehandling.skalBehandlesAutomatisk;
@@ -139,6 +148,9 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
                     brevmottakere={åpenBehandling?.brevmottakere ?? []}
                     åpenBehandling={åpenBehandling}
                 />
+                {distribusjonskanal && !brukerHarUtenlandskAdresse && (
+                    <UkjentAdresseAlert distribusjonskanal={distribusjonskanal} />
+                )}
                 {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
                 åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
                 åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -1,5 +1,4 @@
 import { useErLesevisning } from '@hooks/useErLesevisning';
-import { useHentDistribusjonskanal } from '@hooks/useHentDistribusjonskanal';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '@komponenter/Brevmottaker/BrevmottakereAlert';
 import { Mottaker } from '@komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
@@ -49,8 +48,6 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
 
     const saksbehandler = useSaksbehandler();
     const erLesevisning = useErLesevisning();
-
-    const { data: distribusjonskanal } = useHentDistribusjonskanal(bruker.personIdent);
 
     const brukerHarUtenlandskAdresse = åpenBehandling.brevmottakere.some(
         mottaker => mottaker.type === Mottaker.BRUKER_MED_UTENLANDSK_ADRESSE
@@ -148,9 +145,7 @@ export const VedtaksbrevBygger = ({ åpenBehandling, bruker }: Props) => {
                     brevmottakere={åpenBehandling?.brevmottakere ?? []}
                     åpenBehandling={åpenBehandling}
                 />
-                {distribusjonskanal && !brukerHarUtenlandskAdresse && (
-                    <UkjentAdresseAlert distribusjonskanal={distribusjonskanal} />
-                )}
+                {!brukerHarUtenlandskAdresse && <UkjentAdresseAlert />}
                 {åpenBehandling.årsak === BehandlingÅrsak.DØDSFALL_BRUKER ||
                 åpenBehandling.årsak === BehandlingÅrsak.KORREKSJON_VEDTAKSBREV ||
                 åpenBehandling.status === BehandlingStatus.AVSLUTTET ? (

--- a/src/frontend/sider/Fagsak/DistribusjonskanalProvider.tsx
+++ b/src/frontend/sider/Fagsak/DistribusjonskanalProvider.tsx
@@ -1,0 +1,26 @@
+import type { PropsWithChildren } from 'react';
+import { createContext, useContext } from 'react';
+
+import type { Distribusjonskanal } from '@typer/dokument';
+
+type DistribusjonskanalContext =
+    | { distribusjonskanal: Distribusjonskanal; distribusjonskanalError: undefined }
+    | { distribusjonskanal: undefined; distribusjonskanalError: Error };
+
+const Context = createContext<DistribusjonskanalContext | undefined>(undefined);
+
+interface Props extends PropsWithChildren {
+    context: DistribusjonskanalContext;
+}
+
+export function DistribusjonskanalProvider({ context, children }: Props) {
+    return <Context.Provider value={context}>{children}</Context.Provider>;
+}
+
+export function useDistribusjonskanalContext() {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useDistribusjonskanalContext må brukes innenfor en DistribusjonskanalProvider.');
+    }
+    return context;
+}

--- a/src/frontend/sider/Fagsak/Fagsak.tsx
+++ b/src/frontend/sider/Fagsak/Fagsak.tsx
@@ -1,4 +1,5 @@
 import { useFagsakIdParam } from '@hooks/useFagsakIdParam';
+import { useHentDistribusjonskanal } from '@hooks/useHentDistribusjonskanal';
 import { useHentFagsak } from '@hooks/useHentFagsak';
 import { useHentPerson } from '@hooks/useHentPerson';
 import { useScrollTilAnker } from '@hooks/useScrollTilAnker';
@@ -11,6 +12,7 @@ import { Outlet } from 'react-router';
 import { Box, GlobalAlert, HStack, Loader } from '@navikt/ds-react';
 
 import { BrukerProvider } from './BrukerContext';
+import { DistribusjonskanalProvider } from './DistribusjonskanalProvider';
 import Styles from './Fagsak.module.css';
 import { FagsakProvider } from './FagsakContext';
 import { ManuelleBrevmottakerePåFagsakProvider } from './ManuelleBrevmottakerePåFagsakContext';
@@ -23,6 +25,12 @@ export function Fagsak() {
     const ident = fagsak?.fagsakType === FagsakType.SKJERMET_BARN ? fagsak?.fagsakeier : fagsak?.søkerFødselsnummer;
 
     const { data: bruker, isPending: isPendingBruker, error: brukerError } = useHentPerson({ ident });
+
+    const {
+        data: distribusjonskanal,
+        isPending: isPendingDistribusjonskanal,
+        error: distribusjonskanalError,
+    } = useHentDistribusjonskanal(bruker?.personIdent);
 
     useScrollTilAnker();
     useSyncModiaContext(bruker);
@@ -75,14 +83,29 @@ export function Fagsak() {
         );
     }
 
+    if (isPendingDistribusjonskanal) {
+        return (
+            <HStack gap={'space-16'} margin={'space-16'}>
+                <Loader size={'small'} />
+                Laster distribusjonskanal...
+            </HStack>
+        );
+    }
+
+    const distribusjonskanalContext = distribusjonskanalError
+        ? { distribusjonskanal: undefined, distribusjonskanalError }
+        : { distribusjonskanal, distribusjonskanalError: undefined };
+
     return (
         <Box className={Styles.container}>
             <FagsakProvider fagsak={fagsak}>
                 <BrukerProvider bruker={bruker}>
-                    <ManuelleBrevmottakerePåFagsakProvider key={fagsak.id}>
-                        <Personlinje bruker={bruker} fagsak={fagsak} />
-                        <Outlet />
-                    </ManuelleBrevmottakerePåFagsakProvider>
+                    <DistribusjonskanalProvider context={distribusjonskanalContext}>
+                        <ManuelleBrevmottakerePåFagsakProvider key={fagsak.id}>
+                            <Personlinje bruker={bruker} fagsak={fagsak} />
+                            <Outlet />
+                        </ManuelleBrevmottakerePåFagsakProvider>
+                    </DistribusjonskanalProvider>
                 </BrukerProvider>
             </FagsakProvider>
         </Box>


### PR DESCRIPTION
### 📮 Favro: NAV-29378

### 💰 Hva skal gjøres, og hvorfor?
Viser et varsel i vedtaksbrev-steget dersom bruker ikke mottar digitale brev og heller ikke har en kjent adresse (distribusjonskanal er `INGEN_DISTRIBUSJON` eller `UKJENT`). Uten dette varselet risikerer saksbehandler å sende et vedtaksbrev som aldri når frem til bruker, uten at det oppdages før i etterkant.

Varselet vises ikke dersom bruker har utenlandsk adresse registrert som brevmottaker, siden det da håndteres av den vanlige brevmottaker-flyten.

**Implementasjon:**
- Henter `distribusjonskanal` for brukeren i `Fagsak.tsx`, samme sted og på samme måte som `bruker` hentes i dag (blokkerer innlasting av fagsaken, med egen loader og feilhåndtering).
- Eksponerer resultatet (data eller feil) via en ny `DistribusjonskanalProvider`/context, slik at alle behandlinger under samme fagsak kan lese distribusjonskanalen uten å hente den på nytt.
- Lagt til en `UkjentAdresseAlert`-komponent i `VedtaksbrevBygger` som viser varselet basert på konteksten over.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Distribusjonskanalen avhenger kun av `personIdent`, ikke av behandlingen, og hentes derfor på fagsak-nivå (samme sted som bruker) i stedet for i `VedtakContainer`. Si ifra hvis dere er uenig i at dette skal blokkere innlasting av hele fagsaken, eller i plasseringen av providern.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Endringen er i hovedsak visningslogikk og datahenting via eksisterende, testede mønstre (React Query + Context), uten ny forretningslogikk som isolert sett trenger dekning.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<img width="940" height="404" alt="7fa39e41599b489b27cc4535cdd9d033" src="https://github.com/user-attachments/assets/28d3d09f-7499-42e4-b9ae-1d0bc6d71887" />
<img width="940" height="404" alt="935fbf64b5d30f69dabcc7b44f009f81" src="https://github.com/user-attachments/assets/94260707-4e36-47ae-8688-219bb5a5df19" />

