### PR TITLE
NAV-29957: Skriver om valutakurs til react query og rhf

### DIFF
--- a/src/frontend/api/valutakurs.ts
+++ b/src/frontend/api/valutakurs.ts
@@ -1,0 +1,34 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling, VurderingsstrategiForValutakurser } from '@typer/behandling';
+
+export interface OppdaterValutakursPayload {
+    id: number;
+    fom: string;
+    tom?: string;
+    barnIdenter: string[];
+    valutakode?: string;
+    valutakursdato?: string;
+    kurs?: string;
+}
+
+export async function oppdaterValutakurs(payload: OppdaterValutakursPayload, behandlingId: number) {
+    return apiClient.put<OppdaterValutakursPayload, IBehandling>({
+        data: payload,
+        url: `/familie-ba-sak/api/differanseberegning/valutakurs/${behandlingId}`,
+    });
+}
+
+export async function slettValutakurs(behandlingId: number, valutakursId: number) {
+    return apiClient.delete<void, IBehandling>({
+        url: `/familie-ba-sak/api/differanseberegning/valutakurs/${behandlingId}/${valutakursId}`,
+    });
+}
+
+export async function endreVurderingsstrategiForValutakurser(
+    behandlingId: number,
+    vurderingsstrategi: VurderingsstrategiForValutakurser
+) {
+    return apiClient.put<undefined, IBehandling>({
+        url: `/familie-ba-sak/api/differanseberegning/valutakurs/behandlinger/${behandlingId}/endre-vurderingsstrategi-til/${vurderingsstrategi}`,
+    });
+}

--- a/src/frontend/hooks/useEndreVurderingsstrategiForValutakurser.ts
+++ b/src/frontend/hooks/useEndreVurderingsstrategiForValutakurser.ts
@@ -1,0 +1,18 @@
+import { endreVurderingsstrategiForValutakurser } from '@api/valutakurs';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling, VurderingsstrategiForValutakurser } from '@typer/behandling';
+
+interface EndreVurderingsstrategiParameters {
+    behandlingId: number;
+    vurderingsstrategi: VurderingsstrategiForValutakurser;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, EndreVurderingsstrategiParameters>, 'mutationFn'>;
+
+export function useEndreVurderingsstrategiForValutakurser(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, vurderingsstrategi }: EndreVurderingsstrategiParameters) =>
+            endreVurderingsstrategiForValutakurser(behandlingId, vurderingsstrategi),
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useOppdaterValutakurs.ts
+++ b/src/frontend/hooks/useOppdaterValutakurs.ts
@@ -1,0 +1,17 @@
+import { oppdaterValutakurs, type OppdaterValutakursPayload } from '@api/valutakurs';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface OppdaterValutakursParameters extends OppdaterValutakursPayload {
+    behandlingId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OppdaterValutakursParameters>, 'mutationFn'>;
+
+export function useOppdaterValutakurs(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, ...payload }: OppdaterValutakursParameters) =>
+            oppdaterValutakurs(payload, behandlingId),
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useSlettValutakurs.ts
+++ b/src/frontend/hooks/useSlettValutakurs.ts
@@ -1,0 +1,18 @@
+import { slettValutakurs } from '@api/valutakurs';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface SlettValutakursParameters {
+    behandlingId: number;
+    valutakursId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, SlettValutakursParameters>, 'mutationFn'>;
+
+export function useSlettValutakurs(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, valutakursId }: SlettValutakursParameters) =>
+            slettValutakurs(behandlingId, valutakursId),
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursBarnFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursBarnFelt.tsx
@@ -1,0 +1,49 @@
+import type { OptionType } from '@typer/common';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { UNSAFE_Combobox } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+interface Props {
+    tilgjengeligeBarn: OptionType[];
+    lesevisning: boolean;
+}
+
+export function ValutakursBarnFelt({ tilgjengeligeBarn, lesevisning }: Props) {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+    } = useController({
+        name: ValutakursFelt.BARN,
+        control,
+        rules: {
+            validate: barn => (barn.length > 0 ? undefined : 'Minst ett barn må være valgt'),
+        },
+    });
+
+    const onToggleSelected = (optionValue: string, isSelected: boolean) => {
+        if (isSelected) {
+            const nyttValg = tilgjengeligeBarn.find(barn => barn.value === optionValue);
+            if (nyttValg) {
+                onChange([...value, nyttValg]);
+            }
+        } else {
+            onChange(value.filter(barn => barn.value !== optionValue));
+        }
+    };
+
+    return (
+        <UNSAFE_Combobox
+            isMultiSelect
+            label={'Barn'}
+            options={tilgjengeligeBarn}
+            selectedOptions={value}
+            onToggleSelected={onToggleSelected}
+            readOnly={lesevisning}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursBarnFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursBarnFelt.tsx
@@ -14,8 +14,9 @@ export function ValutakursBarnFelt({ tilgjengeligeBarn, lesevisning }: Props) {
     const { control } = useFormContext<ValutakursFormValues>();
 
     const {
-        field: { value, onChange },
+        field: { value, onChange, onBlur, ref },
         fieldState: { error },
+        formState: { isSubmitting },
     } = useController({
         name: ValutakursFelt.BARN,
         control,
@@ -42,7 +43,9 @@ export function ValutakursBarnFelt({ tilgjengeligeBarn, lesevisning }: Props) {
             options={tilgjengeligeBarn}
             selectedOptions={value}
             onToggleSelected={onToggleSelected}
-            readOnly={lesevisning}
+            onBlur={onBlur}
+            ref={ref}
+            readOnly={lesevisning || isSubmitting}
             error={error?.message}
         />
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+
+import { dagensDato } from '@utils/dato';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { DatePicker, type DateValidationT, useDatepicker } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+interface Props {
+    readOnly: boolean;
+}
+
+export function ValutakursDatoFelt({ readOnly }: Props) {
+    const { control, trigger, setValue } = useFormContext<ValutakursFormValues>();
+
+    const [dateValidation, setDateValidation] = useState<DateValidationT | undefined>(undefined);
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+        formState: { isSubmitted },
+    } = useController({
+        name: ValutakursFelt.VALUTAKURSDATO,
+        control,
+        rules: {
+            validate: valgtDato => {
+                if (dateValidation?.isWeekend) {
+                    return 'Du må velge en dato som er en ukedag';
+                }
+                if (dateValidation?.isAfter) {
+                    return 'Du kan ikke sette en dato som er frem i tid';
+                }
+                if (!valgtDato || dateValidation?.isInvalid || (dateValidation && !dateValidation.isValidDate)) {
+                    return 'Du må velge en gyldig dato';
+                }
+                return undefined;
+            },
+        },
+    });
+
+    const { datepickerProps, inputProps, setSelected, selectedDay } = useDatepicker({
+        defaultSelected: value,
+        toDate: dagensDato,
+        disableWeekends: true,
+        onDateChange: dato => {
+            onChange(dato);
+            // Når valutakursdato endres må registrert kurs nullstilles slik at ny kurs hentes/registreres.
+            setValue(ValutakursFelt.KURS, '', { shouldDirty: true });
+            if (isSubmitted) {
+                trigger(ValutakursFelt.VALUTAKURSDATO);
+            }
+        },
+        onValidate: validation => {
+            setDateValidation(validation);
+            if (isSubmitted) {
+                trigger(ValutakursFelt.VALUTAKURSDATO);
+            }
+        },
+    });
+
+    // Synkroniser datovelgeren dersom feltverdien endres uten at det er datovelgeren som trigget endringen.
+    const [forrigeVerdi, settForrigeVerdi] = useState<Date | undefined>(value);
+    if (value !== forrigeVerdi) {
+        settForrigeVerdi(value);
+        if (value !== selectedDay) {
+            setSelected(value);
+        }
+    }
+
+    return (
+        <DatePicker dropdownCaption {...datepickerProps}>
+            <DatePicker.Input
+                {...inputProps}
+                label={'Valutakursdato'}
+                placeholder={'DD.MM.ÅÅÅÅ'}
+                readOnly={readOnly}
+                error={error?.message}
+            />
+        </DatePicker>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
@@ -17,9 +17,9 @@ export function ValutakursDatoFelt({ readOnly }: Props) {
     const [dateValidation, setDateValidation] = useState<DateValidationT | undefined>(undefined);
 
     const {
-        field: { value, onChange },
+        field: { value, onChange, ref },
         fieldState: { error },
-        formState: { isSubmitted },
+        formState: { isSubmitting, isSubmitted },
     } = useController({
         name: ValutakursFelt.VALUTAKURSDATO,
         control,
@@ -74,7 +74,8 @@ export function ValutakursDatoFelt({ readOnly }: Props) {
                 {...inputProps}
                 label={'Valutakursdato'}
                 placeholder={'DD.MM.ÅÅÅÅ'}
-                readOnly={readOnly}
+                ref={ref}
+                readOnly={readOnly || isSubmitting}
                 error={error?.message}
             />
         </DatePicker>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursKursFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursKursFelt.tsx
@@ -35,8 +35,9 @@ export function ValutakursKursFelt({ readOnly, erManuellInputAvKurs }: Props) {
     const { control } = useFormContext<ValutakursFormValues>();
 
     const {
-        field: { value, onChange },
+        field: { value, onChange, onBlur, ref },
         fieldState: { error },
+        formState: { isSubmitting },
     } = useController({
         name: ValutakursFelt.KURS,
         control,
@@ -48,9 +49,11 @@ export function ValutakursKursFelt({ readOnly, erManuellInputAvKurs }: Props) {
     return (
         <TextField
             label={'Valutakurs'}
-            readOnly={readOnly}
+            readOnly={readOnly || isSubmitting}
             value={value ?? ''}
             onChange={event => onChange(event.target.value)}
+            onBlur={onBlur}
+            ref={ref}
             error={error?.message}
         />
     );

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursKursFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursKursFelt.tsx
@@ -1,0 +1,57 @@
+import { konverterSkjemaverdiTilDesimal } from '@utils/eøs';
+import { isEmpty, isNumeric, tellAntallDesimaler } from '@utils/eøsValidators';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { TextField } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+const validerKurs = (verdi: string | undefined): string | undefined => {
+    if (!verdi || isEmpty(verdi) || typeof verdi != 'string') {
+        return 'Valutakurs er påkrevd, men mangler input';
+    }
+    const nyKurs = konverterSkjemaverdiTilDesimal(verdi);
+    if (!nyKurs) {
+        return 'Valutakurs er påkrevd, men mangler input';
+    }
+    if (!isNumeric(nyKurs)) {
+        return `Valutakurs innholder ugyldige verdier, kurs: ${verdi}`;
+    }
+    if (tellAntallDesimaler(nyKurs) === 0) {
+        return `Valutakurs må oppgis med desimaler, kurs: ${verdi}`;
+    }
+    if (Number(nyKurs) < 0) {
+        return `Kan ikke registrere negativt kurs: ${verdi}`;
+    }
+    return undefined;
+};
+
+interface Props {
+    readOnly: boolean;
+    erManuellInputAvKurs: boolean;
+}
+
+export function ValutakursKursFelt({ readOnly, erManuellInputAvKurs }: Props) {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+    } = useController({
+        name: ValutakursFelt.KURS,
+        control,
+        rules: {
+            validate: kurs => (erManuellInputAvKurs ? validerKurs(kurs) : undefined),
+        },
+    });
+
+    return (
+        <TextField
+            label={'Valutakurs'}
+            readOnly={readOnly}
+            value={value ?? ''}
+            onChange={event => onChange(event.target.value)}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
@@ -3,26 +3,10 @@ import { dagensDato, isoStringTilDate } from '@utils/dato';
 import { isEmpty } from '@utils/eøsValidators';
 import { addMonths, endOfMonth, isAfter } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';
-import styled from 'styled-components';
 
-import { Fieldset } from '@navikt/ds-react';
+import { Fieldset, HStack } from '@navikt/ds-react';
 
 import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
-
-const FlexDiv = styled.div`
-    width: 32rem;
-    display: flex;
-    justify-content: space-between;
-    font-size: 1rem;
-
-    div {
-        z-index: 0;
-    }
-
-    div div.skjemaelement {
-        margin-bottom: 0;
-    }
-`;
 
 const valgtDatoErNesteMånedEllerSenere = (valgtDato: string) =>
     isAfter(isoStringTilDate(valgtDato), endOfMonth(dagensDato));
@@ -31,12 +15,12 @@ const valgtDatoErSenereEnnNesteMåned = (valgtDato: string) =>
     isAfter(isoStringTilDate(valgtDato), endOfMonth(addMonths(dagensDato, 1)));
 
 interface Props {
-    initielFom: string;
+    initiellFom: string;
     periodeFeilmeldingId: string;
     lesevisning: boolean;
 }
 
-export function ValutakursPeriodeFelt({ initielFom, periodeFeilmeldingId, lesevisning }: Props) {
+export function ValutakursPeriodeFelt({ initiellFom, periodeFeilmeldingId, lesevisning }: Props) {
     const { control } = useFormContext<ValutakursFormValues>();
 
     const {
@@ -56,8 +40,8 @@ export function ValutakursPeriodeFelt({ initielFom, periodeFeilmeldingId, lesevi
                 if (fom && valgtDatoErSenereEnnNesteMåned(fom)) {
                     return 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere';
                 }
-                if (initielFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initielFom))) {
-                    return `Du kan ikke legge inn fra og med måned som er før: ${initielFom}`;
+                if (initiellFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initiellFom))) {
+                    return `Du kan ikke legge inn fra og med måned som er før: ${initiellFom}`;
                 }
                 if (tom && valgtDatoErNesteMånedEllerSenere(tom)) {
                     return 'Du kan ikke sette til og med (t.o.m.) til neste måned eller senere';
@@ -67,7 +51,7 @@ export function ValutakursPeriodeFelt({ initielFom, periodeFeilmeldingId, lesevi
         },
     });
 
-    const finnÅrTilbakeTil = (): number => new Date().getFullYear() - new Date(initielFom).getFullYear();
+    const finnÅrTilbakeTil = (): number => new Date().getFullYear() - new Date(initiellFom).getFullYear();
 
     return (
         <Fieldset
@@ -77,7 +61,7 @@ export function ValutakursPeriodeFelt({ initielFom, periodeFeilmeldingId, lesevi
             legend="Periode"
             size="medium"
         >
-            <FlexDiv>
+            <HStack justify={'space-between'} gap={'space-16'} width={'32rem'}>
                 <MånedÅrVelger
                     lesevisning={lesevisning}
                     id={'periode_fom'}
@@ -106,7 +90,7 @@ export function ValutakursPeriodeFelt({ initielFom, periodeFeilmeldingId, lesevi
                         onChange({ ...value, tom: årMåned });
                     }}
                 />
-            </FlexDiv>
+            </HStack>
         </Fieldset>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
@@ -1,0 +1,112 @@
+import MånedÅrVelger from '@komponenter/MånedÅrInput/MånedÅrVelger';
+import { dagensDato, isoStringTilDate } from '@utils/dato';
+import { isEmpty } from '@utils/eøsValidators';
+import { addMonths, endOfMonth, isAfter } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
+import styled from 'styled-components';
+
+import { Fieldset } from '@navikt/ds-react';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+const FlexDiv = styled.div`
+    width: 32rem;
+    display: flex;
+    justify-content: space-between;
+    font-size: 1rem;
+
+    div {
+        z-index: 0;
+    }
+
+    div div.skjemaelement {
+        margin-bottom: 0;
+    }
+`;
+
+const valgtDatoErNesteMånedEllerSenere = (valgtDato: string) =>
+    isAfter(isoStringTilDate(valgtDato), endOfMonth(dagensDato));
+
+const valgtDatoErSenereEnnNesteMåned = (valgtDato: string) =>
+    isAfter(isoStringTilDate(valgtDato), endOfMonth(addMonths(dagensDato, 1)));
+
+interface Props {
+    initielFom: string;
+    periodeFeilmeldingId: string;
+    lesevisning: boolean;
+}
+
+export function ValutakursPeriodeFelt({ initielFom, periodeFeilmeldingId, lesevisning }: Props) {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+    } = useController({
+        name: ValutakursFelt.PERIODE,
+        control,
+        rules: {
+            validate: periode => {
+                const fom = periode.fom;
+                const tom = periode.tom;
+
+                if (!fom || isEmpty(fom)) {
+                    return 'Fra og med måned må være utfylt';
+                }
+                if (fom && valgtDatoErSenereEnnNesteMåned(fom)) {
+                    return 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere';
+                }
+                if (initielFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initielFom))) {
+                    return `Du kan ikke legge inn fra og med måned som er før: ${initielFom}`;
+                }
+                if (tom && valgtDatoErNesteMånedEllerSenere(tom)) {
+                    return 'Du kan ikke sette til og med (t.o.m.) til neste måned eller senere';
+                }
+                return undefined;
+            },
+        },
+    });
+
+    const finnÅrTilbakeTil = (): number => new Date().getFullYear() - new Date(initielFom).getFullYear();
+
+    return (
+        <Fieldset
+            className={lesevisning ? 'lesevisning' : ''}
+            errorId={periodeFeilmeldingId}
+            error={error?.message}
+            legend="Periode"
+            size="medium"
+        >
+            <FlexDiv>
+                <MånedÅrVelger
+                    lesevisning={lesevisning}
+                    id={'periode_fom'}
+                    label={'F.o.m'}
+                    antallÅrTilbake={finnÅrTilbakeTil()}
+                    antallÅrFrem={0}
+                    value={value.fom ?? undefined}
+                    onEndret={årMåned => {
+                        if (årMåned === value.fom) {
+                            return;
+                        }
+                        onChange({ ...value, fom: årMåned });
+                    }}
+                />
+                <MånedÅrVelger
+                    lesevisning={lesevisning}
+                    id={'periode_tom'}
+                    label={'T.o.m (valgfri)'}
+                    antallÅrTilbake={finnÅrTilbakeTil()}
+                    antallÅrFrem={0}
+                    value={value.tom ?? undefined}
+                    onEndret={årMåned => {
+                        if (årMåned === value.tom) {
+                            return;
+                        }
+                        onChange({ ...value, tom: årMåned });
+                    }}
+                />
+            </FlexDiv>
+        </Fieldset>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -1,4 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
+import { FormProvider } from 'react-hook-form';
 
 import { Table } from '@navikt/ds-react';
 
@@ -19,6 +21,7 @@ interface IProps {
 }
 
 const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: IProps) => {
+    const [erValutakursEkspandert, settErValutakursEkspandert] = useState(false);
     const [skalRendreContentIEkspanderbartPanel, settSkalRendreContentIEkspanderbartPanel] = useState(false);
 
     const barn: OptionType[] = valutakurs.barnIdenter.map(barn => ({
@@ -26,22 +29,12 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
         label: lagPersonLabel(barn, åpenBehandling.personer),
     }));
 
-    const {
-        erValutakursEkspandert,
-        settErValutakursEkspandert,
-        skjema,
-        valideringErOk,
-        sendInnSkjema,
-        tilbakestillFelterTilDefault,
-        kanSendeSkjema,
-        erValutakursSkjemaEndret,
-        slettValutakurs,
-        sletterValutakurs,
-        erManuellInputAvKurs,
-    } = useValutakursSkjema({
-        valutakurs,
-        barnIValutakurs: barn,
-    });
+    const { form, onSubmit, slettValutakurs, sletterValutakurs, erManuellInputAvKurs, initielFom } =
+        useValutakursSkjema({
+            valutakurs,
+            barnIValutakurs: barn,
+            lukkSkjema: () => settErValutakursEkspandert(false),
+        });
 
     if (erValutakursEkspandert && !skalRendreContentIEkspanderbartPanel) {
         settSkalRendreContentIEkspanderbartPanel(true);
@@ -49,16 +42,16 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
 
     useEffect(() => {
         if (visFeilmeldinger && erValutakursEkspandert) {
-            kanSendeSkjema();
+            form.trigger();
         }
     }, [visFeilmeldinger, erValutakursEkspandert]);
 
     const toggleForm = (visAlert: boolean) => {
-        if (erValutakursEkspandert && visAlert && erValutakursSkjemaEndret()) {
+        if (erValutakursEkspandert && visAlert && form.formState.isDirty) {
             alert('Valutakurs har endringer som ikke er lagret!');
         } else {
             settErValutakursEkspandert(!erValutakursEkspandert);
-            tilbakestillFelterTilDefault();
+            form.reset();
         }
     };
 
@@ -70,21 +63,21 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
             id={valutakursFeilmeldingId(valutakurs)}
             content={
                 skalRendreContentIEkspanderbartPanel ? (
-                    <ValutakursTabellRadEndre
-                        skjema={skjema}
-                        tilgjengeligeBarn={barn}
-                        status={valutakurs.status}
-                        valideringErOk={valideringErOk}
-                        sendInnSkjema={sendInnSkjema}
-                        toggleForm={toggleForm}
-                        slettValutakurs={slettValutakurs}
-                        sletterValutakurs={sletterValutakurs}
-                        erManuellInputAvKurs={erManuellInputAvKurs}
-                        key={`${valutakurs.id}-${erValutakursEkspandert ? 'ekspandert' : 'lukket'}`}
-                        vurderingsform={valutakurs.vurderingsform}
-                        åpenBehandling={åpenBehandling}
-                        inneholderBarnSomSkalSkjermes={valutakurs.inneholderBarnSomSkalSkjermes}
-                    />
+                    <FormProvider {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)}>
+                            <ValutakursTabellRadEndre
+                                valutakurs={valutakurs}
+                                tilgjengeligeBarn={barn}
+                                initielFom={initielFom}
+                                erManuellInputAvKurs={erManuellInputAvKurs}
+                                vurderingsform={valutakurs.vurderingsform}
+                                inneholderBarnSomSkalSkjermes={valutakurs.inneholderBarnSomSkalSkjermes}
+                                onAvbryt={() => toggleForm(false)}
+                                slettValutakurs={slettValutakurs}
+                                sletterValutakurs={sletterValutakurs}
+                            />
+                        </form>
+                    </FormProvider>
                 ) : null
             }
         >

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRad.tsx
@@ -29,7 +29,7 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
         label: lagPersonLabel(barn, åpenBehandling.personer),
     }));
 
-    const { form, onSubmit, slettValutakurs, sletterValutakurs, erManuellInputAvKurs, initielFom } =
+    const { form, onSubmit, slettValutakurs, sletterValutakurs, erManuellInputAvKurs, initiellFom } =
         useValutakursSkjema({
             valutakurs,
             barnIValutakurs: barn,
@@ -68,7 +68,7 @@ const ValutakursTabellRad = ({ valutakurs, åpenBehandling, visFeilmeldinger }: 
                             <ValutakursTabellRadEndre
                                 valutakurs={valutakurs}
                                 tilgjengeligeBarn={barn}
-                                initielFom={initielFom}
+                                initiellFom={initiellFom}
                                 erManuellInputAvKurs={erManuellInputAvKurs}
                                 vurderingsform={valutakurs.vurderingsform}
                                 inneholderBarnSomSkalSkjermes={valutakurs.inneholderBarnSomSkalSkjermes}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -1,113 +1,65 @@
-import type { ReactNode, ChangeEvent } from 'react';
-
+import { useBehandling } from '@hooks/useBehandling';
 import { useErLesevisning } from '@hooks/useErLesevisning';
-import { type Valutakode, ValutaCombobox, EØS_VALUTAKODER } from '@komponenter/FlaggCombobox';
-import type { IBehandling } from '@typer/behandling';
 import { VurderingsstrategiForValutakurser } from '@typer/behandling';
-import type { ComboboxOption } from '@typer/common';
-import { EøsPeriodeStatus, type IValutakurs, Vurderingsform } from '@typer/eøsPerioder';
-import { onOptionSelected } from '@utils/skjema';
+import type { OptionType } from '@typer/common';
+import { EøsPeriodeStatus, type IRestValutakurs, Vurderingsform } from '@typer/eøsPerioder';
+import { useFormContext } from 'react-hook-form';
 
 import { CogRotationIcon, PersonGavelIcon, TrashIcon } from '@navikt/aksel-icons';
-import {
-    Box,
-    Button,
-    Fieldset,
-    Heading,
-    HGrid,
-    HStack,
-    InlineMessage,
-    Label,
-    Link,
-    TextField,
-    UNSAFE_Combobox,
-} from '@navikt/ds-react';
-import type { ISkjema } from '@navikt/familie-skjema';
-import { Valideringsstatus } from '@navikt/familie-skjema';
-import { RessursStatus } from '@navikt/familie-typer';
+import { Box, Button, Fieldset, Heading, HGrid, HStack, InlineMessage, Label, Link } from '@navikt/ds-react';
 
-import Datovelger from '../../../../../../../komponenter/Datovelger/Datovelger';
-import EøsPeriodeSkjema from '../EøsKomponenter/EøsPeriodeSkjema';
+import { type ValutakursFormValues } from './useValutakursSkjema';
+import { ValutakursBarnFelt } from './ValutakursBarnFelt';
+import { ValutakursDatoFelt } from './ValutakursDatoFelt';
+import { ValutakursKursFelt } from './ValutakursKursFelt';
+import { ValutakursPeriodeFelt } from './ValutakursPeriodeFelt';
+import { ValutakursValutaFelt } from './ValutakursValutaFelt';
 import { EøsPeriodeSkjemaContainer, Knapperad } from '../EøsKomponenter/EøsSkjemaKomponenter';
 
-const valutakursPeriodeFeilmeldingId = (valutakurs: ISkjema<IValutakurs, IBehandling>): string =>
-    `valutakurs-periode_${valutakurs.felter.barnIdenter.verdi.map(barn => `${barn.value}`)}_${
-        valutakurs.felter.initielFom.verdi
-    }`;
-
-const valutakursValutaFeilmeldingId = (valutakurs: ISkjema<IValutakurs, IBehandling>): string =>
-    `valutakurs-valuta_${valutakurs.felter.barnIdenter.verdi.map(barn => `${barn.value}`)}_${
-        valutakurs.felter.initielFom.verdi
-    }`;
-
-interface IProps {
-    skjema: ISkjema<IValutakurs, IBehandling>;
-    tilgjengeligeBarn: ComboboxOption[];
-    status: EøsPeriodeStatus;
-    valideringErOk: () => boolean;
-    sendInnSkjema: () => void;
-    toggleForm: (visAlert: boolean) => void;
-    slettValutakurs: () => void;
-    sletterValutakurs: boolean;
+interface Props {
+    valutakurs: IRestValutakurs;
+    tilgjengeligeBarn: OptionType[];
+    initielFom: string;
     erManuellInputAvKurs: boolean;
     vurderingsform: Vurderingsform | undefined;
-    åpenBehandling: IBehandling;
     inneholderBarnSomSkalSkjermes?: boolean;
+    onAvbryt: () => void;
+    slettValutakurs: () => void;
+    sletterValutakurs: boolean;
 }
 
 const ValutakursTabellRadEndre = ({
-    vurderingsform,
-    skjema,
+    valutakurs,
     tilgjengeligeBarn,
-    status,
-    sendInnSkjema,
-    toggleForm,
+    initielFom,
+    erManuellInputAvKurs,
+    vurderingsform,
+    inneholderBarnSomSkalSkjermes,
+    onAvbryt,
     slettValutakurs,
     sletterValutakurs,
-    erManuellInputAvKurs,
-    åpenBehandling,
-    inneholderBarnSomSkalSkjermes,
-}: IProps) => {
+}: Props) => {
     const erLesevisning = useErLesevisning();
+    const behandling = useBehandling();
+
+    const {
+        formState: { isSubmitting, errors },
+    } = useFormContext<ValutakursFormValues>();
 
     const erValutakursVurdertAutomatisk = vurderingsform === Vurderingsform.AUTOMATISK;
     const skaAutomatiskeValutakurserKunneRedigeres =
-        åpenBehandling.vurderingsstrategiForValutakurser === VurderingsstrategiForValutakurser.MANUELL;
+        behandling.vurderingsstrategiForValutakurser === VurderingsstrategiForValutakurser.MANUELL;
 
     const erRedigeringDeaktivert =
         erLesevisning ||
         !!inneholderBarnSomSkalSkjermes ||
         (erValutakursVurdertAutomatisk && !skaAutomatiskeValutakurserKunneRedigeres);
 
-    const visKursGruppeFeilmelding = (): ReactNode => {
-        if (skjema.felter.valutakode?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.valutakode.feilmelding;
-        } else if (skjema.felter.valutakursdato?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.valutakursdato.feilmelding;
-        } else if (skjema.felter.kurs?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.kurs.feilmelding;
-        }
-    };
-
-    const visSubmitFeilmelding = () => {
-        if (
-            skjema.submitRessurs.status === RessursStatus.FEILET ||
-            skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL ||
-            skjema.submitRessurs.status === RessursStatus.IKKE_TILGANG
-        ) {
-            return skjema.submitRessurs.frontendFeilmelding;
-        } else {
-            return null;
-        }
-    };
-
-    const onBarnSelected = (optionValue: string, isSelected: boolean) => {
-        onOptionSelected(optionValue, isSelected, skjema.felter.barnIdenter, tilgjengeligeBarn);
-    };
+    const periodeFeilmeldingId = `valutakurs-periode_${valutakurs.barnIdenter.map(barn => `${barn}`)}_${valutakurs.fom}`;
 
     return (
-        <Fieldset error={skjema.visFeilmeldinger && visSubmitFeilmelding()} legend={'Valutakurs skjema'} hideLegend>
-            <EøsPeriodeSkjemaContainer $lesevisning={erRedigeringDeaktivert} $status={status} gap="space-24">
+        <Fieldset error={errors.root?.message} legend={'Valutakurs skjema'} hideLegend>
+            <EøsPeriodeSkjemaContainer $lesevisning={erRedigeringDeaktivert} $status={valutakurs.status} gap="space-24">
                 {erValutakursVurdertAutomatisk && (
                     <HStack wrap={false} align={'center'} gap={'space-16'}>
                         <CogRotationIcon title="Automatisk registrert valutakurs" fontSize="1.5rem" />
@@ -120,52 +72,23 @@ const ValutakursTabellRadEndre = ({
                         <Label>Manuelt registrert valutakurs</Label>
                     </HStack>
                 )}
-                <UNSAFE_Combobox
-                    isMultiSelect
-                    label={'Barn'}
-                    options={tilgjengeligeBarn}
-                    selectedOptions={skjema.felter.barnIdenter.verdi}
-                    onToggleSelected={onBarnSelected}
-                    readOnly={erRedigeringDeaktivert}
-                    error={skjema.felter.barnIdenter.hentNavInputProps(skjema.visFeilmeldinger).error}
-                />
-                <EøsPeriodeSkjema
-                    periode={skjema.felter.periode}
-                    periodeFeilmeldingId={valutakursPeriodeFeilmeldingId(skjema)}
-                    initielFom={skjema.felter.initielFom}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
+                <ValutakursBarnFelt tilgjengeligeBarn={tilgjengeligeBarn} lesevisning={erRedigeringDeaktivert} />
+                <ValutakursPeriodeFelt
+                    initielFom={initielFom}
+                    periodeFeilmeldingId={periodeFeilmeldingId}
                     lesevisning={erRedigeringDeaktivert}
                 />
                 <Fieldset
                     className={erRedigeringDeaktivert ? 'lesevisning' : ''}
-                    errorId={valutakursValutaFeilmeldingId(skjema)}
-                    error={skjema.visFeilmeldinger && visKursGruppeFeilmelding()}
                     legend={'Registrer valutakursdato'}
                     hideLegend={erValutakursVurdertAutomatisk}
                 >
                     <HGrid columns={'1fr 2fr 1fr'} gap={'space-12'}>
-                        <Datovelger
-                            felt={skjema.felter.valutakursdato}
-                            label={'Valutakursdato'}
-                            visFeilmeldinger={false}
-                            readOnly={erRedigeringDeaktivert}
-                            disableWeekends
-                            kanKunVelgeFortid
-                        />
-                        <ValutaCombobox
-                            label={'Valuta'}
-                            value={skjema.felter.valutakode?.verdi as Valutakode}
-                            options={EØS_VALUTAKODER}
-                            onChange={() => {}}
-                            readOnly={true}
-                        />
-                        <TextField
-                            label={'Valutakurs'}
+                        <ValutakursDatoFelt readOnly={erRedigeringDeaktivert} />
+                        <ValutakursValutaFelt />
+                        <ValutakursKursFelt
                             readOnly={erRedigeringDeaktivert || !erManuellInputAvKurs}
-                            value={skjema.felter.kurs?.verdi}
-                            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                                skjema.felter.kurs?.validerOgSettFelt(event.target.value)
-                            }
+                            erManuellInputAvKurs={erManuellInputAvKurs}
                         />
                     </HGrid>
                     {erManuellInputAvKurs && (
@@ -191,17 +114,13 @@ const ValutakursTabellRadEndre = ({
                 {!erRedigeringDeaktivert && (
                     <Knapperad>
                         <div>
-                            <Button
-                                onClick={() => sendInnSkjema()}
-                                size="small"
-                                variant={'primary'}
-                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            >
+                            <Button type={'submit'} size="small" variant={'primary'} loading={isSubmitting}>
                                 Ferdig
                             </Button>
                             <Button
+                                type={'button'}
                                 style={{ marginLeft: '1rem' }}
-                                onClick={() => toggleForm(false)}
+                                onClick={onAvbryt}
                                 size="small"
                                 variant="tertiary"
                             >
@@ -209,13 +128,12 @@ const ValutakursTabellRadEndre = ({
                             </Button>
                         </div>
 
-                        {skjema.felter.status?.verdi !== EøsPeriodeStatus.IKKE_UTFYLT && !erRedigeringDeaktivert && (
+                        {valutakurs.status !== EøsPeriodeStatus.IKKE_UTFYLT && (
                             <Button
+                                type={'button'}
                                 variant={'tertiary'}
-                                onClick={() => slettValutakurs()}
-                                id={`slett_valutakurs_${skjema.felter.barnIdenter.verdi.map(
-                                    barn => `${barn}-`
-                                )}_${skjema.felter.initielFom.verdi}`}
+                                onClick={slettValutakurs}
+                                id={`slett_valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${initielFom}`}
                                 loading={sletterValutakurs}
                                 size={'small'}
                                 icon={<TrashIcon />}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursTabellRadEndre.tsx
@@ -19,7 +19,7 @@ import { EøsPeriodeSkjemaContainer, Knapperad } from '../EøsKomponenter/EøsSk
 interface Props {
     valutakurs: IRestValutakurs;
     tilgjengeligeBarn: OptionType[];
-    initielFom: string;
+    initiellFom: string;
     erManuellInputAvKurs: boolean;
     vurderingsform: Vurderingsform | undefined;
     inneholderBarnSomSkalSkjermes?: boolean;
@@ -31,7 +31,7 @@ interface Props {
 const ValutakursTabellRadEndre = ({
     valutakurs,
     tilgjengeligeBarn,
-    initielFom,
+    initiellFom,
     erManuellInputAvKurs,
     vurderingsform,
     inneholderBarnSomSkalSkjermes,
@@ -74,7 +74,7 @@ const ValutakursTabellRadEndre = ({
                 )}
                 <ValutakursBarnFelt tilgjengeligeBarn={tilgjengeligeBarn} lesevisning={erRedigeringDeaktivert} />
                 <ValutakursPeriodeFelt
-                    initielFom={initielFom}
+                    initiellFom={initiellFom}
                     periodeFeilmeldingId={periodeFeilmeldingId}
                     lesevisning={erRedigeringDeaktivert}
                 />
@@ -133,7 +133,7 @@ const ValutakursTabellRadEndre = ({
                                 type={'button'}
                                 variant={'tertiary'}
                                 onClick={slettValutakurs}
-                                id={`slett_valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${initielFom}`}
+                                id={`slett_valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${initiellFom}`}
                                 loading={sletterValutakurs}
                                 size={'small'}
                                 icon={<TrashIcon />}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursValutaFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursValutaFelt.tsx
@@ -1,0 +1,20 @@
+import { EØS_VALUTAKODER, type Valutakode, ValutaCombobox } from '@komponenter/FlaggCombobox';
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { ValutakursFelt, type ValutakursFormValues } from './useValutakursSkjema';
+
+export function ValutakursValutaFelt() {
+    const { control } = useFormContext<ValutakursFormValues>();
+
+    const valutakode = useWatch({ control, name: ValutakursFelt.VALUTAKODE });
+
+    return (
+        <ValutaCombobox
+            label={'Valuta'}
+            value={valutakode as Valutakode}
+            options={EØS_VALUTAKODER}
+            onChange={() => {}}
+            readOnly={true}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/Valutakurser.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useEndreVurderingsstrategiForValutakurser } from '@hooks/useEndreVurderingsstrategiForValutakurser';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useSaksbehandler } from '@hooks/useSaksbehandler';
 import { Behandlingstype, type IBehandling, VurderingsstrategiForValutakurser } from '@typer/behandling';
@@ -19,8 +20,7 @@ import {
     Table,
     VStack,
 } from '@navikt/ds-react';
-import { useHttp } from '@navikt/familie-http';
-import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import ValutakursTabellRad from './ValutakursTabellRad';
 import { useBehandlingContext } from '../../../../context/BehandlingContext';
@@ -64,7 +64,7 @@ interface IProps {
 
 const Valutakurser = ({ valutakurser, erValutakurserGyldige, åpenBehandling, visFeilmeldinger }: IProps) => {
     const { settÅpenBehandling } = useBehandlingContext();
-    const { request } = useHttp();
+    const { mutateAsync: endreVurderingsstrategi } = useEndreVurderingsstrategiForValutakurser();
     const [erGjenopprettAutomatiskeValutakurserModalÅpen, settErGjenopprettAutomatiskeValutakurserModalÅpen] =
         useState(false);
 
@@ -90,14 +90,11 @@ const Valutakurser = ({ valutakurser, erValutakurserGyldige, åpenBehandling, vi
     const endreVurderingsstrategiForValutakurser = () => {
         const nesteVurderingsstrategi = hentNesteVurderingsstrategi(åpenBehandling.vurderingsstrategiForValutakurser);
 
-        request<undefined, IBehandling>({
-            method: 'PUT',
-            url: `/familie-ba-sak/api/differanseberegning/valutakurs/behandlinger/${åpenBehandling.behandlingId}/endre-vurderingsstrategi-til/${nesteVurderingsstrategi}`,
-            påvirkerSystemLaster: true,
-        }).then((response: Ressurs<IBehandling>) => {
-            if (response.status === RessursStatus.SUKSESS) {
-                settÅpenBehandling(response);
-            }
+        endreVurderingsstrategi({
+            behandlingId: åpenBehandling.behandlingId,
+            vurderingsstrategi: nesteVurderingsstrategi,
+        }).then(oppdatertBehandling => {
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
         });
     };
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
@@ -115,6 +115,6 @@ export const useValutakursSkjema = ({ valutakurs, barnIValutakurs, lukkSkjema }:
         slettValutakurs,
         sletterValutakurs,
         erManuellInputAvKurs,
-        initielFom: valutakurs.fom,
+        initiellFom: valutakurs.fom,
     };
 };

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/useValutakursSkjema.ts
@@ -1,256 +1,120 @@
-import { useState } from 'react';
-
-import { isBefore } from 'date-fns';
-
-import { useHttp } from '@navikt/familie-http';
-import type { FeltState } from '@navikt/familie-skjema';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
-
-import type { IBehandling } from '../../../../../../../typer/behandling';
-import type { OptionType } from '../../../../../../../typer/common';
-import type { EøsPeriodeStatus, IRestValutakurs, IValutakurs } from '../../../../../../../typer/eøsPerioder';
-import type { IIsoMånedPeriode } from '../../../../../../../utils/dato';
+import { useOnFormSubmitSuccessful } from '@hooks/useOnFormSubmitSuccessful';
+import { useOppdaterValutakurs } from '@hooks/useOppdaterValutakurs';
+import { useSlettValutakurs } from '@hooks/useSlettValutakurs';
+import type { OptionType } from '@typer/common';
+import type { IRestValutakurs } from '@typer/eøsPerioder';
 import {
-    dateTilIsoDatoString,
     dateTilIsoDatoStringEllerUndefined,
+    type IIsoMånedPeriode,
+    isoStringTilDate,
     nyIsoMånedPeriode,
-    validerGyldigDato,
-} from '../../../../../../../utils/dato';
-import { konverterDesimalverdiTilSkjemaVisning, konverterSkjemaverdiTilDesimal } from '../../../../../../../utils/eøs';
-import {
-    erBarnGyldig,
-    erEøsPeriodeGyldig,
-    erValutakodeGyldig,
-    isEmpty,
-    isNumeric,
-    tellAntallDesimaler,
-} from '../../../../../../../utils/eøsValidators';
+} from '@utils/dato';
+import { konverterDesimalverdiTilSkjemaVisning, konverterSkjemaverdiTilDesimal } from '@utils/eøs';
+import { isBefore } from 'date-fns';
+import { useForm, useWatch } from 'react-hook-form';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
 import { useBehandlingContext } from '../../../../context/BehandlingContext';
 
-const erValutakursGyldig = (
-    felt: FeltState<string | undefined>,
-    skalValideres: boolean
-): FeltState<string | undefined> => {
-    if (skalValideres) {
-        if (!felt.verdi || isEmpty(felt.verdi) || typeof felt.verdi != 'string') {
-            return feil(felt, 'Valutakurs er påkrevd, men mangler input');
-        }
-        const nyKurs = konverterSkjemaverdiTilDesimal(felt.verdi);
-        if (!nyKurs) {
-            return feil(felt, 'Valutakurs er påkrevd, men mangler input');
-        }
-        if (!isNumeric(nyKurs)) {
-            return feil(felt, `Valutakurs innholder ugyldige verdier, kurs: ${felt.verdi}`);
-        }
-        if (tellAntallDesimaler(nyKurs) === 0) {
-            return feil(felt, `Valutakurs må oppgis med desimaler, kurs: ${felt.verdi}`);
-        }
-        const kurs = Number(nyKurs);
-        if (kurs < 0) {
-            return feil(felt, `Kan ikke registrere negativt kurs: ${felt.verdi}`);
-        }
-        return ok(felt);
-    }
-    return ok(felt);
-};
+export enum ValutakursFelt {
+    BARN = 'barnIdenter',
+    PERIODE = 'periode',
+    VALUTAKODE = 'valutakode',
+    VALUTAKURSDATO = 'valutakursdato',
+    KURS = 'kurs',
+}
+
+export interface ValutakursFormValues {
+    [ValutakursFelt.BARN]: OptionType[];
+    [ValutakursFelt.PERIODE]: IIsoMånedPeriode;
+    [ValutakursFelt.VALUTAKODE]: string | undefined;
+    [ValutakursFelt.VALUTAKURSDATO]: Date | undefined;
+    [ValutakursFelt.KURS]: string | undefined;
+}
 
 export const valutakursFeilmeldingId = (valutakurs: IRestValutakurs): string =>
     `valutakurs_${valutakurs.barnIdenter.map(barn => `${barn}-`)}_${valutakurs.fom}`;
 
-interface IProps {
+// Systemet har ikke automatiske valutakurser for islandske kroner (ISK) med valutakursdato før 1. februar 2018.
+const FØRSTE_DATO_MED_AUTOMATISK_ISK_KURS = new Date(2018, 1, 1, 0, 0, 0);
+
+interface Props {
     valutakurs: IRestValutakurs;
     barnIValutakurs: OptionType[];
+    lukkSkjema: () => void;
 }
 
-const useValutakursSkjema = ({ barnIValutakurs, valutakurs }: IProps) => {
-    const [erValutakursEkspandert, settErValutakursEkspandert] = useState<boolean>(false);
-    const [sletterValutakurs, settSletterValutakurs] = useState<boolean>(false);
+export const useValutakursSkjema = ({ valutakurs, barnIValutakurs, lukkSkjema }: Props) => {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
-    const initelFom = useFelt<string>({ verdi: valutakurs.fom });
-    const { request } = useHttp();
 
-    const valutakode = useFelt<string | undefined>({
-        verdi: valutakurs.valutakode,
-        valideringsfunksjon: erValutakodeGyldig,
+    const { mutateAsync: oppdaterValutakurs } = useOppdaterValutakurs();
+    const { mutateAsync: slettValutakursMutate, isPending: sletterValutakurs } = useSlettValutakurs();
+
+    const form = useForm<ValutakursFormValues>({
+        values: {
+            [ValutakursFelt.BARN]: barnIValutakurs,
+            [ValutakursFelt.PERIODE]: nyIsoMånedPeriode(valutakurs.fom, valutakurs.tom),
+            [ValutakursFelt.VALUTAKODE]: valutakurs.valutakode,
+            [ValutakursFelt.VALUTAKURSDATO]: valutakurs.valutakursdato
+                ? isoStringTilDate(valutakurs.valutakursdato)
+                : undefined,
+            [ValutakursFelt.KURS]: konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs),
+        },
     });
 
-    const valutakursdato = useFelt<Date | undefined>({
-        verdi: undefined,
-        valideringsfunksjon: validerGyldigDato,
-    });
+    const { control, setError, reset } = form;
+
+    useOnFormSubmitSuccessful(control, () => reset());
+
+    const valutakode = useWatch({ control, name: ValutakursFelt.VALUTAKODE });
+    const valutakursdato = useWatch({ control, name: ValutakursFelt.VALUTAKURSDATO });
 
     const erManuellInputAvKurs: boolean =
-        valutakode?.verdi === 'ISK' &&
-        !!valutakursdato?.verdi &&
-        isBefore(new Date(valutakursdato.verdi), new Date(2018, 1, 1, 0, 0, 0));
+        valutakode === 'ISK' && !!valutakursdato && isBefore(valutakursdato, FØRSTE_DATO_MED_AUTOMATISK_ISK_KURS);
 
-    const kurs = useFelt<string | undefined>({
-        avhengigheter: {
-            erManuellInputAvKurs,
-        },
-        verdi: konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs),
-        valideringsfunksjon: (felt, avhengigheter): FeltState<string | undefined> => {
-            return erValutakursGyldig(felt, avhengigheter?.erManuellInputAvKurs);
-        },
-    });
-
-    const {
-        skjema,
-        valideringErOk,
-        kanSendeSkjema,
-        nullstillSkjema,
-        onSubmit,
-        settSubmitRessurs,
-        settVisfeilmeldinger,
-    } = useSkjema<IValutakurs, IBehandling>({
-        felter: {
-            periodeId: useFelt<string>({
-                verdi: valutakursFeilmeldingId(valutakurs),
-            }),
-            id: useFelt<number>({ verdi: valutakurs.id }),
-            status: useFelt<EøsPeriodeStatus>({ verdi: valutakurs.status }),
-            initielFom: initelFom,
-            barnIdenter: useFelt<OptionType[]>({
-                verdi: barnIValutakurs,
-                valideringsfunksjon: erBarnGyldig,
-            }),
-            periode: useFelt<IIsoMånedPeriode>({
-                verdi: nyIsoMånedPeriode(valutakurs.fom, valutakurs.tom),
-                avhengigheter: { initelFom },
-                valideringsfunksjon: erEøsPeriodeGyldig,
-            }),
-            valutakode,
-            valutakursdato,
-            kurs,
-        },
-        skjemanavn: valutakursFeilmeldingId(valutakurs),
-    });
-
-    const [tidligereValutakurs, settTidligereValutakurs] = useState<IRestValutakurs>();
-
-    const settDatofelterTilDefault = () => {
-        if (valutakurs.valutakursdato) {
-            skjema.felter.valutakursdato.validerOgSettFelt(new Date(valutakurs.valutakursdato));
-        } else {
-            skjema.felter.valutakursdato.nullstill();
+    const onSubmit = async (values: ValutakursFormValues) => {
+        try {
+            const oppdatertBehandling = await oppdaterValutakurs({
+                behandlingId: behandling.behandlingId,
+                id: valutakurs.id,
+                fom: values.periode.fom ?? '',
+                tom: values.periode.tom,
+                barnIdenter: values.barnIdenter.map(barn => barn.value),
+                valutakode: values.valutakode,
+                valutakursdato: dateTilIsoDatoStringEllerUndefined(values.valutakursdato),
+                kurs: konverterSkjemaverdiTilDesimal(values.kurs),
+            });
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+            lukkSkjema();
+        } catch (error) {
+            setError('root', {
+                message: error instanceof Error ? error.message : 'Teknisk feil ved lagring av valutakurs.',
+            });
         }
     };
 
-    const tilbakestillFelterTilDefault = () => {
-        skjema.felter.periodeId.nullstill();
-        skjema.felter.id.nullstill();
-        skjema.felter.status.nullstill();
-        skjema.felter.initielFom.nullstill();
-        skjema.felter.barnIdenter.nullstill();
-        skjema.felter.periode.nullstill();
-        skjema.felter.valutakode.nullstill();
-        skjema.felter.kurs.nullstill();
-        settDatofelterTilDefault();
-    };
-
-    if (valutakurs !== tidligereValutakurs) {
-        settTidligereValutakurs(valutakurs);
-        tilbakestillFelterTilDefault();
-    }
-
-    if (dateTilIsoDatoString(skjema.felter.valutakursdato.verdi) !== valutakurs.valutakursdato) {
-        skjema.felter.kurs?.validerOgSettFelt('');
-    }
-
-    if (valutakurs.valutakode !== skjema.felter.valutakode.verdi) {
-        skjema.felter.kurs?.validerOgSettFelt('');
-        skjema.felter.valutakursdato?.nullstill();
-        skjema.felter.valutakode?.validerOgSettFelt(valutakurs.valutakode);
-    }
-
-    const sendInnSkjema = () => {
-        if (kanSendeSkjema()) {
-            settSubmitRessurs(byggTomRessurs());
-            settVisfeilmeldinger(false);
-            onSubmit<Omit<IRestValutakurs, 'status'>>(
-                {
-                    method: 'PUT',
-                    data: {
-                        id: valutakurs.id,
-                        fom: skjema.felter.periode.verdi.fom ?? '',
-                        tom: skjema.felter.periode.verdi.tom,
-                        barnIdenter: skjema.felter.barnIdenter.verdi.map(barn => barn.value),
-                        valutakode: skjema.felter.valutakode?.verdi,
-                        valutakursdato: dateTilIsoDatoStringEllerUndefined(skjema.felter.valutakursdato?.verdi),
-                        kurs: konverterSkjemaverdiTilDesimal(skjema.felter.kurs?.verdi),
-                    },
-                    url: `/familie-ba-sak/api/differanseberegning/valutakurs/${behandling.behandlingId}`,
-                },
-                (response: Ressurs<IBehandling>) => {
-                    if (response.status === RessursStatus.SUKSESS) {
-                        nullstillSkjema();
-                        settErValutakursEkspandert(false);
-                        settÅpenBehandling(response);
-                    }
-                }
-            );
+    const slettValutakurs = async () => {
+        try {
+            const oppdatertBehandling = await slettValutakursMutate({
+                behandlingId: behandling.behandlingId,
+                valutakursId: valutakurs.id,
+            });
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+            lukkSkjema();
+        } catch (error) {
+            setError('root', {
+                message: error instanceof Error ? error.message : 'Teknisk feil ved sletting av valutakurs.',
+            });
         }
-    };
-
-    const slettValutakurs = () => {
-        settSubmitRessurs(byggTomRessurs());
-        settVisfeilmeldinger(false);
-        settSletterValutakurs(true);
-        request<void, IBehandling>({
-            method: 'DELETE',
-            url: `/familie-ba-sak/api/differanseberegning/valutakurs/${behandling.behandlingId}/${valutakurs.id}`,
-        }).then((response: Ressurs<IBehandling>) => {
-            settSletterValutakurs(false);
-            if (response.status === RessursStatus.SUKSESS) {
-                nullstillSkjema();
-                settErValutakursEkspandert(false);
-                settÅpenBehandling(response);
-            } else {
-                settSubmitRessurs(response);
-                settVisfeilmeldinger(true);
-            }
-        });
-    };
-
-    const erValutakursdatoerLike = () =>
-        (!valutakursdato.verdi && !valutakurs.valutakursdato) ||
-        dateTilIsoDatoStringEllerUndefined(valutakursdato?.verdi) === valutakurs.valutakursdato;
-
-    const erValutakurserLike = () =>
-        (!kurs.verdi && !valutakurs.kurs) || kurs.verdi === konverterDesimalverdiTilSkjemaVisning(valutakurs.kurs);
-
-    const erValutakursSkjemaEndret = () => {
-        const barnFjernetISkjema = valutakurs.barnIdenter.filter(
-            barn => !skjema.felter.barnIdenter.verdi.some(ident => ident.value === barn)
-        );
-        const erTomEndret =
-            !(skjema.felter.periode.verdi.tom === undefined && valutakurs.tom === null) &&
-            skjema.felter.periode?.verdi.tom !== valutakurs.tom;
-        return (
-            barnFjernetISkjema.length > 0 ||
-            skjema.felter.periode?.verdi.fom !== valutakurs.fom ||
-            erTomEndret ||
-            skjema.felter.valutakode?.verdi !== valutakurs.valutakode ||
-            !erValutakursdatoerLike() ||
-            !erValutakurserLike()
-        );
     };
 
     return {
-        erValutakursEkspandert,
-        settErValutakursEkspandert,
-        skjema,
-        valideringErOk,
-        kanSendeSkjema,
-        sendInnSkjema,
-        erValutakursSkjemaEndret,
-        tilbakestillFelterTilDefault,
+        form,
+        onSubmit,
         slettValutakurs,
         sletterValutakurs,
         erManuellInputAvKurs,
+        initielFom: valutakurs.fom,
     };
 };
-
-export { useValutakursSkjema };


### PR DESCRIPTION
### 📮 Favro:
NAV-29957

### 💰 Hva skal gjøres, og hvorfor?
Skriver om valutakurs-komponentene til å bruke React Query og React Hook Form. Erstatter `useHttp`/`Ressurs`-baserte kall og `useSkjema`/`useFelt` med react-query hooks (`useOppdaterValutakurs`, `useSlettValutakurs`) og RHF-baserte feltkomponenter (`ValutakursBarnFelt`, `ValutakursDatoFelt`, `ValutakursKursFelt`, `ValutakursPeriodeFelt`, `ValutakursValutaFelt`).

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ren omskriving av eksisterende funksjonalitet.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
