### PR TITLE
Oppdater til riktig url for umami

### DIFF
--- a/src/frontend/hooks/useStartUmami.ts
+++ b/src/frontend/hooks/useStartUmami.ts
@@ -5,10 +5,12 @@ import { erProd } from '../utils/miljø';
 export const useStartUmami = () => {
     useEffect(() => {
         const websiteId = erProd() ? 'e0e5e641-6d90-46ef-823c-e11ef40472cc' : 'a95c215b-4c37-450f-8ec6-b1355d53a36b';
-        const hostUrl = erProd() ? 'https://umami.nav.no' : 'https://reops-event-proxy.ekstern.dev.nav.no';
+        const hostUrl = erProd() ? 'https://reops-event-proxy.nav.no' : 'https://reops-event-proxy.ekstern.dev.nav.no';
 
         const script = document.createElement('script');
-        script.src = 'https://cdn.nav.no/team-researchops/sporing/sporing.js';
+        script.src = erProd()
+            ? 'https://cdn.nav.no/team-researchops/sporing/sporing.js'
+            : 'https://cdn.nav.no/team-researchops/sporing/sporing-dev.js';
         script.defer = true;
         script.setAttribute('data-host-url', hostUrl);
         script.setAttribute('data-website-id', websiteId);


### PR DESCRIPTION
### 📮 Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-27327

### 💰 Hva skal gjøres, og hvorfor?
30. mars endret research-opps url man skal bruke for umami. https://nav-it.slack.com/archives/C02UGFS2J4B/p1775636405056739

Må derfor bytte slik at vi kan få inn data igjen

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
