### PR TITLE
NAV-29968: Skriv om utbetalt annet land til React Query og RHF

### DIFF
--- a/src/frontend/api/utenlandskPeriodeBeløp.ts
+++ b/src/frontend/api/utenlandskPeriodeBeløp.ts
@@ -1,0 +1,30 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling } from '@typer/behandling';
+import type { UtenlandskPeriodeBeløpIntervall } from '@typer/eøsPerioder';
+
+export interface OppdaterUtenlandskPeriodeBeløpPayload {
+    id: number;
+    fom: string;
+    tom?: string;
+    barnIdenter: string[];
+    beløp: string;
+    valutakode?: string;
+    intervall?: UtenlandskPeriodeBeløpIntervall;
+    utbetalingsland?: string;
+}
+
+export async function oppdaterUtenlandskPeriodeBeløp(
+    payload: OppdaterUtenlandskPeriodeBeløpPayload,
+    behandlingId: number
+) {
+    return apiClient.put<OppdaterUtenlandskPeriodeBeløpPayload, IBehandling>({
+        data: payload,
+        url: `/familie-ba-sak/api/differanseberegning/utenlandskperidebeløp/${behandlingId}`,
+    });
+}
+
+export async function slettUtenlandskPeriodeBeløp(behandlingId: number, utenlandskPeriodeBeløpId: number) {
+    return apiClient.delete<void, IBehandling>({
+        url: `/familie-ba-sak/api/differanseberegning/utenlandskperidebeløp/${behandlingId}/${utenlandskPeriodeBeløpId}`,
+    });
+}

--- a/src/frontend/hooks/useOppdaterUtenlandskPeriodeBeløp.ts
+++ b/src/frontend/hooks/useOppdaterUtenlandskPeriodeBeløp.ts
@@ -1,0 +1,23 @@
+import {
+    oppdaterUtenlandskPeriodeBeløp,
+    type OppdaterUtenlandskPeriodeBeløpPayload,
+} from '@api/utenlandskPeriodeBeløp';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface OppdaterUtenlandskPeriodeBeløpParameters extends OppdaterUtenlandskPeriodeBeløpPayload {
+    behandlingId: number;
+}
+
+type Options = Omit<
+    UseMutationOptions<IBehandling, DefaultError, OppdaterUtenlandskPeriodeBeløpParameters>,
+    'mutationFn'
+>;
+
+export function useOppdaterUtenlandskPeriodeBeløp(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, ...payload }: OppdaterUtenlandskPeriodeBeløpParameters) =>
+            oppdaterUtenlandskPeriodeBeløp(payload, behandlingId),
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useSlettUtenlandskPeriodeBeløp.ts
+++ b/src/frontend/hooks/useSlettUtenlandskPeriodeBeløp.ts
@@ -1,0 +1,18 @@
+import { slettUtenlandskPeriodeBeløp } from '@api/utenlandskPeriodeBeløp';
+import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface SlettUtenlandskPeriodeBeløpParameters {
+    behandlingId: number;
+    utenlandskPeriodeBeløpId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, DefaultError, SlettUtenlandskPeriodeBeløpParameters>, 'mutationFn'>;
+
+export function useSlettUtenlandskPeriodeBeløp(options?: Options) {
+    return useMutation({
+        mutationFn: ({ behandlingId, utenlandskPeriodeBeløpId }: SlettUtenlandskPeriodeBeløpParameters) =>
+            slettUtenlandskPeriodeBeløp(behandlingId, utenlandskPeriodeBeløpId),
+        ...options,
+    });
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpBarnFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpBarnFelt.tsx
@@ -1,0 +1,52 @@
+import type { OptionType } from '@typer/common';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { UNSAFE_Combobox } from '@navikt/ds-react';
+
+import { UtenlandskPeriodeBeløpFelt, type UtenlandskPeriodeBeløpFormValues } from './useUtenlandskPeriodeBeløpSkjema';
+
+interface Props {
+    tilgjengeligeBarn: OptionType[];
+    lesevisning: boolean;
+}
+
+export function UtenlandskPeriodeBeløpBarnFelt({ tilgjengeligeBarn, lesevisning }: Props) {
+    const { control } = useFormContext<UtenlandskPeriodeBeløpFormValues>();
+
+    const {
+        field: { value, onChange, onBlur, ref },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: UtenlandskPeriodeBeløpFelt.BARN,
+        control,
+        rules: {
+            validate: barn => (barn.length > 0 ? undefined : 'Minst ett barn må være valgt'),
+        },
+    });
+
+    const onToggleSelected = (optionValue: string, isSelected: boolean) => {
+        if (isSelected) {
+            const nyttValg = tilgjengeligeBarn.find(barn => barn.value === optionValue);
+            if (nyttValg) {
+                onChange([...value, nyttValg]);
+            }
+        } else {
+            onChange(value.filter(barn => barn.value !== optionValue));
+        }
+    };
+
+    return (
+        <UNSAFE_Combobox
+            isMultiSelect
+            label={'Barn'}
+            options={tilgjengeligeBarn}
+            selectedOptions={value}
+            onToggleSelected={onToggleSelected}
+            onBlur={onBlur}
+            ref={ref}
+            readOnly={lesevisning || isSubmitting}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpBeløpFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpBeløpFelt.tsx
@@ -1,0 +1,57 @@
+import { konverterSkjemaverdiTilDesimal } from '@utils/eøs';
+import { isEmpty, isNumeric } from '@utils/eøsValidators';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { TextField } from '@navikt/ds-react';
+
+import { UtenlandskPeriodeBeløpFelt, type UtenlandskPeriodeBeløpFormValues } from './useUtenlandskPeriodeBeløpSkjema';
+
+const validerBeløp = (verdi: string | undefined): string | undefined => {
+    if (!verdi || isEmpty(verdi) || typeof verdi != 'string') {
+        return 'Beløp er påkrevd, men mangler input';
+    }
+    const nyttBeløp = konverterSkjemaverdiTilDesimal(verdi);
+    if (!nyttBeløp) {
+        return 'Beløp er påkrevd, men mangler input';
+    }
+    if (!isNumeric(nyttBeløp)) {
+        return `Beløp innholder ugyldige verdier, beløp: ${verdi}`;
+    }
+    if (Number(nyttBeløp) < 0) {
+        return `Kan ikke registrere negativt utbetalt beløp: ${verdi}`;
+    }
+    return undefined;
+};
+
+interface Props {
+    readOnly: boolean;
+}
+
+export function UtenlandskPeriodeBeløpBeløpFelt({ readOnly }: Props) {
+    const { control } = useFormContext<UtenlandskPeriodeBeløpFormValues>();
+
+    const {
+        field: { value, onChange, onBlur, ref },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: UtenlandskPeriodeBeløpFelt.BELØP,
+        control,
+        rules: {
+            validate: beløp => validerBeløp(beløp),
+        },
+    });
+
+    return (
+        <TextField
+            label={'Beløp per barn'}
+            readOnly={readOnly || isSubmitting}
+            value={value ?? ''}
+            onChange={event => onChange(event.target.value)}
+            onBlur={onBlur}
+            ref={ref}
+            error={error?.message}
+            size={'medium'}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpIntervallFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpIntervallFelt.tsx
@@ -1,0 +1,49 @@
+import { UtenlandskPeriodeBeløpIntervall, utenlandskPeriodeBeløpIntervaller } from '@typer/eøsPerioder';
+import { isEmpty } from '@utils/eøsValidators';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Select } from '@navikt/ds-react';
+
+import { UtenlandskPeriodeBeløpFelt, type UtenlandskPeriodeBeløpFormValues } from './useUtenlandskPeriodeBeløpSkjema';
+
+interface Props {
+    readOnly: boolean;
+}
+
+export function UtenlandskPeriodeBeløpIntervallFelt({ readOnly }: Props) {
+    const { control } = useFormContext<UtenlandskPeriodeBeløpFormValues>();
+
+    const {
+        field: { value, onChange, onBlur, ref },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: UtenlandskPeriodeBeløpFelt.INTERVALL,
+        control,
+        rules: {
+            validate: intervall => (!isEmpty(intervall) ? undefined : 'Intervall er påkrevd, men mangler input'),
+        },
+    });
+
+    return (
+        <Select
+            label={'Intervall'}
+            readOnly={readOnly || isSubmitting}
+            value={value || ''}
+            onChange={event => onChange((event.target.value as UtenlandskPeriodeBeløpIntervall) || undefined)}
+            onBlur={onBlur}
+            ref={ref}
+            error={error?.message}
+            size={'medium'}
+        >
+            <option key={'-'} value={''}>
+                Velg
+            </option>
+            {Object.values(UtenlandskPeriodeBeløpIntervall).map(intervall => (
+                <option key={intervall} value={intervall}>
+                    {utenlandskPeriodeBeløpIntervaller[intervall]}
+                </option>
+            ))}
+        </Select>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpPeriodeFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpPeriodeFelt.tsx
@@ -1,0 +1,96 @@
+import MånedÅrVelger from '@komponenter/MånedÅrInput/MånedÅrVelger';
+import { dagensDato, isoStringTilDate } from '@utils/dato';
+import { isEmpty } from '@utils/eøsValidators';
+import { addMonths, endOfMonth, isAfter } from 'date-fns';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Fieldset, HStack } from '@navikt/ds-react';
+
+import { UtenlandskPeriodeBeløpFelt, type UtenlandskPeriodeBeløpFormValues } from './useUtenlandskPeriodeBeløpSkjema';
+
+const valgtDatoErNesteMånedEllerSenere = (valgtDato: string) =>
+    isAfter(isoStringTilDate(valgtDato), endOfMonth(dagensDato));
+
+const valgtDatoErSenereEnnNesteMåned = (valgtDato: string) =>
+    isAfter(isoStringTilDate(valgtDato), endOfMonth(addMonths(dagensDato, 1)));
+
+interface Props {
+    initiellFom: string;
+    periodeFeilmeldingId: string;
+    lesevisning: boolean;
+}
+
+export function UtenlandskPeriodeBeløpPeriodeFelt({ initiellFom, periodeFeilmeldingId, lesevisning }: Props) {
+    const { control } = useFormContext<UtenlandskPeriodeBeløpFormValues>();
+
+    const {
+        field: { value, onChange },
+        fieldState: { error },
+    } = useController({
+        name: UtenlandskPeriodeBeløpFelt.PERIODE,
+        control,
+        rules: {
+            validate: periode => {
+                const fom = periode.fom;
+                const tom = periode.tom;
+
+                if (!fom || isEmpty(fom)) {
+                    return 'Fra og med måned må være utfylt';
+                }
+                if (fom && valgtDatoErSenereEnnNesteMåned(fom)) {
+                    return 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere';
+                }
+                if (initiellFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initiellFom))) {
+                    return `Du kan ikke legge inn fra og med måned som er før: ${initiellFom}`;
+                }
+                if (tom && valgtDatoErNesteMånedEllerSenere(tom)) {
+                    return 'Du kan ikke sette til og med (t.o.m.) til neste måned eller senere';
+                }
+                return undefined;
+            },
+        },
+    });
+
+    const finnÅrTilbakeTil = (): number => new Date().getFullYear() - new Date(initiellFom).getFullYear();
+
+    return (
+        <Fieldset
+            className={lesevisning ? 'lesevisning' : ''}
+            errorId={periodeFeilmeldingId}
+            error={error?.message}
+            legend="Periode"
+            size="medium"
+        >
+            <HStack justify={'space-between'} gap={'space-16'} width={'32rem'}>
+                <MånedÅrVelger
+                    lesevisning={lesevisning}
+                    id={'periode_fom'}
+                    label={'F.o.m'}
+                    antallÅrTilbake={finnÅrTilbakeTil()}
+                    antallÅrFrem={0}
+                    value={value.fom ?? undefined}
+                    onEndret={årMåned => {
+                        if (årMåned === value.fom) {
+                            return;
+                        }
+                        onChange({ ...value, fom: årMåned });
+                    }}
+                />
+                <MånedÅrVelger
+                    lesevisning={lesevisning}
+                    id={'periode_tom'}
+                    label={'T.o.m (valgfri)'}
+                    antallÅrTilbake={finnÅrTilbakeTil()}
+                    antallÅrFrem={0}
+                    value={value.tom ?? undefined}
+                    onEndret={årMåned => {
+                        if (årMåned === value.tom) {
+                            return;
+                        }
+                        onChange({ ...value, tom: årMåned });
+                    }}
+                />
+            </HStack>
+        </Fieldset>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRad.tsx
@@ -1,4 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
+import { FormProvider } from 'react-hook-form';
 
 import { Table } from '@navikt/ds-react';
 
@@ -20,44 +22,37 @@ interface IProps {
 }
 
 const UtenlandskPeriodeBeløpRad = ({ utenlandskPeriodeBeløp, åpenBehandling, visFeilmeldinger }: IProps) => {
+    const [erUtenlandskPeriodeBeløpEkspandert, settErUtenlandskPeriodeBeløpEkspandert] = useState(false);
+    const [skalRendreContentIEkspanderbartPanel, settSkalRendreContentIEkspanderbartPanel] = useState(false);
+
     const barn: OptionType[] = utenlandskPeriodeBeløp.barnIdenter.map(barn => ({
         value: barn,
         label: lagPersonLabel(barn, åpenBehandling.personer),
     }));
 
-    const {
-        erUtenlandskPeriodeBeløpEkspandert,
-        settErUtenlandskPeriodeBeløpEkspandert,
-        skjema,
-        sendInnSkjema,
-        slettUtenlandskPeriodeBeløp,
-        nullstillSkjema,
-        kanSendeSkjema,
-        erUtenlandskPeriodeBeløpSkjemaEndret,
-    } = useUtenlandskPeriodeBeløpSkjema({
-        utenlandskPeriodeBeløp,
-        barnIUtenlandskPeriodeBeløp: barn,
-    });
+    const { form, onSubmit, slettUtenlandskPeriodeBeløp, sletterUtenlandskPeriodeBeløp, initiellFom } =
+        useUtenlandskPeriodeBeløpSkjema({
+            utenlandskPeriodeBeløp,
+            barnIUtenlandskPeriodeBeløp: barn,
+            lukkSkjema: () => settErUtenlandskPeriodeBeløpEkspandert(false),
+        });
 
-    useEffect(() => {
-        if (åpenBehandling) {
-            nullstillSkjema();
-            settErUtenlandskPeriodeBeløpEkspandert(false);
-        }
-    }, [åpenBehandling]);
+    if (erUtenlandskPeriodeBeløpEkspandert && !skalRendreContentIEkspanderbartPanel) {
+        settSkalRendreContentIEkspanderbartPanel(true);
+    }
 
     useEffect(() => {
         if (visFeilmeldinger && erUtenlandskPeriodeBeløpEkspandert) {
-            kanSendeSkjema();
+            form.trigger();
         }
     }, [visFeilmeldinger, erUtenlandskPeriodeBeløpEkspandert]);
 
     const toggleForm = (visAlert: boolean) => {
-        if (erUtenlandskPeriodeBeløpEkspandert && visAlert && erUtenlandskPeriodeBeløpSkjemaEndret()) {
+        if (erUtenlandskPeriodeBeløpEkspandert && visAlert && form.formState.isDirty) {
             alert('Utenlandsk beløp har endringer som ikke er lagret!');
         } else {
             settErUtenlandskPeriodeBeløpEkspandert(!erUtenlandskPeriodeBeløpEkspandert);
-            nullstillSkjema();
+            form.reset();
         }
     };
 
@@ -76,17 +71,21 @@ const UtenlandskPeriodeBeløpRad = ({ utenlandskPeriodeBeløp, åpenBehandling, 
             onOpenChange={() => toggleForm(true)}
             id={utenlandskPeriodeBeløpFeilmeldingId(utenlandskPeriodeBeløp)}
             content={
-                erUtenlandskPeriodeBeløpEkspandert && (
-                    <UtenlandskPeriodeBeløpTabellRadEndre
-                        skjema={skjema}
-                        tilgjengeligeBarn={barn}
-                        sendInnSkjema={sendInnSkjema}
-                        toggleForm={toggleForm}
-                        slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
-                        status={utenlandskPeriodeBeløp.status}
-                        inneholderBarnSomSkalSkjermes={utenlandskPeriodeBeløp.inneholderBarnSomSkalSkjermes}
-                    />
-                )
+                skalRendreContentIEkspanderbartPanel ? (
+                    <FormProvider {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)}>
+                            <UtenlandskPeriodeBeløpTabellRadEndre
+                                utenlandskPeriodeBeløp={utenlandskPeriodeBeløp}
+                                tilgjengeligeBarn={barn}
+                                initiellFom={initiellFom}
+                                inneholderBarnSomSkalSkjermes={utenlandskPeriodeBeløp.inneholderBarnSomSkalSkjermes}
+                                onAvbryt={() => toggleForm(false)}
+                                slettUtenlandskPeriodeBeløp={slettUtenlandskPeriodeBeløp}
+                                sletterUtenlandskPeriodeBeløp={sletterUtenlandskPeriodeBeløp}
+                            />
+                        </form>
+                    </FormProvider>
+                ) : null
             }
         >
             <StatusBarnCelleOgPeriodeCelle

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpTabellRadEndre.tsx
@@ -1,226 +1,99 @@
-import type { ReactNode, ChangeEvent } from 'react';
-
 import { useErLesevisning } from '@hooks/useErLesevisning';
-import {
-    type Valutakode,
-    ValutaCombobox,
-    EØS_VALUTAKODER,
-    RegionCombobox,
-    type Regionkode,
-    EØS_LAND_REGIONKODER,
-} from '@komponenter/FlaggCombobox';
-import type { IBehandling } from '@typer/behandling';
-import type { ComboboxOption } from '@typer/common';
-import type { IUtenlandskPeriodeBeløp } from '@typer/eøsPerioder';
-import {
-    EøsPeriodeStatus,
-    UtenlandskPeriodeBeløpIntervall,
-    utenlandskPeriodeBeløpIntervaller,
-} from '@typer/eøsPerioder';
-import { onOptionSelected } from '@utils/skjema';
+import type { OptionType } from '@typer/common';
+import { EøsPeriodeStatus, type IRestUtenlandskPeriodeBeløp } from '@typer/eøsPerioder';
+import { useFormContext } from 'react-hook-form';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import {
-    BodyShort,
-    Button,
-    Fieldset,
-    HGrid,
-    InlineMessage,
-    Select,
-    TextField,
-    UNSAFE_Combobox,
-} from '@navikt/ds-react';
-import type { ISkjema } from '@navikt/familie-skjema';
-import { Valideringsstatus } from '@navikt/familie-skjema';
-import { RessursStatus } from '@navikt/familie-typer';
+import { BodyShort, Button, Fieldset, HGrid, InlineMessage } from '@navikt/ds-react';
 
-import EøsPeriodeSkjema from '../EøsKomponenter/EøsPeriodeSkjema';
+import { type UtenlandskPeriodeBeløpFormValues } from './useUtenlandskPeriodeBeløpSkjema';
+import { UtenlandskPeriodeBeløpBarnFelt } from './UtenlandskPeriodeBeløpBarnFelt';
+import { UtenlandskPeriodeBeløpBeløpFelt } from './UtenlandskPeriodeBeløpBeløpFelt';
+import { UtenlandskPeriodeBeløpIntervallFelt } from './UtenlandskPeriodeBeløpIntervallFelt';
+import { UtenlandskPeriodeBeløpPeriodeFelt } from './UtenlandskPeriodeBeløpPeriodeFelt';
+import { UtenlandskPeriodeBeløpUtbetalingslandFelt } from './UtenlandskPeriodeBeløpUtbetalingslandFelt';
+import { UtenlandskPeriodeBeløpValutaFelt } from './UtenlandskPeriodeBeløpValutaFelt';
 import { EøsPeriodeSkjemaContainer, Knapperad } from '../EøsKomponenter/EøsSkjemaKomponenter';
 
 const UtbetaltBeløpText = styled(BodyShort)`
     font-weight: bold;
 `;
 
-const utenlandskPeriodeBeløpPeriodeFeilmeldingId = (
-    utenlandskPeriodeBeløp: ISkjema<IUtenlandskPeriodeBeløp, IBehandling>
-): string =>
-    `utd_beløp-periode_${utenlandskPeriodeBeløp.felter.barnIdenter.verdi.map(
-        barn => `${barn.value}`
-    )}_${utenlandskPeriodeBeløp.felter.initielFom.verdi}`;
-
-const utenlandskPeriodeBeløpUtbetaltFeilmeldingId = (
-    utenlandskPeriodeBeløp: ISkjema<IUtenlandskPeriodeBeløp, IBehandling>
-): string =>
-    `utd_beløp-utbetalt_${utenlandskPeriodeBeløp.felter.barnIdenter.verdi.map(
-        barn => `${barn.value}`
-    )}_${utenlandskPeriodeBeløp.felter.initielFom.verdi}`;
-
-interface IProps {
-    skjema: ISkjema<IUtenlandskPeriodeBeløp, IBehandling>;
-    tilgjengeligeBarn: ComboboxOption[];
-    status: EøsPeriodeStatus;
-    sendInnSkjema: () => void;
-    toggleForm: (visAlert: boolean) => void;
-    slettUtenlandskPeriodeBeløp: () => void;
+interface Props {
+    utenlandskPeriodeBeløp: IRestUtenlandskPeriodeBeløp;
+    tilgjengeligeBarn: OptionType[];
+    initiellFom: string;
     inneholderBarnSomSkalSkjermes?: boolean;
+    onAvbryt: () => void;
+    slettUtenlandskPeriodeBeløp: () => void;
+    sletterUtenlandskPeriodeBeløp: boolean;
 }
 
 const UtenlandskPeriodeBeløpTabellRadEndre = ({
-    skjema,
+    utenlandskPeriodeBeløp,
     tilgjengeligeBarn,
-    status,
-    sendInnSkjema,
-    toggleForm,
-    slettUtenlandskPeriodeBeløp,
+    initiellFom,
     inneholderBarnSomSkalSkjermes,
-}: IProps) => {
+    onAvbryt,
+    slettUtenlandskPeriodeBeløp,
+    sletterUtenlandskPeriodeBeløp,
+}: Props) => {
     const erLesevisning = useErLesevisning();
     const erRedigeringDeaktivert = erLesevisning || !!inneholderBarnSomSkalSkjermes;
 
-    const visUtbetaltBeløpGruppeFeilmelding = (): ReactNode => {
-        if (skjema.felter.beløp?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.beløp.feilmelding;
-        } else if (skjema.felter.valutakode?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.valutakode.feilmelding;
-        } else if (skjema.felter.intervall?.valideringsstatus === Valideringsstatus.FEIL) {
-            return skjema.felter.intervall.feilmelding;
-        }
-    };
+    const {
+        formState: { isSubmitting, errors },
+    } = useFormContext<UtenlandskPeriodeBeløpFormValues>();
 
-    const visSubmitFeilmelding = () => {
-        if (
-            skjema.submitRessurs.status === RessursStatus.FEILET ||
-            skjema.submitRessurs.status === RessursStatus.FUNKSJONELL_FEIL ||
-            skjema.submitRessurs.status === RessursStatus.IKKE_TILGANG
-        ) {
-            return skjema.submitRessurs.frontendFeilmelding;
-        } else {
-            return null;
-        }
-    };
-
-    const onBarnSelected = (optionValue: string, isSelected: boolean) => {
-        onOptionSelected(optionValue, isSelected, skjema.felter.barnIdenter, tilgjengeligeBarn);
-    };
+    const periodeFeilmeldingId = `utd_beløp-periode_${utenlandskPeriodeBeløp.barnIdenter.map(
+        barn => `${barn}`
+    )}_${utenlandskPeriodeBeløp.fom}`;
 
     return (
-        <Fieldset
-            error={skjema.visFeilmeldinger && visSubmitFeilmelding()}
-            legend={'Utenlandsk periodebeløp'}
-            hideLegend
-        >
-            <EøsPeriodeSkjemaContainer $lesevisning={erRedigeringDeaktivert} $status={status} gap="space-24">
+        <Fieldset error={errors.root?.message} legend={'Utenlandsk periodebeløp'} hideLegend>
+            <EøsPeriodeSkjemaContainer
+                $lesevisning={erRedigeringDeaktivert}
+                $status={utenlandskPeriodeBeløp.status}
+                gap="space-24"
+            >
                 <InlineMessage status="info">
                     <UtbetaltBeløpText size="small">
                         Dersom det er ulike beløp per barn utbetalt i det andre landet, må barna registreres separat
                     </UtbetaltBeløpText>
                 </InlineMessage>
-                <UNSAFE_Combobox
-                    isMultiSelect
-                    label={'Barn'}
-                    options={tilgjengeligeBarn}
-                    selectedOptions={skjema.felter.barnIdenter.verdi}
-                    onToggleSelected={onBarnSelected}
-                    readOnly={erRedigeringDeaktivert}
-                    error={skjema.felter.barnIdenter.hentNavInputProps(skjema.visFeilmeldinger).error}
+                <UtenlandskPeriodeBeløpBarnFelt
+                    tilgjengeligeBarn={tilgjengeligeBarn}
+                    lesevisning={erRedigeringDeaktivert}
                 />
-                <EøsPeriodeSkjema
-                    periode={skjema.felter.periode}
-                    periodeFeilmeldingId={utenlandskPeriodeBeløpPeriodeFeilmeldingId(skjema)}
-                    initielFom={skjema.felter.initielFom}
-                    visFeilmeldinger={skjema.visFeilmeldinger}
+                <UtenlandskPeriodeBeløpPeriodeFelt
+                    initiellFom={initiellFom}
+                    periodeFeilmeldingId={periodeFeilmeldingId}
                     lesevisning={erRedigeringDeaktivert}
                 />
                 <Fieldset
                     className={erRedigeringDeaktivert ? 'lesevisning' : ''}
-                    errorId={utenlandskPeriodeBeløpUtbetaltFeilmeldingId(skjema)}
-                    error={skjema.visFeilmeldinger && visUtbetaltBeløpGruppeFeilmelding()}
                     legend={'Utbetalt i det andre landet'}
                     size={'medium'}
                 >
                     <HGrid columns={'1fr 2fr 1fr'} gap={'space-12'}>
-                        <TextField
-                            label={'Beløp per barn'}
-                            readOnly={erRedigeringDeaktivert}
-                            value={skjema.felter.beløp?.verdi}
-                            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                                skjema.felter.beløp?.validerOgSettFelt(event.target.value)
-                            }
-                            size={'medium'}
-                        />
-                        <ValutaCombobox
-                            label={'Valuta'}
-                            value={skjema.felter.valutakode?.verdi as Valutakode}
-                            options={EØS_VALUTAKODER}
-                            onChange={value => {
-                                if (value) {
-                                    skjema.felter.valutakode?.validerOgSettFelt(value);
-                                } else {
-                                    skjema.felter.valutakode?.nullstill();
-                                }
-                            }}
-                            readOnly={erRedigeringDeaktivert}
-                            error={skjema.felter.valutakode?.feilmelding?.toString()}
-                        />
-                        <Select
-                            label={'Intervall'}
-                            readOnly={erRedigeringDeaktivert}
-                            value={skjema.felter.intervall?.verdi || undefined}
-                            onChange={event =>
-                                skjema.felter.intervall?.validerOgSettFelt(
-                                    event.target.value as UtenlandskPeriodeBeløpIntervall
-                                )
-                            }
-                            size={'medium'}
-                        >
-                            <option key={'-'} value={''}>
-                                Velg
-                            </option>
-                            {Object.values(UtenlandskPeriodeBeløpIntervall).map(intervall => {
-                                return (
-                                    <option key={intervall} value={intervall}>
-                                        {utenlandskPeriodeBeløpIntervaller[intervall]}
-                                    </option>
-                                );
-                            })}
-                        </Select>
+                        <UtenlandskPeriodeBeløpBeløpFelt readOnly={erRedigeringDeaktivert} />
+                        <UtenlandskPeriodeBeløpValutaFelt readOnly={erRedigeringDeaktivert} />
+                        <UtenlandskPeriodeBeløpIntervallFelt readOnly={erRedigeringDeaktivert} />
                     </HGrid>
-                    <RegionCombobox
-                        label={'Utbetalingsland'}
-                        value={skjema.felter.utbetalingsland.verdi as Regionkode}
-                        options={EØS_LAND_REGIONKODER}
-                        onChange={value => {
-                            if (value) {
-                                skjema.felter.utbetalingsland.validerOgSettFelt(value);
-                            } else {
-                                skjema.felter.utbetalingsland.nullstill();
-                            }
-                        }}
-                        readOnly={erRedigeringDeaktivert}
-                        error={
-                            skjema.visFeilmeldinger &&
-                            skjema.felter.utbetalingsland.valideringsstatus === Valideringsstatus.FEIL
-                                ? skjema.felter.utbetalingsland.feilmelding?.toString()
-                                : ''
-                        }
-                    />
+                    <UtenlandskPeriodeBeløpUtbetalingslandFelt readOnly={erRedigeringDeaktivert} />
                 </Fieldset>
 
                 {!erRedigeringDeaktivert && (
                     <Knapperad>
                         <div>
-                            <Button
-                                onClick={() => sendInnSkjema()}
-                                size="small"
-                                variant={'primary'}
-                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
-                            >
+                            <Button type={'submit'} size="small" variant={'primary'} loading={isSubmitting}>
                                 Ferdig
                             </Button>
                             <Button
+                                type={'button'}
                                 style={{ marginLeft: '1rem' }}
-                                onClick={() => toggleForm(false)}
+                                onClick={onAvbryt}
                                 size="small"
                                 variant="tertiary"
                             >
@@ -228,18 +101,19 @@ const UtenlandskPeriodeBeløpTabellRadEndre = ({
                             </Button>
                         </div>
 
-                        {skjema.felter.status?.verdi !== EøsPeriodeStatus.IKKE_UTFYLT && (
+                        {utenlandskPeriodeBeløp.status !== EøsPeriodeStatus.IKKE_UTFYLT && (
                             <Button
+                                type={'button'}
                                 variant={'tertiary'}
-                                onClick={() => slettUtenlandskPeriodeBeløp()}
-                                id={`slett_utd_beløp_${skjema.felter.barnIdenter.verdi.map(
+                                onClick={slettUtenlandskPeriodeBeløp}
+                                id={`slett_utd_beløp_${utenlandskPeriodeBeløp.barnIdenter.map(
                                     barn => `${barn}-`
-                                )}_${skjema.felter.initielFom.verdi}`}
-                                loading={skjema.submitRessurs.status === RessursStatus.HENTER}
+                                )}_${initiellFom}`}
+                                loading={sletterUtenlandskPeriodeBeløp}
                                 size={'small'}
                                 icon={<TrashIcon />}
                             >
-                                {'Fjern'}
+                                Fjern
                             </Button>
                         )}
                     </Knapperad>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpUtbetalingslandFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpUtbetalingslandFelt.tsx
@@ -1,0 +1,38 @@
+import { EØS_LAND_REGIONKODER, RegionCombobox, type Regionkode } from '@komponenter/FlaggCombobox';
+import { isEmpty } from '@utils/eøsValidators';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { UtenlandskPeriodeBeløpFelt, type UtenlandskPeriodeBeløpFormValues } from './useUtenlandskPeriodeBeløpSkjema';
+
+interface Props {
+    readOnly: boolean;
+}
+
+export function UtenlandskPeriodeBeløpUtbetalingslandFelt({ readOnly }: Props) {
+    const { control } = useFormContext<UtenlandskPeriodeBeløpFormValues>();
+
+    const {
+        field: { value, onChange, ref },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: UtenlandskPeriodeBeløpFelt.UTBETALINGSLAND,
+        control,
+        rules: {
+            validate: utbetalingsland =>
+                !isEmpty(utbetalingsland) ? undefined : 'Utbetalingsland er påkrevd, men mangler input',
+        },
+    });
+
+    return (
+        <RegionCombobox
+            label={'Utbetalingsland'}
+            value={value as Regionkode}
+            options={EØS_LAND_REGIONKODER}
+            onChange={nyttUtbetalingsland => onChange(nyttUtbetalingsland ?? undefined)}
+            ref={ref}
+            readOnly={readOnly || isSubmitting}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpValutaFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpValutaFelt.tsx
@@ -1,0 +1,37 @@
+import { EØS_VALUTAKODER, type Valutakode, ValutaCombobox } from '@komponenter/FlaggCombobox';
+import { isEmpty } from '@utils/eøsValidators';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { UtenlandskPeriodeBeløpFelt, type UtenlandskPeriodeBeløpFormValues } from './useUtenlandskPeriodeBeløpSkjema';
+
+interface Props {
+    readOnly: boolean;
+}
+
+export function UtenlandskPeriodeBeløpValutaFelt({ readOnly }: Props) {
+    const { control } = useFormContext<UtenlandskPeriodeBeløpFormValues>();
+
+    const {
+        field: { value, onChange, ref },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: UtenlandskPeriodeBeløpFelt.VALUTAKODE,
+        control,
+        rules: {
+            validate: valutakode => (!isEmpty(valutakode) ? undefined : 'Valuta er påkrevd, men mangler input'),
+        },
+    });
+
+    return (
+        <ValutaCombobox
+            label={'Valuta'}
+            value={value as Valutakode}
+            options={EØS_VALUTAKODER}
+            onChange={nyValutakode => onChange(nyValutakode ?? undefined)}
+            ref={ref}
+            readOnly={readOnly || isSubmitting}
+            error={error?.message}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/useUtenlandskPeriodeBeløpSkjema.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/useUtenlandskPeriodeBeløpSkjema.ts
@@ -1,191 +1,116 @@
-import { useState } from 'react';
+import { useOnFormSubmitSuccessful } from '@hooks/useOnFormSubmitSuccessful';
+import { useOppdaterUtenlandskPeriodeBeløp } from '@hooks/useOppdaterUtenlandskPeriodeBeløp';
+import { useSlettUtenlandskPeriodeBeløp } from '@hooks/useSlettUtenlandskPeriodeBeløp';
+import type { OptionType } from '@typer/common';
+import type { IRestUtenlandskPeriodeBeløp, UtenlandskPeriodeBeløpIntervall } from '@typer/eøsPerioder';
+import { type IIsoMånedPeriode, nyIsoMånedPeriode } from '@utils/dato';
+import { konverterDesimalverdiTilSkjemaVisning, konverterSkjemaverdiTilDesimal } from '@utils/eøs';
+import { useForm } from 'react-hook-form';
 
-import { useHttp } from '@navikt/familie-http';
-import type { FeltState } from '@navikt/familie-skjema';
-import { feil, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
-import type { Ressurs } from '@navikt/familie-typer';
-import { byggTomRessurs, RessursStatus } from '@navikt/familie-typer';
+import { byggSuksessRessurs } from '@navikt/familie-typer';
 
-import type { IBehandling } from '../../../../../../../typer/behandling';
-import type { OptionType } from '../../../../../../../typer/common';
-import type {
-    EøsPeriodeStatus,
-    IRestUtenlandskPeriodeBeløp,
-    IUtenlandskPeriodeBeløp,
-    UtenlandskPeriodeBeløpIntervall,
-} from '../../../../../../../typer/eøsPerioder';
-import type { IIsoMånedPeriode } from '../../../../../../../utils/dato';
-import { nyIsoMånedPeriode } from '../../../../../../../utils/dato';
-import { konverterDesimalverdiTilSkjemaVisning, konverterSkjemaverdiTilDesimal } from '../../../../../../../utils/eøs';
-import { erBarnGyldig, erEøsPeriodeGyldig, isEmpty, isNumeric } from '../../../../../../../utils/eøsValidators';
 import { useBehandlingContext } from '../../../../context/BehandlingContext';
 
-const erBeløpGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> => {
-    if (!felt.verdi || isEmpty(felt.verdi) || typeof felt.verdi != 'string') {
-        return feil(felt, 'Beløp er påkrevd, men mangler input');
-    }
-    const nyttBeløp = konverterSkjemaverdiTilDesimal(felt.verdi);
-    if (!nyttBeløp) {
-        return feil(felt, 'Beløp er påkrevd, men mangler input');
-    }
-    if (!isNumeric(nyttBeløp)) {
-        return feil(felt, `Beløp innholder ugyldige verdier, beløp: ${felt.verdi}`);
-    }
-    const beløp = Number(nyttBeløp);
-    if (beløp < 0) {
-        return feil(felt, `Kan ikke registrere negativt utbetalt beløp: ${felt.verdi}`);
-    }
-    return ok(felt);
-};
-const erValutaGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> =>
-    !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Valuta er påkrevd, men mangler input');
-const erIntervallGyldig = (
-    felt: FeltState<UtenlandskPeriodeBeløpIntervall | undefined>
-): FeltState<UtenlandskPeriodeBeløpIntervall | undefined> =>
-    !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Intervall er påkrevd, men mangler input');
-const erUtbetalingslandGyldig = (felt: FeltState<string | undefined>): FeltState<string | undefined> =>
-    !isEmpty(felt.verdi) ? ok(felt) : feil(felt, 'Utbetalingsland er påkrevd, men mangler input');
+export enum UtenlandskPeriodeBeløpFelt {
+    BARN = 'barnIdenter',
+    PERIODE = 'periode',
+    BELØP = 'beløp',
+    VALUTAKODE = 'valutakode',
+    INTERVALL = 'intervall',
+    UTBETALINGSLAND = 'utbetalingsland',
+}
+
+export interface UtenlandskPeriodeBeløpFormValues {
+    [UtenlandskPeriodeBeløpFelt.BARN]: OptionType[];
+    [UtenlandskPeriodeBeløpFelt.PERIODE]: IIsoMånedPeriode;
+    [UtenlandskPeriodeBeløpFelt.BELØP]: string | undefined;
+    [UtenlandskPeriodeBeløpFelt.VALUTAKODE]: string | undefined;
+    [UtenlandskPeriodeBeløpFelt.INTERVALL]: UtenlandskPeriodeBeløpIntervall | undefined;
+    [UtenlandskPeriodeBeløpFelt.UTBETALINGSLAND]: string | undefined;
+}
 
 export const utenlandskPeriodeBeløpFeilmeldingId = (utenlandskPeriodeBeløp: IRestUtenlandskPeriodeBeløp): string =>
     `utd_beløp_${utenlandskPeriodeBeløp.barnIdenter.map(barn => `${barn}-`)}_${utenlandskPeriodeBeløp.fom}`;
 
-interface IProps {
+interface Props {
     utenlandskPeriodeBeløp: IRestUtenlandskPeriodeBeløp;
     barnIUtenlandskPeriodeBeløp: OptionType[];
+    lukkSkjema: () => void;
 }
 
-const useUtenlandskPeriodeBeløpSkjema = ({ barnIUtenlandskPeriodeBeløp, utenlandskPeriodeBeløp }: IProps) => {
-    const [erUtenlandskPeriodeBeløpEkspandert, settErUtenlandskPeriodeBeløpEkspandert] = useState<boolean>(false);
+export const useUtenlandskPeriodeBeløpSkjema = ({
+    utenlandskPeriodeBeløp,
+    barnIUtenlandskPeriodeBeløp,
+    lukkSkjema,
+}: Props) => {
     const { behandling, settÅpenBehandling } = useBehandlingContext();
-    const initelFom = useFelt<string>({ verdi: utenlandskPeriodeBeløp.fom });
-    const { request } = useHttp();
 
-    const {
-        skjema,
-        valideringErOk,
-        kanSendeSkjema,
-        onSubmit,
-        nullstillSkjema,
-        settSubmitRessurs,
-        settVisfeilmeldinger,
-    } = useSkjema<IUtenlandskPeriodeBeløp, IBehandling>({
-        felter: {
-            periodeId: useFelt<string>({
-                verdi: utenlandskPeriodeBeløpFeilmeldingId(utenlandskPeriodeBeløp),
-            }),
-            id: useFelt<number>({ verdi: utenlandskPeriodeBeløp.id }),
-            status: useFelt<EøsPeriodeStatus>({ verdi: utenlandskPeriodeBeløp.status }),
-            initielFom: initelFom,
-            barnIdenter: useFelt<OptionType[]>({
-                verdi: barnIUtenlandskPeriodeBeløp,
-                valideringsfunksjon: erBarnGyldig,
-            }),
-            periode: useFelt<IIsoMånedPeriode>({
-                verdi: nyIsoMånedPeriode(utenlandskPeriodeBeløp.fom, utenlandskPeriodeBeløp.tom),
-                avhengigheter: { initelFom },
-                valideringsfunksjon: erEøsPeriodeGyldig,
-            }),
-            beløp: useFelt<string | undefined>({
-                verdi: konverterDesimalverdiTilSkjemaVisning(utenlandskPeriodeBeløp.beløp),
-                valideringsfunksjon: erBeløpGyldig,
-            }),
-            valutakode: useFelt<string | undefined>({
-                verdi: utenlandskPeriodeBeløp.valutakode,
-                valideringsfunksjon: erValutaGyldig,
-            }),
-            intervall: useFelt<UtenlandskPeriodeBeløpIntervall | undefined>({
-                verdi: utenlandskPeriodeBeløp.intervall,
-                valideringsfunksjon: erIntervallGyldig,
-            }),
-            utbetalingsland: useFelt<string | undefined>({
-                verdi: utenlandskPeriodeBeløp.utbetalingsland,
-                valideringsfunksjon: erUtbetalingslandGyldig,
-            }),
+    const { mutateAsync: oppdaterUtenlandskPeriodeBeløp } = useOppdaterUtenlandskPeriodeBeløp();
+    const { mutateAsync: slettUtenlandskPeriodeBeløpMutate, isPending: sletterUtenlandskPeriodeBeløp } =
+        useSlettUtenlandskPeriodeBeløp();
+
+    const form = useForm<UtenlandskPeriodeBeløpFormValues>({
+        values: {
+            [UtenlandskPeriodeBeløpFelt.BARN]: barnIUtenlandskPeriodeBeløp,
+            [UtenlandskPeriodeBeløpFelt.PERIODE]: nyIsoMånedPeriode(
+                utenlandskPeriodeBeløp.fom,
+                utenlandskPeriodeBeløp.tom
+            ),
+            [UtenlandskPeriodeBeløpFelt.BELØP]: konverterDesimalverdiTilSkjemaVisning(utenlandskPeriodeBeløp.beløp),
+            [UtenlandskPeriodeBeløpFelt.VALUTAKODE]: utenlandskPeriodeBeløp.valutakode,
+            [UtenlandskPeriodeBeløpFelt.INTERVALL]: utenlandskPeriodeBeløp.intervall,
+            [UtenlandskPeriodeBeløpFelt.UTBETALINGSLAND]: utenlandskPeriodeBeløp.utbetalingsland,
         },
-        skjemanavn: utenlandskPeriodeBeløpFeilmeldingId(utenlandskPeriodeBeløp),
     });
 
-    const sendInnSkjema = () => {
-        if (kanSendeSkjema()) {
-            const nyttBeløp = konverterSkjemaverdiTilDesimal(skjema.felter.beløp?.verdi);
-            if (!nyttBeløp || !isNumeric(nyttBeløp)) {
-                throw Error('Skal ikke kunne skje. Beløp er validert annen plass i koden.');
-            }
-            settSubmitRessurs(byggTomRessurs());
-            settVisfeilmeldinger(false);
-            onSubmit(
-                {
-                    method: 'PUT',
-                    data: {
-                        id: utenlandskPeriodeBeløp.id,
-                        fom: skjema.felter.periode.verdi.fom,
-                        tom: skjema.felter.periode.verdi.tom,
-                        barnIdenter: skjema.felter.barnIdenter.verdi.map(barn => barn.value),
-                        beløp: nyttBeløp,
-                        valutakode: skjema.felter.valutakode?.verdi,
-                        intervall: skjema.felter.intervall?.verdi,
-                        utbetalingsland: skjema.felter.utbetalingsland?.verdi,
-                    },
-                    url: `/familie-ba-sak/api/differanseberegning/utenlandskperidebeløp/${behandling.behandlingId}`,
-                },
-                (response: Ressurs<IBehandling>) => {
-                    if (response.status === RessursStatus.SUKSESS) {
-                        nullstillSkjema();
-                        settErUtenlandskPeriodeBeløpEkspandert(false);
-                        settÅpenBehandling(response);
-                    }
-                }
-            );
+    const { control, setError, reset } = form;
+
+    useOnFormSubmitSuccessful(control, () => reset());
+
+    const onSubmit = async (values: UtenlandskPeriodeBeløpFormValues) => {
+        try {
+            const oppdatertBehandling = await oppdaterUtenlandskPeriodeBeløp({
+                behandlingId: behandling.behandlingId,
+                id: utenlandskPeriodeBeløp.id,
+                fom: values.periode.fom ?? '',
+                tom: values.periode.tom,
+                barnIdenter: values.barnIdenter.map(barn => barn.value),
+                beløp: konverterSkjemaverdiTilDesimal(values.beløp) ?? '',
+                valutakode: values.valutakode,
+                intervall: values.intervall,
+                utbetalingsland: values.utbetalingsland,
+            });
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+            lukkSkjema();
+        } catch (error) {
+            setError('root', {
+                message:
+                    error instanceof Error ? error.message : 'Teknisk feil ved lagring av utenlandsk periodebeløp.',
+            });
         }
     };
 
-    const slettUtenlandskPeriodeBeløp = () => {
-        settSubmitRessurs(byggTomRessurs());
-        settVisfeilmeldinger(false);
-        request<void, IBehandling>({
-            method: 'DELETE',
-            url: `/familie-ba-sak/api/differanseberegning/utenlandskperidebeløp/${behandling.behandlingId}/${utenlandskPeriodeBeløp.id}`,
-        }).then((response: Ressurs<IBehandling>) => {
-            if (response.status === RessursStatus.SUKSESS) {
-                nullstillSkjema();
-                settErUtenlandskPeriodeBeløpEkspandert(false);
-                settÅpenBehandling(response);
-            } else {
-                settSubmitRessurs(response);
-                settVisfeilmeldinger(true);
-            }
-        });
-    };
-
-    const erUtenlandskPeriodeBeløpSkjemaEndret = () => {
-        const barnFjernetISkjema = utenlandskPeriodeBeløp.barnIdenter.filter(
-            barn => !skjema.felter.barnIdenter.verdi.some(ident => ident.value === barn)
-        );
-        const erTomEndret =
-            !(skjema.felter.periode.verdi.tom === undefined && utenlandskPeriodeBeløp.tom === null) &&
-            skjema.felter.periode?.verdi.tom !== utenlandskPeriodeBeløp.tom;
-        return (
-            barnFjernetISkjema.length > 0 ||
-            skjema.felter.periode?.verdi.fom !== utenlandskPeriodeBeløp.fom ||
-            erTomEndret ||
-            skjema.felter.beløp?.verdi !== konverterDesimalverdiTilSkjemaVisning(utenlandskPeriodeBeløp.beløp) ||
-            skjema.felter.valutakode?.verdi !== utenlandskPeriodeBeløp.valutakode ||
-            skjema.felter.intervall?.verdi !== utenlandskPeriodeBeløp.intervall ||
-            skjema.felter.utbetalingsland?.verdi !== utenlandskPeriodeBeløp.utbetalingsland
-        );
+    const slettUtenlandskPeriodeBeløp = async () => {
+        try {
+            const oppdatertBehandling = await slettUtenlandskPeriodeBeløpMutate({
+                behandlingId: behandling.behandlingId,
+                utenlandskPeriodeBeløpId: utenlandskPeriodeBeløp.id,
+            });
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+            lukkSkjema();
+        } catch (error) {
+            setError('root', {
+                message:
+                    error instanceof Error ? error.message : 'Teknisk feil ved sletting av utenlandsk periodebeløp.',
+            });
+        }
     };
 
     return {
-        erUtenlandskPeriodeBeløpEkspandert,
-        settErUtenlandskPeriodeBeløpEkspandert,
-        skjema,
-        valideringErOk,
-        sendInnSkjema,
+        form,
+        onSubmit,
         slettUtenlandskPeriodeBeløp,
-        nullstillSkjema,
-        kanSendeSkjema,
-        erUtenlandskPeriodeBeløpSkjemaEndret,
+        sletterUtenlandskPeriodeBeløp,
+        initiellFom: utenlandskPeriodeBeløp.fom,
     };
 };
-
-export { useUtenlandskPeriodeBeløpSkjema };


### PR DESCRIPTION
### 📮 Favro:
NAV-29968

### 💰 Hva skal gjøres, og hvorfor?
Skriver om «utbetalt annet land»-komponentene (utenlandsk periodebeløp) til å bruke **React Query** og **React Hook Form**, på samme måte som valutakurs-omskrivingen (NAV-29957).

**Erstatter:**
- `useHttp`/`Ressurs`-baserte kall → react-query hooks
- `useSkjema`/`useFelt` → RHF (`useForm`/`useController`)
- Layout med styled-components → Aksel-primitiver (`HStack`)

**Nye react-query hooks:**
- `useOppdaterUtenlandskPeriodeBeløp`
- `useSlettUtenlandskPeriodeBeløp`

**Nye RHF-feltkomponenter:**
- `UtenlandskPeriodeBeløpBarnFelt`
- `UtenlandskPeriodeBeløpBeløpFelt`
- `UtenlandskPeriodeBeløpValutaFelt`
- `UtenlandskPeriodeBeløpIntervallFelt`
- `UtenlandskPeriodeBeløpPeriodeFelt`
- `UtenlandskPeriodeBeløpUtbetalingslandFelt`

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ren omskriving av eksisterende funksjonalitet.

### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Ingen visuelle endringer.
