### PR TITLE
NAV-29213 Ta i bruk react hook form for OpprettBehandling

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/BehandlingstemaSelect.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/EndreBehandling/BehandlingstemaSelect.tsx
@@ -1,11 +1,11 @@
+import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
+import { BehandlingKategori, behandlingstemaer, konverterTilBehandlingstema } from '@typer/behandlingstema';
+import { FagsakType } from '@typer/fagsak';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Select } from '@navikt/ds-react';
 
 import { EndreBehandlingstemaFelt, type EndreBehandlingstemaFormValues } from './useEndreBehandlingstemaSkjema';
-import { useFagsakContext } from '../../../../sider/Fagsak/FagsakContext';
-import { BehandlingKategori, behandlingstemaer, type IBehandlingstema } from '../../../../typer/behandlingstema';
-import { FagsakType } from '../../../../typer/fagsak';
 
 interface Props {
     erLesevisning: boolean;
@@ -26,10 +26,6 @@ export const BehandlingstemaSelect = ({ erLesevisning }: Props) => {
             required: 'Behandlingstema må velges.',
         },
     });
-
-    const konverterTilBehandlingstema = (behandlingstemaId: string): IBehandlingstema => {
-        return behandlingstemaer[behandlingstemaId as keyof typeof behandlingstemaer];
-    };
 
     return (
         <Select

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -1,16 +1,20 @@
-import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
+import { useFagsak } from '@hooks/useFagsak';
+import { BegrunnelseFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/BegrunnelseFelt';
+import { BehandlingstemaFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt';
+import { BehandlingstypeFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstypeFelt';
+import { BehandlingsårsakFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt';
+import { KlageMottattDatoFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/KlageMottattDatoFelt';
+import { MigreringsdatoFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/MigreringsdatoFelt';
+import { SøknadMottattDatoFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/SøknadMottattDatoFelt';
+import { ValgteBarnFelt } from '@komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt';
 import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
-import { dagensDato } from '@utils/dato';
-import { hentFrontendFeilmelding } from '@utils/ressursUtils';
-import { isBefore, subDays } from 'date-fns';
+import { FagsakType } from '@typer/fagsak';
+import { Klagebehandlingstype } from '@typer/klage';
+import { FormProvider } from 'react-hook-form';
 
-import { Box, Button, Fieldset, LocalAlert, Modal, Textarea, VStack } from '@navikt/ds-react';
-import { Valideringsstatus } from '@navikt/familie-skjema';
-import { RessursStatus } from '@navikt/familie-typer';
+import { Button, Fieldset, Modal, VStack } from '@navikt/ds-react';
 
-import OpprettBehandlingValg from './OpprettBehandlingValg';
-import { useOpprettBehandlingSkjema } from './useOpprettBehandlingSkjema';
-import Datovelger from '../../../Datovelger/Datovelger';
+import { OpprettBehandlingFelt, useOpprettBehandlingSkjema } from './useOpprettBehandlingSkjema';
 
 interface Props {
     lukkModal: () => void;
@@ -18,24 +22,46 @@ interface Props {
 }
 
 export function OpprettBehandlingModal({ lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
-    const { fagsak } = useFagsakContext();
+    const fagsak = useFagsak();
 
-    const { onBekreft, opprettBehandlingSkjema, nullstillSkjemaStatus, bruker, maksdatoForMigrering } =
-        useOpprettBehandlingSkjema({ fagsakId: fagsak.id, lukkModal, onTilbakekrevingsbehandlingOpprettet });
+    const { form, onSubmit } = useOpprettBehandlingSkjema({
+        lukkModal,
+        onTilbakekrevingsbehandlingOpprettet,
+    });
 
-    const lukkOpprettBehandlingModal = () => {
-        nullstillSkjemaStatus();
-        lukkModal();
-    };
+    const {
+        handleSubmit,
+        formState: { isSubmitting, errors },
+        watch,
+    } = form;
 
-    const søknadMottattDatoErMerEnn360DagerSiden =
-        opprettBehandlingSkjema.felter.søknadMottattDato.verdi &&
-        isBefore(opprettBehandlingSkjema.felter.søknadMottattDato.verdi, subDays(dagensDato, 360));
+    const behandlingstype = watch(OpprettBehandlingFelt.BEHANDLINGSTYPE);
+    const behandlingsårsak = watch(OpprettBehandlingFelt.BEHANDLINGSÅRSAK);
+
+    const skalViseBehandlingsårsakFelt =
+        behandlingstype === Behandlingstype.REVURDERING || behandlingstype === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
+    const skalViseBehandlingstemaFelt =
+        fagsak.fagsakType !== FagsakType.INSTITUSJON &&
+        behandlingstype in Behandlingstype &&
+        behandlingsårsak in
+            [BehandlingÅrsak.SØKNAD, BehandlingÅrsak.ENDRE_MIGRERINGSDATO, BehandlingÅrsak.HELMANUELL_MIGRERING];
+    const skalViseSøknadMottattDatoFelt =
+        behandlingstype === Behandlingstype.FØRSTEGANGSBEHANDLING ||
+        (behandlingstype === Behandlingstype.REVURDERING && behandlingsårsak === BehandlingÅrsak.SØKNAD);
+    const skalViseKlageMottattDatoFelt = behandlingstype === Klagebehandlingstype.KLAGE;
+    const skalViseBegrunnelseFelt = behandlingsårsak === BehandlingÅrsak.TEKNISK_ENDRING;
+
+    // Migrering fra infotrygd
+    const skalViseMigreringsdatoFelt =
+        behandlingstype === Behandlingstype.MIGRERING_FRA_INFOTRYGD && behandlingsårsak in BehandlingÅrsak;
+    const skalViseValgteBarnFelt =
+        behandlingstype === Behandlingstype.MIGRERING_FRA_INFOTRYGD &&
+        behandlingsårsak === BehandlingÅrsak.HELMANUELL_MIGRERING;
 
     return (
         <Modal
             open
-            onClose={lukkOpprettBehandlingModal}
+            onClose={lukkModal}
             width={'35rem'}
             portal={true}
             header={{
@@ -43,90 +69,32 @@ export function OpprettBehandlingModal({ lukkModal, onTilbakekrevingsbehandlingO
                 size: 'medium',
             }}
         >
-            <Modal.Body>
-                <Fieldset
-                    error={hentFrontendFeilmelding(opprettBehandlingSkjema.submitRessurs)}
-                    legend={'Opprett ny behandling'}
-                    hideLegend
-                >
-                    <VStack gap={'space-16'}>
-                        <OpprettBehandlingValg
-                            skjema={opprettBehandlingSkjema}
-                            minimalFagsak={fagsak}
-                            bruker={bruker}
-                        />
-                        {opprettBehandlingSkjema.felter.behandlingstype.verdi ===
-                            Behandlingstype.MIGRERING_FRA_INFOTRYGD &&
-                            opprettBehandlingSkjema.felter.migreringsdato?.erSynlig && (
-                                <Datovelger
-                                    felt={opprettBehandlingSkjema.felter.migreringsdato}
-                                    visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
-                                    label={'Ny migreringsdato'}
-                                    maksDatoAvgrensning={maksdatoForMigrering}
-                                />
-                            )}
-                        {opprettBehandlingSkjema.felter.behandlingsårsak.verdi === BehandlingÅrsak.TEKNISK_ENDRING &&
-                            opprettBehandlingSkjema.felter.begrunnelse?.erSynlig && (
-                                <Textarea
-                                    label={'Begrunnelse for opprettelse av teknisk endring'}
-                                    onChange={(event): void => {
-                                        opprettBehandlingSkjema.felter.begrunnelse.validerOgSettFelt(
-                                            event.target.value
-                                        );
-                                    }}
-                                    error={
-                                        opprettBehandlingSkjema.felter.begrunnelse.valideringsstatus ==
-                                            Valideringsstatus.FEIL &&
-                                        opprettBehandlingSkjema.felter.begrunnelse.feilmelding
-                                    }
-                                />
-                            )}
-                        {opprettBehandlingSkjema.felter.søknadMottattDato?.erSynlig && (
-                            <Datovelger
-                                felt={opprettBehandlingSkjema.felter.søknadMottattDato}
-                                visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
-                                label={'Mottatt dato'}
-                                kanKunVelgeFortid
-                            />
-                        )}
-                        {opprettBehandlingSkjema.felter.klageMottattDato?.erSynlig && (
-                            <Datovelger
-                                felt={opprettBehandlingSkjema.felter.klageMottattDato}
-                                visFeilmeldinger={opprettBehandlingSkjema.visFeilmeldinger}
-                                label={'Klage mottatt'}
-                                kanKunVelgeFortid
-                            />
-                        )}
-                    </VStack>
-                </Fieldset>
-                {søknadMottattDatoErMerEnn360DagerSiden && (
-                    <Box marginBlock={'space-24 space-0'}>
-                        <LocalAlert status="warning">
-                            <LocalAlert.Header>
-                                <LocalAlert.Title>
-                                    Er mottatt dato riktig? <br />
-                                    Det er mer enn 360 dager siden denne datoen.
-                                </LocalAlert.Title>
-                            </LocalAlert.Header>
-                        </LocalAlert>
-                    </Box>
-                )}
-            </Modal.Body>
-            <Modal.Footer>
-                <Button
-                    key={'bekreft'}
-                    variant={'primary'}
-                    onClick={() => {
-                        if (opprettBehandlingSkjema.submitRessurs.status === RessursStatus.HENTER) {
-                            return;
-                        }
-                        onBekreft();
-                    }}
-                    children={'Bekreft'}
-                    loading={opprettBehandlingSkjema.submitRessurs.status === RessursStatus.HENTER}
-                />
-                <Button key={'avbryt'} variant="tertiary" onClick={lukkOpprettBehandlingModal} children={'Avbryt'} />
-            </Modal.Footer>
+            <FormProvider {...form}>
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <Modal.Body>
+                        <Fieldset error={errors.root?.message} legend={'Opprett ny behandling'} hideLegend>
+                            <VStack gap={'space-16'}>
+                                <BehandlingstypeFelt />
+                                {skalViseBehandlingsårsakFelt && <BehandlingsårsakFelt />}
+                                {skalViseValgteBarnFelt && <ValgteBarnFelt />}
+                                {skalViseBehandlingstemaFelt && <BehandlingstemaFelt />}
+                                {skalViseMigreringsdatoFelt && <MigreringsdatoFelt />}
+                                {skalViseBegrunnelseFelt && <BegrunnelseFelt />}
+                                {skalViseSøknadMottattDatoFelt && <SøknadMottattDatoFelt />}
+                                {skalViseKlageMottattDatoFelt && <KlageMottattDatoFelt />}
+                            </VStack>
+                        </Fieldset>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button variant={'primary'} type={'submit'} loading={isSubmitting}>
+                            Bekreft
+                        </Button>
+                        <Button type={'button'} variant={'tertiary'} disabled={isSubmitting} onClick={lukkModal}>
+                            Avbryt
+                        </Button>
+                    </Modal.Footer>
+                </form>
+            </FormProvider>
         </Modal>
     );
 }

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingModal.tsx
@@ -43,8 +43,13 @@ export function OpprettBehandlingModal({ lukkModal, onTilbakekrevingsbehandlingO
     const skalViseBehandlingstemaFelt =
         fagsak.fagsakType !== FagsakType.INSTITUSJON &&
         behandlingstype in Behandlingstype &&
-        behandlingsårsak in
-            [BehandlingÅrsak.SØKNAD, BehandlingÅrsak.ENDRE_MIGRERINGSDATO, BehandlingÅrsak.HELMANUELL_MIGRERING];
+        (
+            [
+                BehandlingÅrsak.SØKNAD,
+                BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
+                BehandlingÅrsak.HELMANUELL_MIGRERING,
+            ] as string[]
+        ).includes(behandlingsårsak);
     const skalViseSøknadMottattDatoFelt =
         behandlingstype === Behandlingstype.FØRSTEGANGSBEHANDLING ||
         (behandlingstype === Behandlingstype.REVURDERING && behandlingsårsak === BehandlingÅrsak.SØKNAD);

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BegrunnelseFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BegrunnelseFelt.tsx
@@ -1,0 +1,45 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Textarea } from '@navikt/ds-react';
+
+export function BegrunnelseFelt() {
+    const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<OpprettBehandlingFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: OpprettBehandlingFelt.BEGRUNNELSE,
+        control,
+        rules: {
+            validate: verdi => {
+                const trimmed = verdi.trim();
+                if (trimmed.length < 5) {
+                    return 'Skriv en begrunnelse med minst 5 tegn.';
+                }
+                if (trimmed.length > 4000) {
+                    return 'Begrunnelsen kan ikke være lengre enn 4000 tegn.';
+                }
+            },
+        },
+    });
+
+    return (
+        <Textarea
+            label={'Begrunnelse for opprettelse av teknisk endring'}
+            readOnly={erLesevisning || isSubmitting}
+            maxLength={4000}
+            value={value}
+            onChange={onChange}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BegrunnelseFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BegrunnelseFelt.tsx
@@ -1,4 +1,3 @@
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import {
     OpprettBehandlingFelt,
     type OpprettBehandlingFormValues,
@@ -8,8 +7,6 @@ import { useController, useFormContext } from 'react-hook-form';
 import { Textarea } from '@navikt/ds-react';
 
 export function BegrunnelseFelt() {
-    const erLesevisning = useErLesevisning();
-
     const { control } = useFormContext<OpprettBehandlingFormValues>();
 
     const {
@@ -35,7 +32,7 @@ export function BegrunnelseFelt() {
     return (
         <Textarea
             label={'Begrunnelse for opprettelse av teknisk endring'}
-            readOnly={erLesevisning || isSubmitting}
+            readOnly={isSubmitting}
             maxLength={4000}
             value={value}
             onChange={onChange}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
@@ -1,4 +1,3 @@
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
 import {
     OpprettBehandlingFelt,
@@ -12,7 +11,6 @@ import { Select } from '@navikt/ds-react';
 
 export const BehandlingstemaFelt = () => {
     const fagsak = useFagsak();
-    const erLesevisning = useErLesevisning();
 
     const { control } = useFormContext<OpprettBehandlingFormValues>();
     const {
@@ -30,7 +28,7 @@ export const BehandlingstemaFelt = () => {
     return (
         <Select
             label={'Velg behandlingstema'}
-            readOnly={erLesevisning || isSubmitting}
+            readOnly={isSubmitting}
             value={value?.id}
             onChange={event => {
                 onChange(konverterTilBehandlingstema(event.target.value));

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
@@ -29,12 +29,15 @@ export const BehandlingstemaFelt = () => {
         <Select
             label={'Velg behandlingstema'}
             readOnly={isSubmitting}
-            value={value?.id}
+            value={value?.id ?? ''}
             onChange={event => {
                 onChange(konverterTilBehandlingstema(event.target.value));
             }}
             error={error?.message}
         >
+            <option disabled value={''}>
+                Velg behandlingstema
+            </option>
             {Object.values(behandlingstemaer)
                 .filter(it => it.id !== 'NASJONAL_INSTITUSJON')
                 .filter(

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
@@ -4,7 +4,7 @@ import {
     OpprettBehandlingFelt,
     type OpprettBehandlingFormValues,
 } from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
-import { BehandlingKategori, behandlingstemaer, type IBehandlingstema } from '@typer/behandlingstema';
+import { BehandlingKategori, behandlingstemaer, konverterTilBehandlingstema } from '@typer/behandlingstema';
 import { FagsakType } from '@typer/fagsak';
 import { useController, useFormContext } from 'react-hook-form';
 
@@ -27,16 +27,11 @@ export const BehandlingstemaFelt = () => {
         },
     });
 
-    // TODO: fiks herfra og ned
-    const konverterTilBehandlingstema = (behandlingstemaId: string): IBehandlingstema => {
-        return behandlingstemaer[behandlingstemaId as keyof typeof behandlingstemaer];
-    };
-
     return (
         <Select
             label={'Velg behandlingstema'}
             readOnly={erLesevisning || isSubmitting}
-            value={value.id}
+            value={value?.id}
             onChange={event => {
                 onChange(konverterTilBehandlingstema(event.target.value));
             }}
@@ -51,7 +46,7 @@ export const BehandlingstemaFelt = () => {
                 )
                 .map(tema => {
                     return (
-                        <option key={tema.id} aria-selected={value.id === tema.id} value={tema.id}>
+                        <option key={tema.id} aria-selected={value?.id === tema.id} value={tema.id}>
                             {tema.navn}
                         </option>
                     );

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
@@ -1,0 +1,61 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { BehandlingKategori, behandlingstemaer, type IBehandlingstema } from '@typer/behandlingstema';
+import { FagsakType } from '@typer/fagsak';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Select } from '@navikt/ds-react';
+
+export const BehandlingstemaFelt = () => {
+    const fagsak = useFagsak();
+    const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<OpprettBehandlingFormValues>();
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: OpprettBehandlingFelt.BEHANDLINGSTEMA,
+        control,
+        rules: {
+            required: 'Behandlingstema må velges.',
+        },
+    });
+
+    // TODO: fiks herfra og ned
+    const konverterTilBehandlingstema = (behandlingstemaId: string): IBehandlingstema => {
+        return behandlingstemaer[behandlingstemaId as keyof typeof behandlingstemaer];
+    };
+
+    return (
+        <Select
+            label={'Velg behandlingstema'}
+            readOnly={erLesevisning || isSubmitting}
+            value={value.id}
+            onChange={event => {
+                onChange(konverterTilBehandlingstema(event.target.value));
+            }}
+            error={error?.message}
+        >
+            {Object.values(behandlingstemaer)
+                .filter(it => it.id !== 'NASJONAL_INSTITUSJON')
+                .filter(
+                    it =>
+                        it.kategori !== BehandlingKategori.EØS ||
+                        fagsak.fagsakType !== FagsakType.BARN_ENSLIG_MINDREÅRIG
+                )
+                .map(tema => {
+                    return (
+                        <option key={tema.id} aria-selected={value.id === tema.id} value={tema.id}>
+                            {tema.navn}
+                        </option>
+                    );
+                })}
+        </Select>
+    );
+};

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstemaFelt.tsx
@@ -45,13 +45,11 @@ export const BehandlingstemaFelt = () => {
                         it.kategori !== BehandlingKategori.EØS ||
                         fagsak.fagsakType !== FagsakType.BARN_ENSLIG_MINDREÅRIG
                 )
-                .map(tema => {
-                    return (
-                        <option key={tema.id} aria-selected={value?.id === tema.id} value={tema.id}>
-                            {tema.navn}
-                        </option>
-                    );
-                })}
+                .map(tema => (
+                    <option key={tema.id} aria-selected={value?.id === tema.id} value={tema.id}>
+                        {tema.navn}
+                    </option>
+                ))}
         </Select>
     );
 };

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstypeFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstypeFelt.tsx
@@ -1,4 +1,3 @@
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import {
@@ -16,7 +15,6 @@ import { Select } from '@navikt/ds-react';
 
 export function BehandlingstypeFelt() {
     const fagsak = useFagsak();
-    const erLesevisning = useErLesevisning();
     const saksbehandler = useSaksbehandler();
 
     const { control, setValue, reset } = useFormContext<OpprettBehandlingFormValues>();
@@ -60,7 +58,7 @@ export function BehandlingstypeFelt() {
     return (
         <Select
             label={'Velg type behandling'}
-            readOnly={isSubmitting || erLesevisning}
+            readOnly={isSubmitting}
             value={value}
             onChange={handleOnChange}
             error={error?.message}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstypeFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstypeFelt.tsx
@@ -4,11 +4,8 @@ import {
     OpprettBehandlingFelt,
     type OpprettBehandlingFormValues,
 } from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
-import { BehandlingStatus, Behandlingstype, BehandlingÅrsak, erBehandlingHenlagt } from '@typer/behandling';
-import { FagsakStatus } from '@typer/fagsak';
-import { Klagebehandlingstype } from '@typer/klage';
-import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
-import { hentAktivBehandlingPåMinimalFagsak } from '@utils/fagsak';
+import { Behandlingstype, behandlingstyper, BehandlingÅrsak } from '@typer/behandling';
+import { hentTilgjengeligeBehandlingstyper } from '@utils/behandling';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Select } from '@navikt/ds-react';
@@ -30,17 +27,6 @@ export function BehandlingstypeFelt() {
             required: 'Velg type behandling som skal opprettes fra nedtrekkslisten.',
         },
     });
-
-    const behandling = fagsak ? hentAktivBehandlingPåMinimalFagsak(fagsak) : undefined;
-    const harIkkeAktivBehandling = !behandling || behandling?.status === BehandlingStatus.AVSLUTTET;
-
-    const kanOppretteFørstegangsbehandling =
-        fagsak === undefined || (fagsak.status !== FagsakStatus.LØPENDE && harIkkeAktivBehandling);
-    const kanOppretteRevurdering =
-        harIkkeAktivBehandling &&
-        (fagsak?.behandlinger.some(behandling => !erBehandlingHenlagt(behandling.resultat)) ?? false);
-    const kanOppretteTekniskEndring = harIkkeAktivBehandling && saksbehandler.harSuperbrukertilgang;
-    const kanOppretteKlagebehandling = fagsak !== undefined && !fagsak.finnesStrengtFortroligPersonIFagsak;
 
     function handleOnChange(event: React.ChangeEvent<HTMLSelectElement>) {
         reset();
@@ -66,46 +52,11 @@ export function BehandlingstypeFelt() {
             <option disabled={true} value={''}>
                 Velg
             </option>
-            {kanOppretteFørstegangsbehandling && (
-                <option
-                    aria-selected={value === Behandlingstype.FØRSTEGANGSBEHANDLING}
-                    value={Behandlingstype.FØRSTEGANGSBEHANDLING}
-                >
-                    Førstegangsbehandling
+            {hentTilgjengeligeBehandlingstyper(fagsak, saksbehandler).map(type => (
+                <option key={type} aria-selected={value === type} value={type}>
+                    {behandlingstyper[type].navn}
                 </option>
-            )}
-            {kanOppretteRevurdering && (
-                <option aria-selected={value === Behandlingstype.REVURDERING} value={Behandlingstype.REVURDERING}>
-                    Revurdering
-                </option>
-            )}
-            {kanOppretteTekniskEndring && (
-                <option
-                    aria-selected={value === Behandlingstype.TEKNISK_ENDRING}
-                    value={Behandlingstype.TEKNISK_ENDRING}
-                >
-                    Teknisk endring
-                </option>
-            )}
-            <option
-                aria-selected={value === Tilbakekrevingsbehandlingstype.TILBAKEKREVING}
-                value={Tilbakekrevingsbehandlingstype.TILBAKEKREVING}
-            >
-                Tilbakekreving
-            </option>
-            {kanOppretteKlagebehandling && (
-                <option aria-selected={value === Klagebehandlingstype.KLAGE} value={Klagebehandlingstype.KLAGE}>
-                    Klage
-                </option>
-            )}
-            {harIkkeAktivBehandling && (
-                <option
-                    aria-selected={value === Behandlingstype.MIGRERING_FRA_INFOTRYGD}
-                    value={Behandlingstype.MIGRERING_FRA_INFOTRYGD}
-                >
-                    Migrering fra infotrygd
-                </option>
-            )}
+            ))}
         </Select>
     );
 }

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstypeFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingstypeFelt.tsx
@@ -1,0 +1,113 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { BehandlingStatus, Behandlingstype, BehandlingÅrsak, erBehandlingHenlagt } from '@typer/behandling';
+import { FagsakStatus } from '@typer/fagsak';
+import { Klagebehandlingstype } from '@typer/klage';
+import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import { hentAktivBehandlingPåMinimalFagsak } from '@utils/fagsak';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Select } from '@navikt/ds-react';
+
+export function BehandlingstypeFelt() {
+    const fagsak = useFagsak();
+    const erLesevisning = useErLesevisning();
+    const saksbehandler = useSaksbehandler();
+
+    const { control, setValue, reset } = useFormContext<OpprettBehandlingFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: OpprettBehandlingFelt.BEHANDLINGSTYPE,
+        control,
+        rules: {
+            required: 'Velg type behandling som skal opprettes fra nedtrekkslisten.',
+        },
+    });
+
+    const behandling = fagsak ? hentAktivBehandlingPåMinimalFagsak(fagsak) : undefined;
+    const harIkkeAktivBehandling = !behandling || behandling?.status === BehandlingStatus.AVSLUTTET;
+
+    const kanOppretteFørstegangsbehandling =
+        fagsak === undefined || (fagsak.status !== FagsakStatus.LØPENDE && harIkkeAktivBehandling);
+    const kanOppretteRevurdering =
+        harIkkeAktivBehandling &&
+        (fagsak?.behandlinger.some(behandling => !erBehandlingHenlagt(behandling.resultat)) ?? false);
+    const kanOppretteTekniskEndring = harIkkeAktivBehandling && saksbehandler.harSuperbrukertilgang;
+    const kanOppretteKlagebehandling = fagsak !== undefined && !fagsak.finnesStrengtFortroligPersonIFagsak;
+
+    function handleOnChange(event: React.ChangeEvent<HTMLSelectElement>) {
+        reset();
+
+        const nyVerdi = event.target.value;
+        onChange(nyVerdi);
+
+        if (nyVerdi === Behandlingstype.FØRSTEGANGSBEHANDLING) {
+            setValue(OpprettBehandlingFelt.BEHANDLINGSÅRSAK, BehandlingÅrsak.SØKNAD);
+        } else if (nyVerdi === Behandlingstype.TEKNISK_ENDRING) {
+            setValue(OpprettBehandlingFelt.BEHANDLINGSÅRSAK, BehandlingÅrsak.TEKNISK_ENDRING);
+        }
+    }
+
+    return (
+        <Select
+            label={'Velg type behandling'}
+            readOnly={isSubmitting || erLesevisning}
+            value={value}
+            onChange={handleOnChange}
+            error={error?.message}
+        >
+            <option disabled={true} value={''}>
+                Velg
+            </option>
+            {kanOppretteFørstegangsbehandling && (
+                <option
+                    aria-selected={value === Behandlingstype.FØRSTEGANGSBEHANDLING}
+                    value={Behandlingstype.FØRSTEGANGSBEHANDLING}
+                >
+                    Førstegangsbehandling
+                </option>
+            )}
+            {kanOppretteRevurdering && (
+                <option aria-selected={value === Behandlingstype.REVURDERING} value={Behandlingstype.REVURDERING}>
+                    Revurdering
+                </option>
+            )}
+            {kanOppretteTekniskEndring && (
+                <option
+                    aria-selected={value === Behandlingstype.TEKNISK_ENDRING}
+                    value={Behandlingstype.TEKNISK_ENDRING}
+                >
+                    Teknisk endring
+                </option>
+            )}
+            <option
+                aria-selected={value === Tilbakekrevingsbehandlingstype.TILBAKEKREVING}
+                value={Tilbakekrevingsbehandlingstype.TILBAKEKREVING}
+            >
+                Tilbakekreving
+            </option>
+            {kanOppretteKlagebehandling && (
+                <option aria-selected={value === Klagebehandlingstype.KLAGE} value={Klagebehandlingstype.KLAGE}>
+                    Klage
+                </option>
+            )}
+            {harIkkeAktivBehandling && (
+                <option
+                    aria-selected={value === Behandlingstype.MIGRERING_FRA_INFOTRYGD}
+                    value={Behandlingstype.MIGRERING_FRA_INFOTRYGD}
+                >
+                    Migrering fra infotrygd
+                </option>
+            )}
+        </Select>
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
@@ -54,13 +54,11 @@ export function BehandlingsårsakFelt() {
                 erMigreringFraInfotrygd,
                 kanOppretteMigreringsbehandlingMedHelmanuellMigrering,
                 kanOppretteMigreringsbehandlingMedEndreMigreringsdato
-            ).map(årsak => {
-                return (
-                    <option key={årsak} aria-selected={value === årsak} value={årsak}>
-                        {behandlingÅrsak[årsak]}
-                    </option>
-                );
-            })}
+            ).map(årsak => (
+                <option key={årsak} aria-selected={value === årsak} value={årsak}>
+                    {behandlingÅrsak[årsak]}
+                </option>
+            ))}
         </Select>
     );
 }

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
@@ -1,0 +1,68 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { BehandlingStatus, Behandlingstype, behandlingÅrsak, erBehandlingHenlagt } from '@typer/behandling';
+import { FagsakStatus } from '@typer/fagsak';
+import { forrigeBehandlingVarTekniskEndringMedOpphør, hentTilgjengeligeBehandlingsårsaker } from '@utils/behandling';
+import { hentAktivBehandlingPåMinimalFagsak } from '@utils/fagsak';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Select } from '@navikt/ds-react';
+
+export function BehandlingsårsakFelt() {
+    const fagsak = useFagsak();
+    const erLesevisning = useErLesevisning();
+
+    const { control, watch } = useFormContext<OpprettBehandlingFormValues>();
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: OpprettBehandlingFelt.BEHANDLINGSÅRSAK,
+        control,
+        rules: {
+            required: 'Velg årsak for opprettelse av behandlingen fra nedtrekkslisten.',
+        },
+    });
+
+    const behandlingstype = watch(OpprettBehandlingFelt.BEHANDLINGSTYPE);
+    const erMigreringFraInfotrygd = behandlingstype === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
+
+    const aktivBehandling = fagsak ? hentAktivBehandlingPåMinimalFagsak(fagsak) : undefined;
+    const kanOppretteMigreringFraInfotrygd = !aktivBehandling || aktivBehandling?.status === BehandlingStatus.AVSLUTTET;
+    const kanOppretteMigreringsbehandlingMedHelmanuellMigrering =
+        (kanOppretteMigreringFraInfotrygd && forrigeBehandlingVarTekniskEndringMedOpphør(fagsak)) ||
+        fagsak?.status !== FagsakStatus.LØPENDE;
+    const kanOppretteMigreringsbehandlingMedEndreMigreringsdato =
+        kanOppretteMigreringFraInfotrygd &&
+        (fagsak?.behandlinger.some(behandling => !erBehandlingHenlagt(behandling.resultat)) ?? false);
+
+    return (
+        <Select
+            label={'Velg behandlingsårsak'}
+            readOnly={erLesevisning || isSubmitting}
+            value={value}
+            onChange={onChange}
+            error={error?.message}
+        >
+            <option disabled={true} value={''}>
+                Velg
+            </option>
+            {hentTilgjengeligeBehandlingsårsaker(
+                erMigreringFraInfotrygd,
+                kanOppretteMigreringsbehandlingMedHelmanuellMigrering,
+                kanOppretteMigreringsbehandlingMedEndreMigreringsdato
+            ).map(årsak => {
+                return (
+                    <option key={årsak} aria-selected={value === årsak} value={årsak}>
+                        {behandlingÅrsak[årsak]}
+                    </option>
+                );
+            })}
+        </Select>
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
@@ -1,4 +1,3 @@
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
 import {
     OpprettBehandlingFelt,
@@ -14,7 +13,6 @@ import { Select } from '@navikt/ds-react';
 
 export function BehandlingsårsakFelt() {
     const fagsak = useFagsak();
-    const erLesevisning = useErLesevisning();
 
     const { control, watch } = useFormContext<OpprettBehandlingFormValues>();
     const {
@@ -44,7 +42,7 @@ export function BehandlingsårsakFelt() {
     return (
         <Select
             label={'Velg behandlingsårsak'}
-            readOnly={erLesevisning || isSubmitting}
+            readOnly={isSubmitting}
             value={value}
             onChange={onChange}
             error={error?.message}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/BehandlingsårsakFelt.tsx
@@ -33,8 +33,8 @@ export function BehandlingsårsakFelt() {
     const aktivBehandling = fagsak ? hentAktivBehandlingPåMinimalFagsak(fagsak) : undefined;
     const kanOppretteMigreringFraInfotrygd = !aktivBehandling || aktivBehandling?.status === BehandlingStatus.AVSLUTTET;
     const kanOppretteMigreringsbehandlingMedHelmanuellMigrering =
-        (kanOppretteMigreringFraInfotrygd && forrigeBehandlingVarTekniskEndringMedOpphør(fagsak)) ||
-        fagsak?.status !== FagsakStatus.LØPENDE;
+        kanOppretteMigreringFraInfotrygd &&
+        (forrigeBehandlingVarTekniskEndringMedOpphør(fagsak) || fagsak?.status !== FagsakStatus.LØPENDE);
     const kanOppretteMigreringsbehandlingMedEndreMigreringsdato =
         kanOppretteMigreringFraInfotrygd &&
         (fagsak?.behandlinger.some(behandling => !erBehandlingHenlagt(behandling.resultat)) ?? false);

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/KlageMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/KlageMottattDatoFelt.tsx
@@ -1,6 +1,5 @@
 import { useRef } from 'react';
 
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import { tidligsteRelevanteDato } from '@komponenter/Datovelger/utils';
 import {
     OpprettBehandlingFelt,
@@ -13,8 +12,6 @@ import { useController, useFormContext } from 'react-hook-form';
 import { DatePicker, type DateValidationT, useDatepicker } from '@navikt/ds-react';
 
 export function KlageMottattDatoFelt() {
-    const erLesevisning = useErLesevisning();
-
     const { control, trigger } = useFormContext<OpprettBehandlingFormValues>();
     const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
 
@@ -74,7 +71,7 @@ export function KlageMottattDatoFelt() {
                 label={'Klage mottatt dato'}
                 placeholder={'DD.MM.ÅÅÅÅ'}
                 error={error?.message}
-                readOnly={isSubmitting || erLesevisning}
+                readOnly={isSubmitting}
             />
         </DatePicker>
     );

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/KlageMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/KlageMottattDatoFelt.tsx
@@ -31,7 +31,7 @@ export function KlageMottattDatoFelt() {
                 }
 
                 if (dateValidation && dateValidation.isBefore) {
-                    return `Du kan ikke sette en dato som er etter ${format(tidligsteRelevanteDato, 'dd.MM.yyyy')}.`;
+                    return `Du må velge en dato som er etter ${format(tidligsteRelevanteDato, 'dd.MM.yyyy')}.`;
                 }
 
                 if (dateValidation && (dateValidation.isInvalid || !dateValidation.isValidDate)) {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/KlageMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/KlageMottattDatoFelt.tsx
@@ -1,0 +1,81 @@
+import { useRef } from 'react';
+
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { tidligsteRelevanteDato } from '@komponenter/Datovelger/utils';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { dagensDato, dateTilIsoDatoString, isoStringTilDate } from '@utils/dato';
+import { format, startOfDay } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { DatePicker, type DateValidationT, useDatepicker } from '@navikt/ds-react';
+
+export function KlageMottattDatoFelt() {
+    const erLesevisning = useErLesevisning();
+
+    const { control, trigger } = useFormContext<OpprettBehandlingFormValues>();
+    const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
+
+    const {
+        field: { onChange, value },
+        fieldState: { error },
+        formState: { isSubmitting, isSubmitted },
+    } = useController({
+        name: OpprettBehandlingFelt.KLAGE_MOTTATT_DATO,
+        control,
+        rules: {
+            validate: value => {
+                const dateValidation = dateValidationRef.current;
+
+                if (dateValidation && dateValidation.isAfter) {
+                    return 'Du kan ikke sette en dato som er frem i tid.';
+                }
+
+                if (dateValidation && dateValidation.isBefore) {
+                    return `Du kan ikke sette en dato som er etter ${format(tidligsteRelevanteDato, 'dd.MM.yyyy')}.`;
+                }
+
+                if (dateValidation && (dateValidation.isInvalid || !dateValidation.isValidDate)) {
+                    return 'Du må velge en gyldig dato';
+                }
+
+                if (!value) {
+                    return 'Du må velge en gyldig dato';
+                }
+
+                return undefined;
+            },
+        },
+    });
+
+    const { datepickerProps, inputProps } = useDatepicker({
+        onDateChange: dato => {
+            onChange(dato ? dateTilIsoDatoString(startOfDay(dato)) : '');
+            if (isSubmitted) {
+                trigger(OpprettBehandlingFelt.KLAGE_MOTTATT_DATO);
+            }
+        },
+        fromDate: tidligsteRelevanteDato,
+        toDate: dagensDato,
+        required: true,
+        onValidate: validation => {
+            dateValidationRef.current = validation;
+            trigger(OpprettBehandlingFelt.KLAGE_MOTTATT_DATO);
+        },
+        defaultSelected: value ? isoStringTilDate(value) : undefined,
+    });
+
+    return (
+        <DatePicker {...datepickerProps}>
+            <DatePicker.Input
+                {...inputProps}
+                label={'Klage mottatt dato'}
+                placeholder={'DD.MM.ÅÅÅÅ'}
+                error={error?.message}
+                readOnly={isSubmitting || erLesevisning}
+            />
+        </DatePicker>
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/MigreringsdatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/MigreringsdatoFelt.tsx
@@ -1,0 +1,83 @@
+import { useRef } from 'react';
+
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { tidligsteRelevanteDato } from '@komponenter/Datovelger/utils';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { dateTilIsoDatoString, isoStringTilDate } from '@utils/dato';
+import { format, startOfDay } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { DatePicker, type DateValidationT, useDatepicker } from '@navikt/ds-react';
+
+export function MigreringsdatoFelt() {
+    const MAKSDATO_FOR_MIGRERING = new Date('2023-01-01');
+
+    const erLesevisning = useErLesevisning();
+
+    const { control, trigger } = useFormContext<OpprettBehandlingFormValues>();
+    const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
+
+    const {
+        field: { onChange, value },
+        fieldState: { error },
+        formState: { isSubmitting, isSubmitted },
+    } = useController({
+        name: OpprettBehandlingFelt.MIGRERINGSDATO,
+        control,
+        rules: {
+            validate: value => {
+                const dateValidation = dateValidationRef.current;
+
+                if (dateValidation && dateValidation.isAfter) {
+                    return `Du kan ikke sette en dato som er etter ${format(MAKSDATO_FOR_MIGRERING, 'dd.MM.yyyy')}.`;
+                }
+
+                if (dateValidation && dateValidation.isBefore) {
+                    return `Du må velge en dato som er etter ${format(tidligsteRelevanteDato, 'dd.MM.yyyy')}.`;
+                }
+
+                if (dateValidation && (dateValidation.isInvalid || !dateValidation.isValidDate)) {
+                    return 'Du må velge en gyldig dato';
+                }
+
+                if (!value) {
+                    return 'Du må velge en gyldig dato';
+                }
+
+                return undefined;
+            },
+        },
+    });
+
+    const { datepickerProps, inputProps } = useDatepicker({
+        onDateChange: dato => {
+            onChange(dato ? dateTilIsoDatoString(startOfDay(dato)) : '');
+            if (isSubmitted) {
+                trigger(OpprettBehandlingFelt.MIGRERINGSDATO);
+            }
+        },
+        fromDate: tidligsteRelevanteDato,
+        toDate: MAKSDATO_FOR_MIGRERING,
+        required: true,
+        onValidate: validation => {
+            dateValidationRef.current = validation;
+            trigger(OpprettBehandlingFelt.MIGRERINGSDATO);
+        },
+        defaultSelected: value ? isoStringTilDate(value) : undefined,
+    });
+
+    return (
+        <DatePicker {...datepickerProps}>
+            <DatePicker.Input
+                {...inputProps}
+                label={'Ny migreringsdato'}
+                placeholder={'DD.MM.ÅÅÅÅ'}
+                error={error?.message}
+                readOnly={isSubmitting || erLesevisning}
+            />
+        </DatePicker>
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/MigreringsdatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/MigreringsdatoFelt.tsx
@@ -11,9 +11,9 @@ import { useController, useFormContext } from 'react-hook-form';
 
 import { DatePicker, type DateValidationT, useDatepicker } from '@navikt/ds-react';
 
-export function MigreringsdatoFelt() {
-    const MAKSDATO_FOR_MIGRERING = new Date('2023-01-01');
+const MAKSDATO_FOR_MIGRERING = new Date('2023-01-01');
 
+export function MigreringsdatoFelt() {
     const { control, trigger } = useFormContext<OpprettBehandlingFormValues>();
     const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
 

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/MigreringsdatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/MigreringsdatoFelt.tsx
@@ -1,6 +1,5 @@
 import { useRef } from 'react';
 
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import { tidligsteRelevanteDato } from '@komponenter/Datovelger/utils';
 import {
     OpprettBehandlingFelt,
@@ -14,8 +13,6 @@ import { DatePicker, type DateValidationT, useDatepicker } from '@navikt/ds-reac
 
 export function MigreringsdatoFelt() {
     const MAKSDATO_FOR_MIGRERING = new Date('2023-01-01');
-
-    const erLesevisning = useErLesevisning();
 
     const { control, trigger } = useFormContext<OpprettBehandlingFormValues>();
     const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
@@ -76,7 +73,7 @@ export function MigreringsdatoFelt() {
                 label={'Ny migreringsdato'}
                 placeholder={'DD.MM.ÅÅÅÅ'}
                 error={error?.message}
-                readOnly={isSubmitting || erLesevisning}
+                readOnly={isSubmitting}
             />
         </DatePicker>
     );

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/SøknadMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/SøknadMottattDatoFelt.tsx
@@ -1,6 +1,5 @@
 import { useRef } from 'react';
 
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import { tidligsteRelevanteDato } from '@komponenter/Datovelger/utils';
 import {
     OpprettBehandlingFelt,
@@ -13,8 +12,6 @@ import { useController, useFormContext } from 'react-hook-form';
 import { Box, DatePicker, type DateValidationT, LocalAlert, useDatepicker } from '@navikt/ds-react';
 
 export function SøknadMottattDatoFelt() {
-    const erLesevisning = useErLesevisning();
-
     const { control, trigger } = useFormContext<OpprettBehandlingFormValues>();
     const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
 
@@ -77,7 +74,7 @@ export function SøknadMottattDatoFelt() {
                     label={'Søknad mottatt dato'}
                     placeholder={'DD.MM.ÅÅÅÅ'}
                     error={error?.message}
-                    readOnly={isSubmitting || erLesevisning}
+                    readOnly={isSubmitting}
                 />
             </DatePicker>
             {søknadMottattDatoErMerEnn360DagerSiden && (

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/SøknadMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/SøknadMottattDatoFelt.tsx
@@ -47,7 +47,8 @@ export function SøknadMottattDatoFelt() {
         },
     });
 
-    const søknadMottattDatoErMerEnn360DagerSiden = value && isBefore(value, subDays(dagensDato, 360));
+    const søknadMottattDatoErMerEnn360DagerSiden =
+        !!value && isBefore(isoStringTilDate(value), subDays(dagensDato, 360));
 
     const { datepickerProps, inputProps } = useDatepicker({
         onDateChange: dato => {

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/SøknadMottattDatoFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/SøknadMottattDatoFelt.tsx
@@ -1,0 +1,95 @@
+import { useRef } from 'react';
+
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { tidligsteRelevanteDato } from '@komponenter/Datovelger/utils';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import { dagensDato, dateTilIsoDatoString, isoStringTilDate } from '@utils/dato';
+import { format, isBefore, startOfDay, subDays } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Box, DatePicker, type DateValidationT, LocalAlert, useDatepicker } from '@navikt/ds-react';
+
+export function SøknadMottattDatoFelt() {
+    const erLesevisning = useErLesevisning();
+
+    const { control, trigger } = useFormContext<OpprettBehandlingFormValues>();
+    const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
+
+    const {
+        field: { onChange, value },
+        fieldState: { error },
+        formState: { isSubmitting, isSubmitted },
+    } = useController({
+        name: OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO,
+        control,
+        rules: {
+            validate: value => {
+                const dateValidation = dateValidationRef.current;
+
+                if (dateValidation && dateValidation.isAfter) {
+                    return 'Du kan ikke sette en dato som er frem i tid.';
+                }
+
+                if (dateValidation && dateValidation.isBefore) {
+                    return `Du må velge en dato som er etter ${format(tidligsteRelevanteDato, 'dd.MM.yyyy')}.`;
+                }
+
+                if (dateValidation && (dateValidation.isInvalid || !dateValidation.isValidDate)) {
+                    return 'Du må velge en gyldig dato';
+                }
+
+                if (!value) {
+                    return 'Du må velge en gyldig dato';
+                }
+
+                return undefined;
+            },
+        },
+    });
+
+    const søknadMottattDatoErMerEnn360DagerSiden = value && isBefore(value, subDays(dagensDato, 360));
+
+    const { datepickerProps, inputProps } = useDatepicker({
+        onDateChange: dato => {
+            onChange(dato ? dateTilIsoDatoString(startOfDay(dato)) : '');
+            if (isSubmitted) {
+                trigger(OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO);
+            }
+        },
+        fromDate: tidligsteRelevanteDato,
+        toDate: dagensDato,
+        required: true,
+        onValidate: validation => {
+            dateValidationRef.current = validation;
+            trigger(OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO);
+        },
+        defaultSelected: value ? isoStringTilDate(value) : undefined,
+    });
+
+    return (
+        <>
+            <DatePicker {...datepickerProps}>
+                <DatePicker.Input
+                    {...inputProps}
+                    label={'Søknad mottatt dato'}
+                    placeholder={'DD.MM.ÅÅÅÅ'}
+                    error={error?.message}
+                    readOnly={isSubmitting || erLesevisning}
+                />
+            </DatePicker>
+            {søknadMottattDatoErMerEnn360DagerSiden && (
+                <Box marginBlock={'space-24 space-0'}>
+                    <LocalAlert status={'warning'}>
+                        <LocalAlert.Header>
+                            <LocalAlert.Title>Er mottatt dato riktig?</LocalAlert.Title>
+                        </LocalAlert.Header>
+                        <LocalAlert.Content>Det er mer enn 360 dager siden denne datoen.</LocalAlert.Content>
+                    </LocalAlert>
+                </Box>
+            )}
+        </>
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
@@ -1,0 +1,50 @@
+import { useBruker } from '@hooks/useBruker';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import {
+    OpprettBehandlingFelt,
+    type OpprettBehandlingFormValues,
+} from '@komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
+import type { ComboboxOption } from '@typer/common';
+import { ForelderBarnRelasjonRolle } from '@typer/person';
+import { hentAlder } from '@utils/formatter';
+import { onOptionSelected } from '@utils/skjema';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { UNSAFE_Combobox } from '@navikt/ds-react';
+
+export function ValgteBarnFelt() {
+    const erLesevisning = useErLesevisning();
+    const bruker = useBruker();
+
+    const { control } = useFormContext<OpprettBehandlingFormValues>();
+
+    const {
+        field: { value },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: OpprettBehandlingFelt.VALGTE_BARN,
+        control,
+    });
+
+    const barn =
+        bruker?.forelderBarnRelasjon
+            .filter(relasjon => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
+            .map<ComboboxOption>(relasjon => ({
+                value: relasjon.personIdent,
+                label: `${relasjon.navn} (${hentAlder(relasjon.fødselsdato)} år) | ${relasjon.personIdent}`,
+            })) ?? [];
+
+    // TODO: sjekk Personvelger.tsx for inspo
+    return (
+        <UNSAFE_Combobox
+            label={'Legg til juridiske barn for migrering'}
+            isMultiSelect
+            readOnly={isSubmitting || erLesevisning}
+            options={barn}
+            selectedOptions={value.map(barn => barn.value)}
+            onToggleSelected={(valgtOption, isSelected) => onOptionSelected(valgtOption, isSelected)}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
@@ -1,5 +1,4 @@
 import { useBruker } from '@hooks/useBruker';
-import { useErLesevisning } from '@hooks/useErLesevisning';
 import {
     OpprettBehandlingFelt,
     type OpprettBehandlingFormValues,
@@ -12,7 +11,6 @@ import { useController, useFormContext } from 'react-hook-form';
 import { UNSAFE_Combobox } from '@navikt/ds-react';
 
 export function ValgteBarnFelt() {
-    const erLesevisning = useErLesevisning();
     const bruker = useBruker();
 
     const { control } = useFormContext<OpprettBehandlingFormValues>();
@@ -46,7 +44,7 @@ export function ValgteBarnFelt() {
         <UNSAFE_Combobox
             label={'Legg til juridiske barn for migrering'}
             isMultiSelect
-            readOnly={isSubmitting || erLesevisning}
+            readOnly={isSubmitting}
             options={barn}
             selectedOptions={value.map(barn => barn.value)}
             onToggleSelected={onToggleSelected}

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
@@ -35,7 +35,7 @@ export function ValgteBarnFelt() {
     function onToggleSelected(optionValue: string, isSelected: boolean) {
         const valgteBarn = value;
         const nyVerdi = isSelected
-            ? [...valgteBarn, barn.find(b => b.value === optionValue)]
+            ? [...valgteBarn, barn.find(b => b.value === optionValue)].filter(Boolean)
             : valgteBarn.filter(b => b.value !== optionValue);
         onChange(nyVerdi);
     }

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/felter/ValgteBarnFelt.tsx
@@ -7,7 +7,6 @@ import {
 import type { ComboboxOption } from '@typer/common';
 import { ForelderBarnRelasjonRolle } from '@typer/person';
 import { hentAlder } from '@utils/formatter';
-import { onOptionSelected } from '@utils/skjema';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';
@@ -19,7 +18,7 @@ export function ValgteBarnFelt() {
     const { control } = useFormContext<OpprettBehandlingFormValues>();
 
     const {
-        field: { value },
+        field: { value, onChange },
         fieldState: { error },
         formState: { isSubmitting },
     } = useController({
@@ -35,7 +34,14 @@ export function ValgteBarnFelt() {
                 label: `${relasjon.navn} (${hentAlder(relasjon.fødselsdato)} år) | ${relasjon.personIdent}`,
             })) ?? [];
 
-    // TODO: sjekk Personvelger.tsx for inspo
+    function onToggleSelected(optionValue: string, isSelected: boolean) {
+        const valgteBarn = value;
+        const nyVerdi = isSelected
+            ? [...valgteBarn, barn.find(b => b.value === optionValue)]
+            : valgteBarn.filter(b => b.value !== optionValue);
+        onChange(nyVerdi);
+    }
+
     return (
         <UNSAFE_Combobox
             label={'Legg til juridiske barn for migrering'}
@@ -43,7 +49,7 @@ export function ValgteBarnFelt() {
             readOnly={isSubmitting || erLesevisning}
             options={barn}
             selectedOptions={value.map(barn => barn.value)}
-            onToggleSelected={(valgtOption, isSelected) => onOptionSelected(valgtOption, isSelected)}
+            onToggleSelected={onToggleSelected}
             error={error?.message}
         />
     );

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -35,7 +35,7 @@ export interface OpprettBehandlingFormValues {
         | Klagebehandlingstype
         | string;
     [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: BehandlingÅrsak | string;
-    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema | undefined;
+    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema | null;
     [OpprettBehandlingFelt.MIGRERINGSDATO]: IsoDatoString;
     [OpprettBehandlingFelt.BEGRUNNELSE]: string;
     [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: IsoDatoString;
@@ -69,7 +69,7 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
         defaultValues: {
             [OpprettBehandlingFelt.BEHANDLINGSTYPE]: '',
             [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: '',
-            [OpprettBehandlingFelt.BEHANDLINGSTEMA]: undefined,
+            [OpprettBehandlingFelt.BEHANDLINGSTEMA]: null,
             [OpprettBehandlingFelt.MIGRERINGSDATO]: '',
             [OpprettBehandlingFelt.BEGRUNNELSE]: '',
             [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: '',
@@ -129,8 +129,8 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
 
                 const opprettBehandlingParameters = {
                     // TODO: test at alle verdiene kommer frem som forventet, ref bug sist
-                    kategori: behandlingstema.kategori || null,
-                    underkategori: behandlingstema.underkategori || null,
+                    kategori: behandlingstema?.kategori || null,
+                    underkategori: behandlingstema?.underkategori || null,
                     behandlingType: behandlingstype,
                     behandlingÅrsak: behandlingsårsak,
                     navIdent: saksbehandler.navIdent,

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -128,7 +128,6 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
                     erMigreringFraInfoTrygd && behandlingsårsak === BehandlingÅrsak.HELMANUELL_MIGRERING;
 
                 const opprettBehandlingParameters = {
-                    // TODO: test at alle verdiene kommer frem som forventet, ref bug sist
                     kategori: behandlingstema?.kategori || null,
                     underkategori: behandlingstema?.underkategori || null,
                     behandlingType: behandlingstype,
@@ -138,7 +137,7 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
                     søknadMottattDato: søknadMottattDato || undefined,
                     barnasIdenter: erHelmanuellMigrering ? valgteBarn.map(option => option.value) : undefined,
                     fagsakId: fagsakId,
-                    begrunnelse: begrunnelse,
+                    begrunnelse: begrunnelse || undefined,
                 };
                 const behandling = await opprettBehandling(opprettBehandlingParameters);
                 queryClient.invalidateQueries({

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -74,7 +74,7 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
             [OpprettBehandlingFelt.BEGRUNNELSE]: '',
             [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: '',
             [OpprettBehandlingFelt.KLAGE_MOTTATT_DATO]: '',
-            [OpprettBehandlingFelt.VALGTE_BARN]: undefined,
+            [OpprettBehandlingFelt.VALGTE_BARN]: [],
         },
     });
 

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -35,23 +35,23 @@ export interface OpprettBehandlingFormValues {
         | Klagebehandlingstype
         | string;
     [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: BehandlingÅrsak | string;
-    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema | undefined; // TODO: fix
+    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema | undefined;
     [OpprettBehandlingFelt.MIGRERINGSDATO]: IsoDatoString;
     [OpprettBehandlingFelt.BEGRUNNELSE]: string;
     [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: IsoDatoString;
     [OpprettBehandlingFelt.KLAGE_MOTTATT_DATO]: IsoDatoString;
-    [OpprettBehandlingFelt.VALGTE_BARN]: OptionType[]; // TODO: fix
+    [OpprettBehandlingFelt.VALGTE_BARN]: OptionType[];
 }
 
 interface TransformedOpprettBehandlingFormValues {
     [OpprettBehandlingFelt.BEHANDLINGSTYPE]: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype;
     [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: BehandlingÅrsak;
-    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema; // TODO: fix
+    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema;
     [OpprettBehandlingFelt.MIGRERINGSDATO]: IsoDatoString;
     [OpprettBehandlingFelt.BEGRUNNELSE]: string;
     [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: IsoDatoString;
     [OpprettBehandlingFelt.KLAGE_MOTTATT_DATO]: IsoDatoString;
-    [OpprettBehandlingFelt.VALGTE_BARN]: OptionType[]; // TODO: fix
+    [OpprettBehandlingFelt.VALGTE_BARN]: OptionType[];
 }
 
 interface Props {
@@ -69,12 +69,12 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
         defaultValues: {
             [OpprettBehandlingFelt.BEHANDLINGSTYPE]: '',
             [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: '',
-            [OpprettBehandlingFelt.BEHANDLINGSTEMA]: undefined, // TODO
+            [OpprettBehandlingFelt.BEHANDLINGSTEMA]: undefined,
             [OpprettBehandlingFelt.MIGRERINGSDATO]: '',
             [OpprettBehandlingFelt.BEGRUNNELSE]: '',
             [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: '',
             [OpprettBehandlingFelt.KLAGE_MOTTATT_DATO]: '',
-            [OpprettBehandlingFelt.VALGTE_BARN]: undefined, // TODO
+            [OpprettBehandlingFelt.VALGTE_BARN]: undefined,
         },
     });
 
@@ -131,12 +131,12 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
                     // TODO: test at alle verdiene kommer frem som forventet, ref bug sist
                     kategori: behandlingstema.kategori || null,
                     underkategori: behandlingstema.underkategori || null,
-                    behandlingType: behandlingstype as Behandlingstype,
-                    behandlingÅrsak: behandlingsårsak as BehandlingÅrsak,
+                    behandlingType: behandlingstype,
+                    behandlingÅrsak: behandlingsårsak,
                     navIdent: saksbehandler.navIdent,
                     nyMigreringsdato: migreringsdato || undefined,
                     søknadMottattDato: søknadMottattDato || undefined,
-                    barnasIdenter: erHelmanuellMigrering ? valgteBarn.map(option => option.value) : undefined, // TODO: trenger vi sjekken?
+                    barnasIdenter: erHelmanuellMigrering ? valgteBarn.map(option => option.value) : undefined,
                     fagsakId: fagsakId,
                     begrunnelse: begrunnelse,
                 };

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -108,7 +108,10 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
                     message: error instanceof Error ? error.message : 'Teknisk feil ved oppretting av klagebehandling.',
                 });
             }
-        } else if (behandlingstype === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
+        } else if (
+            behandlingstype === Tilbakekrevingsbehandlingstype.TILBAKEKREVING ||
+            behandlingstype === Tilbakekrevingsbehandlingstype.REVURDERING_TILBAKEKREVING
+        ) {
             try {
                 await opprettTilbakekreving({ fagsakId });
                 await queryClient.invalidateQueries({
@@ -140,7 +143,7 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
                     begrunnelse: begrunnelse || undefined,
                 };
                 const behandling = await opprettBehandling(opprettBehandlingParameters);
-                queryClient.invalidateQueries({
+                await queryClient.invalidateQueries({
                     queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
                 });
                 await queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) });

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-
+import { useFagsakId } from '@hooks/useFagsakId';
 import { HentBarnetrygdbehandlingerQueryKeyFactory } from '@hooks/useHentBarnetrygdbehandlinger';
 import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
 import { HentKlagebehandlingerQueryKeyFactory } from '@hooks/useHentKlagebehandlinger';
@@ -8,174 +7,85 @@ import { useOpprettBehandling } from '@hooks/useOpprettBehandling';
 import { useOpprettKlagebehandling } from '@hooks/useOpprettKlagebehandling';
 import { useOpprettTilbakekreving } from '@hooks/useOpprettTilbakekreving';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
-import { useBrukerContext } from '@sider/Fagsak/BrukerContext';
-import { useFagsakContext } from '@sider/Fagsak/FagsakContext';
 import { useQueryClient } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
 import { BehandlingSteg, Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
 import type { IBehandlingstema } from '@typer/behandlingstema';
-import { behandlingstemaer } from '@typer/behandlingstema';
 import type { OptionType } from '@typer/common';
-import { FagsakType } from '@typer/fagsak';
 import { Klagebehandlingstype } from '@typer/klage';
 import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
-import { dateTilIsoDatoString, dateTilIsoDatoStringEllerUndefined, validerGyldigDato } from '@utils/dato';
+import { type IsoDatoString } from '@utils/dato';
+import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
-import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import {
-    byggFunksjonellFeilRessurs,
-    byggHenterRessurs,
-    byggSuksessRessurs,
-    byggTomRessurs,
-} from '@navikt/familie-typer';
-
-export interface IOpprettBehandlingSkjemaBase {
-    behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | '';
-    behandlingsårsak: BehandlingÅrsak | '';
-    behandlingstema: IBehandlingstema | undefined;
+export enum OpprettBehandlingFelt {
+    BEHANDLINGSTYPE = 'behandlingstype',
+    BEHANDLINGSÅRSAK = 'behandlingsårsak',
+    BEHANDLINGSTEMA = 'behandlingstema',
+    MIGRERINGSDATO = 'migreringsdato',
+    BEGRUNNELSE = 'begrunnelse',
+    SØKNAD_MOTTATT_DATO = 'søknadMottattDato',
+    KLAGE_MOTTATT_DATO = 'klageMottattDato',
+    VALGTE_BARN = 'valgteBarn',
 }
 
-export interface IOpprettBehandlingSkjemaFelter extends IOpprettBehandlingSkjemaBase {
-    migreringsdato: Date | undefined;
-    søknadMottattDato: Date | undefined;
-    klageMottattDato: Date | undefined;
-    begrunnelse: string | undefined;
-    valgteBarn: OptionType[];
+export interface OpprettBehandlingFormValues {
+    [OpprettBehandlingFelt.BEHANDLINGSTYPE]:
+        | Behandlingstype
+        | Tilbakekrevingsbehandlingstype
+        | Klagebehandlingstype
+        | string;
+    [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: BehandlingÅrsak | string;
+    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema | undefined; // TODO: fix
+    [OpprettBehandlingFelt.MIGRERINGSDATO]: IsoDatoString;
+    [OpprettBehandlingFelt.BEGRUNNELSE]: string;
+    [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: IsoDatoString;
+    [OpprettBehandlingFelt.KLAGE_MOTTATT_DATO]: IsoDatoString;
+    [OpprettBehandlingFelt.VALGTE_BARN]: OptionType[]; // TODO: fix
+}
+
+interface TransformedOpprettBehandlingFormValues {
+    [OpprettBehandlingFelt.BEHANDLINGSTYPE]: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype;
+    [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: BehandlingÅrsak;
+    [OpprettBehandlingFelt.BEHANDLINGSTEMA]: IBehandlingstema; // TODO: fix
+    [OpprettBehandlingFelt.MIGRERINGSDATO]: IsoDatoString;
+    [OpprettBehandlingFelt.BEGRUNNELSE]: string;
+    [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: IsoDatoString;
+    [OpprettBehandlingFelt.KLAGE_MOTTATT_DATO]: IsoDatoString;
+    [OpprettBehandlingFelt.VALGTE_BARN]: OptionType[]; // TODO: fix
 }
 
 interface Props {
-    fagsakId: number;
     lukkModal: () => void;
     onTilbakekrevingsbehandlingOpprettet: () => void;
 }
 
-export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
-    const { fagsak } = useFagsakContext();
-    const { bruker } = useBrukerContext();
-
+export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
+    const fagsakId = useFagsakId();
     const saksbehandler = useSaksbehandler();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
 
-    const behandlingstype = useFelt<Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | ''>({
-        verdi: '',
-        valideringsfunksjon: felt => {
-            return felt.verdi !== ''
-                ? ok(felt)
-                : feil(felt, 'Velg type behandling som skal opprettes fra nedtrekkslisten');
+    const form = useForm<OpprettBehandlingFormValues, unknown, TransformedOpprettBehandlingFormValues>({
+        defaultValues: {
+            [OpprettBehandlingFelt.BEHANDLINGSTYPE]: '',
+            [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: '',
+            [OpprettBehandlingFelt.BEHANDLINGSTEMA]: undefined, // TODO
+            [OpprettBehandlingFelt.MIGRERINGSDATO]: '',
+            [OpprettBehandlingFelt.BEGRUNNELSE]: '',
+            [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: '',
+            [OpprettBehandlingFelt.KLAGE_MOTTATT_DATO]: '',
+            [OpprettBehandlingFelt.VALGTE_BARN]: undefined, // TODO
         },
     });
 
-    const behandlingsårsak = useFelt<BehandlingÅrsak | ''>({
-        verdi: '',
-        valideringsfunksjon: felt => {
-            return felt.verdi !== ''
-                ? ok(felt)
-                : feil(felt, 'Velg årsak for opprettelse av behandlingen fra nedtrekkslisten');
-        },
-        skalFeltetVises: (avhengigheter: Avhengigheter) => {
-            const behandlingstypeVerdi = avhengigheter.behandlingstype.verdi;
-            return (
-                behandlingstypeVerdi === Behandlingstype.REVURDERING ||
-                behandlingstypeVerdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD
-            );
-        },
-        avhengigheter: { behandlingstype },
-    });
+    const { setError } = form;
 
-    const behandlingstema = useFelt<IBehandlingstema | undefined>({
-        verdi: fagsak.fagsakType === FagsakType.INSTITUSJON ? behandlingstemaer.NASJONAL_INSTITUSJON : undefined,
-        valideringsfunksjon: (felt: FeltState<IBehandlingstema | undefined>) =>
-            felt.verdi ? ok(felt) : feil(felt, 'Behandlingstema må settes.'),
-        avhengigheter: { behandlingstype, behandlingsårsak },
-        skalFeltetVises: avhengigheter => {
-            if (fagsak.fagsakType === FagsakType.INSTITUSJON) return false;
+    const { mutateAsync: opprettBehandling } = useOpprettBehandling();
+    const { mutateAsync: opprettKlagebehandling } = useOpprettKlagebehandling();
+    const { mutateAsync: opprettTilbakekreving } = useOpprettTilbakekreving();
 
-            const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;
-            const { verdi: behandlingsårsakVerdi } = avhengigheter.behandlingsårsak;
-            const behandlingsårsakerFeltetSkalVisesFor = [
-                BehandlingÅrsak.SØKNAD,
-                BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
-                BehandlingÅrsak.HELMANUELL_MIGRERING,
-            ];
-            return (
-                behandlingstypeVerdi in Behandlingstype &&
-                behandlingsårsakerFeltetSkalVisesFor.includes(behandlingsårsakVerdi)
-            );
-        },
-    });
-
-    const migreringsdato = useFelt<Date | undefined>({
-        verdi: undefined,
-        valideringsfunksjon: validerGyldigDato,
-        avhengigheter: { behandlingstype, behandlingsårsak },
-        skalFeltetVises: avhengigheter => {
-            const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;
-            const { verdi: behandlingsårsakVerdi } = avhengigheter.behandlingsårsak;
-            return (
-                behandlingstypeVerdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD &&
-                behandlingsårsakVerdi in BehandlingÅrsak
-            );
-        },
-    });
-
-    const søknadMottattDato = useFelt<Date | undefined>({
-        verdi: undefined,
-        valideringsfunksjon: validerGyldigDato,
-        avhengigheter: { behandlingstype, behandlingsårsak },
-        skalFeltetVises: avhengigheter => {
-            const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;
-            const { verdi: behandlingsårsakVerdi } = avhengigheter.behandlingsårsak;
-            return (
-                behandlingstypeVerdi === Behandlingstype.FØRSTEGANGSBEHANDLING ||
-                (behandlingstypeVerdi === Behandlingstype.REVURDERING &&
-                    behandlingsårsakVerdi === BehandlingÅrsak.SØKNAD)
-            );
-        },
-    });
-
-    const begrunnelse = useFelt<string | undefined>({
-        verdi: undefined,
-        avhengigheter: { behandlingsårsak, fagsak },
-        valideringsfunksjon: felt => {
-            return felt.verdi !== '' && felt.verdi !== undefined
-                ? ok(felt)
-                : feil(felt, 'Vennligst skriv en begrunnelse på hvorfor den tekniske endringen er opprettet.');
-        },
-        skalFeltetVises: avhengigheter => {
-            const { verdi: behandlingsårsakVerdi } = avhengigheter.behandlingsårsak;
-            return behandlingsårsakVerdi == BehandlingÅrsak.TEKNISK_ENDRING;
-        },
-    });
-
-    const klageMottattDato = useFelt<Date | undefined>({
-        verdi: undefined,
-        valideringsfunksjon: validerGyldigDato,
-        avhengigheter: { behandlingstype },
-        skalFeltetVises: avhengigheter => avhengigheter.behandlingstype.verdi === Klagebehandlingstype.KLAGE,
-    });
-
-    const valgteBarn = useFelt({
-        verdi: [],
-        valideringsfunksjon: (felt: FeltState<OptionType[]>) => ok(felt),
-        avhengigheter: { behandlingstype, behandlingsårsak },
-        skalFeltetVises: avhengigheter => {
-            const { verdi: behandlingstypeVerdi } = avhengigheter.behandlingstype;
-            const { verdi: behandlingsårsakVerdi } = avhengigheter.behandlingsårsak;
-            return (
-                behandlingstypeVerdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD &&
-                behandlingsårsakVerdi === BehandlingÅrsak.HELMANUELL_MIGRERING
-            );
-        },
-    });
-
-    const { skjema, nullstillSkjema, kanSendeSkjema, settSubmitRessurs, valideringErOk } = useSkjema<
-        IOpprettBehandlingSkjemaFelter,
-        IBehandling
-    >({
-        felter: {
+    async function onSubmit(values: TransformedOpprettBehandlingFormValues) {
+        const {
             behandlingstype,
             behandlingsårsak,
             behandlingstema,
@@ -184,120 +94,78 @@ export function useOpprettBehandlingSkjema({ fagsakId, lukkModal, onTilbakekrevi
             søknadMottattDato,
             klageMottattDato,
             valgteBarn,
-        },
-        skjemanavn: 'Opprett behandling modal',
-    });
+        } = values;
 
-    const { mutate: opprettBehandling } = useOpprettBehandling({
-        onSuccess: async behandling => {
-            await Promise.all([
+        if (behandlingstype === Klagebehandlingstype.KLAGE) {
+            try {
+                await opprettKlagebehandling({ klageMottattDato, fagsakId });
+                await queryClient.invalidateQueries({
+                    queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId),
+                });
+                lukkModal();
+            } catch (error) {
+                setError('root', {
+                    message: error instanceof Error ? error.message : 'Teknisk feil ved oppretting av klagebehandling.',
+                });
+            }
+        } else if (behandlingstype === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
+            try {
+                await opprettTilbakekreving({ fagsakId });
+                await queryClient.invalidateQueries({
+                    queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
+                });
+                onTilbakekrevingsbehandlingOpprettet();
+                lukkModal();
+            } catch (error) {
+                setError('root', {
+                    message: error instanceof Error ? error.message : 'Teknisk feil ved oppretting av tilbakekreving.',
+                });
+            }
+        } else {
+            try {
+                const erMigreringFraInfoTrygd = behandlingstype === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
+                const erHelmanuellMigrering =
+                    erMigreringFraInfoTrygd && behandlingsårsak === BehandlingÅrsak.HELMANUELL_MIGRERING;
+
+                const opprettBehandlingParameters = {
+                    // TODO: test at alle verdiene kommer frem som forventet, ref bug sist
+                    kategori: behandlingstema.kategori || null,
+                    underkategori: behandlingstema.underkategori || null,
+                    behandlingType: behandlingstype as Behandlingstype,
+                    behandlingÅrsak: behandlingsårsak as BehandlingÅrsak,
+                    navIdent: saksbehandler.navIdent,
+                    nyMigreringsdato: migreringsdato || undefined,
+                    søknadMottattDato: søknadMottattDato || undefined,
+                    barnasIdenter: erHelmanuellMigrering ? valgteBarn.map(option => option.value) : undefined, // TODO: trenger vi sjekken?
+                    fagsakId: fagsakId,
+                    begrunnelse: begrunnelse,
+                };
+                const behandling = await opprettBehandling(opprettBehandlingParameters);
                 queryClient.invalidateQueries({
                     queryKey: HentBarnetrygdbehandlingerQueryKeyFactory.fagsak(fagsakId),
-                }),
-                queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) }),
-            ]);
-
-            lukkModal();
-            nullstillSkjema();
-            settSubmitRessurs(byggSuksessRessurs(behandling));
-
-            if (behandling.årsak === BehandlingÅrsak.SØKNAD) {
-                navigate(
-                    behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON
-                        ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
-                        : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
-                );
-            } else {
-                navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
-            }
-        },
-        onError: error => {
-            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
-        },
-    });
-
-    const { mutate: opprettKlagebehandling } = useOpprettKlagebehandling({
-        onSuccess: async behandling => {
-            await queryClient.invalidateQueries({ queryKey: HentKlagebehandlingerQueryKeyFactory.fagsak(fagsakId) });
-            lukkModal();
-            nullstillSkjema();
-            settSubmitRessurs(byggSuksessRessurs(behandling));
-        },
-        onError: error => {
-            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
-        },
-    });
-
-    const { mutate: opprettTilbakekreving } = useOpprettTilbakekreving({
-        onSuccess: async behandling => {
-            await queryClient.invalidateQueries({
-                queryKey: HentTilbakekrevingsbehandlingerQueryKeyFactory.fagsak(fagsakId),
-            });
-
-            nullstillSkjemaStatus();
-            onTilbakekrevingsbehandlingOpprettet();
-            settSubmitRessurs(byggSuksessRessurs(behandling));
-        },
-        onError: error => {
-            settSubmitRessurs(byggFunksjonellFeilRessurs(error.message));
-        },
-    });
-
-    useEffect(() => {
-        if (behandlingstype.verdi === Behandlingstype.TEKNISK_ENDRING) {
-            behandlingsårsak.validerOgSettFelt(BehandlingÅrsak.TEKNISK_ENDRING);
-        } else if (behandlingstype.verdi === Behandlingstype.FØRSTEGANGSBEHANDLING) {
-            behandlingsårsak.validerOgSettFelt(BehandlingÅrsak.SØKNAD);
-        }
-    }, [behandlingstype.verdi]);
-
-    const onBekreft = () => {
-        if (kanSendeSkjema()) {
-            settSubmitRessurs(byggHenterRessurs());
-            if (behandlingstype.verdi === Tilbakekrevingsbehandlingstype.TILBAKEKREVING) {
-                opprettTilbakekreving({ fagsakId });
-            } else if (behandlingstype.verdi === Klagebehandlingstype.KLAGE) {
-                opprettKlagebehandling({
-                    klageMottattDato: dateTilIsoDatoString(klageMottattDato.verdi),
-                    fagsakId,
                 });
-            } else {
-                const erMigreringFraInfoTrygd = behandlingstype.verdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
-                const erHelmanuellMigrering =
-                    erMigreringFraInfoTrygd && behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
+                await queryClient.invalidateQueries({ queryKey: HentFagsakQueryKeyFactory.fagsak(fagsakId) });
+                lukkModal();
 
-                const payload = {
-                    kategori: behandlingstema.verdi?.kategori ?? null,
-                    underkategori: behandlingstema.verdi?.underkategori ?? null,
-                    behandlingType: behandlingstype.verdi as Behandlingstype,
-                    behandlingÅrsak: behandlingsårsak.verdi as BehandlingÅrsak,
-                    navIdent: saksbehandler.navIdent,
-                    nyMigreringsdato: erMigreringFraInfoTrygd
-                        ? dateTilIsoDatoStringEllerUndefined(migreringsdato.verdi)
-                        : undefined,
-                    søknadMottattDato: dateTilIsoDatoStringEllerUndefined(søknadMottattDato.verdi),
-                    barnasIdenter: erHelmanuellMigrering ? valgteBarn.verdi.map(option => option.value) : undefined,
-                    fagsakId: fagsakId,
-                    begrunnelse: begrunnelse.verdi,
-                };
-                opprettBehandling(payload);
+                if (behandling.årsak === BehandlingÅrsak.SØKNAD) {
+                    navigate(
+                        behandling.steg === BehandlingSteg.REGISTRERE_INSTITUSJON
+                            ? `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-mottaker`
+                            : `/fagsak/${fagsakId}/${behandling?.behandlingId}/registrer-soknad`
+                    );
+                } else {
+                    navigate(`/fagsak/${fagsakId}/${behandling?.behandlingId}/vilkaarsvurdering`);
+                }
+            } catch (error) {
+                setError('root', {
+                    message: error instanceof Error ? error.message : 'Teknisk feil ved opprettelse av behandling.',
+                });
             }
         }
-    };
-
-    const nullstillSkjemaStatus = () => {
-        settSubmitRessurs(byggTomRessurs());
-        nullstillSkjema();
-    };
-
-    const MAKSDATO_FOR_MIGRERING = new Date('2023-01-01');
+    }
 
     return {
-        onBekreft,
-        opprettBehandlingSkjema: skjema,
-        nullstillSkjemaStatus,
-        bruker,
-        maksdatoForMigrering: MAKSDATO_FOR_MIGRERING,
-        valideringErOk,
+        form,
+        onSubmit,
     };
 }

--- a/src/frontend/sider/ManuellJournalføring/BehandlingstemaSelect.tsx
+++ b/src/frontend/sider/ManuellJournalføring/BehandlingstemaSelect.tsx
@@ -1,9 +1,9 @@
+import type { Behandlingstema } from '@typer/behandlingstema';
+import { BehandlingKategori, behandlingstemaer, type IBehandlingstema } from '@typer/behandlingstema';
+import { FagsakType } from '@typer/fagsak';
+
 import { Select } from '@navikt/ds-react';
 import type { Felt } from '@navikt/familie-skjema';
-
-import type { Behandlingstema } from '../../../../typer/behandlingstema';
-import { BehandlingKategori, behandlingstemaer, type IBehandlingstema } from '../../../../typer/behandlingstema';
-import { FagsakType } from '../../../../typer/fagsak';
 
 interface Props {
     behandlingstema: Felt<IBehandlingstema | undefined>;
@@ -12,7 +12,7 @@ interface Props {
     visFeilmeldinger?: boolean;
 }
 
-export const OpprettBehandlingBehandlingstemaSelect = ({
+export const BehandlingstemaSelect = ({
     behandlingstema,
     fagsakType,
     erLesevisning,

--- a/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
+++ b/src/frontend/sider/ManuellJournalføring/KnyttTilNyBehandling.tsx
@@ -1,7 +1,7 @@
 import { Box, Checkbox, Fieldset, Heading } from '@navikt/ds-react';
 
 import { useManuellJournalføringContext } from './ManuellJournalføringContext';
-import OpprettBehandlingValg from '../../komponenter/Saklinje/Meny/OpprettBehandling/OpprettBehandlingValg';
+import OpprettBehandlingValg from './OpprettBehandlingValg';
 
 /**
  * Legger inn lesevisning slik at på sikt

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -1,13 +1,44 @@
 import type { PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
 
+import { useKlageApi } from '@api/useKlageApi';
+import { useSaksbehandler } from '@hooks/useSaksbehandler';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import type { IBehandlingstema } from '@typer/behandlingstema';
+import { behandlingstemaer } from '@typer/behandlingstema';
+import type { IMinimalFagsak } from '@typer/fagsak';
+import { FagsakType } from '@typer/fagsak';
+import {
+    type Journalføringsbehandling,
+    opprettJournalføringsbehandlingFraBarnetrygdbehandling,
+    opprettJournalføringsbehandlingFraKlagebehandling,
+} from '@typer/journalføringsbehandling';
+import type { IKlagebehandling } from '@typer/klage';
+import { Klagebehandlingstype } from '@typer/klage';
+import type {
+    IDataForManuellJournalføring,
+    IRestJournalføring,
+    TilknyttetBehandling,
+} from '@typer/manuell-journalføring';
+import { JournalpostKanal } from '@typer/manuell-journalføring';
+import {
+    finnBehandlingstemaFraOppgave,
+    type IRestLukkOppgaveOgKnyttJournalpost,
+    OppgavetypeFilter,
+} from '@typer/oppgave';
+import type { IPersonInfo } from '@typer/person';
+import { Adressebeskyttelsegradering } from '@typer/person';
+import type { ISamhandlerInfo } from '@typer/samhandler';
+import type { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import { isoStringTilDate } from '@utils/dato';
+import { hentAktivBehandlingPåMinimalFagsak } from '@utils/fagsak';
 import type { AxiosError } from 'axios';
 import { differenceInMilliseconds } from 'date-fns';
 import { useNavigate, useParams } from 'react-router';
 
 import { useHttp } from '@navikt/familie-http';
-import type { Avhengigheter, FeiloppsummeringFeil, Felt, FeltState, ISkjema } from '@navikt/familie-skjema';
 import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
+import type { Avhengigheter, FeiloppsummeringFeil, Felt, FeltState, ISkjema } from '@navikt/familie-skjema';
 import {
     byggFeiletRessurs,
     byggHenterRessurs,
@@ -19,40 +50,14 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
-import { useKlageApi } from '../../api/useKlageApi';
 import useDokument from '../../hooks/useDokument';
-import { useSaksbehandler } from '../../hooks/useSaksbehandler';
-import type { IOpprettBehandlingSkjemaBase } from '../../komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema';
-import { Behandlingstype, BehandlingÅrsak } from '../../typer/behandling';
-import type { IBehandlingstema } from '../../typer/behandlingstema';
-import { behandlingstemaer } from '../../typer/behandlingstema';
-import type { IMinimalFagsak } from '../../typer/fagsak';
-import { FagsakType } from '../../typer/fagsak';
-import {
-    type Journalføringsbehandling,
-    opprettJournalføringsbehandlingFraBarnetrygdbehandling,
-    opprettJournalføringsbehandlingFraKlagebehandling,
-} from '../../typer/journalføringsbehandling';
-import type { IKlagebehandling } from '../../typer/klage';
-import { Klagebehandlingstype } from '../../typer/klage';
-import type {
-    IDataForManuellJournalføring,
-    IRestJournalføring,
-    TilknyttetBehandling,
-} from '../../typer/manuell-journalføring';
-import { JournalpostKanal } from '../../typer/manuell-journalføring';
-import {
-    finnBehandlingstemaFraOppgave,
-    type IRestLukkOppgaveOgKnyttJournalpost,
-    OppgavetypeFilter,
-} from '../../typer/oppgave';
-import type { IPersonInfo } from '../../typer/person';
-import { Adressebeskyttelsegradering } from '../../typer/person';
-import type { ISamhandlerInfo } from '../../typer/samhandler';
-import type { Tilbakekrevingsbehandlingstype } from '../../typer/tilbakekrevingsbehandling';
-import { isoStringTilDate } from '../../utils/dato';
-import { hentAktivBehandlingPåMinimalFagsak } from '../../utils/fagsak';
 import type { VisningBehandling } from '../Fagsak/Saksoversikt/visningBehandling';
+
+export interface IOpprettBehandlingSkjemaBase {
+    behandlingstype: Behandlingstype | Tilbakekrevingsbehandlingstype | Klagebehandlingstype | '';
+    behandlingsårsak: BehandlingÅrsak | '';
+    behandlingstema: IBehandlingstema | undefined;
+}
 
 export interface ManuellJournalføringSkjemaFelter extends IOpprettBehandlingSkjemaBase {
     journalpostTittel: string;

--- a/src/frontend/sider/ManuellJournalføring/OpprettBehandlingValg.tsx
+++ b/src/frontend/sider/ManuellJournalføring/OpprettBehandlingValg.tsx
@@ -8,7 +8,6 @@ import type { BehandlingÅrsak } from '@typer/behandling';
 import { BehandlingStatus, Behandlingstype, behandlingÅrsak, erBehandlingHenlagt } from '@typer/behandling';
 import { FagsakStatus, type IMinimalFagsak } from '@typer/fagsak';
 import { Klagebehandlingstype } from '@typer/klage';
-import type { IPersonInfo } from '@typer/person';
 import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
 import { forrigeBehandlingVarTekniskEndringMedOpphør, hentTilgjengeligeBehandlingsårsaker } from '@utils/behandling';
 import { hentAktivBehandlingPåMinimalFagsak } from '@utils/fagsak';
@@ -21,7 +20,6 @@ interface IProps {
     minimalFagsak?: IMinimalFagsak;
     erLesevisning?: boolean;
     manuellJournalfør?: boolean;
-    bruker?: IPersonInfo | undefined;
 }
 
 interface BehandlingstypeSelect extends HTMLSelectElement {

--- a/src/frontend/sider/ManuellJournalføring/OpprettBehandlingValg.tsx
+++ b/src/frontend/sider/ManuellJournalføring/OpprettBehandlingValg.tsx
@@ -2,81 +2,22 @@ import type { ChangeEvent } from 'react';
 
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import type { VisningBehandling } from '@sider/Fagsak/Saksoversikt/visningBehandling';
+import { BehandlingstemaSelect } from '@sider/ManuellJournalføring/BehandlingstemaSelect';
 import type { ManuellJournalføringSkjemaFelter } from '@sider/ManuellJournalføring/ManuellJournalføringContext';
-import type { IBehandling } from '@typer/behandling';
-import {
-    BehandlingResultat,
-    BehandlingStatus,
-    Behandlingstype,
-    behandlingÅrsak,
-    BehandlingÅrsak,
-    erBehandlingHenlagt,
-} from '@typer/behandling';
-import type { ComboboxOption } from '@typer/common';
+import type { BehandlingÅrsak } from '@typer/behandling';
+import { BehandlingStatus, Behandlingstype, behandlingÅrsak, erBehandlingHenlagt } from '@typer/behandling';
 import { FagsakStatus, type IMinimalFagsak } from '@typer/fagsak';
 import { Klagebehandlingstype } from '@typer/klage';
 import type { IPersonInfo } from '@typer/person';
-import { ForelderBarnRelasjonRolle } from '@typer/person';
 import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
-import { hentAktivBehandlingPåMinimalFagsak, hentSisteIkkeHenlagteBehandling } from '@utils/fagsak';
-import { hentAlder } from '@utils/formatter';
-import { onOptionSelected } from '@utils/skjema';
+import { forrigeBehandlingVarTekniskEndringMedOpphør, hentTilgjengeligeBehandlingsårsaker } from '@utils/behandling';
+import { hentAktivBehandlingPåMinimalFagsak } from '@utils/fagsak';
 
-import { Select, UNSAFE_Combobox } from '@navikt/ds-react';
+import { Select } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 
-import { OpprettBehandlingBehandlingstemaSelect } from './OpprettBehandlingBehandlingstemaSelect';
-import type { IOpprettBehandlingSkjemaFelter } from './useOpprettBehandlingSkjema';
-
-const erOpprettBehandlingSkjema = (
-    skjema: ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling> | ISkjema<ManuellJournalføringSkjemaFelter, string>
-): skjema is ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling> => {
-    return Object.hasOwn(skjema.felter, 'valgteBarn');
-};
-
-const forrigeBehandlingVarTekniskEndringMedOpphør = (minimalFagsak?: IMinimalFagsak) => {
-    const behandling = hentSisteIkkeHenlagteBehandling(minimalFagsak);
-    return (
-        behandling?.årsak === BehandlingÅrsak.TEKNISK_ENDRING &&
-        (behandling.resultat === BehandlingResultat.OPPHØRT ||
-            behandling.resultat === BehandlingResultat.ENDRET_OG_OPPHØRT)
-    );
-};
-
-const hentTilgjengeligeBehandlingsårsaker = (
-    erMigreringFraInfotrygd: boolean,
-    kanOpprettMigreringsbehandlingMedHelmanuellMigrering: boolean,
-    kanOppretteMigreringsbehandlingMedEndreMigreringsdato: boolean
-): BehandlingÅrsak[] =>
-    erMigreringFraInfotrygd
-        ? Object.values(BehandlingÅrsak).filter(
-              årsak =>
-                  (kanOpprettMigreringsbehandlingMedHelmanuellMigrering &&
-                      årsak === BehandlingÅrsak.HELMANUELL_MIGRERING) ||
-                  (kanOppretteMigreringsbehandlingMedEndreMigreringsdato &&
-                      årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO)
-          )
-        : Object.values(BehandlingÅrsak).filter(
-              årsak =>
-                  årsak !== BehandlingÅrsak.TEKNISK_OPPHØR &&
-                  årsak !== BehandlingÅrsak.TEKNISK_ENDRING &&
-                  årsak !== BehandlingÅrsak.FØDSELSHENDELSE &&
-                  årsak !== BehandlingÅrsak.SATSENDRING &&
-                  årsak !== BehandlingÅrsak.MIGRERING &&
-                  årsak !== BehandlingÅrsak.OMREGNING_6ÅR &&
-                  årsak !== BehandlingÅrsak.OMREGNING_18ÅR &&
-                  årsak !== BehandlingÅrsak.OMREGNING_SMÅBARNSTILLEGG &&
-                  årsak !== BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-                  årsak !== BehandlingÅrsak.ENDRE_MIGRERINGSDATO &&
-                  årsak !== BehandlingÅrsak.HELMANUELL_MIGRERING &&
-                  årsak !== BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING &&
-                  årsak !== BehandlingÅrsak.KLAGE &&
-                  årsak !== BehandlingÅrsak.FINNMARKSTILLEGG &&
-                  årsak !== BehandlingÅrsak.SVALBARDTILLEGG
-          );
-
 interface IProps {
-    skjema: ISkjema<IOpprettBehandlingSkjemaFelter, IBehandling> | ISkjema<ManuellJournalføringSkjemaFelter, string>;
+    skjema: ISkjema<ManuellJournalføringSkjemaFelter, string>;
     minimalFagsak?: IMinimalFagsak;
     erLesevisning?: boolean;
     manuellJournalfør?: boolean;
@@ -91,13 +32,7 @@ interface BehandlingÅrsakSelect extends HTMLSelectElement {
     value: BehandlingÅrsak | '';
 }
 
-const OpprettBehandlingValg = ({
-    skjema,
-    minimalFagsak,
-    erLesevisning = false,
-    manuellJournalfør = false,
-    bruker = undefined,
-}: IProps) => {
+const OpprettBehandlingValg = ({ skjema, minimalFagsak, erLesevisning = false, manuellJournalfør = false }: IProps) => {
     const saksbehandler = useSaksbehandler();
     const aktivBehandling: VisningBehandling | undefined = minimalFagsak
         ? hentAktivBehandlingPåMinimalFagsak(minimalFagsak)
@@ -116,8 +51,6 @@ const OpprettBehandlingValg = ({
     const kanOppretteMigreringFraInfotrygd = !manuellJournalfør && kanOppretteBehandling;
     const erMigreringFraInfotrygd =
         !manuellJournalfør && skjema.felter.behandlingstype.verdi === Behandlingstype.MIGRERING_FRA_INFOTRYGD;
-    const erHelmanuellMigrering =
-        erMigreringFraInfotrygd && skjema.felter.behandlingsårsak.verdi === BehandlingÅrsak.HELMANUELL_MIGRERING;
     const kanOpprettMigreringsbehandlingMedHelmanuellMigrering =
         kanOppretteMigreringFraInfotrygd &&
         (forrigeBehandlingVarTekniskEndringMedOpphør(minimalFagsak) || minimalFagsak?.status !== FagsakStatus.LØPENDE);
@@ -127,14 +60,6 @@ const OpprettBehandlingValg = ({
 
     const kanOppretteKlagebehandling =
         minimalFagsak !== undefined && !minimalFagsak.finnesStrengtFortroligPersonIFagsak;
-
-    const barn =
-        bruker?.forelderBarnRelasjon
-            .filter(relasjon => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
-            .map<ComboboxOption>(relasjon => ({
-                value: relasjon.personIdent,
-                label: `${relasjon.navn} (${hentAlder(relasjon.fødselsdato)} år) | ${relasjon.personIdent}`,
-            })) ?? [];
 
     const { behandlingsårsak, behandlingstype, behandlingstema } = skjema.felter;
 
@@ -229,21 +154,8 @@ const OpprettBehandlingValg = ({
                     })}
                 </Select>
             )}
-            {erHelmanuellMigrering && erOpprettBehandlingSkjema(skjema) && skjema.felter.valgteBarn?.erSynlig && (
-                <UNSAFE_Combobox
-                    label={'Legg til juridiske barn for migrering'}
-                    isMultiSelect
-                    readOnly={erLesevisning}
-                    options={barn}
-                    onToggleSelected={(valgtOption: string, isSelected: boolean) =>
-                        onOptionSelected(valgtOption, isSelected, skjema.felter.valgteBarn, barn)
-                    }
-                    selectedOptions={skjema.felter.valgteBarn.verdi.map(barn => barn.value)}
-                    error={skjema.felter.valgteBarn.hentNavInputProps(skjema.visFeilmeldinger).error}
-                />
-            )}
             {behandlingstema.erSynlig && (
-                <OpprettBehandlingBehandlingstemaSelect
+                <BehandlingstemaSelect
                     behandlingstema={behandlingstema}
                     fagsakType={minimalFagsak?.fagsakType}
                     erLesevisning={erLesevisning}

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -16,6 +16,7 @@ import { type ISøknadDTO, Målform } from './søknad';
 import type {
     Behandlingsstatus,
     TilbakekrevingsbehandlingResultat,
+    Tilbakekrevingsbehandlingstype,
     TilbakekrevingsbehandlingÅrsak,
 } from './tilbakekrevingsbehandling';
 import type { TilbakekrevingsvedtakMotregningDTO } from './tilbakekrevingsvedtakMotregning';
@@ -30,7 +31,7 @@ export const MIDLERTIDIG_BEHANDLENDE_ENHET_ID = '4863';
 export interface NyBehandling {
     kategori: BehandlingKategori | null;
     underkategori: BehandlingUnderkategori | null;
-    behandlingType: Behandlingstype;
+    behandlingType: Behandlingstype | Tilbakekrevingsbehandlingstype.REVURDERING_TILBAKEKREVING;
     journalpostID?: string;
     behandlingÅrsak?: BehandlingÅrsak;
     skalBehandlesAutomatisk?: boolean;

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -16,7 +16,6 @@ import { type ISøknadDTO, Målform } from './søknad';
 import type {
     Behandlingsstatus,
     TilbakekrevingsbehandlingResultat,
-    Tilbakekrevingsbehandlingstype,
     TilbakekrevingsbehandlingÅrsak,
 } from './tilbakekrevingsbehandling';
 import type { TilbakekrevingsvedtakMotregningDTO } from './tilbakekrevingsvedtakMotregning';
@@ -31,7 +30,7 @@ export const MIDLERTIDIG_BEHANDLENDE_ENHET_ID = '4863';
 export interface NyBehandling {
     kategori: BehandlingKategori | null;
     underkategori: BehandlingUnderkategori | null;
-    behandlingType: Behandlingstype | Tilbakekrevingsbehandlingstype.REVURDERING_TILBAKEKREVING;
+    behandlingType: Behandlingstype;
     journalpostID?: string;
     behandlingÅrsak?: BehandlingÅrsak;
     skalBehandlesAutomatisk?: boolean;

--- a/src/frontend/typer/behandlingstema.ts
+++ b/src/frontend/typer/behandlingstema.ts
@@ -74,6 +74,10 @@ export const tilBehandlingstema = (
     );
 };
 
+export const konverterTilBehandlingstema = (behandlingstemaId: string): IBehandlingstema => {
+    return behandlingstemaer[behandlingstemaId as keyof typeof behandlingstemaer];
+};
+
 export const kodeTilBehandlingUnderkategoriMap: Record<string, BehandlingUnderkategori> = {
     ab0180: BehandlingUnderkategori.ORDINÆR,
     ab0096: BehandlingUnderkategori.UTVIDET,

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -1,7 +1,9 @@
-import { Behandlingstype, BehandlingÅrsak, type IBehandling } from '../typer/behandling';
-import type { IGrunnlagPerson } from '../typer/person';
-import { PersonType } from '../typer/person';
-import { Målform } from '../typer/søknad';
+import { BehandlingResultat, Behandlingstype, BehandlingÅrsak, type IBehandling } from '@typer/behandling';
+import type { IMinimalFagsak } from '@typer/fagsak';
+import type { IGrunnlagPerson } from '@typer/person';
+import { PersonType } from '@typer/person';
+import { Målform } from '@typer/søknad';
+import { hentSisteIkkeHenlagteBehandling } from '@utils/fagsak';
 
 export const hentSøkersMålform = (behandling: IBehandling) =>
     behandling.personer.find((person: IGrunnlagPerson) => {
@@ -27,4 +29,45 @@ export const erBehandlingMedVedtaksbrevutsending = (åpenBehandling: IBehandling
     ].includes(type);
 
     return !erBehandlingTypeUtenBrevutsending && !erBehandlingÅrsakUtenBrevutsending;
+};
+
+export const hentTilgjengeligeBehandlingsårsaker = (
+    erMigreringFraInfotrygd: boolean,
+    kanOpprettMigreringsbehandlingMedHelmanuellMigrering: boolean,
+    kanOppretteMigreringsbehandlingMedEndreMigreringsdato: boolean
+): BehandlingÅrsak[] =>
+    erMigreringFraInfotrygd
+        ? Object.values(BehandlingÅrsak).filter(
+              årsak =>
+                  (kanOpprettMigreringsbehandlingMedHelmanuellMigrering &&
+                      årsak === BehandlingÅrsak.HELMANUELL_MIGRERING) ||
+                  (kanOppretteMigreringsbehandlingMedEndreMigreringsdato &&
+                      årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO)
+          )
+        : Object.values(BehandlingÅrsak).filter(
+              årsak =>
+                  årsak !== BehandlingÅrsak.TEKNISK_OPPHØR &&
+                  årsak !== BehandlingÅrsak.TEKNISK_ENDRING &&
+                  årsak !== BehandlingÅrsak.FØDSELSHENDELSE &&
+                  årsak !== BehandlingÅrsak.SATSENDRING &&
+                  årsak !== BehandlingÅrsak.MIGRERING &&
+                  årsak !== BehandlingÅrsak.OMREGNING_6ÅR &&
+                  årsak !== BehandlingÅrsak.OMREGNING_18ÅR &&
+                  årsak !== BehandlingÅrsak.OMREGNING_SMÅBARNSTILLEGG &&
+                  årsak !== BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
+                  årsak !== BehandlingÅrsak.ENDRE_MIGRERINGSDATO &&
+                  årsak !== BehandlingÅrsak.HELMANUELL_MIGRERING &&
+                  årsak !== BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING &&
+                  årsak !== BehandlingÅrsak.KLAGE &&
+                  årsak !== BehandlingÅrsak.FINNMARKSTILLEGG &&
+                  årsak !== BehandlingÅrsak.SVALBARDTILLEGG
+          );
+
+export const forrigeBehandlingVarTekniskEndringMedOpphør = (minimalFagsak?: IMinimalFagsak) => {
+    const behandling = hentSisteIkkeHenlagteBehandling(minimalFagsak);
+    return (
+        behandling?.årsak === BehandlingÅrsak.TEKNISK_ENDRING &&
+        (behandling.resultat === BehandlingResultat.OPPHØRT ||
+            behandling.resultat === BehandlingResultat.ENDRET_OG_OPPHØRT)
+    );
 };

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -1,9 +1,19 @@
-import { BehandlingResultat, Behandlingstype, BehandlingÅrsak, type IBehandling } from '@typer/behandling';
-import type { IMinimalFagsak } from '@typer/fagsak';
+import {
+    BehandlingResultat,
+    BehandlingStatus,
+    Behandlingstype,
+    BehandlingÅrsak,
+    erBehandlingHenlagt,
+    type IBehandling,
+} from '@typer/behandling';
+import { FagsakStatus, type IMinimalFagsak } from '@typer/fagsak';
+import { Klagebehandlingstype } from '@typer/klage';
 import type { IGrunnlagPerson } from '@typer/person';
 import { PersonType } from '@typer/person';
+import type { Saksbehandler } from '@typer/saksbehandler';
 import { Målform } from '@typer/søknad';
-import { hentSisteIkkeHenlagteBehandling } from '@utils/fagsak';
+import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import { hentAktivBehandlingPåMinimalFagsak, hentSisteIkkeHenlagteBehandling } from '@utils/fagsak';
 
 export const hentSøkersMålform = (behandling: IBehandling) =>
     behandling.personer.find((person: IGrunnlagPerson) => {
@@ -30,6 +40,38 @@ export const erBehandlingMedVedtaksbrevutsending = (åpenBehandling: IBehandling
 
     return !erBehandlingTypeUtenBrevutsending && !erBehandlingÅrsakUtenBrevutsending;
 };
+
+const TILGJENGELIGE_BEHANDLINGSTYPER = [
+    Behandlingstype.FØRSTEGANGSBEHANDLING,
+    Behandlingstype.REVURDERING,
+    Behandlingstype.TEKNISK_ENDRING,
+    Tilbakekrevingsbehandlingstype.TILBAKEKREVING,
+    Klagebehandlingstype.KLAGE,
+    Behandlingstype.MIGRERING_FRA_INFOTRYGD,
+];
+
+export function hentTilgjengeligeBehandlingstyper(fagsak: IMinimalFagsak, saksbehandler: Saksbehandler) {
+    const behandling = fagsak ? hentAktivBehandlingPåMinimalFagsak(fagsak) : undefined;
+    const harIkkeAktivBehandling = !behandling || behandling?.status === BehandlingStatus.AVSLUTTET;
+
+    const kanOppretteFørstegangsbehandling =
+        fagsak === undefined || (fagsak.status !== FagsakStatus.LØPENDE && harIkkeAktivBehandling);
+    const kanOppretteRevurdering =
+        harIkkeAktivBehandling &&
+        (fagsak?.behandlinger.some(behandling => !erBehandlingHenlagt(behandling.resultat)) ?? false);
+    const kanOppretteTekniskEndring = harIkkeAktivBehandling && saksbehandler.harSuperbrukertilgang;
+    const kanOppretteKlagebehandling = fagsak !== undefined && !fagsak.finnesStrengtFortroligPersonIFagsak;
+
+    return TILGJENGELIGE_BEHANDLINGSTYPER.filter(
+        type =>
+            (kanOppretteFørstegangsbehandling && type === Behandlingstype.FØRSTEGANGSBEHANDLING) ||
+            (kanOppretteRevurdering && type === Behandlingstype.REVURDERING) ||
+            (kanOppretteTekniskEndring && type === Behandlingstype.TEKNISK_ENDRING) ||
+            type === Tilbakekrevingsbehandlingstype.TILBAKEKREVING ||
+            (kanOppretteKlagebehandling && type === Klagebehandlingstype.KLAGE) ||
+            (harIkkeAktivBehandling && type === Behandlingstype.MIGRERING_FRA_INFOTRYGD)
+    );
+}
 
 export const hentTilgjengeligeBehandlingsårsaker = (
     erMigreringFraInfotrygd: boolean,


### PR DESCRIPTION
### 📮 Favro:
[NAV-29213](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29213)

### 💰 Hva skal gjøres, og hvorfor?
 - Skriv om skjemaet brukt i `<OpprettBehandlingModal />` til React Hook Form, for konsekvenshet og oppdatering til moderne rammeverk.
 - Opprett nye filer for hvert enkelt felt, i stedet for at disse opprettes underveis i `<OpprettBehandlingModal />` og `<OpprettBehandlingValg />`.
 - Flytt hjelpefunksjoner til `utils` for mer oversiktlige filer.

`<KnyttTilNyBehandling />` bruker også `<OpprettBehandlingValg />`, så denne beholdes siden skjemaet i denne komponenten ikke er skrevet om til React Hook Form enda. Har fjernet det som spesfikt ble brukt til opprettelse av behandling.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
 - Tar gjerne et ekstra par øyne på omskrivingen av variablene ala `kanOppretteBehandling` osv. (i `BehandlingstypeFelt.tsx` og `BehandlingsårsakFelt.tsx`.
 - Stemmer det at det ikke trengs å sjekke for `erLesevisning` i feltene i skjemaet? (var ikke det fra før)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_ ingen funksjonelle endringer


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_ ingen visuelle endringer
