### PR TITLE
NAV-29930: Send behandlingskategori ved opprettelse av behandling på institusjonssak

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.test.tsx
@@ -1,0 +1,103 @@
+import type { PropsWithChildren } from 'react';
+
+import { opprettBehandling } from '@api/opprettBehandling';
+import { FagsakProvider } from '@sider/Fagsak/FagsakContext';
+import { act, renderHook } from '@testing-library/react';
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { lagFagsak } from '@testutils/testdata/fagsakTestdata';
+import { TestProviders } from '@testutils/testrender';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { BehandlingKategori, BehandlingUnderkategori } from '@typer/behandlingstema';
+import { FagsakStatus, FagsakType } from '@typer/fagsak';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { OpprettBehandlingFelt, useOpprettBehandlingSkjema } from './useOpprettBehandlingSkjema';
+
+vi.mock('@api/opprettBehandling');
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+function lagWrapper(fagsakType: FagsakType) {
+    return function Wrapper({ children }: PropsWithChildren) {
+        return (
+            <TestProviders>
+                <FagsakProvider
+                    fagsak={lagFagsak({
+                        fagsakType,
+                        status: FagsakStatus.OPPRETTET,
+                        behandlinger: [],
+                    })}
+                >
+                    {children}
+                </FagsakProvider>
+            </TestProviders>
+        );
+    };
+}
+
+describe('useOpprettBehandlingSkjema', () => {
+    test('skal sende kategori og underkategori ved opprettelse av førstegangsbehandling på institusjonssak', async () => {
+        // Arrange
+        vi.mocked(opprettBehandling).mockResolvedValue(lagBehandling());
+
+        const { result } = renderHook(
+            () =>
+                useOpprettBehandlingSkjema({
+                    lukkModal: vi.fn(),
+                    onTilbakekrevingsbehandlingOpprettet: vi.fn(),
+                }),
+            { wrapper: lagWrapper(FagsakType.INSTITUSJON) }
+        );
+
+        // Act
+        await act(async () => {
+            result.current.form.setValue(OpprettBehandlingFelt.BEHANDLINGSTYPE, Behandlingstype.FØRSTEGANGSBEHANDLING);
+            result.current.form.setValue(OpprettBehandlingFelt.BEHANDLINGSÅRSAK, BehandlingÅrsak.SØKNAD);
+            result.current.form.setValue(OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO, '2026-06-17');
+            await result.current.form.handleSubmit(result.current.onSubmit)();
+        });
+
+        // Assert
+        expect(opprettBehandling).toHaveBeenCalledWith(
+            expect.objectContaining({
+                behandlingType: Behandlingstype.FØRSTEGANGSBEHANDLING,
+                behandlingÅrsak: BehandlingÅrsak.SØKNAD,
+                kategori: BehandlingKategori.NASJONAL,
+                underkategori: BehandlingUnderkategori.ORDINÆR,
+                søknadMottattDato: '2026-06-17',
+            })
+        );
+    });
+
+    test('skal ikke sende kategori og underkategori når behandlingstema ikke er valgt på ordinær fagsak', async () => {
+        // Arrange
+        vi.mocked(opprettBehandling).mockResolvedValue(lagBehandling());
+
+        const { result } = renderHook(
+            () =>
+                useOpprettBehandlingSkjema({
+                    lukkModal: vi.fn(),
+                    onTilbakekrevingsbehandlingOpprettet: vi.fn(),
+                }),
+            { wrapper: lagWrapper(FagsakType.NORMAL) }
+        );
+
+        // Act
+        await act(async () => {
+            result.current.form.setValue(OpprettBehandlingFelt.BEHANDLINGSTYPE, Behandlingstype.FØRSTEGANGSBEHANDLING);
+            result.current.form.setValue(OpprettBehandlingFelt.BEHANDLINGSÅRSAK, BehandlingÅrsak.SØKNAD);
+            result.current.form.setValue(OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO, '2026-06-17');
+            await result.current.form.handleSubmit(result.current.onSubmit)();
+        });
+
+        // Assert
+        expect(opprettBehandling).toHaveBeenCalledWith(
+            expect.objectContaining({
+                kategori: null,
+                underkategori: null,
+            })
+        );
+    });
+});

--- a/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
+++ b/src/frontend/komponenter/Saklinje/Meny/OpprettBehandling/useOpprettBehandlingSkjema.ts
@@ -1,4 +1,4 @@
-import { useFagsakId } from '@hooks/useFagsakId';
+import { useFagsak } from '@hooks/useFagsak';
 import { HentBarnetrygdbehandlingerQueryKeyFactory } from '@hooks/useHentBarnetrygdbehandlinger';
 import { HentFagsakQueryKeyFactory } from '@hooks/useHentFagsak';
 import { HentKlagebehandlingerQueryKeyFactory } from '@hooks/useHentKlagebehandlinger';
@@ -13,6 +13,7 @@ import type { IBehandlingstema } from '@typer/behandlingstema';
 import type { OptionType } from '@typer/common';
 import { Klagebehandlingstype } from '@typer/klage';
 import { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import { hentDefaultBehandlingstema } from '@utils/behandling';
 import { type IsoDatoString } from '@utils/dato';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -60,7 +61,8 @@ interface Props {
 }
 
 export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandlingOpprettet }: Props) {
-    const fagsakId = useFagsakId();
+    const fagsak = useFagsak();
+    const fagsakId = fagsak.id;
     const saksbehandler = useSaksbehandler();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -69,7 +71,7 @@ export function useOpprettBehandlingSkjema({ lukkModal, onTilbakekrevingsbehandl
         defaultValues: {
             [OpprettBehandlingFelt.BEHANDLINGSTYPE]: '',
             [OpprettBehandlingFelt.BEHANDLINGSÅRSAK]: '',
-            [OpprettBehandlingFelt.BEHANDLINGSTEMA]: null,
+            [OpprettBehandlingFelt.BEHANDLINGSTEMA]: hentDefaultBehandlingstema(fagsak.fagsakType) ?? null,
             [OpprettBehandlingFelt.MIGRERINGSDATO]: '',
             [OpprettBehandlingFelt.BEGRUNNELSE]: '',
             [OpprettBehandlingFelt.SØKNAD_MOTTATT_DATO]: '',

--- a/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
+++ b/src/frontend/sider/ManuellJournalføring/ManuellJournalføringContext.tsx
@@ -5,7 +5,6 @@ import { useKlageApi } from '@api/useKlageApi';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
 import type { IBehandlingstema } from '@typer/behandlingstema';
-import { behandlingstemaer } from '@typer/behandlingstema';
 import type { IMinimalFagsak } from '@typer/fagsak';
 import { FagsakType } from '@typer/fagsak';
 import {
@@ -30,6 +29,7 @@ import type { IPersonInfo } from '@typer/person';
 import { Adressebeskyttelsegradering } from '@typer/person';
 import type { ISamhandlerInfo } from '@typer/samhandler';
 import type { Tilbakekrevingsbehandlingstype } from '@typer/tilbakekrevingsbehandling';
+import { hentDefaultBehandlingstema } from '@utils/behandling';
 import { isoStringTilDate } from '@utils/dato';
 import { hentAktivBehandlingPåMinimalFagsak } from '@utils/fagsak';
 import type { AxiosError } from 'axios';
@@ -172,10 +172,7 @@ export const ManuellJournalføringProvider = (props: PropsWithChildren) => {
                 },
             }),
             behandlingstema: useFelt<IBehandlingstema | undefined>({
-                verdi:
-                    minimalFagsak?.fagsakType === FagsakType.INSTITUSJON
-                        ? behandlingstemaer.NASJONAL_INSTITUSJON
-                        : undefined,
+                verdi: hentDefaultBehandlingstema(minimalFagsak?.fagsakType),
                 avhengigheter: {
                     knyttTilNyBehandling: knyttTilNyBehandling.verdi,
                     behandlingstype: behandlingstype.verdi,

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -6,7 +6,8 @@ import {
     erBehandlingHenlagt,
     type IBehandling,
 } from '@typer/behandling';
-import { FagsakStatus, type IMinimalFagsak } from '@typer/fagsak';
+import { behandlingstemaer, type IBehandlingstema } from '@typer/behandlingstema';
+import { FagsakStatus, FagsakType, type IMinimalFagsak } from '@typer/fagsak';
 import { Klagebehandlingstype } from '@typer/klage';
 import type { IGrunnlagPerson } from '@typer/person';
 import { PersonType } from '@typer/person';
@@ -49,6 +50,11 @@ const TILGJENGELIGE_BEHANDLINGSTYPER = [
     Klagebehandlingstype.KLAGE,
     Behandlingstype.MIGRERING_FRA_INFOTRYGD,
 ];
+
+// Behandlingstema-feltet vises ikke for institusjonssaker, men backend krever kategori/underkategori
+export function hentDefaultBehandlingstema(fagsakType: FagsakType | undefined): IBehandlingstema | undefined {
+    return fagsakType === FagsakType.INSTITUSJON ? behandlingstemaer.NASJONAL_INSTITUSJON : undefined;
+}
 
 export function hentTilgjengeligeBehandlingstyper(fagsak: IMinimalFagsak, saksbehandler: Saksbehandler) {
     const behandling = fagsak ? hentAktivBehandlingPåMinimalFagsak(fagsak) : undefined;


### PR DESCRIPTION
### 📮 Favro:NAV-29930

### 💰 Hva skal gjøres, og hvorfor?
Saksbehandler fikk feilmelding ved opprettelse av førstegangsbehandling på institusjonssak. Behandlingstema-feltet vises ikke for institusjonssaker, men backend krever kategori/underkategori. Dermed ble ikke `behandlingskategori` sendt med ved opprettelse, og behandlingen kunne ikke opprettes. Dette oppstår etter vi gikk over til react query for oppretting av behandling.

Endringer:
- Ny hjelpefunksjon `hentDefaultBehandlingstema` som gir `NASJONAL_INSTITUSJON` for institusjonssaker (ellers `undefined`).
- `useOpprettBehandlingSkjema` setter default behandlingstema slik at behandlingskategori sendes med for institusjonssaker.
- `ManuellJournalføringContext` gjenbruker samme hjelpefunksjon.