### PR TITLE
NAV-26302:  Refaktorer bort styled-components til module.css og Aksel primitives

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { HentVedtaksperioderQueryKeyFactory } from '@hooks/useHentVedtaksperioder';
 import { useKontrollsiderContext } from '@sider/Fagsak/Behandling/KontrollsiderContext';
@@ -8,8 +8,8 @@ import { BehandlingStatus } from '@typer/behandling';
 import type { ITotrinnskontrollData } from '@typer/totrinnskontroll';
 import { TotrinnskontrollBeslutning } from '@typer/totrinnskontroll';
 import type { AxiosError } from 'axios';
-import styled from 'styled-components';
 
+import { Box } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import type { Ressurs } from '@navikt/familie-typer';
 import {
@@ -25,11 +25,6 @@ import { Totrinnskontrollskjema } from './Totrinnskontrollskjema';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 import { KontrollertStatus } from '../../Sider/sider';
 import { Tab, useTabContext } from '../TabContextProvider';
-
-const Container = styled.div`
-    padding: 0.5rem 1.5rem;
-    display: flex;
-`;
 
 export function Totrinnskontroll() {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
@@ -108,9 +103,9 @@ export function Totrinnskontroll() {
     return (
         <>
             {behandling.status === BehandlingStatus.FATTER_VEDTAK && (
-                <Container className="totrinnskontroll">
+                <Box paddingInline={'space-24'} paddingBlock={'space-8'}>
                     <Totrinnskontrollskjema sendInnVedtak={sendInnVedtak} innsendtVedtak={innsendtVedtak} />
-                </Container>
+                </Box>
             )}
         </>
     );

--- a/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Høyremeny/Totrinnskontroll/Totrinnskontrollskjema.tsx
@@ -7,7 +7,6 @@ import type { IBehandling } from '@typer/behandling';
 import { TotrinnskontrollBeslutning } from '@typer/totrinnskontroll';
 import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
 import { hentFrontendFeilmelding } from '@utils/ressursUtils';
-import styled from 'styled-components';
 
 import {
     BodyShort,
@@ -15,6 +14,7 @@ import {
     Detail,
     Fieldset,
     Heading,
+    HStack,
     Label,
     Radio,
     RadioGroup,
@@ -162,23 +162,15 @@ export function Totrinnskontrollskjema({ innsendtVedtak, sendInnVedtak }: Props)
     );
 }
 
-const Trinn = styled.div`
-    display: flex;
-
-    svg {
-        margin-right: 1rem;
-    }
-`;
-
 const TrinnStatus = ({ kontrollertStatus, navn }: { kontrollertStatus: KontrollertStatus; navn: string }) => {
     return (
-        <Trinn>
+        <HStack gap={'space-16'}>
             {kontrollertStatus === KontrollertStatus.IKKE_KONTROLLERT && <ØyeGrå height={24} width={24} />}
 
             {kontrollertStatus === KontrollertStatus.KONTROLLERT && <ØyeGrønn height={24} width={24} />}
 
             {kontrollertStatus === KontrollertStatus.MANGLER_KONTROLL && <ØyeRød height={24} width={24} />}
             <BodyShort>{navn}</BodyShort>
-        </Trinn>
+        </HStack>
     );
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringPanel.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringPanel.tsx
@@ -1,29 +1,9 @@
+import type { ISimuleringDTO, ISimuleringPeriode } from '@typer/simulering';
+import { Datoformat, isoStringTilDate, isoStringTilFormatertString } from '@utils/dato';
+import { formaterBeløp } from '@utils/formatter';
 import { isBefore } from 'date-fns';
-import styled from 'styled-components';
 
 import { BodyShort, Box, HStack, Spacer, VStack } from '@navikt/ds-react';
-import {
-    BorderNeutral,
-    FontWeightBold,
-    Space16,
-    TextDangerSubtle,
-    TextNeutral,
-    TextSuccessSubtle,
-} from '@navikt/ds-tokens/dist/tokens';
-
-import type { ISimuleringDTO, ISimuleringPeriode } from '../../../../../typer/simulering';
-import { Datoformat, isoStringTilDate, isoStringTilFormatertString } from '../../../../../utils/dato';
-import { formaterBeløp } from '../../../../../utils/formatter';
-
-const BoldTekstMedFarge = styled(BodyShort)<{ $farge?: string }>`
-    color: ${props => (props.$farge ? props.$farge : TextNeutral)};
-    font-weight: ${FontWeightBold};
-`;
-
-const HStackMedBorderTop = styled(HStack)`
-    border-top: 1px solid ${BorderNeutral};
-    padding-top: ${Space16};
-`;
 
 interface ISimuleringProps {
     simulering: ISimuleringDTO;
@@ -82,21 +62,27 @@ const SimuleringPanel = ({
                 <HStack>
                     <BodyShort>Feilutbetaling</BodyShort>
                     <Spacer />
-                    <BoldTekstMedFarge $farge={feilutbetaling > 0 ? TextDangerSubtle : TextNeutral}>
+                    <BodyShort
+                        weight={'semibold'}
+                        textColor={feilutbetaling > 0 ? 'subtle' : 'default'}
+                        data-color={feilutbetaling > 0 ? 'danger' : 'neutral'}
+                    >
                         {formaterBeløpEllerDashOmUndefined(feilutbetaling)}
-                    </BoldTekstMedFarge>
+                    </BodyShort>
                 </HStack>
 
                 <HStack>
                     <BodyShort>Etterbetaling</BodyShort>
                     <Spacer />
-                    <BoldTekstMedFarge>{formaterBeløpEllerDashOmUndefined(etterbetaling)}</BoldTekstMedFarge>
+                    <BodyShort weight={'semibold'}>{formaterBeløpEllerDashOmUndefined(etterbetaling)}</BodyShort>
                 </HStack>
-                <HStackMedBorderTop>
-                    <BodyShort weight="semibold">Neste utbetaling</BodyShort>
-                    <Spacer />
-                    {!nestePeriode && <BodyShort weight="semibold">-</BodyShort>}
-                </HStackMedBorderTop>
+                <Box borderColor={'neutral'} borderWidth="1 0 0 0">
+                    <HStack paddingBlock={'space-16 space-0'}>
+                        <BodyShort weight="semibold">Neste utbetaling</BodyShort>
+                        <Spacer />
+                        {!nestePeriode && <BodyShort weight="semibold">-</BodyShort>}
+                    </HStack>
+                </Box>
                 {nestePeriode && (
                     <HStack>
                         <BodyShort>
@@ -108,13 +94,13 @@ const SimuleringPanel = ({
                             )}
                         </BodyShort>
                         <Spacer />
-                        <BoldTekstMedFarge
-                            $farge={
-                                nestePeriode?.resultat && nestePeriode.resultat > 0 ? TextSuccessSubtle : TextNeutral
-                            }
+                        <BodyShort
+                            weight={'semibold'}
+                            textColor={nestePeriode?.resultat && nestePeriode.resultat > 0 ? 'subtle' : 'default'}
+                            data-color={nestePeriode?.resultat && nestePeriode.resultat > 0 ? 'success' : 'neutral'}
                         >
                             {formaterBeløpEllerDashOmUndefined(nestePeriode?.resultat)}
-                        </BoldTekstMedFarge>
+                        </BodyShort>
                     </HStack>
                 )}
             </VStack>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.module.css
@@ -1,0 +1,35 @@
+.switch {
+    width: fit-content;
+}
+
+.table {
+    width: unset;
+
+    tbody {
+        th {
+            width: 10rem;
+        }
+    }
+}
+
+.nestePeriode {
+    border-left: 1px dashed;
+}
+
+.dataCell {
+    width: var(--ax-space-72);
+    color: var(--ax-text-neutral);
+}
+
+.negativ {
+    color: var(--ax-text-danger-subtle);
+}
+
+.nesteUtbetaling {
+    color: var(--ax-text-success-subtle);
+    font-weight: var(--ax-font-weight-bold);
+}
+
+.manuellPosteringRad {
+    background-color: var(--ax-bg-neutral-soft);
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/SimuleringTabell.tsx
@@ -1,68 +1,21 @@
 import { useState } from 'react';
 
-import { isAfter } from 'date-fns';
-import styled from 'styled-components';
-
-import { Box, Heading, LocalAlert, Switch, Table } from '@navikt/ds-react';
-import {
-    BgNeutralSoft,
-    FontWeightBold,
-    FontWeightRegular,
-    TextDangerSubtle,
-    TextNeutral,
-    TextSuccessSubtle,
-} from '@navikt/ds-tokens/dist/tokens';
-
-import { formaterBeløpUtenValutakode, kapitaliserTekst } from './simuleringUtil';
-import { Årsvelger } from './Årsvelger';
-import type { ISimuleringDTO, ISimuleringPeriode } from '../../../../../typer/simulering';
+import type { ISimuleringDTO, ISimuleringPeriode } from '@typer/simulering';
 import {
     Datoformat,
     isoDatoPeriodeTilFormatertString,
     isoStringTilDate,
     isoStringTilFormatertString,
-} from '../../../../../utils/dato';
-import { hentPeriodelisteMedTommePerioder, hentÅrISimuleringen } from '../../../../../utils/simulering';
+} from '@utils/dato';
+import { hentPeriodelisteMedTommePerioder, hentÅrISimuleringen } from '@utils/simulering';
+import classNames from 'classnames';
+import { isAfter } from 'date-fns';
 
-const IkkeFullBreddeTabell = styled(Table)`
-    width: unset;
-`;
+import { Box, Heading, LocalAlert, Switch, Table } from '@navikt/ds-react';
 
-const ManuellPosteringRad = styled(Table.Row)`
-    background-color: ${BgNeutralSoft};
-`;
-
-const HeaderCelle = styled(Table.HeaderCell)<{ $skalViseStipletLinje: boolean }>`
-    border-left: ${props => props.$skalViseStipletLinje && '1px dashed'};
-`;
-
-const DataCelle = styled(Table.DataCell)<{ $skalViseStipletLinje: boolean }>`
-    width: var(--ax-space-72);
-    border-left: ${props => props.$skalViseStipletLinje && '1px dashed'};
-`;
-
-const DataCellMedFarge = styled(DataCelle)<{
-    $erNegativtBeløp: boolean;
-    $erNesteUtbetalingsperiode: boolean;
-    $skalViseStipletLinje: boolean; // Sendes videre til DataCelle
-}>`
-    color: ${props => {
-        if (props.$erNegativtBeløp) return TextDangerSubtle;
-        else if (props.$erNesteUtbetalingsperiode) {
-            return TextSuccessSubtle;
-        }
-        return TextNeutral;
-    }};
-    font-weight: ${props => (props.$erNesteUtbetalingsperiode ? FontWeightBold : FontWeightRegular)};
-`;
-
-const StyledSwitch = styled(Switch)`
-    width: fit-content;
-`;
-
-const FørsteKolonne = styled(Table.HeaderCell)`
-    width: 10rem;
-`;
+import styles from './SimuleringTabell.module.css';
+import { formaterBeløpUtenValutakode, kapitaliserTekst } from './simuleringUtil';
+import { Årsvelger } from './Årsvelger';
 
 interface ISimuleringProps {
     simulering: ISimuleringDTO;
@@ -139,17 +92,18 @@ const SimuleringTabell = ({ simulering }: ISimuleringProps) => {
                       })}`
                     : `perioden ${tilOgFraDatoForSimulering}`}
             </Heading>
-
             {finnesManuellePosteringer && (
-                <StyledSwitch
+                <Switch
+                    className={styles.switch}
                     checked={visManuellePosteringer}
                     onChange={() => setVisManuellePosteringer(!visManuellePosteringer)}
                     size="small"
                 >
                     Vis manuelle posteringer
-                </StyledSwitch>
+                </Switch>
             )}
-            <IkkeFullBreddeTabell
+            <Table
+                className={styles.table}
                 aria-label={`Simuleringsresultat for ${
                     erMerEnn12MånederISimulering ? aktueltÅr : `perioden ${tilOgFraDatoForSimulering}`
                 }`}
@@ -168,10 +122,10 @@ const SimuleringTabell = ({ simulering }: ISimuleringProps) => {
                             )}
                         </Table.DataCell>
                         {perioderSomSkalVisesITabellen.map(periode => (
-                            <HeaderCelle
+                            <Table.HeaderCell
                                 key={'måned - ' + periode.fom}
                                 align={'right'}
-                                $skalViseStipletLinje={erNesteUtbetalingsperiode(periode)}
+                                className={classNames({ [styles.nestePeriode]: erNesteUtbetalingsperiode(periode) })}
                             >
                                 {kapitaliserTekst(
                                     isoStringTilFormatertString({
@@ -179,68 +133,76 @@ const SimuleringTabell = ({ simulering }: ISimuleringProps) => {
                                         tilFormat: Datoformat.MÅNED_NAVN,
                                     })
                                 )}
-                            </HeaderCelle>
+                            </Table.HeaderCell>
                         ))}
                     </Table.Row>
                 </Table.Header>
 
                 <Table.Body>
                     <Table.Row>
-                        <FørsteKolonne>Nytt beløp</FørsteKolonne>
+                        <Table.HeaderCell>Nytt beløp</Table.HeaderCell>
                         {perioderSomSkalVisesITabellen.map(periode => (
-                            <DataCelle
+                            <Table.DataCell
+                                className={classNames(styles.dataCell, {
+                                    [styles.nestePeriode]: erNesteUtbetalingsperiode(periode),
+                                })}
                                 key={'nytt beløp - ' + periode.fom}
                                 align={'right'}
-                                $skalViseStipletLinje={erNesteUtbetalingsperiode(periode)}
                             >
                                 {formaterBeløpUtenValutakode(periode.nyttBeløp)}
-                            </DataCelle>
+                            </Table.DataCell>
                         ))}
                     </Table.Row>
                     <Table.Row>
-                        <FørsteKolonne>Tidligere utbetalt</FørsteKolonne>
+                        <Table.HeaderCell>Tidligere utbetalt</Table.HeaderCell>
                         {perioderSomSkalVisesITabellen.map(periode => {
                             return (
-                                <DataCelle
+                                <Table.DataCell
+                                    className={classNames(styles.dataCell, {
+                                        [styles.nestePeriode]: erNesteUtbetalingsperiode(periode),
+                                    })}
                                     key={'tidligere utbetalt - ' + periode.fom}
                                     align={'right'}
-                                    $skalViseStipletLinje={erNesteUtbetalingsperiode(periode)}
                                 >
                                     {formaterBeløpUtenValutakode(periode.tidligereUtbetalt)}
-                                </DataCelle>
+                                </Table.DataCell>
                             );
                         })}
                     </Table.Row>
                     <Table.Row>
-                        <FørsteKolonne>Resultat</FørsteKolonne>
+                        <Table.HeaderCell>Resultat</Table.HeaderCell>
                         {perioderSomSkalVisesITabellen.map(periode => (
-                            <DataCellMedFarge
+                            <Table.DataCell
+                                className={classNames(styles.dataCell, {
+                                    [styles.nestePeriode]: erNesteUtbetalingsperiode(periode),
+                                    [styles.nesteUtbetaling]: erNesteUtbetalingsperiode(periode),
+                                    [styles.negativ]: !!periode.resultat && periode.resultat < 0,
+                                })}
                                 key={'resultat - ' + periode.fom}
                                 align={'right'}
-                                $erNegativtBeløp={!!periode.resultat && periode.resultat < 0}
-                                $erNesteUtbetalingsperiode={erNesteUtbetalingsperiode(periode)}
-                                $skalViseStipletLinje={erNesteUtbetalingsperiode(periode)}
                             >
                                 {formaterBeløpUtenValutakode(periode.resultat)}
-                            </DataCellMedFarge>
+                            </Table.DataCell>
                         ))}
                     </Table.Row>
                     {visManuellePosteringer && (
-                        <ManuellPosteringRad>
-                            <FørsteKolonne>Manuell postering</FørsteKolonne>
+                        <Table.Row className={styles.manuellPosteringRad}>
+                            <Table.HeaderCell>Manuell postering</Table.HeaderCell>
                             {perioderSomSkalVisesITabellen.map(periode => (
-                                <DataCelle
+                                <Table.DataCell
+                                    className={classNames(styles.dataCell, {
+                                        [styles.nestePeriode]: erNesteUtbetalingsperiode(periode),
+                                    })}
                                     key={'manuell postering - ' + periode.fom}
                                     align={'right'}
-                                    $skalViseStipletLinje={erNesteUtbetalingsperiode(periode)}
                                 >
                                     {formaterBeløpUtenValutakode(periode.manuellPostering)}
-                                </DataCelle>
+                                </Table.DataCell>
                             ))}
-                        </ManuellPosteringRad>
+                        </Table.Row>
                     )}
                 </Table.Body>
-            </IkkeFullBreddeTabell>
+            </Table>
         </>
     );
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/UlovfestetMotregning/SettBehandlingPåVentModalMotregning.tsx
@@ -1,29 +1,16 @@
 import { useState } from 'react';
 
+import { type IBehandling, type ISettPåVent, SettPåVentÅrsak, settPåVentÅrsaker } from '@typer/behandling';
+import { dagensDato, dateTilIsoDatoString } from '@utils/dato';
+import { hentFrontendFeilmelding } from '@utils/ressursUtils';
 import { addDays } from 'date-fns';
-import styled from 'styled-components';
 
-import { BodyShort, Button, DatePicker, Fieldset, Modal, Select, useDatepicker } from '@navikt/ds-react';
+import { BodyShort, Button, DatePicker, Fieldset, Modal, Select, useDatepicker, VStack } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import { byggHenterRessurs, byggTomRessurs, type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { dagerFristForAvventerSamtykkeUlovfestetMotregning } from './useTilbakekrevingsvedtakMotregning';
-import {
-    type IBehandling,
-    type ISettPåVent,
-    SettPåVentÅrsak,
-    settPåVentÅrsaker,
-} from '../../../../../../typer/behandling';
-import { dagensDato, dateTilIsoDatoString } from '../../../../../../utils/dato';
-import { hentFrontendFeilmelding } from '../../../../../../utils/ressursUtils';
 import { useBehandlingContext } from '../../../context/BehandlingContext';
-
-const Feltmargin = styled.div`
-    margin-bottom: 2rem;
-`;
-const StyledBodyShort = styled(BodyShort)`
-    margin-bottom: 2rem;
-`;
 
 interface IProps {
     lukkModal: () => void;
@@ -80,23 +67,23 @@ export const SettBehandlingPåVentModalMotregning = ({ lukkModal, behandling }: 
                     legend="Sett behandling på vent"
                     hideLegend
                 >
-                    {erBehandlingAlleredePåVent && <StyledBodyShort>Behandlingen er satt på vent.</StyledBodyShort>}
+                    <VStack gap={'space-32'}>
+                        {erBehandlingAlleredePåVent && <BodyShort>Behandlingen er satt på vent.</BodyShort>}
 
-                    <StyledBodyShort>
-                        Behandlingen settes på vent i {dagerFristForAvventerSamtykkeUlovfestetMotregning} dager mens vi
-                        venter på svar fra bruker.
-                    </StyledBodyShort>
+                        <BodyShort>
+                            Behandlingen settes på vent i {dagerFristForAvventerSamtykkeUlovfestetMotregning} dager mens
+                            vi venter på svar fra bruker.
+                        </BodyShort>
 
-                    <Feltmargin>
                         <DatePicker dropdownCaption {...datepickerProps}>
                             <DatePicker.Input {...inputProps} label={'Frist'} readOnly={true} />
                         </DatePicker>
-                    </Feltmargin>
-                    <Select label={'Årsak'} readOnly={true}>
-                        <option value={årsak.valueOf()} key={årsak.valueOf()}>
-                            {settPåVentÅrsaker[årsak]}
-                        </option>
-                    </Select>
+                        <Select label={'Årsak'} readOnly={true}>
+                            <option value={årsak.valueOf()} key={årsak.valueOf()}>
+                                {settPåVentÅrsaker[årsak]}
+                            </option>
+                        </Select>
+                    </VStack>
                 </Fieldset>
             </Modal.Body>
             <Modal.Footer>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Årsvelger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Simulering/Årsvelger.tsx
@@ -1,14 +1,8 @@
-import styled from 'styled-components';
+import { NavigeringsRetning } from '@komponenter/Tidslinje/TidslinjeContext';
 
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, VStack } from '@navikt/ds-react';
 
-import { NavigeringsRetning } from '../../../../../komponenter/Tidslinje/TidslinjeContext';
 import TidslinjeNavigering from '../../../../../komponenter/Tidslinje/TidslinjeNavigering';
-
-const FlexColumn = styled.div`
-    display: flex;
-    flex-direction: column;
-`;
 
 interface Props {
     settIndexFramvistÅr: (value: ((prevState: number) => number) | number) => void;
@@ -25,7 +19,7 @@ export const Årsvelger = ({
     aktueltÅr,
     årISimuleringen,
 }: Props) => (
-    <FlexColumn>
+    <VStack>
         <TidslinjeNavigering
             naviger={retning =>
                 retning === NavigeringsRetning.VENSTRE
@@ -39,5 +33,5 @@ export const Årsvelger = ({
         >
             <BodyShort size={'small'}>{årISimuleringen[indexFramvistÅr]}</BodyShort>
         </TidslinjeNavigering>
-    </FlexColumn>
+    </VStack>
 );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Skjemasteg.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 import { useEffect } from 'react';
 
 import { useBehandling } from '@hooks/useBehandling';
@@ -7,9 +7,8 @@ import { BehandlingPåVentAlert } from '@komponenter/Alert/BehandlingPåVentAler
 import { MidlertidigEnhetAlert } from '@komponenter/Alert/MidlertidigEnhetAlert';
 import { BehandlingSteg } from '@typer/behandling';
 import { behandlingErEtterSteg } from '@utils/steg';
-import styled from 'styled-components';
 
-import { Box, Button, ErrorMessage, Heading, VStack } from '@navikt/ds-react';
+import { Box, Button, ErrorMessage, Heading, Stack, VStack } from '@navikt/ds-react';
 
 export const MAX_SKJEMASTEG_BREDDE = '1440px';
 
@@ -28,21 +27,6 @@ interface IProps extends PropsWithChildren {
     feilmelding?: string;
     steg: BehandlingSteg;
 }
-
-const StyledErrorMessage = styled(ErrorMessage)`
-    margin-top: var(--ax-space-16);
-`;
-
-const Navigering = styled.div`
-    margin: var(--ax-space-96) 0 var(--ax-space-16);
-    display: flex;
-    flex-direction: row-reverse;
-    justify-content: flex-end;
-
-    button:not(:first-child) {
-        margin-right: var(--ax-space-24);
-    }
-`;
 
 const Skjemasteg = ({
     children,
@@ -93,8 +77,18 @@ const Skjemasteg = ({
                         {tittel}
                     </Heading>
                     {children}
-                    {feilmelding !== '' && <StyledErrorMessage>{feilmelding}</StyledErrorMessage>}
-                    <Navigering>
+                    {feilmelding !== '' && (
+                        <Box marginBlock={'space-16 space-0'}>
+                            <ErrorMessage>{'feilmelding'}</ErrorMessage>
+                        </Box>
+                    )}
+                    <Stack
+                        direction={'row-reverse'}
+                        justify={'start'}
+                        marginBlock={'space-96 space-16'}
+                        marginInline={'space-0'}
+                        gap={'space-24'}
+                    >
                         {nesteOnClick && skalViseNesteKnapp && (!erLesevisning || kanGåVidereILesevisning) && (
                             <Button
                                 variant={'primary'}
@@ -110,7 +104,7 @@ const Skjemasteg = ({
                                 {forrigeKnappTittel}
                             </Button>
                         )}
-                    </Navigering>
+                    </Stack>
                 </Box>
             </VStack>
         </Box>

--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.module.css
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.module.css
@@ -1,0 +1,14 @@
+.vedleggListe {
+    list-style-type: none;
+    margin: 0;
+
+    &:first-child {
+        padding-inline-start: 0;
+    }
+}
+
+.text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.tsx
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostDokument.tsx
@@ -1,20 +1,11 @@
 import type { FamilieAxiosRequestConfig } from '@hooks/useDokument';
 import type { ITilgangsstyrtJournalpost } from '@typer/journalpost';
-import styled from 'styled-components';
 
 import { ExternalLinkIcon, PadlockLockedIcon } from '@navikt/aksel-icons';
-import { BodyShort, HStack, Link } from '@navikt/ds-react';
-import type { IDokumentInfo } from '@navikt/familie-typer';
+import { BodyShort, HStack, Link, VStack } from '@navikt/ds-react';
+import { type IDokumentInfo } from '@navikt/familie-typer';
 
-import { EllipsisBodyShort, Vedleggsliste } from './JournalpostListe';
-
-const ListeElement = styled.li`
-    margin-bottom: 1rem;
-
-    &:last-child {
-        margin-bottom: 0;
-    }
-`;
+import styles from './JournalpostDokument.module.css';
 
 interface IProps {
     dokument: IDokumentInfo;
@@ -39,15 +30,15 @@ export const JournalpostDokument = ({ dokument, hentForhåndsvisning, tilgangsst
     const dokumentTittel = dokument.tittel || 'Uten tittel';
 
     return (
-        <ListeElement>
+        <li>
             <HStack gap="space-4">
                 {journalpostTilgang.harTilgang ? (
                     <>
-                        <EllipsisBodyShort size="small" title={dokumentTittel}>
+                        <BodyShort className={styles.text} size="small" title={dokumentTittel}>
                             <Link href="#" onClick={() => hentPdfDokument(dokument.dokumentInfoId)}>
                                 {dokumentTittel}
                             </Link>
-                        </EllipsisBodyShort>
+                        </BodyShort>
 
                         <Link
                             href={`/familie-ba-sak/api/journalpost/${journalpost.journalpostId}/dokument/${dokument.dokumentInfoId}`}
@@ -68,16 +59,18 @@ export const JournalpostDokument = ({ dokument, hentForhåndsvisning, tilgangsst
                 )}
             </HStack>
             {dokument.logiskeVedlegg && dokument.logiskeVedlegg.length > 0 && (
-                <Vedleggsliste>
-                    {dokument.logiskeVedlegg.map(vedlegg => (
-                        <ListeElement key={vedlegg.logiskVedleggId}>
-                            <EllipsisBodyShort size="small" title={vedlegg.tittel}>
-                                {vedlegg.tittel}
-                            </EllipsisBodyShort>
-                        </ListeElement>
-                    ))}
-                </Vedleggsliste>
+                <ul className={styles.vedleggListe}>
+                    <VStack gap={'space-16'}>
+                        {dokument.logiskeVedlegg.map(vedlegg => (
+                            <li key={vedlegg.logiskVedleggId}>
+                                <BodyShort className={styles.text} size="small" title={vedlegg.tittel}>
+                                    {vedlegg.tittel}
+                                </BodyShort>
+                            </li>
+                        ))}
+                    </VStack>
+                </ul>
             )}
-        </ListeElement>
+        </li>
     );
 };

--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.module.css
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.module.css
@@ -1,0 +1,71 @@
+.table {
+    table-layout: fixed;
+}
+
+.headerRow {
+    th {
+        white-space: nowrap;
+
+        &:nth-of-type(1) {
+            width: 3.5rem;
+        }
+
+        &:nth-of-type(2) {
+            width: 10rem;
+        }
+
+        &:nth-of-type(3) {
+            width: 25%;
+        }
+
+        &:nth-of-type(4) {
+            width: 15%;
+        }
+
+        &:nth-of-type(5) {
+            width: 20%;
+        }
+
+        &:nth-of-type(6) {
+            width: 22%;
+        }
+
+        &:nth-of-type(7) {
+            width: 8%;
+        }
+    }
+}
+
+.dataCell {
+    vertical-align: top;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.vedleggListe {
+    list-style-type: none;
+    margin: 0;
+
+    &:first-child {
+        padding-inline-start: 0;
+    }
+}
+
+.searchNameLink {
+    padding: 0;
+
+    span {
+        font-weight: normal;
+    }
+
+    svg {
+        transform: rotate(90deg);
+    }
+}

--- a/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.tsx
+++ b/src/frontend/sider/Fagsak/Dokumenter/JournalpostListe.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 
-import styled from 'styled-components';
+import type { ITilgangsstyrtJournalpost } from '@typer/journalpost';
+import { hentSortState, Sorteringsrekkefølge } from '@utils/tabell';
 
 import { ArrowDownIcon, ArrowLeftIcon, ArrowRightIcon, MagnifyingGlassIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, Heading, LocalAlert, Table } from '@navikt/ds-react';
+import { BodyShort, Box, Button, Heading, HStack, LocalAlert, Table, VStack } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import type { IJournalpost, Ressurs, Utsendingsinfo } from '@navikt/familie-typer';
 import {
@@ -24,97 +25,8 @@ import {
 import { UtsendingsinfoModal } from './UtsendingsinfoModal';
 import useDokument from '../../../hooks/useDokument';
 import PdfVisningModal from '../../../komponenter/PdfVisningModal/PdfVisningModal';
-import type { ITilgangsstyrtJournalpost } from '../../../typer/journalpost';
-import { hentSortState, Sorteringsrekkefølge } from '../../../utils/tabell';
 import { useBrukerContext } from '../BrukerContext';
-
-const Container = styled.div`
-    padding: 2rem;
-    overflow: auto;
-`;
-
-const InnUtWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    font-weight: bold;
-`;
-
-const IkonWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    margin-right: 0.5rem;
-`;
-
-const StyledTable = styled(Table)`
-    table-layout: fixed;
-`;
-
-const StyledDataCell = styled(Table.DataCell)`
-    vertical-align: top;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
-
-const StyledHeaderCell = styled(Table.HeaderCell)`
-    white-space: nowrap;
-
-    &:nth-of-type(1) {
-        width: 3.5rem;
-    }
-
-    &:nth-of-type(3) {
-        width: 25%;
-    }
-
-    &:nth-of-type(4) {
-        width: 15%;
-    }
-
-    &:nth-of-type(5) {
-        width: 20%;
-    }
-
-    &:nth-of-type(6) {
-        width: 22%;
-    }
-
-    &:nth-of-type(7) {
-        width: 8%;
-    }
-`;
-
-const StyledColumnHeader = styled(Table.ColumnHeader)`
-    white-space: nowrap;
-    width: 10rem;
-`;
-
-const StyledButton = styled(Button)`
-    padding: 0;
-
-    .aksel-label {
-        font-weight: normal;
-    }
-`;
-
-const StyledMagnifyingGlassIcon = styled(MagnifyingGlassIcon)`
-    transform: rotate(90deg);
-`;
-
-export const Vedleggsliste = styled.ul`
-    list-style-type: none;
-    margin: 0;
-
-    &:first-child {
-        padding-inline-start: 0;
-    }
-`;
-
-export const EllipsisBodyShort = styled(BodyShort)`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-`;
+import styles from './JournalpostListe.module.css';
 
 const hentIkonForJournalpostType = (journalposttype: Journalposttype) => {
     switch (journalposttype) {
@@ -181,13 +93,13 @@ export function JournalpostListe() {
         journalposterRessurs.status === RessursStatus.IKKE_TILGANG
     ) {
         return (
-            <Container>
+            <Box padding={'space-32'} overflow={'auto'}>
                 <LocalAlert status={'error'}>
                     <LocalAlert.Header>
                         <LocalAlert.Title>Klarte ikke å hente inn journalposter for fagsak.</LocalAlert.Title>
                     </LocalAlert.Header>
                 </LocalAlert>
-            </Container>
+            </Box>
         );
     }
 
@@ -203,69 +115,72 @@ export function JournalpostListe() {
         );
         const sorterteJournalPoster = hentSorterteJournalposter(journalposterMedOverstyrtDato, sortering);
         return (
-            <Container>
+            <Box padding={'space-32'} overflow={'auto'}>
                 <Heading level="2" size="large" spacing>
                     Dokumentoversikt
                 </Heading>
-
-                <StyledTable
+                <Table
+                    className={styles.table}
                     size="small"
                     zebraStripes
                     sort={hentSortState(sortering, 'datoRegistrertSendt')}
                     onSortChange={settNesteSorteringsrekkefølge}
                 >
                     <Table.Header>
-                        <Table.Row>
-                            <StyledHeaderCell>Inn/ut</StyledHeaderCell>
-                            <StyledColumnHeader sortKey="datoRegistrertSendt" sortable>
+                        <Table.Row className={styles.headerRow}>
+                            <Table.HeaderCell>Inn/ut</Table.HeaderCell>
+                            <Table.ColumnHeader sortKey="datoRegistrertSendt" sortable>
                                 Registrert/sendt
-                            </StyledColumnHeader>
+                            </Table.ColumnHeader>
 
-                            <StyledHeaderCell>Dokumenter</StyledHeaderCell>
-                            <StyledHeaderCell>Fagsystem | Saksid</StyledHeaderCell>
-                            <StyledHeaderCell>Avsender/Mottaker</StyledHeaderCell>
-                            <StyledHeaderCell>Journalpost</StyledHeaderCell>
-                            <StyledHeaderCell>Status</StyledHeaderCell>
+                            <Table.HeaderCell>Dokumenter</Table.HeaderCell>
+                            <Table.HeaderCell>Fagsystem | Saksid</Table.HeaderCell>
+                            <Table.HeaderCell>Avsender/Mottaker</Table.HeaderCell>
+                            <Table.HeaderCell>Journalpost</Table.HeaderCell>
+                            <Table.HeaderCell>Status</Table.HeaderCell>
                         </Table.Row>
                     </Table.Header>
                     <Table.Body>
                         {sorterteJournalPoster.map(tilgangsstyrtJournalpost => (
                             <Table.Row key={tilgangsstyrtJournalpost.journalpost.journalpostId}>
-                                <StyledDataCell>
-                                    <InnUtWrapper>
-                                        <IkonWrapper>
-                                            {hentIkonForJournalpostType(
-                                                tilgangsstyrtJournalpost.journalpost.journalposttype
-                                            )}{' '}
-                                        </IkonWrapper>
-                                        {tilgangsstyrtJournalpost.journalpost.journalposttype}
-                                    </InnUtWrapper>
-                                </StyledDataCell>
-                                <StyledDataCell>
+                                <Table.DataCell className={styles.dataCell}>
+                                    <HStack align={'center'} gap={'space-8'} wrap={false}>
+                                        {hentIkonForJournalpostType(
+                                            tilgangsstyrtJournalpost.journalpost.journalposttype
+                                        )}
+                                        <BodyShort weight={'semibold'}>
+                                            {tilgangsstyrtJournalpost.journalpost.journalposttype}
+                                        </BodyShort>
+                                    </HStack>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
                                     {formaterDatoRegistrertSendtMottatt(
                                         tilgangsstyrtJournalpost.journalpost.datoMottatt
                                     )}
-                                </StyledDataCell>
+                                </Table.DataCell>
 
-                                <StyledDataCell>
+                                <Table.DataCell className={styles.dataCell}>
                                     {tilgangsstyrtJournalpost.journalpost.dokumenter?.length ? (
-                                        <Vedleggsliste>
-                                            {tilgangsstyrtJournalpost.journalpost.dokumenter?.map(dokument => (
-                                                <JournalpostDokument
-                                                    dokument={dokument}
-                                                    key={dokument.dokumentInfoId}
-                                                    hentForhåndsvisning={hentForhåndsvisning}
-                                                    tilgangsstyrtJournalpost={tilgangsstyrtJournalpost}
-                                                />
-                                            ))}
-                                        </Vedleggsliste>
+                                        <ul className={styles.vedleggListe}>
+                                            <VStack gap={'space-16'}>
+                                                {tilgangsstyrtJournalpost.journalpost.dokumenter?.map(dokument => (
+                                                    <JournalpostDokument
+                                                        dokument={dokument}
+                                                        key={dokument.dokumentInfoId}
+                                                        hentForhåndsvisning={hentForhåndsvisning}
+                                                        tilgangsstyrtJournalpost={tilgangsstyrtJournalpost}
+                                                    />
+                                                ))}
+                                            </VStack>
+                                        </ul>
                                     ) : (
                                         <BodyShort>Ingen dokumenter</BodyShort>
                                     )}
-                                </StyledDataCell>
+                                </Table.DataCell>
 
-                                <StyledDataCell>
-                                    <EllipsisBodyShort
+                                <Table.DataCell className={styles.dataCell}>
+                                    <BodyShort
+                                        className={styles.text}
                                         size="small"
                                         title={formaterFagsak(
                                             tilgangsstyrtJournalpost.journalpost.sak?.fagsaksystem,
@@ -276,12 +191,13 @@ export function JournalpostListe() {
                                             tilgangsstyrtJournalpost.journalpost.sak?.fagsaksystem,
                                             tilgangsstyrtJournalpost.journalpost.sak?.fagsakId
                                         )}
-                                    </EllipsisBodyShort>
-                                </StyledDataCell>
-                                <StyledDataCell>
+                                    </BodyShort>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
                                     {tilgangsstyrtJournalpost.journalpost.utsendingsinfo ? (
-                                        <StyledButton
-                                            icon={<StyledMagnifyingGlassIcon />}
+                                        <Button
+                                            className={styles.searchNameLink}
+                                            icon={<MagnifyingGlassIcon />}
                                             iconPosition={'right'}
                                             variant={'tertiary'}
                                             size={'xsmall'}
@@ -290,40 +206,46 @@ export function JournalpostListe() {
                                             }
                                         >
                                             {tilgangsstyrtJournalpost.journalpost.avsenderMottaker?.navn}
-                                        </StyledButton>
+                                        </Button>
                                     ) : (
-                                        <EllipsisBodyShort
+                                        <BodyShort
+                                            className={styles.text}
                                             size="small"
                                             title={tilgangsstyrtJournalpost.journalpost.avsenderMottaker?.navn}
                                         >
                                             {tilgangsstyrtJournalpost.journalpost.avsenderMottaker?.navn}
-                                        </EllipsisBodyShort>
+                                        </BodyShort>
                                     )}
-                                </StyledDataCell>
-                                <StyledDataCell>
-                                    <EllipsisBodyShort size="small" title={tilgangsstyrtJournalpost.journalpost.tittel}>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
+                                    <BodyShort
+                                        className={styles.text}
+                                        size="small"
+                                        title={tilgangsstyrtJournalpost.journalpost.tittel}
+                                    >
                                         {tilgangsstyrtJournalpost.journalpost.tittel}
-                                    </EllipsisBodyShort>
-                                </StyledDataCell>
-                                <StyledDataCell>
-                                    <EllipsisBodyShort
+                                    </BodyShort>
+                                </Table.DataCell>
+                                <Table.DataCell className={styles.dataCell}>
+                                    <BodyShort
+                                        className={styles.text}
                                         size="small"
                                         title={journalpoststatus[tilgangsstyrtJournalpost.journalpost.journalstatus]}
                                     >
                                         {journalpoststatus[tilgangsstyrtJournalpost.journalpost.journalstatus]}
-                                    </EllipsisBodyShort>
-                                </StyledDataCell>
+                                    </BodyShort>
+                                </Table.DataCell>
                             </Table.Row>
                         ))}
                     </Table.Body>
-                </StyledTable>
+                </Table>
                 {visDokumentModal && (
                     <PdfVisningModal onRequestClose={() => settVisDokumentModal(false)} pdfdata={hentetDokument} />
                 )}
                 {utsendingsinfo && (
                     <UtsendingsinfoModal onClose={() => settUtsendingsinfo(undefined)} data={utsendingsinfo} />
                 )}
-            </Container>
+            </Box>
         );
     } else {
         return null;

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.module.css
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.module.css
@@ -1,0 +1,11 @@
+.headerRow {
+    th {
+        &:nth-of-type(1) {
+            width: 10%;
+        }
+
+        &:nth-of-type(7) {
+            width: 22%;
+        }
+    }
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Behandlinger.tsx
@@ -1,4 +1,7 @@
-import styled from 'styled-components';
+import { useHentBarnetrygdbehandlinger } from '@hooks/useHentBarnetrygdbehandlinger';
+import { useHentKlagebehandlinger } from '@hooks/useHentKlagebehandlinger';
+import { useHentTilbakekrevingsbehandlinger } from '@hooks/useHentTilbakekrevingsbehandlinger';
+import { useToggle } from '@hooks/useToggle';
 
 import { BodyShort, Heading, HStack, LocalAlert, Skeleton, Table, VStack } from '@navikt/ds-react';
 
@@ -6,31 +9,20 @@ import { Behandling } from './Behandling';
 import { filtrerSaksoversiktbehandlinger, hentBehandlingerTilSaksoversikten, hentBehandlingId } from './utils';
 import { VisHenlagtBehandlingerSwitch } from './VisHenlagtBehandlingerSwitch';
 import { VisMånedligValutajuseringBehandlingerSwitch } from './VisMånedligValutajuseringBehandlingerSwitch';
-import { useHentBarnetrygdbehandlinger } from '../../../hooks/useHentBarnetrygdbehandlinger';
-import { useHentKlagebehandlinger } from '../../../hooks/useHentKlagebehandlinger';
-import { useHentTilbakekrevingsbehandlinger } from '../../../hooks/useHentTilbakekrevingsbehandlinger';
-import { useToggle } from '../../../hooks/useToggle';
 import { useFagsakContext } from '../FagsakContext';
-
-const StyledHeaderCell = styled(Table.HeaderCell)<{ width?: string }>`
-    width ${props => props.width};
-`;
+import styles from './Behandlinger.module.css';
 
 function TableHeader() {
     return (
         <Table.Header>
-            <Table.Row>
-                <StyledHeaderCell width={'10%'} scope={'col'}>
-                    Opprettet
-                </StyledHeaderCell>
+            <Table.Row className={styles.headerRow}>
+                <Table.HeaderCell scope={'col'}>Opprettet</Table.HeaderCell>
                 <Table.HeaderCell scope={'col'}>Årsak</Table.HeaderCell>
                 <Table.HeaderCell scope={'col'}>Type</Table.HeaderCell>
                 <Table.HeaderCell scope={'col'}>Behandlingstema</Table.HeaderCell>
                 <Table.HeaderCell scope={'col'}>Status</Table.HeaderCell>
                 <Table.HeaderCell scope={'col'}>Vedtaksdato</Table.HeaderCell>
-                <StyledHeaderCell width={'22%'} scope={'col'}>
-                    Resultat
-                </StyledHeaderCell>
+                <Table.HeaderCell scope={'col'}>Resultat</Table.HeaderCell>
             </Table.Row>
         </Table.Header>
     );

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.module.css
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.module.css
@@ -1,0 +1,3 @@
+.bodyText {
+    font-size: var(--ax-font-size-heading-medium);
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/FagsakLenkepanel.tsx
@@ -1,28 +1,19 @@
+import { BehandlingStatus } from '@typer/behandling';
+import type { IBehandlingstema } from '@typer/behandlingstema';
+import { tilBehandlingstema } from '@typer/behandlingstema';
+import { FagsakStatus, FagsakType } from '@typer/fagsak';
+import { Datoformat, isoStringTilFormatertString } from '@utils/dato';
+import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '@utils/fagsak';
 import { Link as ReactRouterLink } from 'react-router';
-import styled from 'styled-components';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
 import { BodyShort, Box, HStack, InfoCard, Link, LinkCard, VStack } from '@navikt/ds-react';
-import { FontSizeHeadingMedium, FontSizeXlarge } from '@navikt/ds-tokens/dist/tokens';
 
+import styles from './FagsakLenkepanel.module.css';
 import type { VisningBehandling } from './visningBehandling';
-import { BehandlingStatus } from '../../../typer/behandling';
-import type { IBehandlingstema } from '../../../typer/behandlingstema';
-import { tilBehandlingstema } from '../../../typer/behandlingstema';
-import { FagsakStatus, FagsakType } from '../../../typer/fagsak';
-import { Datoformat, isoStringTilFormatertString } from '../../../utils/dato';
-import { hentAktivBehandlingPåMinimalFagsak, hentFagsakStatusVisning } from '../../../utils/fagsak';
 import { useFagsakContext } from '../FagsakContext';
 
 export const SaksoversiktPanelBredde = `calc(10 * var(--ax-space-64))`;
-
-const HeaderTekst = styled(BodyShort)`
-    font-size: ${FontSizeXlarge};
-`;
-
-const BodyTekst = styled(BodyShort)`
-    font-size: ${FontSizeHeadingMedium};
-`;
 
 function Innholdstabell() {
     const { fagsak } = useFagsakContext();
@@ -35,22 +26,32 @@ function Innholdstabell() {
     return (
         <HStack gap="space-80">
             <div>
-                <HeaderTekst spacing>Behandlingstema</HeaderTekst>
-                <BodyTekst weight="semibold">{behandlingstema ? behandlingstema.navn : '-'}</BodyTekst>
+                <BodyShort size={'large'} spacing>
+                    Behandlingstema
+                </BodyShort>
+                <BodyShort className={styles.bodyText} weight="semibold">
+                    {behandlingstema ? behandlingstema.navn : '-'}
+                </BodyShort>
             </div>
             <div>
-                <HeaderTekst spacing>Status</HeaderTekst>
-                <BodyTekst weight="semibold">{hentFagsakStatusVisning(fagsak)}</BodyTekst>
+                <BodyShort size={'large'} spacing>
+                    Status
+                </BodyShort>
+                <BodyShort className={styles.bodyText} weight="semibold">
+                    {hentFagsakStatusVisning(fagsak)}
+                </BodyShort>
             </div>
             {fagsakErLåst && fagsak.låstTidspunkt && (
                 <div>
-                    <HeaderTekst spacing>Låst dato</HeaderTekst>
-                    <BodyTekst weight="semibold">
+                    <BodyShort size={'large'} spacing>
+                        Låst dato
+                    </BodyShort>
+                    <BodyShort className={styles.bodyText} weight="semibold">
                         {isoStringTilFormatertString({
                             isoString: fagsak.låstTidspunkt,
                             tilFormat: Datoformat.DATO,
                         })}
-                    </BodyTekst>
+                    </BodyShort>
                 </div>
             )}
         </HStack>

--- a/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/GjennomførValutajusteringKnapp.tsx
@@ -1,22 +1,16 @@
 import { useState } from 'react';
 
+import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
 import { useQueryClient } from '@tanstack/react-query';
-import styled from 'styled-components';
+import type { IMinimalFagsak } from '@typer/fagsak';
 
-import { Button, ErrorMessage } from '@navikt/ds-react';
+import { Box, Button, ErrorMessage } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import { RessursStatus } from '@navikt/familie-typer/dist/ressurs';
-
-import { HentFagsakQueryKeyFactory } from '../../../hooks/useHentFagsak';
-import type { IMinimalFagsak } from '../../../typer/fagsak';
 
 interface Props {
     fagsakId: number;
 }
-
-const StyledButton = styled(Button)`
-    margin-top: 1rem;
-`;
 
 export const GjennomførValutajusteringKnapp = ({ fagsakId }: Props) => {
     const { request } = useHttp();
@@ -41,9 +35,9 @@ export const GjennomførValutajusteringKnapp = ({ fagsakId }: Props) => {
     };
 
     return (
-        <>
-            <StyledButton onClick={gjenomførValutajustering}>Gjennomfør valutajustering</StyledButton>
+        <Box marginBlock={'space-16 space-0'}>
+            <Button onClick={gjenomførValutajustering}>Gjennomfør valutajustering</Button>
             {visFeilmelidng && <ErrorMessage>Noe gikk galt med gjennomføringen av valutajustering</ErrorMessage>}
-        </>
+        </Box>
     );
 };

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.module.css
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.module.css
@@ -1,0 +1,3 @@
+.ytelse {
+    border-style: dashed;
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/PersonUtbetaling.tsx
@@ -1,21 +1,11 @@
-import styled from 'styled-components';
+import { YtelseType, ytelsetype } from '@typer/beregning';
+import type { IUtbetalingsperiodeDetalj } from '@typer/vedtaksperiode';
+import { formaterBeløp, hentAlder } from '@utils/formatter';
 
-import { BodyShort, HStack } from '@navikt/ds-react';
-import { Space16, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
+import { BodyShort, Box, HStack } from '@navikt/ds-react';
 
 import { PersonInformasjonUtbetaling } from './PersonInformasjonUtbetaling';
-import { YtelseType, ytelsetype } from '../../../typer/beregning';
-import type { IUtbetalingsperiodeDetalj } from '../../../typer/vedtaksperiode';
-import { formaterBeløp, hentAlder } from '../../../utils/formatter';
-
-const Ytelser = styled.section`
-    margin: ${Space8} 0 ${Space16} ${Space32};
-    border-bottom: 1px dashed;
-`;
-
-const Ytelselinje = styled(HStack)`
-    margin-bottom: ${Space16};
-`;
+import styles from './PersonUtbetaling.module.css';
 
 interface IPersonUtbetalingProps {
     utbetalingsperiodeDetaljer: IUtbetalingsperiodeDetalj[];
@@ -34,20 +24,33 @@ const PersonUtbetaling = ({ utbetalingsperiodeDetaljer }: IPersonUtbetalingProps
     return (
         <section>
             <PersonInformasjonUtbetaling person={utbetalingsperiodeDetaljer[0].person} />
-            <Ytelser>
-                {utbetalingsperiodeDetaljer.map(utbetalingsperiodeDetalj => {
-                    return (
-                        <Ytelselinje justify="space-between" key={utbetalingsperiodeDetalj.person.personIdent}>
-                            <BodyShort>
-                                {utbetalingsperiodeDetalj.ytelseType === YtelseType.ORDINÆR_BARNETRYGD
-                                    ? genererTekstForOrdinær(utbetalingsperiodeDetalj)
-                                    : ytelsetype[utbetalingsperiodeDetalj.ytelseType].navn}
-                            </BodyShort>
-                            <BodyShort>{formaterBeløp(utbetalingsperiodeDetalj.utbetaltPerMnd)}</BodyShort>
-                        </Ytelselinje>
-                    );
-                })}
-            </Ytelser>
+            <Box
+                asChild
+                borderColor={'neutral'}
+                borderWidth={'0 0 1 0'}
+                marginBlock={'space-8 space-16'}
+                marginInline={'space-32 space-0'}
+                className={styles.ytelse}
+            >
+                <section>
+                    {utbetalingsperiodeDetaljer.map(utbetalingsperiodeDetalj => {
+                        return (
+                            <HStack
+                                justify="space-between"
+                                key={utbetalingsperiodeDetalj.person.personIdent}
+                                marginBlock={'space-0 space-16'}
+                            >
+                                <BodyShort>
+                                    {utbetalingsperiodeDetalj.ytelseType === YtelseType.ORDINÆR_BARNETRYGD
+                                        ? genererTekstForOrdinær(utbetalingsperiodeDetalj)
+                                        : ytelsetype[utbetalingsperiodeDetalj.ytelseType].navn}
+                                </BodyShort>
+                                <BodyShort>{formaterBeløp(utbetalingsperiodeDetalj.utbetaltPerMnd)}</BodyShort>
+                            </HStack>
+                        );
+                    })}
+                </section>
+            </Box>
         </section>
     );
 };

--- a/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.module.css
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.module.css
@@ -1,0 +1,3 @@
+.total {
+    border-bottom: 1px solid var(--ax-border-neutral-strong);
+}

--- a/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
+++ b/src/frontend/sider/Fagsak/Saksoversikt/Utbetalinger.tsx
@@ -1,24 +1,12 @@
-import styled from 'styled-components';
+import type { IUtbetalingsperiodeDetalj, Vedtaksperiode } from '@typer/vedtaksperiode';
+import { Vedtaksperiodetype } from '@typer/vedtaksperiode';
+import { formaterBeløp, sorterUtbetaling } from '@utils/formatter';
 
 import { BodyShort, HStack, VStack } from '@navikt/ds-react';
-import { BorderNeutralStrong, Space24, Space32, Space8 } from '@navikt/ds-tokens/dist/tokens';
 
 import { SaksoversiktPanelBredde } from './FagsakLenkepanel';
 import PersonUtbetaling from './PersonUtbetaling';
-import type { IUtbetalingsperiodeDetalj, Vedtaksperiode } from '../../../typer/vedtaksperiode';
-import { Vedtaksperiodetype } from '../../../typer/vedtaksperiode';
-import { formaterBeløp, sorterUtbetaling } from '../../../utils/formatter';
-
-const LøpendeUtbetalinger = styled(VStack)`
-    max-width: ${SaksoversiktPanelBredde};
-    margin-top: ${Space24};
-`;
-
-const Totallinje = styled(HStack)`
-    margin-left: ${Space32};
-    padding-bottom: ${Space8};
-    border-bottom: 1px solid ${BorderNeutralStrong};
-`;
+import styles from './Utbetalinger.module.css';
 
 interface IUtbetalingerProps {
     vedtaksperiode?: Vedtaksperiode;
@@ -43,7 +31,7 @@ const Utbetalinger = ({ vedtaksperiode }: IUtbetalingerProps) => {
             }, {}) ?? {};
 
     return (
-        <LøpendeUtbetalinger gap="space-16">
+        <VStack maxWidth={SaksoversiktPanelBredde} gap="space-16" marginBlock={'space-24 space-0'}>
             {Object.values(utbetalingsperiodeDetaljerGruppertPåPerson).map(
                 (utbetalingsperiodeDetaljerForPerson, index) => {
                     return (
@@ -54,13 +42,18 @@ const Utbetalinger = ({ vedtaksperiode }: IUtbetalingerProps) => {
                     );
                 }
             )}
-            <Totallinje justify="space-between">
+            <HStack
+                className={styles.total}
+                marginInline={'space-32 space-0'}
+                paddingBlock={'space-0 space-8'}
+                justify="space-between"
+            >
                 <BodyShort>Totalt utbetalt/mnd</BodyShort>
                 <BodyShort weight="semibold">
                     {vedtaksperiode ? formaterBeløp(vedtaksperiode.utbetaltPerMnd) : '-'}
                 </BodyShort>
-            </Totallinje>
-        </LøpendeUtbetalinger>
+            </HStack>
+        </VStack>
     );
 };
 


### PR DESCRIPTION
### 📮 Favro: NAV-26302

### 👀 Screen shots
Dokumenter, gammel over og ny under
<img width="953" height="817" alt="image" src="https://github.com/user-attachments/assets/b760b24b-7c7c-4960-b79d-bdcd3c1d6dea" />

Saksoversikt, gammel venstre og ny høyre
<img width="1647" height="884" alt="image" src="https://github.com/user-attachments/assets/18760936-3ad4-4bfd-875c-ae1999aba5a4" />

Høyremeny
Totrinnskontroll, gammel venstre og ny høyre
<img width="895" height="394" alt="image" src="https://github.com/user-attachments/assets/7c0d6e45-6175-4366-b56e-5a34db803d0a" />

Simulering
<img width="1493" height="653" alt="image" src="https://github.com/user-attachments/assets/b244fb5f-0574-4c9c-9a9f-ac7dc2438f40" />
