### PR TITLE
NAV-29798: Rydd forhaandsvis brev

### DIFF
--- a/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.test.ts
+++ b/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.test.ts
@@ -1,0 +1,39 @@
+import { apiClient } from '@api/client/apiClient';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { hentEllerOpprettVedtaksbrevPdf } from './hentEllerOpprettVedtaksbrevPdf';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        request: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+const base64Pdf = 'JVBERi0xLjQK'; // base64-encodet "%PDF-1.4"
+
+describe('hentEllerOpprettVedtaksbrevPdf', () => {
+    test.each(['GET', 'POST'] as const)(
+        'kaller apiClient.request med httpMethod %s og riktig URL',
+        async httpMethod => {
+            vi.mocked(apiClient.request).mockResolvedValue(base64Pdf);
+
+            const result = await hentEllerOpprettVedtaksbrevPdf(httpMethod, { vedtakId: 123 });
+
+            expect(apiClient.request).toHaveBeenCalledWith({
+                method: httpMethod,
+                url: '/familie-ba-sak/api/dokument/vedtaksbrev/123',
+            });
+            expect(result).toBe(base64Pdf);
+        }
+    );
+
+    test('kaster feil ved avvist promise', async () => {
+        vi.mocked(apiClient.request).mockRejectedValue(new Error('Noe gikk galt'));
+
+        await expect(hentEllerOpprettVedtaksbrevPdf('POST', { vedtakId: 123 })).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.ts
+++ b/src/frontend/api/hentEllerOpprettVedtaksbrevPdf.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@api/client/apiClient';
+
+interface PathParams {
+    vedtakId: number;
+}
+
+export async function hentEllerOpprettVedtaksbrevPdf(httpMethod: 'GET' | 'POST', pathParams: PathParams) {
+    const { vedtakId } = pathParams;
+    return apiClient.request<void, string>({
+        method: httpMethod,
+        url: `/familie-ba-sak/api/dokument/vedtaksbrev/${vedtakId}`,
+    });
+}

--- a/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.test.ts
+++ b/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.test.ts
@@ -1,0 +1,126 @@
+import { hentEllerOpprettVedtaksbrevPdf } from '@api/hentEllerOpprettVedtaksbrevPdf';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestProviders } from '@testutils/testrender';
+import { opprettPdfBlob } from '@utils/blob';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useHentEllerOpprettVedtaksbrevPdf } from './useHentEllerOpprettVedtaksbrevPdf';
+
+vi.mock('@api/hentEllerOpprettVedtaksbrevPdf');
+vi.mock('@utils/blob');
+
+const bytes = 'JVBERi0xLjQK'; // base64-encodet "%PDF-1.4"
+const blob = new Blob([bytes], { type: 'application/pdf' });
+const objectUrl = 'blob:http://localhost/abc-123';
+
+beforeEach(() => {
+    // jsdom implementerer ikke createObjectURL, så den må stubbes
+    window.URL.createObjectURL = vi.fn().mockReturnValue(objectUrl);
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('useHentEllerOpprettVedtaksbrevPdf', () => {
+    test.each(['GET', 'POST'] as const)(
+        'kaller hentEllerOpprettVedtaksbrevPdf med httpMethod %s og riktig vedtakId',
+        async httpMethod => {
+            // Arrange
+            vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+            vi.mocked(opprettPdfBlob).mockReturnValue(blob);
+
+            const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+                wrapper: TestProviders,
+            });
+
+            // Act
+            result.current.mutate({ vedtakId: 123, httpMethod });
+
+            // Assert
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+            expect(hentEllerOpprettVedtaksbrevPdf).toHaveBeenCalledWith(httpMethod, { vedtakId: 123 });
+        }
+    );
+
+    test('oppretter en pdf-blob av bytene og returnerer en object-URL', async () => {
+        // Arrange
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+        vi.mocked(opprettPdfBlob).mockReturnValue(blob);
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({ vedtakId: 123, httpMethod: 'GET' });
+
+        // Assert
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(opprettPdfBlob).toHaveBeenCalledWith(bytes);
+        expect(window.URL.createObjectURL).toHaveBeenCalledWith(blob);
+        expect(result.current.data).toBe(objectUrl);
+    });
+
+    test('kaller onSuccess-callback med object-URL ved vellykket mutasjon', async () => {
+        // Arrange
+        const onSuccess = vi.fn();
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+        vi.mocked(opprettPdfBlob).mockReturnValue(blob);
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf({ onSuccess }), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({ vedtakId: 123, httpMethod: 'POST' });
+
+        // Assert
+        await waitFor(() =>
+            expect(onSuccess).toHaveBeenCalledWith(
+                objectUrl,
+                { vedtakId: 123, httpMethod: 'POST' },
+                undefined,
+                expect.any(Object)
+            )
+        );
+    });
+
+    test('Skal håndtere feil fra api-kallet', async () => {
+        // Arrange
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockRejectedValue(new Error('Noe gikk galt'));
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({ vedtakId: 123, httpMethod: 'GET' });
+
+        // Assert
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error?.message).toBe('Noe gikk galt');
+        expect(opprettPdfBlob).not.toHaveBeenCalled();
+        expect(window.URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    test('Skal håndtere feil ved oppretting av pdf-blob', async () => {
+        // Arrange
+        vi.mocked(hentEllerOpprettVedtaksbrevPdf).mockResolvedValue(bytes);
+        vi.mocked(opprettPdfBlob).mockImplementation(() => {
+            throw new Error('Ugyldig pdf');
+        });
+
+        const { result } = renderHook(() => useHentEllerOpprettVedtaksbrevPdf(), {
+            wrapper: TestProviders,
+        });
+
+        // Act
+        result.current.mutate({ vedtakId: 123, httpMethod: 'GET' });
+
+        // Assert
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error?.message).toBe('Ugyldig pdf');
+        expect(window.URL.createObjectURL).not.toHaveBeenCalled();
+    });
+});

--- a/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.ts
+++ b/src/frontend/hooks/useHentEllerOpprettVedtaksbrevPdf.ts
@@ -1,0 +1,22 @@
+import { hentEllerOpprettVedtaksbrevPdf } from '@api/hentEllerOpprettVedtaksbrevPdf';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import { opprettPdfBlob } from '@utils/blob';
+
+interface Parameters {
+    vedtakId: number;
+    httpMethod: 'GET' | 'POST';
+}
+
+type Options = Omit<UseMutationOptions<string, DefaultError, Parameters>, 'mutationFn'>;
+
+export function useHentEllerOpprettVedtaksbrevPdf(options?: Options) {
+    return useMutation({
+        mutationFn: async (parameters: Parameters) => {
+            const { httpMethod, vedtakId } = parameters;
+            const bytes = await hentEllerOpprettVedtaksbrevPdf(httpMethod, { vedtakId });
+            const blob = opprettPdfBlob(bytes);
+            return window.URL.createObjectURL(blob);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/ForhåndsvisVedtaksbrev.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/ForhåndsvisVedtaksbrev.module.css
@@ -1,0 +1,17 @@
+.modal {
+    width: 80%;
+    height: 80%;
+    overflow: hidden;
+
+    section {
+        height: 100%;
+        width: 90%;
+        margin: 0 auto;
+    }
+}
+
+.iframe {
+    margin: 0 auto;
+    height: 100%;
+    width: 100%;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/ForhåndsvisVedtaksbrev.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/ForhåndsvisVedtaksbrev.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+
+import { useBehandling } from '@hooks/useBehandling';
+import { useHentEllerOpprettVedtaksbrevPdf } from '@hooks/useHentEllerOpprettVedtaksbrevPdf';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { BehandlerRolle, BehandlingSteg, hentStegNummer } from '@typer/behandling';
+
+import { FileTextIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
+import { Button, ErrorMessage, Heading, HStack, Loader, Modal } from '@navikt/ds-react';
+
+import Styles from './ForhåndsvisVedtaksbrev.module.css';
+
+export function ForhåndsvisVedtaksbrev() {
+    const behandling = useBehandling();
+    const saksbehandler = useSaksbehandler();
+
+    const [visModal, settVisModal] = useState(false);
+
+    const {
+        data: vedtaksbrevPdf,
+        mutate: hentEllerOpprettVedtaksbrevPdf,
+        isPending: hentEllerOpprettVedtaksbrevPdfIsPending,
+        error: hentEllerOpprettVedtaksbrevPdfError,
+    } = useHentEllerOpprettVedtaksbrevPdf();
+
+    function onVisVedtaksbrevClicked() {
+        const vedtakId = behandling.vedtak?.id;
+
+        if (!vedtakId) {
+            throw Error(`Fant ikke forventet vedtak for behandling ${behandling.behandlingId}`);
+        }
+
+        const erFørBeslutteVedtak = hentStegNummer(behandling.steg) < hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
+        const erPåBeslutteVedtak = hentStegNummer(behandling.steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
+
+        const erMinstSaksbehandler = saksbehandler.rolle >= BehandlerRolle.SAKSBEHANDLER;
+        const erBeslutter = saksbehandler.rolle === BehandlerRolle.BESLUTTER;
+
+        const skalGenerereBrevUnderBehandling = erMinstSaksbehandler && erFørBeslutteVedtak;
+        const skalGenerereBrevUnderBeslutning = erBeslutter && erPåBeslutteVedtak;
+
+        const httpMethod = skalGenerereBrevUnderBehandling || skalGenerereBrevUnderBeslutning ? 'POST' : 'GET';
+
+        hentEllerOpprettVedtaksbrevPdf({ httpMethod, vedtakId });
+
+        settVisModal(true);
+    }
+
+    return (
+        <>
+            <Button
+                variant={'secondary'}
+                size={'medium'}
+                onClick={onVisVedtaksbrevClicked}
+                loading={hentEllerOpprettVedtaksbrevPdfIsPending}
+                icon={<FileTextIcon aria-hidden={true} />}
+            >
+                Vis vedtaksbrev
+            </Button>
+            <Modal
+                className={Styles.modal}
+                open={visModal}
+                onClose={() => settVisModal(false)}
+                header={{ heading: 'Forhåndsvis vedtaksbrev', closeButton: true }}
+                width={'100rem'}
+                portal={true}
+            >
+                {hentEllerOpprettVedtaksbrevPdfIsPending && (
+                    <HStack height={'100%'} justify={'center'} align={'center'} gap={'space-8'}>
+                        <Loader size={'small'} title={'Laster vedtaksbrev...'} />
+                        <Heading size={'small'} level={'2'}>
+                            Laster vedtaksbrev...
+                        </Heading>
+                    </HStack>
+                )}
+                {hentEllerOpprettVedtaksbrevPdfError && (
+                    <HStack height={'100%'} justify={'center'} align={'center'} gap={'space-8'}>
+                        <XMarkOctagonFillIcon color={'var(--ax-text-danger-subtle)'} fontSize={'1.2rem'} />
+                        <ErrorMessage>{hentEllerOpprettVedtaksbrevPdfError.message}</ErrorMessage>
+                    </HStack>
+                )}
+                {!hentEllerOpprettVedtaksbrevPdfIsPending && !hentEllerOpprettVedtaksbrevPdfError && (
+                    <iframe className={Styles.iframe} title={'Vedtaksbrev'} src={vedtaksbrevPdf} />
+                )}
+            </Modal>
+        </>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Vedtak/VedtaksbrevBygger.tsx
@@ -4,6 +4,7 @@ import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { BrevmottakereAlert } from '@komponenter/Brevmottaker/BrevmottakereAlert';
 import { Mottaker } from '@komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/useBrevmottakerSkjema';
+import { ForhåndsvisVedtaksbrev } from '@sider/Fagsak/Behandling/Sider/Vedtak/ForhåndsvisVedtaksbrev';
 import {
     BehandlerRolle,
     BehandlingResultat,
@@ -13,9 +14,8 @@ import {
     hentStegNummer,
 } from '@typer/behandling';
 
-import { FileTextIcon, InformationSquareIcon } from '@navikt/aksel-icons';
-import { Box, Button, InfoCard } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { Box, InfoCard } from '@navikt/ds-react';
 
 import { FeilutbetaltValutaTabell } from './FeilutbetaltValuta/FeilutbetaltValutaTabell';
 import { useFeilutbetaltValutaTabellContext } from './FeilutbetaltValuta/FeilutbetaltValutaTabellContext';
@@ -63,24 +63,6 @@ export function VedtaksbrevBygger() {
         } else if (årsak === BehandlingÅrsak.DØDSFALL_BRUKER) {
             return 'Vedtak om opphør på grunn av dødsfall er automatisk generert.';
         } else return '';
-    };
-
-    const hentVedtaksbrev = () => {
-        const vedtak = behandling.vedtak;
-        const genererBrevUnderBehandling =
-            saksbehandler.rolle > BehandlerRolle.VEILEDER &&
-            hentStegNummer(behandling.steg) < hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
-
-        const genererBrevUnderBeslutning =
-            saksbehandler.rolle === BehandlerRolle.BESLUTTER &&
-            hentStegNummer(behandling.steg) === hentStegNummer(BehandlingSteg.BESLUTTE_VEDTAK);
-
-        const httpMethod = genererBrevUnderBehandling || genererBrevUnderBeslutning ? 'POST' : 'GET';
-
-        hentForhåndsvisning({
-            method: httpMethod,
-            url: `/familie-ba-sak/api/dokument/vedtaksbrev/${vedtak?.id}`,
-        });
     };
 
     const hentBrevForTilbakekrevingsvedtakMotregning = () => {
@@ -164,21 +146,7 @@ export function VedtaksbrevBygger() {
                         )}
                     </>
                 )}
-                {!automatiskBehandlingMedFortsattInnvilgetSomResultat && (
-                    <Button
-                        id={'forhandsvis-vedtaksbrev'}
-                        variant={'secondary'}
-                        size={'medium'}
-                        onClick={() => {
-                            settVisDokumentModal(true);
-                            hentVedtaksbrev();
-                        }}
-                        loading={hentetDokument.status === RessursStatus.HENTER}
-                        icon={<FileTextIcon aria-hidden />}
-                    >
-                        Vis vedtaksbrev
-                    </Button>
-                )}
+                {!automatiskBehandlingMedFortsattInnvilgetSomResultat && <ForhåndsvisVedtaksbrev />}
                 {behandling.tilbakekrevingsvedtakMotregning !== null && (
                     <TilbakekrevingsvedtakMotregning
                         tilbakekrevingsvedtakMotregning={behandling.tilbakekrevingsvedtakMotregning}


### PR DESCRIPTION
### 📮 Favro
NAV-29798

### 💰 Hva skal gjøres, og hvorfor?
Refaktorer visning av vedtaksbrev til å bruke react-query.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.

### 👀 Screen shots

Laster vedtaksbrev:

<img width="1296" height="585" alt="image" src="https://github.com/user-attachments/assets/924fbb32-3ce1-4cc1-8c31-aea60a9e4fa3" />

Feil ved innlasting av vedtaksbrev:

<img width="1296" height="585" alt="image" src="https://github.com/user-attachments/assets/da3347d5-ed38-456e-93ca-0b6e73c9d527" />

Innlasted vedtaksbrev:

<img width="1296" height="585" alt="image" src="https://github.com/user-attachments/assets/3a94e97b-7cdd-4a5a-8abd-ae564a3acfe7" />

