### PR TITLE
Fjern teknisk opphør som behandlingstype og -årsak

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/LeggTilEllerFjernBrevmottakere/LeggTilEllerFjernBrevmottakerePåBehandling.test.tsx
@@ -90,7 +90,7 @@ describe('LeggTilEllerFjernBrevmottakerePåBehandling', () => {
         const åpneModal = vi.fn();
         const { screen } = render(<LeggTilEllerFjernBrevmottakerePåBehandling åpneModal={åpneModal} />, {
             wrapper: props => (
-                <Wrapper {...props} behandling={lagBehandling({ type: Behandlingstype.TEKNISK_OPPHØR })} />
+                <Wrapper {...props} behandling={lagBehandling({ type: Behandlingstype.TEKNISK_ENDRING })} />
             ),
         });
         expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -62,7 +62,6 @@ export enum BehandlingÅrsak {
     DØDSFALL_BRUKER = 'DØDSFALL_BRUKER',
     NYE_OPPLYSNINGER = 'NYE_OPPLYSNINGER',
     KLAGE = 'KLAGE',
-    TEKNISK_OPPHØR = 'TEKNISK_OPPHØR',
     TEKNISK_ENDRING = 'TEKNISK_ENDRING',
     KORREKSJON_VEDTAKSBREV = 'KORREKSJON_VEDTAKSBREV',
     OMREGNING_6ÅR = 'OMREGNING_6ÅR',
@@ -88,7 +87,6 @@ export const behandlingÅrsak: Record<BehandlingÅrsak | Tilbakekrevingsbehandli
     DØDSFALL_BRUKER: 'Dødsfall bruker',
     NYE_OPPLYSNINGER: 'Nye opplysninger',
     KLAGE: 'Klage',
-    TEKNISK_OPPHØR: 'Teknisk opphør',
     TEKNISK_ENDRING: 'Teknisk endring',
     KORREKSJON_VEDTAKSBREV: 'Korrigere vedtak med egen brevmal',
     OMREGNING_6ÅR: 'Omregning 6 år',
@@ -205,7 +203,6 @@ export enum Behandlingstype {
     FØRSTEGANGSBEHANDLING = 'FØRSTEGANGSBEHANDLING',
     MIGRERING_FRA_INFOTRYGD = 'MIGRERING_FRA_INFOTRYGD',
     REVURDERING = 'REVURDERING',
-    TEKNISK_OPPHØR = 'TEKNISK_OPPHØR',
     TEKNISK_ENDRING = 'TEKNISK_ENDRING',
 }
 
@@ -349,10 +346,6 @@ export const behandlingstyper: INøkkelPar = {
     REVURDERING: {
         id: 'REVURDERING',
         navn: 'Revurdering',
-    },
-    TEKNISK_OPPHØR: {
-        id: 'TEKNISK_OPPHØR',
-        navn: 'Teknisk opphør',
     },
     TEKNISK_ENDRING: {
         id: 'TEKNISK_ENDRING',

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -88,7 +88,6 @@ export const hentTilgjengeligeBehandlingsårsaker = (
           )
         : Object.values(BehandlingÅrsak).filter(
               årsak =>
-                  årsak !== BehandlingÅrsak.TEKNISK_OPPHØR &&
                   årsak !== BehandlingÅrsak.TEKNISK_ENDRING &&
                   årsak !== BehandlingÅrsak.FØDSELSHENDELSE &&
                   årsak !== BehandlingÅrsak.SATSENDRING &&


### PR DESCRIPTION
### 📮 Favro: NAV-29928

### 💰 Hva skal gjøres, og hvorfor?
Fjerner `TEKNISK_OPPHØR` som behandlingstype og behandlingsårsak, siden `TEKNISK_ENDRING` erstatter dette. Oppdaterer også tester som brukte `TEKNISK_OPPHØR`. Ingen spor av behandlingstypen eller behandlingårsaken i backenden eller databasen.

https://github.com/navikt/familie-ba-sak/pull/4553
https://github.com/navikt/familie-ba-sak/pull/4586