### PR TITLE
Legg til SATSENDRING_EØS som behandlingsårsak

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/sider.test.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/sider.test.ts
@@ -101,6 +101,12 @@ describe('Sider', () => {
 
             expect(finnSiderForBehandling(behandling).map(side => side.id)).not.toContain(SideId.VEDTAK);
         });
+
+        test('skal vise vedtak når årsaken er satsendring EØS', () => {
+            const behandling = lagBehandling({ årsak: BehandlingÅrsak.SATSENDRING_EØS });
+
+            expect(finnSiderForBehandling(behandling).map(side => side.id)).toContain(SideId.VEDTAK);
+        });
     });
 
     describe('Sjekk ved endring av sider', () => {
@@ -176,6 +182,18 @@ describe('Sider', () => {
                     steg: BehandlingSteg.BEHANDLING_AVSLUTTET,
                 });
                 expect(finnSideForBehandlingssteg(behandling)).toEqual(sider.SIMULERING);
+            }
+        );
+
+        test(
+            'Skal returnere Vedtak-siden dersom behandlingssteget er etter "send til beslutter" ' +
+                'og behandlinsårsaken er "satsendring EØS"',
+            () => {
+                const behandling = lagBehandling({
+                    årsak: BehandlingÅrsak.SATSENDRING_EØS,
+                    steg: BehandlingSteg.BEHANDLING_AVSLUTTET,
+                });
+                expect(finnSideForBehandlingssteg(behandling)).toEqual(sider.VEDTAK);
             }
         );
     });

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -68,6 +68,7 @@ export enum BehandlingÅrsak {
     OMREGNING_18ÅR = 'OMREGNING_18ÅR',
     SMÅBARNSTILLEGG = 'SMÅBARNSTILLEGG',
     SATSENDRING = 'SATSENDRING',
+    SATSENDRING_EØS = 'SATSENDRING_EØS',
     MIGRERING = 'MIGRERING',
     ENDRE_MIGRERINGSDATO = 'ENDRE_MIGRERINGSDATO',
     HELMANUELL_MIGRERING = 'HELMANUELL_MIGRERING',
@@ -95,20 +96,22 @@ export const behandlingÅrsak: Record<BehandlingÅrsak | Tilbakekrevingsbehandli
     SMÅBARNSTILLEGG: 'Småbarnstillegg',
     SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID: 'Småbarnstillegg med endring fram i tid',
     SATSENDRING: 'Satsendring',
+    SATSENDRING_EØS: 'Satsendring EØS',
     MIGRERING: 'Migrering',
     ENDRE_MIGRERINGSDATO: 'Endre migreringsdato',
     HELMANUELL_MIGRERING: 'Manuell migrering',
+    MÅNEDLIG_VALUTAJUSTERING: 'Månedlig valutajustering',
+    IVERKSETTE_KA_VEDTAK: 'Iverksette KA-vedtak',
+    FINNMARKSTILLEGG: 'Finnmarkstillegg',
+    SVALBARDTILLEGG: 'Svalbardtillegg',
+    FALSK_IDENTITET: 'Falsk identitet',
+
     /** De neste er revurderingsårsaker for tilbakekrevingsbehandlinger **/
     REVURDERING_KLAGE_NFP: 'Klage tilbakekreving',
     REVURDERING_KLAGE_KA: 'Klage omgjort av KA',
     REVURDERING_OPPLYSNINGER_OM_VILKÅR: 'Nye opplysninger',
     REVURDERING_OPPLYSNINGER_OM_FORELDELSE: 'Nye opplysninger',
     REVURDERING_FEILUTBETALT_BELØP_HELT_ELLER_DELVIS_BORTFALT: 'Feilutbetalt beløp helt eller delvis bortfalt',
-    MÅNEDLIG_VALUTAJUSTERING: 'Månedlig valutajustering',
-    IVERKSETTE_KA_VEDTAK: 'Iverksette KA-vedtak',
-    FINNMARKSTILLEGG: 'Finnmarkstillegg',
-    SVALBARDTILLEGG: 'Svalbardtillegg',
-    FALSK_IDENTITET: 'Falsk identitet',
 
     /** Klage: **/
     ANNET: 'Annet',
@@ -119,6 +122,25 @@ export const behandlingÅrsak: Record<BehandlingÅrsak | Tilbakekrevingsbehandli
     IKKE_UTREDET_NOK: 'Ikke utredet nok',
     KØET_BEHANDLING: 'Køet behandling',
 };
+
+/**
+ * Behandlingsårsaker som saksbehandler kan velge manuelt, f.eks. ved opprettelse av en revurdering.
+ * Alle andre BehandlingÅrsak-verdier settes kun automatisk i backenden og skal ikke være valgbare.
+ */
+export const MANUELLE_BEHANDLINGSÅRSAKER = [
+    BehandlingÅrsak.SØKNAD,
+    BehandlingÅrsak.ÅRLIG_KONTROLL,
+    BehandlingÅrsak.DØDSFALL_BRUKER,
+    BehandlingÅrsak.NYE_OPPLYSNINGER,
+    BehandlingÅrsak.SMÅBARNSTILLEGG,
+    BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID,
+    BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
+    BehandlingÅrsak.FALSK_IDENTITET,
+    BehandlingÅrsak.ENDRE_MIGRERINGSDATO,
+    BehandlingÅrsak.HELMANUELL_MIGRERING,
+] as const;
+
+export type ManuellBehandlingÅrsak = (typeof MANUELLE_BEHANDLINGSÅRSAKER)[number];
 
 export enum BehandlingSteg {
     HENLEGG_BEHANDLING = 'HENLEGG_BEHANDLING',

--- a/src/frontend/utils/behandling.test.ts
+++ b/src/frontend/utils/behandling.test.ts
@@ -1,0 +1,76 @@
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+
+import { erBehandlingMedVedtaksbrevutsending, hentTilgjengeligeBehandlingsårsaker } from './behandling';
+
+describe('hentTilgjengeligeBehandlingsårsaker', () => {
+    test('skal ikke inneholde automatiske behandlingsårsaker ved vanlig revurdering', () => {
+        const tilgjengeligeÅrsaker = hentTilgjengeligeBehandlingsårsaker(false, false, false);
+
+        expect(tilgjengeligeÅrsaker).not.toContain(BehandlingÅrsak.SATSENDRING);
+        expect(tilgjengeligeÅrsaker).not.toContain(BehandlingÅrsak.SATSENDRING_EØS);
+        expect(tilgjengeligeÅrsaker).not.toContain(BehandlingÅrsak.MIGRERING);
+        expect(tilgjengeligeÅrsaker).not.toContain(BehandlingÅrsak.ENDRE_MIGRERINGSDATO);
+        expect(tilgjengeligeÅrsaker).not.toContain(BehandlingÅrsak.HELMANUELL_MIGRERING);
+    });
+
+    test('skal inneholde manuelle behandlingsårsaker ved vanlig revurdering', () => {
+        const tilgjengeligeÅrsaker = hentTilgjengeligeBehandlingsårsaker(false, false, false);
+
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.SØKNAD);
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.ÅRLIG_KONTROLL);
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.DØDSFALL_BRUKER);
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.NYE_OPPLYSNINGER);
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.SMÅBARNSTILLEGG);
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.SMÅBARNSTILLEGG_ENDRING_FRAM_I_TID);
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.IVERKSETTE_KA_VEDTAK);
+        expect(tilgjengeligeÅrsaker).toContain(BehandlingÅrsak.FALSK_IDENTITET);
+    });
+
+    test('skal kun inneholde helmanuell migrering når det er tillatt ved migrering fra Infotrygd', () => {
+        const tilgjengeligeÅrsaker = hentTilgjengeligeBehandlingsårsaker(true, true, false);
+
+        expect(tilgjengeligeÅrsaker).toEqual([BehandlingÅrsak.HELMANUELL_MIGRERING]);
+    });
+
+    test('skal kun inneholde endre migreringsdato når det er tillatt ved migrering fra Infotrygd', () => {
+        const tilgjengeligeÅrsaker = hentTilgjengeligeBehandlingsårsaker(true, false, true);
+
+        expect(tilgjengeligeÅrsaker).toEqual([BehandlingÅrsak.ENDRE_MIGRERINGSDATO]);
+    });
+
+    test('skal være tom liste ved migrering fra Infotrygd når ingen av migreringsalternativene er tillatt', () => {
+        const tilgjengeligeÅrsaker = hentTilgjengeligeBehandlingsårsaker(true, false, false);
+
+        expect(tilgjengeligeÅrsaker).toEqual([]);
+    });
+});
+
+describe('erBehandlingMedVedtaksbrevutsending', () => {
+    test('skal returnere true for satsendring EØS', () => {
+        const behandling = lagBehandling({
+            type: Behandlingstype.REVURDERING,
+            årsak: BehandlingÅrsak.SATSENDRING_EØS,
+        });
+
+        expect(erBehandlingMedVedtaksbrevutsending(behandling)).toBe(true);
+    });
+
+    test('skal returnere false for satsendring', () => {
+        const behandling = lagBehandling({
+            type: Behandlingstype.REVURDERING,
+            årsak: BehandlingÅrsak.SATSENDRING,
+        });
+
+        expect(erBehandlingMedVedtaksbrevutsending(behandling)).toBe(false);
+    });
+
+    test('skal returnere true for søknad', () => {
+        const behandling = lagBehandling({
+            type: Behandlingstype.FØRSTEGANGSBEHANDLING,
+            årsak: BehandlingÅrsak.SØKNAD,
+        });
+
+        expect(erBehandlingMedVedtaksbrevutsending(behandling)).toBe(true);
+    });
+});

--- a/src/frontend/utils/behandling.ts
+++ b/src/frontend/utils/behandling.ts
@@ -4,7 +4,9 @@ import {
     Behandlingstype,
     BehandlingÅrsak,
     erBehandlingHenlagt,
+    MANUELLE_BEHANDLINGSÅRSAKER,
     type IBehandling,
+    type ManuellBehandlingÅrsak,
 } from '@typer/behandling';
 import { FagsakStatus, type IMinimalFagsak } from '@typer/fagsak';
 import { Klagebehandlingstype } from '@typer/klage';
@@ -75,33 +77,17 @@ export function hentTilgjengeligeBehandlingstyper(fagsak: IMinimalFagsak, saksbe
 
 export const hentTilgjengeligeBehandlingsårsaker = (
     erMigreringFraInfotrygd: boolean,
-    kanOpprettMigreringsbehandlingMedHelmanuellMigrering: boolean,
-    kanOppretteMigreringsbehandlingMedEndreMigreringsdato: boolean
-): BehandlingÅrsak[] =>
+    kanOppretteHelmanuellMigrering: boolean,
+    kanOppretteEndreMigreringsdato: boolean
+): ManuellBehandlingÅrsak[] =>
     erMigreringFraInfotrygd
-        ? Object.values(BehandlingÅrsak).filter(
+        ? MANUELLE_BEHANDLINGSÅRSAKER.filter(
               årsak =>
-                  (kanOpprettMigreringsbehandlingMedHelmanuellMigrering &&
-                      årsak === BehandlingÅrsak.HELMANUELL_MIGRERING) ||
-                  (kanOppretteMigreringsbehandlingMedEndreMigreringsdato &&
-                      årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO)
+                  (kanOppretteHelmanuellMigrering && årsak === BehandlingÅrsak.HELMANUELL_MIGRERING) ||
+                  (kanOppretteEndreMigreringsdato && årsak === BehandlingÅrsak.ENDRE_MIGRERINGSDATO)
           )
-        : Object.values(BehandlingÅrsak).filter(
-              årsak =>
-                  årsak !== BehandlingÅrsak.TEKNISK_ENDRING &&
-                  årsak !== BehandlingÅrsak.FØDSELSHENDELSE &&
-                  årsak !== BehandlingÅrsak.SATSENDRING &&
-                  årsak !== BehandlingÅrsak.MIGRERING &&
-                  årsak !== BehandlingÅrsak.OMREGNING_6ÅR &&
-                  årsak !== BehandlingÅrsak.OMREGNING_18ÅR &&
-                  årsak !== BehandlingÅrsak.OMREGNING_SMÅBARNSTILLEGG &&
-                  årsak !== BehandlingÅrsak.KORREKSJON_VEDTAKSBREV &&
-                  årsak !== BehandlingÅrsak.ENDRE_MIGRERINGSDATO &&
-                  årsak !== BehandlingÅrsak.HELMANUELL_MIGRERING &&
-                  årsak !== BehandlingÅrsak.MÅNEDLIG_VALUTAJUSTERING &&
-                  årsak !== BehandlingÅrsak.KLAGE &&
-                  årsak !== BehandlingÅrsak.FINNMARKSTILLEGG &&
-                  årsak !== BehandlingÅrsak.SVALBARDTILLEGG
+        : MANUELLE_BEHANDLINGSÅRSAKER.filter(
+              årsak => årsak !== BehandlingÅrsak.ENDRE_MIGRERINGSDATO && årsak !== BehandlingÅrsak.HELMANUELL_MIGRERING
           );
 
 export const forrigeBehandlingVarTekniskEndringMedOpphør = (minimalFagsak?: IMinimalFagsak) => {


### PR DESCRIPTION
### 📮 Favro: NAV-29351

### 💰 Hva skal gjøres, og hvorfor?
Legger til `SATSENDRING_EØS` som en ny automatisk behandlingsårsak (settes kun i backend, ikke valgbar av saksbehandler). I motsetning til `SATSENDRING` skal denne årsaken sende vanlig vedtaksbrev og vise Vedtak-siden som normalt.

Samtidig refaktoreres `hentTilgjengeligeBehandlingsårsaker` fra en lang eksklusjonsliste til en eksplisitt positiv liste (`MANUELLE_BEHANDLINGSÅRSAKER`) over behandlingsårsaker saksbehandler kan velge manuelt. Dette gjør det tydeligere hvilke årsaker som er manuelt valgbare, og reduserer risikoen for å glemme å ekskludere nye automatiske årsaker fra nedtrekkslisten fremover.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.