### PR TITLE
NAV-29382: Vis funksjonell feil som warning i PdfVisningModal

### DIFF
--- a/src/frontend/komponenter/PdfVisningModal/PdfVisningModal.tsx
+++ b/src/frontend/komponenter/PdfVisningModal/PdfVisningModal.tsx
@@ -50,8 +50,17 @@ const Dokument = ({ pdfdata }: { pdfdata: Ressurs<string> }) => {
             );
         case RessursStatus.SUKSESS:
             return <iframe className={styles.iframe} title={'Dokument'} src={pdfdata.data} />;
-        case RessursStatus.FEILET:
         case RessursStatus.FUNKSJONELL_FEIL:
+            return (
+                <div>
+                    <LocalAlert status="warning">
+                        <LocalAlert.Header>
+                            <LocalAlert.Title>{pdfdata.frontendFeilmelding}</LocalAlert.Title>
+                        </LocalAlert.Header>
+                    </LocalAlert>
+                </div>
+            );
+        case RessursStatus.FEILET:
         case RessursStatus.IKKE_TILGANG:
             return (
                 <div>


### PR DESCRIPTION
### 📮 Favro: Nav-29382 

### 💰 Hva skal gjøres, og hvorfor?
Backend svarer nå med en funksjonell feil når vedtaksbrevet for en avsluttet behandling ikke finnes i Joark (se tilhørende PR i familie-ba-sak).  Vi henvender nå SB til å sjekke dokumentoversikten hvis vi ikke greier å hente vedtaksbrevet fra joark.