### PR TITLE
Bugfix etter rhf/rq valutakurs og utbetalt i annet land

### DIFF
--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpPeriodeFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/UtbetaltAnnetLand/UtenlandskPeriodeBeløpPeriodeFelt.tsx
@@ -1,7 +1,7 @@
 import MånedÅrVelger from '@komponenter/MånedÅrInput/MånedÅrVelger';
 import { dagensDato, isoStringTilDate } from '@utils/dato';
 import { isEmpty } from '@utils/eøsValidators';
-import { addMonths, endOfMonth, isAfter } from 'date-fns';
+import { addMonths, endOfMonth, isAfter, isBefore } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Fieldset, HStack } from '@navikt/ds-react';
@@ -40,7 +40,7 @@ export function UtenlandskPeriodeBeløpPeriodeFelt({ initiellFom, periodeFeilmel
                 if (fom && valgtDatoErSenereEnnNesteMåned(fom)) {
                     return 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere';
                 }
-                if (initiellFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initiellFom))) {
+                if (initiellFom && isBefore(isoStringTilDate(fom), isoStringTilDate(initiellFom))) {
                     return `Du kan ikke legge inn fra og med måned som er før: ${initiellFom}`;
                 }
                 if (tom && valgtDatoErNesteMånedEllerSenere(tom)) {

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursDatoFelt.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef } from 'react';
 
 import { dagensDato } from '@utils/dato';
 import { useController, useFormContext } from 'react-hook-form';
@@ -14,7 +14,7 @@ interface Props {
 export function ValutakursDatoFelt({ readOnly }: Props) {
     const { control, trigger, setValue } = useFormContext<ValutakursFormValues>();
 
-    const [dateValidation, setDateValidation] = useState<DateValidationT | undefined>(undefined);
+    const dateValidationRef = useRef<DateValidationT | undefined>(undefined);
 
     const {
         field: { value, onChange, ref },
@@ -25,6 +25,8 @@ export function ValutakursDatoFelt({ readOnly }: Props) {
         control,
         rules: {
             validate: valgtDato => {
+                const dateValidation = dateValidationRef.current;
+
                 if (dateValidation?.isWeekend) {
                     return 'Du må velge en dato som er en ukedag';
                 }
@@ -39,7 +41,7 @@ export function ValutakursDatoFelt({ readOnly }: Props) {
         },
     });
 
-    const { datepickerProps, inputProps, setSelected, selectedDay } = useDatepicker({
+    const { datepickerProps, inputProps } = useDatepicker({
         defaultSelected: value,
         toDate: dagensDato,
         disableWeekends: true,
@@ -52,21 +54,12 @@ export function ValutakursDatoFelt({ readOnly }: Props) {
             }
         },
         onValidate: validation => {
-            setDateValidation(validation);
+            dateValidationRef.current = validation;
             if (isSubmitted) {
                 trigger(ValutakursFelt.VALUTAKURSDATO);
             }
         },
     });
-
-    // Synkroniser datovelgeren dersom feltverdien endres uten at det er datovelgeren som trigget endringen.
-    const [forrigeVerdi, settForrigeVerdi] = useState<Date | undefined>(value);
-    if (value !== forrigeVerdi) {
-        settForrigeVerdi(value);
-        if (value !== selectedDay) {
-            setSelected(value);
-        }
-    }
 
     return (
         <DatePicker dropdownCaption {...datepickerProps}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/Eøs/Valutakurs/ValutakursPeriodeFelt.tsx
@@ -1,7 +1,7 @@
 import MånedÅrVelger from '@komponenter/MånedÅrInput/MånedÅrVelger';
 import { dagensDato, isoStringTilDate } from '@utils/dato';
 import { isEmpty } from '@utils/eøsValidators';
-import { addMonths, endOfMonth, isAfter } from 'date-fns';
+import { addMonths, endOfMonth, isAfter, isBefore } from 'date-fns';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { Fieldset, HStack } from '@navikt/ds-react';
@@ -40,7 +40,7 @@ export function ValutakursPeriodeFelt({ initiellFom, periodeFeilmeldingId, lesev
                 if (fom && valgtDatoErSenereEnnNesteMåned(fom)) {
                     return 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere';
                 }
-                if (initiellFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initiellFom))) {
+                if (initiellFom && isBefore(isoStringTilDate(fom), isoStringTilDate(initiellFom))) {
                     return `Du kan ikke legge inn fra og med måned som er før: ${initiellFom}`;
                 }
                 if (tom && valgtDatoErNesteMånedEllerSenere(tom)) {

--- a/src/frontend/utils/eøsValidators.ts
+++ b/src/frontend/utils/eøsValidators.ts
@@ -1,4 +1,4 @@
-import { addMonths, endOfMonth, isAfter } from 'date-fns';
+import { addMonths, endOfMonth, isAfter, isBefore } from 'date-fns';
 
 import { feil, ok } from '@navikt/familie-skjema';
 import type { Avhengigheter, FeltState } from '@navikt/familie-skjema';
@@ -30,7 +30,7 @@ const erEøsPeriodeGyldig = (
     if (fom && valgtDatoErSenereEnnNesteMåned(fom)) {
         return feil(felt, 'Du kan ikke sette fra og med (f.o.m.) til måneden etter neste måned eller senere');
     }
-    if (initielFom && !isAfter(isoStringTilDate(fom), isoStringTilDate(initielFom))) {
+    if (initielFom && isBefore(isoStringTilDate(fom), isoStringTilDate(initielFom))) {
         return feil(felt, `Du kan ikke legge inn fra og med måned som er før: ${avhengigheter?.initielFom}`);
     }
     if (tom && valgtDatoErNesteMånedEllerSenere(tom)) {

--- a/src/frontend/utils/test/eøsValidators.test.ts
+++ b/src/frontend/utils/test/eøsValidators.test.ts
@@ -53,6 +53,14 @@ describe('utils/eøsValidators', () => {
         expect(valideringsresultat.feilmelding).toEqual('Du kan ikke legge inn fra og med måned som er før: 2011-10');
     });
 
+    test('erEøsPeriodeGyldig skal returnere OK dersom fom dato er lik initielFom dato', () => {
+        const eøsPeriode: FeltState<IIsoMånedPeriode> = nyFeltState(nyIsoMånedPeriode('2011-10', '2012-05'));
+
+        const valideringsresultat = erEøsPeriodeGyldig(eøsPeriode, { initielFom: '2011-10' });
+
+        expect(valideringsresultat.valideringsstatus).toEqual(Valideringsstatus.OK);
+    });
+
     test('erEøsPeriodeGyldig skal returnere OK dersom alle felter er fylt inn korrekt', () => {
         const eøsPeriode: FeltState<IIsoMånedPeriode> = nyFeltState(nyIsoMånedPeriode('2010-12', '2012-05'));
 


### PR DESCRIPTION
### 📮 Favro:

### 💰 Hva skal gjøres, og hvorfor?
Retter to feil som oppstod etter migreringen av EØS Valutakurs og «Utbetalt i et annet land» fra `familie-skjema` til react-hook-form (RHF) + react-query.

**1. Kan ikke velge fra-og-med måned lik `initiellFom`**
Valideringen brukte `!isAfter(fom, initiellFom)`, som også avviste tilfellet der `fom` er lik `initiellFom`. Feilmeldingen sier kun at måneden ikke kan være *før* en gitt måned, så måneden som er lik skal være gyldig. Etter RHF-migreringen ble `initiellFom` koblet opp riktig, noe som eksponerte denne off-by-one-feilen (tidligere var sjekken død kode pga. en navnefeil i avhengighetsnøkkelen i `familie-skjema`-varianten).  Denne buggen ble introdusert i 2023, men ble bare slått inn nå pga at jeg fikset typoen.

**2. Uendelig render-løkke ved valg av valutakursdato (React error #301)**
`ValutakursDatoFelt` lagret datovalidering i `useState` og synkroniserte i tillegg datovelgeren under render (`setSelected(value)`). Dette trigget `onChange` → RHF-state-oppdatering under render → ny render → «Maximum update depth exceeded».
- Skrev om feltet til å bruke `useRef` for datovalidering (samme mønster som `VedtaksdatoFelt`/`FristFelt`), og fjernet render-fase-synkroniseringen. Feltet baserer seg nå på `defaultSelected` + `onDateChange`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Har verifisert at ingen andre RHF-datovelgere har render-fase-synkronisering, og at ingen andre steder har samme boundary-feil.