### PR TITLE
NAV-29950 Ta i bruk react hook form og react query for RegistrerSøknad

### DIFF
--- a/src/frontend/api/registrerSøknad.ts
+++ b/src/frontend/api/registrerSøknad.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling } from '@typer/behandling';
+import type { IRestRegistrerSøknad } from '@typer/søknad';
+
+export async function registrerSøknad(payload: IRestRegistrerSøknad, behandlingId: number): Promise<IBehandling> {
+    return apiClient.post<IRestRegistrerSøknad, IBehandling>({
+        url: `/familie-ba-sak/api/behandlinger/${behandlingId}/steg/registrer-søknad`,
+        data: payload,
+    });
+}

--- a/src/frontend/hooks/useRegistrerSøknad.ts
+++ b/src/frontend/hooks/useRegistrerSøknad.ts
@@ -1,0 +1,18 @@
+import { registrerSøknad } from '@api/registrerSøknad';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+import type { IRestRegistrerSøknad } from '@typer/søknad';
+
+interface RegistrerSøknadParameters {
+    behandlingId: number;
+    søknad: IRestRegistrerSøknad;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, RegistrerSøknadParameters>, 'mutationFn'>;
+
+export function useRegistrerSøknad(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, søknad }: RegistrerSøknadParameters) => registrerSøknad(søknad, behandlingId),
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Annet.tsx
@@ -1,20 +1,33 @@
 import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { Heading, Textarea, VStack } from '@navikt/ds-react';
 
-import { useSøknadContext } from './SøknadContext';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues } from './SøknadContext';
 
 export const Annet = () => {
-    const { skjema } = useSøknadContext();
     const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE,
+        control,
+    });
 
     return (
         <VStack marginBlock={'space-32'}>
             <Heading size={'medium'} level={'2'} children={'Annet'} />
             <br />
             <Textarea
-                {...skjema.felter.endringAvOpplysningerBegrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                readOnly={erLesevisning}
+                value={value}
+                onChange={onChange}
+                error={error?.message}
+                readOnly={isSubmitting || erLesevisning}
                 label={!erLesevisning && 'Ved endring av opplysningene er begrunnelse obligatorisk'}
                 maxLength={2000}
             />

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/BarnMedOpplysninger.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/BarnMedOpplysninger.tsx
@@ -4,11 +4,12 @@ import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvT
 import type { IBarnMedOpplysninger } from '@typer/søknad';
 import { formaterIdent, hentAlderSomString } from '@utils/formatter';
 import classNames from 'classnames';
+import { useFormContext } from 'react-hook-form';
 
 import { BodyShort, Button, Checkbox, HStack } from '@navikt/ds-react';
 
 import styles from './BarnMedOpplysninger.module.css';
-import { useSøknadContext } from './SøknadContext';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues, useSøknadContext } from './SøknadContext';
 import Slett from '../../../../../ikoner/Slett';
 
 interface IProps {
@@ -16,7 +17,7 @@ interface IProps {
 }
 
 export const BarnMedOpplysninger = ({ barn }: IProps) => {
-    const { skjema, barnMedLøpendeUtbetaling } = useSøknadContext();
+    const { barnMedLøpendeUtbetaling } = useSøknadContext();
 
     const fagsak = useFagsak();
 
@@ -26,11 +27,26 @@ export const BarnMedOpplysninger = ({ barn }: IProps) => {
 
     const erLesevisning = useErLesevisning();
 
+    const { getValues, setValue } = useFormContext<RegistrerSøknadFormValues>();
+
     const barnetHarLøpendeUtbetaling = barnMedLøpendeUtbetaling.has(barn.ident);
 
     const navnOgIdentTekst = `${barn.navn ?? 'Navn ukjent'} (${hentAlderSomString(
         barn.fødselsdato
     )}) | ${formaterIdent(barn.ident)} ${barnetHarLøpendeUtbetaling ? '(løpende)' : ''}`;
+
+    const fjernBarn = () => {
+        setValue(
+            RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER,
+            getValues(RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER).filter(
+                barnMedOpplysninger =>
+                    barnMedOpplysninger.ident !== barn.ident ||
+                    barnMedOpplysninger.navn !== barn.navn ||
+                    barnMedOpplysninger.fødselsdato !== barn.fødselsdato
+            ),
+            { shouldValidate: true, shouldDirty: true }
+        );
+    };
 
     return (
         <HStack gap={'space-16'}>
@@ -57,16 +73,7 @@ export const BarnMedOpplysninger = ({ barn }: IProps) => {
                     variant={'tertiary'}
                     id={`fjern__${barn.ident}`}
                     size={'small'}
-                    onClick={() => {
-                        skjema.felter.barnaMedOpplysninger.validerOgSettFelt([
-                            ...skjema.felter.barnaMedOpplysninger.verdi.filter(
-                                barnMedOpplysninger =>
-                                    barnMedOpplysninger.ident !== barn.ident ||
-                                    barnMedOpplysninger.navn !== barn.navn ||
-                                    barnMedOpplysninger.fødselsdato !== barn.fødselsdato
-                            ),
-                        ]);
-                    }}
+                    onClick={fjernBarn}
                     icon={<Slett />}
                 >
                     {'Fjern barn'}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Barna.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/Barna.tsx
@@ -1,22 +1,25 @@
 import { useBruker } from '@hooks/useBruker';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
-import { erFagsakAvTypeInstitusjon, erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
+import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
 import type { IForelderBarnRelasjonMaskert } from '@typer/person';
 import { adressebeskyttelsestyper, ForelderBarnRelasjonRolle } from '@typer/person';
 import type { IBarnMedOpplysninger } from '@typer/søknad';
 import { isoStringTilDate } from '@utils/dato';
 import { differenceInMilliseconds } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
 import { BodyShort, CheckboxGroup, Heading, HStack, InfoCard, Label, VStack } from '@navikt/ds-react';
 
 import { BarnMedOpplysninger } from './BarnMedOpplysninger';
-import { useSøknadContext } from './SøknadContext';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues, useSøknadContext } from './SøknadContext';
 import StatusIkon, { Status } from '../../../../../ikoner/StatusIkon';
 
+export const BARN_CHECKBOX_GROUP_ID = 'registrer-søknad-barn';
+
 export const Barna = () => {
-    const { skjema } = useSøknadContext();
+    const { barnMedLøpendeUtbetaling } = useSøknadContext();
 
     const fagsak = useFagsak();
     const bruker = useBruker();
@@ -26,7 +29,24 @@ export const Barna = () => {
     const gjelderEnsligMindreårig = erFagsakAvTypeEnsligMindreårig(fagsak);
     const gjelderSkjermetBarn = erFagsakAvTypeSkjermetBarn(fagsak);
 
-    const sorterteBarnMedOpplysninger = skjema.felter.barnaMedOpplysninger.verdi.sort(
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { value: barnaMedOpplysninger, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER,
+        control,
+        rules: {
+            validate: barna =>
+                barna.some((barn: IBarnMedOpplysninger) => barn.merket) || barnMedLøpendeUtbetaling.size > 0
+                    ? undefined
+                    : 'Ingen av barna er valgt.',
+        },
+    });
+
+    const sorterteBarnMedOpplysninger = [...barnaMedOpplysninger].sort(
         (a: IBarnMedOpplysninger, b: IBarnMedOpplysninger) => {
             if (!a.fødselsdato) {
                 return 1;
@@ -48,8 +68,8 @@ export const Barna = () => {
     );
 
     const oppdaterBarnMedMerketStatus = (barnaSomErSjekketAv: string[]) => {
-        skjema.felter.barnaMedOpplysninger.validerOgSettFelt(
-            skjema.felter.barnaMedOpplysninger.verdi.map((barnMedOpplysninger: IBarnMedOpplysninger) => ({
+        onChange(
+            barnaMedOpplysninger.map((barnMedOpplysninger: IBarnMedOpplysninger) => ({
                 ...barnMedOpplysninger,
                 merket: barnaSomErSjekketAv.includes(barnMedOpplysninger.ident),
             }))
@@ -76,7 +96,9 @@ export const Barna = () => {
             })}
             <br />
             <CheckboxGroup
-                {...skjema.felter.barnaMedOpplysninger.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                id={BARN_CHECKBOX_GROUP_ID}
+                readOnly={isSubmitting}
+                error={error?.message}
                 legend={
                     !erLesevisning && !gjelderInstitusjon && !gjelderEnsligMindreårig && !gjelderSkjermetBarn ? (
                         <Label>Velg hvilke barn det er søkt om</Label>
@@ -84,7 +106,7 @@ export const Barna = () => {
                         <Label>Barn det er søkt om</Label>
                     )
                 }
-                value={skjema.felter.barnaMedOpplysninger.verdi
+                value={barnaMedOpplysninger
                     .filter((barnMedOpplysninger: IBarnMedOpplysninger) => barnMedOpplysninger.merket)
                     .map((barnMedOpplysninger: IBarnMedOpplysninger) => barnMedOpplysninger.ident)}
                 onChange={(merkedeBarn: string[]) => oppdaterBarnMedMerketStatus(merkedeBarn)}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/MålformFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/MålformFelt.tsx
@@ -1,0 +1,57 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { Målform, målform } from '@typer/søknad';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Box, Heading, Radio, RadioGroup } from '@navikt/ds-react';
+
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues } from './SøknadContext';
+
+export const MÅLFORM_RADIOGROUP_ID = 'registrer-søknad-målform';
+
+export const MålformFelt = () => {
+    const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFelt.MÅLFORM,
+        control,
+        rules: {
+            validate: value => (value !== undefined ? undefined : 'Målform er ikke valgt.'),
+        },
+    });
+
+    return (
+        <RadioGroup
+            id={MÅLFORM_RADIOGROUP_ID}
+            readOnly={isSubmitting || erLesevisning}
+            error={error?.message}
+            value={value ? målform[value] : ''}
+            legend={<Heading size={'medium'} level={'2'} children={'Målform'} />}
+        >
+            <Box paddingInline={'space-16 space-0'}>
+                <Radio
+                    value={målform[Målform.NB]}
+                    name={'registrer-søknad-målform'}
+                    checked={value === Målform.NB}
+                    onChange={() => onChange(Målform.NB)}
+                    id={'målform-nb'}
+                >
+                    {målform[Målform.NB]}
+                </Radio>
+                <Radio
+                    value={målform[Målform.NN]}
+                    name={'registrer-søknad-målform'}
+                    checked={value === Målform.NN}
+                    onChange={() => onChange(Målform.NN)}
+                >
+                    {målform[Målform.NN]}
+                </Radio>
+            </Box>
+        </RadioGroup>
+    );
+};

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/RegistrerSøknad.tsx
@@ -6,16 +6,16 @@ import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/
 import { BehandlingSteg } from '@typer/behandling';
 import { erFagsakAvTypeInstitusjon } from '@typer/fagsak';
 import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { useFormContext } from 'react-hook-form';
 
 import { BodyShort, Button, ErrorSummary, LocalAlert, Modal } from '@navikt/ds-react';
-import { RessursStatus } from '@navikt/familie-typer';
 
 import { Annet } from './Annet';
-import { Barna } from './Barna';
+import { Barna, BARN_CHECKBOX_GROUP_ID } from './Barna';
 import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
-import { useSøknadContext } from './SøknadContext';
+import { MÅLFORM_RADIOGROUP_ID, MålformFelt } from './MålformFelt';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues, useSøknadContext } from './SøknadContext';
 import { SøknadType } from './SøknadType';
-import MålformVelger from '../../../../../komponenter/MålformVelger';
 import Skjemasteg from '../Skjemasteg';
 import styles from './RegistrerSøknad.module.css';
 
@@ -25,23 +25,50 @@ export const RegistrerSøknad = () => {
     const erLesevisning = useErLesevisning();
 
     const {
-        hentFeilTilOppsummering,
+        bekreftModalFeilmelding,
+        erSenderInn,
         nesteAction,
         settVisBekreftModal,
-        skjema,
         søknadErLastetFraBackend,
         visBekreftModal,
     } = useSøknadContext();
 
+    const {
+        getValues,
+        setValue,
+        watch,
+        formState: { errors },
+    } = useFormContext<RegistrerSøknadFormValues>();
+
     const gjelderInstitusjon = erFagsakAvTypeInstitusjon(fagsak);
 
+    const barnaMedOpplysninger = watch(RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER);
+
     function onLeggTilBarn(barn: IBarnMedOpplysninger) {
-        skjema.felter.barnaMedOpplysninger.validerOgSettFelt([...skjema.felter.barnaMedOpplysninger.verdi, barn]);
+        setValue(
+            RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER,
+            [...getValues(RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER), barn],
+            {
+                shouldValidate: true,
+                shouldDirty: true,
+            }
+        );
     }
+
+    const feiloppsummering = [
+        errors.barnaMedOpplysninger?.message && {
+            id: BARN_CHECKBOX_GROUP_ID,
+            feilmelding: errors.barnaMedOpplysninger.message,
+        },
+        errors.målform?.message && {
+            id: MÅLFORM_RADIOGROUP_ID,
+            feilmelding: errors.målform.message,
+        },
+    ].filter((feil): feil is { id: string; feilmelding: string } => Boolean(feil));
 
     return (
         <LeggTilBarnModalContextProvider
-            barn={skjema.felter.barnaMedOpplysninger.verdi}
+            barn={barnaMedOpplysninger}
             onLeggTilBarn={onLeggTilBarn}
             harBrevmottaker={behandling.brevmottakere.length > 0}
         >
@@ -53,7 +80,7 @@ export const RegistrerSøknad = () => {
                     nesteAction(false);
                 }}
                 nesteKnappTittel={erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
-                senderInn={skjema.submitRessurs.status === RessursStatus.HENTER}
+                senderInn={erSenderInn}
                 steg={BehandlingSteg.REGISTRERE_SØKNAD}
             >
                 {søknadErLastetFraBackend && !erLesevisning && (
@@ -73,24 +100,21 @@ export const RegistrerSøknad = () => {
                 {!gjelderInstitusjon && <SøknadType />}
                 <Barna />
                 {!erLesevisning && <LeggTilBarnKnapp />}
-                <MålformVelger
-                    målformFelt={skjema.felter.målform}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
-                    erLesevisning={erLesevisning}
-                />
+                <MålformFelt />
                 <Annet />
-                {(skjema.submitRessurs.status === RessursStatus.FEILET ||
-                    skjema.submitRessurs.status === RessursStatus.IKKE_TILGANG) && (
+                {errors.root?.message && (
                     <LocalAlert status="error">
                         <LocalAlert.Header>
-                            <LocalAlert.Title>{skjema.submitRessurs.frontendFeilmelding}</LocalAlert.Title>
+                            <LocalAlert.Title>{errors.root.message}</LocalAlert.Title>
                         </LocalAlert.Header>
                     </LocalAlert>
                 )}
-                {skjema.visFeilmeldinger && hentFeilTilOppsummering().length > 0 && (
+                {feiloppsummering.length > 0 && (
                     <ErrorSummary heading={'For å gå videre må du rette opp følgende:'} size="small">
-                        {hentFeilTilOppsummering().map(item => (
-                            <ErrorSummary.Item href={`#${item.skjemaelementId}`}>{item.feilmelding}</ErrorSummary.Item>
+                        {feiloppsummering.map(item => (
+                            <ErrorSummary.Item key={item.id} href={`#${item.id}`}>
+                                {item.feilmelding}
+                            </ErrorSummary.Item>
                         ))}
                     </ErrorSummary>
                 )}
@@ -106,27 +130,20 @@ export const RegistrerSøknad = () => {
                         width={'35rem'}
                     >
                         <Modal.Body>
-                            <BodyShort className={styles.fjernVilkårAdvarsel}>
-                                {skjema.submitRessurs.status === RessursStatus.FEILET ||
-                                    (skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL &&
-                                        skjema.submitRessurs.frontendFeilmelding)}
-                            </BodyShort>
+                            <BodyShort className={styles.fjernVilkårAdvarsel}>{bekreftModalFeilmelding}</BodyShort>
                         </Modal.Body>
                         <Modal.Footer>
                             <Button
-                                key={'ja'}
                                 variant={'primary'}
                                 onClick={() => {
                                     settVisBekreftModal(false);
                                     nesteAction(true);
                                 }}
                                 children={'Ja'}
-                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                                disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                loading={erSenderInn}
                             />
                             <Button
                                 variant={'secondary'}
-                                key={'nei'}
                                 onClick={() => {
                                     settVisBekreftModal(false);
                                 }}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext.tsx
@@ -1,38 +1,44 @@
 import type { PropsWithChildren } from 'react';
-import { useState, useEffect, createContext, useContext } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
+import { ApiFeil, RessursStatus } from '@api/client/apiClient';
 import { useBruker } from '@hooks/useBruker';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
-import type { IBehandling } from '@typer/behandling';
+import { useRegistrerSøknad } from '@hooks/useRegistrerSøknad';
 import { BehandlingUnderkategori } from '@typer/behandlingstema';
 import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
 import { ForelderBarnRelasjonRolle, type IForelderBarnRelasjon } from '@typer/person';
-import type { IBarnMedOpplysninger, IBarnMedOpplysningerBackend, IRestRegistrerSøknad, Målform } from '@typer/søknad';
+import type { IBarnMedOpplysninger, IBarnMedOpplysningerBackend, Målform } from '@typer/søknad';
 import { hentBarnMedLøpendeUtbetaling } from '@utils/fagsak';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
-import type { Avhengigheter, FeiloppsummeringFeil, ISkjema } from '@navikt/familie-skjema';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { RessursStatus } from '@navikt/familie-typer';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import useDeepEffect from '../../../../../hooks/useDeepEffect';
 import { useBehandlingContext } from '../../context/BehandlingContext';
 
-interface SøknadSkjema {
-    underkategori: BehandlingUnderkategori;
-    barnaMedOpplysninger: IBarnMedOpplysninger[];
-    endringAvOpplysningerBegrunnelse: string;
-    målform: Målform | undefined;
+export enum RegistrerSøknadFelt {
+    UNDERKATEGORI = 'underkategori',
+    BARNA_MED_OPPLYSNINGER = 'barnaMedOpplysninger',
+    ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE = 'endringAvOpplysningerBegrunnelse',
+    MÅLFORM = 'målform',
+}
+
+export interface RegistrerSøknadFormValues {
+    [RegistrerSøknadFelt.UNDERKATEGORI]: BehandlingUnderkategori;
+    [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: IBarnMedOpplysninger[];
+    [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]: string;
+    [RegistrerSøknadFelt.MÅLFORM]: Målform | undefined;
 }
 
 interface SøknadContextValue {
     barnMedLøpendeUtbetaling: Set<string>;
-    hentFeilTilOppsummering: () => FeiloppsummeringFeil[];
+    bekreftModalFeilmelding: string;
+    erSenderInn: boolean;
     nesteAction: (bekreftEndringerViaFrontend: boolean) => void;
     settVisBekreftModal: (vis: boolean) => void;
-    skjema: ISkjema<SøknadSkjema, IBehandling>;
     søknadErLastetFraBackend: boolean;
     visBekreftModal: boolean;
 }
@@ -48,6 +54,8 @@ export const SøknadProvider = ({ children }: PropsWithChildren) => {
     const navigate = useNavigate();
 
     const [visBekreftModal, settVisBekreftModal] = useState<boolean>(false);
+    const [bekreftModalFeilmelding, settBekreftModalFeilmelding] = useState<string>('');
+    const [søknadErLastetFraBackend, settSøknadErLastetFraBackend] = useState(false);
 
     const gjelderInstitusjon = erFagsakAvTypeInstitusjon(fagsak);
     const gjelderEnsligMindreårig = erFagsakAvTypeEnsligMindreårig(fagsak);
@@ -55,43 +63,25 @@ export const SøknadProvider = ({ children }: PropsWithChildren) => {
 
     const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
 
-    const { skjema, nullstillSkjema, onSubmit, hentFeilTilOppsummering } = useSkjema<SøknadSkjema, IBehandling>({
-        felter: {
-            underkategori: useFelt<BehandlingUnderkategori>({
-                verdi:
-                    behandling.underkategori === BehandlingUnderkategori.UTVIDET
-                        ? BehandlingUnderkategori.UTVIDET
-                        : BehandlingUnderkategori.ORDINÆR,
-            }),
-            barnaMedOpplysninger: useFelt<IBarnMedOpplysninger[]>({
-                verdi: [],
-                valideringsfunksjon: (felt, avhengigheter?: Avhengigheter) => {
-                    return felt.verdi.some((barn: IBarnMedOpplysninger) => barn.merket) ||
-                        (avhengigheter?.barnMedLøpendeUtbetaling.size ?? []) > 0
-                        ? ok(felt)
-                        : feil(felt, 'Ingen av barna er valgt.');
-                },
-                avhengigheter: { barnMedLøpendeUtbetaling },
-            }),
-            endringAvOpplysningerBegrunnelse: useFelt<string>({
-                verdi: '',
-            }),
-            målform: useFelt<Målform | undefined>({
-                verdi: undefined,
-                valideringsfunksjon: felt =>
-                    felt.verdi !== undefined ? ok(felt) : feil(felt, 'Målform er ikke valgt.'),
-            }),
+    const { mutateAsync: registrerSøknad, isPending } = useRegistrerSøknad();
+
+    const form = useForm<RegistrerSøknadFormValues>({
+        defaultValues: {
+            [RegistrerSøknadFelt.UNDERKATEGORI]:
+                behandling.underkategori === BehandlingUnderkategori.UTVIDET
+                    ? BehandlingUnderkategori.UTVIDET
+                    : BehandlingUnderkategori.ORDINÆR,
+            [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: [],
+            [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]: '',
+            [RegistrerSøknadFelt.MÅLFORM]: undefined,
         },
-        skjemanavn: 'Registrer søknad',
     });
 
-    const [søknadErLastetFraBackend, settSøknadErLastetFraBackend] = useState(false);
+    const { reset, setError, handleSubmit } = form;
 
-    const tilbakestillSøknad = () => {
-        nullstillSkjema();
-        let barnaMedOpplysninger: IBarnMedOpplysninger[];
+    const byggBarnaFraFolkeregister = (): IBarnMedOpplysninger[] => {
         if (gjelderInstitusjon || gjelderEnsligMindreårig || gjelderSkjermetBarn) {
-            barnaMedOpplysninger = [
+            return [
                 {
                     merket: true,
                     ident: bruker.personIdent,
@@ -101,21 +91,31 @@ export const SøknadProvider = ({ children }: PropsWithChildren) => {
                     erFolkeregistrert: true,
                 },
             ];
-        } else {
-            barnaMedOpplysninger = bruker.forelderBarnRelasjon
-                .filter((relasjon: IForelderBarnRelasjon) => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
-                .map(
-                    (relasjon: IForelderBarnRelasjon): IBarnMedOpplysninger => ({
-                        merket: false,
-                        ident: relasjon.personIdent,
-                        navn: relasjon.navn,
-                        fødselsdato: relasjon.fødselsdato,
-                        manueltRegistrert: false,
-                        erFolkeregistrert: true,
-                    })
-                );
         }
-        skjema.felter.barnaMedOpplysninger.validerOgSettFelt(barnaMedOpplysninger);
+        return bruker.forelderBarnRelasjon
+            .filter((relasjon: IForelderBarnRelasjon) => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
+            .map(
+                (relasjon: IForelderBarnRelasjon): IBarnMedOpplysninger => ({
+                    merket: false,
+                    ident: relasjon.personIdent,
+                    navn: relasjon.navn,
+                    fødselsdato: relasjon.fødselsdato,
+                    manueltRegistrert: false,
+                    erFolkeregistrert: true,
+                })
+            );
+    };
+
+    const tilbakestillSøknad = () => {
+        reset({
+            [RegistrerSøknadFelt.UNDERKATEGORI]:
+                behandling.underkategori === BehandlingUnderkategori.UTVIDET
+                    ? BehandlingUnderkategori.UTVIDET
+                    : BehandlingUnderkategori.ORDINÆR,
+            [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: byggBarnaFraFolkeregister(),
+            [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]: '',
+            [RegistrerSøknadFelt.MÅLFORM]: undefined,
+        });
         settSøknadErLastetFraBackend(false);
     };
 
@@ -126,82 +126,86 @@ export const SøknadProvider = ({ children }: PropsWithChildren) => {
     useDeepEffect(() => {
         if (behandling.søknadsgrunnlag) {
             settSøknadErLastetFraBackend(true);
-            skjema.felter.barnaMedOpplysninger.validerOgSettFelt(
-                behandling.søknadsgrunnlag.barnaMedOpplysninger.map(
+            reset({
+                [RegistrerSøknadFelt.UNDERKATEGORI]: behandling.søknadsgrunnlag.underkategori,
+                [RegistrerSøknadFelt.BARNA_MED_OPPLYSNINGER]: behandling.søknadsgrunnlag.barnaMedOpplysninger.map(
                     (barnMedOpplysninger: IBarnMedOpplysningerBackend) => ({
                         ...barnMedOpplysninger,
                         merket: barnMedOpplysninger.inkludertISøknaden,
                     })
-                )
-            );
-
-            skjema.felter.målform.validerOgSettFelt(behandling.søknadsgrunnlag.søkerMedOpplysninger.målform);
-            skjema.felter.underkategori.validerOgSettFelt(behandling.søknadsgrunnlag.underkategori);
-            skjema.felter.endringAvOpplysningerBegrunnelse.validerOgSettFelt(
-                behandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse
-            );
+                ),
+                [RegistrerSøknadFelt.ENDRING_AV_OPPLYSNINGER_BEGRUNNELSE]:
+                    behandling.søknadsgrunnlag.endringAvOpplysningerBegrunnelse,
+                [RegistrerSøknadFelt.MÅLFORM]: behandling.søknadsgrunnlag.søkerMedOpplysninger.målform,
+            });
         } else {
             // Ny behandling er lastet som ikke har fullført søknad-steget.
             tilbakestillSøknad();
         }
     }, [behandling.behandlingId, behandling.søknadsgrunnlag]);
 
+    const sendInn = async (values: RegistrerSøknadFormValues, bekreftEndringerViaFrontend: boolean) => {
+        return registrerSøknad({
+            behandlingId: behandling.behandlingId,
+            søknad: {
+                søknad: {
+                    underkategori: values.underkategori,
+                    søkerMedOpplysninger: {
+                        ident: fagsak.søkerFødselsnummer,
+                        målform: values.målform,
+                    },
+                    barnaMedOpplysninger: values.barnaMedOpplysninger.map(
+                        (barn: IBarnMedOpplysninger): IBarnMedOpplysningerBackend => ({
+                            ...barn,
+                            inkludertISøknaden: barn.merket,
+                        })
+                    ),
+                    endringAvOpplysningerBegrunnelse: values.endringAvOpplysningerBegrunnelse,
+                    erAutomatiskRegistrert: false,
+                },
+                bekreftEndringerViaFrontend,
+            },
+        })
+            .then(oppdatertBehandling => {
+                settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+                navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
+            })
+            .catch((error: unknown) => {
+                if (error instanceof ApiFeil && error.ressursStatus === RessursStatus.FUNKSJONELL_FEIL) {
+                    settBekreftModalFeilmelding(error.message);
+                    settVisBekreftModal(true);
+                    return;
+                }
+                setError('root', {
+                    message: error instanceof Error ? error.message : 'Teknisk feil ved registrering av søknad.',
+                });
+            });
+    };
+
     const nesteAction = (bekreftEndringerViaFrontend: boolean) => {
         if (erLesevisning) {
             navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
-        } else {
-            onSubmit<IRestRegistrerSøknad>(
-                {
-                    method: 'POST',
-                    data: {
-                        søknad: {
-                            underkategori: skjema.felter.underkategori.verdi,
-                            søkerMedOpplysninger: {
-                                ident: fagsak.søkerFødselsnummer,
-                                målform: skjema.felter.målform.verdi,
-                            },
-                            barnaMedOpplysninger: skjema.felter.barnaMedOpplysninger.verdi.map(
-                                (barn: IBarnMedOpplysninger): IBarnMedOpplysningerBackend => ({
-                                    ...barn,
-                                    inkludertISøknaden: barn.merket,
-                                })
-                            ),
-                            endringAvOpplysningerBegrunnelse: skjema.felter.endringAvOpplysningerBegrunnelse.verdi,
-                            erAutomatiskRegistrert: false,
-                        },
-                        bekreftEndringerViaFrontend,
-                    },
-                    url: `/familie-ba-sak/api/behandlinger/${behandling.behandlingId}/steg/registrer-søknad`,
-                },
-                (response: Ressurs<IBehandling>) => {
-                    if (response.status === RessursStatus.SUKSESS) {
-                        settÅpenBehandling(response);
-                        navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
-                    }
-                },
-                (errorResponse: Ressurs<IBehandling>) => {
-                    if (errorResponse.status === RessursStatus.FUNKSJONELL_FEIL) {
-                        settVisBekreftModal(true);
-                    }
-                }
-            );
+            return;
         }
+        handleSubmit(values => sendInn(values, bekreftEndringerViaFrontend))();
     };
 
     return (
-        <SøknadContext.Provider
-            value={{
-                barnMedLøpendeUtbetaling,
-                hentFeilTilOppsummering,
-                nesteAction,
-                settVisBekreftModal,
-                skjema,
-                søknadErLastetFraBackend,
-                visBekreftModal,
-            }}
-        >
-            {children}
-        </SøknadContext.Provider>
+        <FormProvider {...form}>
+            <SøknadContext.Provider
+                value={{
+                    barnMedLøpendeUtbetaling,
+                    bekreftModalFeilmelding,
+                    erSenderInn: isPending,
+                    nesteAction,
+                    settVisBekreftModal,
+                    søknadErLastetFraBackend,
+                    visBekreftModal,
+                }}
+            >
+                {children}
+            </SøknadContext.Provider>
+        </FormProvider>
     );
 };
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadType.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadType.tsx
@@ -1,34 +1,38 @@
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { behandlingUnderkategori, BehandlingUnderkategori } from '@typer/behandlingstema';
+import { useController, useFormContext } from 'react-hook-form';
 
 import { Heading, Radio, RadioGroup } from '@navikt/ds-react';
 
-import { useSøknadContext } from './SøknadContext';
+import { RegistrerSøknadFelt, type RegistrerSøknadFormValues } from './SøknadContext';
 import styles from './SøknadType.module.css';
 
 export const SøknadType = () => {
-    const { skjema } = useSøknadContext();
-
     const erLesevisning = useErLesevisning();
 
-    const radioOnChange = (underKategori: BehandlingUnderkategori) => {
-        skjema.felter.underkategori.validerOgSettFelt(underKategori);
-    };
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { value, onChange },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFelt.UNDERKATEGORI,
+        control,
+    });
 
     return (
         <RadioGroup
             className={styles.radioGroup}
-            {...skjema.felter.underkategori.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-            readOnly={erLesevisning}
-            value={behandlingUnderkategori[skjema.felter.underkategori.verdi]}
+            readOnly={isSubmitting || erLesevisning}
+            value={behandlingUnderkategori[value]}
             legend={<Heading size={'medium'} level={'2'} children={'Hva har bruker søkt om?'} />}
         >
             <Radio
                 className={styles.radio}
                 value={behandlingUnderkategori[BehandlingUnderkategori.ORDINÆR]}
                 name={'registrer-søknad-søknadtype'}
-                checked={skjema.felter.underkategori.verdi === BehandlingUnderkategori.ORDINÆR}
-                onChange={() => radioOnChange(BehandlingUnderkategori.ORDINÆR)}
+                checked={value === BehandlingUnderkategori.ORDINÆR}
+                onChange={() => onChange(BehandlingUnderkategori.ORDINÆR)}
             >
                 {behandlingUnderkategori[BehandlingUnderkategori.ORDINÆR]}
             </Radio>
@@ -36,8 +40,8 @@ export const SøknadType = () => {
                 className={styles.radio}
                 value={behandlingUnderkategori[BehandlingUnderkategori.UTVIDET]}
                 name={'registrer-søknad-søknadtype'}
-                checked={skjema.felter.underkategori.verdi === BehandlingUnderkategori.UTVIDET}
-                onChange={() => radioOnChange(BehandlingUnderkategori.UTVIDET)}
+                checked={value === BehandlingUnderkategori.UTVIDET}
+                onChange={() => onChange(BehandlingUnderkategori.UTVIDET)}
             >
                 {behandlingUnderkategori[BehandlingUnderkategori.UTVIDET]}
             </Radio>


### PR DESCRIPTION
### 📮 Favro:
NAV-29950

### 💰 Hva skal gjøres, og hvorfor?
Migrerer RegistrerSøknad-steget fra `@navikt/familie-skjema` (`useSkjema`/`useFelt`) til `react-hook-form` + `react-query`, i tråd med etablert mønster i kodebasen.

- Ny API-funksjon `api/registrerSøknad.ts` som bruker `apiClient`.
- Ny mutasjonshook `hooks/useRegistrerSøknad.ts` (tynn `useMutation`-wrapper).
- `SøknadContext` bruker nå `useForm` + `FormProvider`; feltene styres via `useController` i egne feltkomponenter (`MålformFelt`, `SøknadType`, `Annet`, `Barna`).
- Innsending går via `handleSubmit` → `mutateAsync`; funksjonell feil håndteres fortsatt med bekreft-modal, øvrige feil vises via `root`-feil og `ErrorSummary`.

Ingen funksjonell endring – kun teknisk refaktorering.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Håndteringen av bekreft-modal ved funksjonell feil, og synkronisering av skjema mot `søknadsgrunnlag`.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ren teknisk refaktorering uten funksjonell endring.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Ingen visuelle endringer.
