### PR TITLE
NAV-30005: Slett featuretoggle for endret utbetaling og søknadstidspunkt

### DIFF
--- a/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.test.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.test.tsx
@@ -8,7 +8,6 @@ import { BrukerProvider } from '@sider/Fagsak/BrukerContext';
 import { FagsakProvider } from '@sider/Fagsak/FagsakContext';
 import { ManuelleBrevmottakerePåFagsakProvider } from '@sider/Fagsak/ManuelleBrevmottakerePåFagsakContext';
 import { skruPåAlleToggles } from '@testutils/mocks/handlers/featureToggleHandlers';
-import { server } from '@testutils/mocks/node';
 import { lagBehandling, lagVisningBehandling } from '@testutils/testdata/behandlingTestdata';
 import { lagFagsak } from '@testutils/testdata/fagsakTestdata';
 import { lagPerson } from '@testutils/testdata/personTestdata';
@@ -21,13 +20,11 @@ import {
     SettPåVentÅrsak,
 } from '@typer/behandling';
 import type { IMinimalFagsak } from '@typer/fagsak';
-import { FeatureToggle, type FeatureToggles } from '@typer/featureToggles';
-import { http, HttpResponse } from 'msw';
+import type { FeatureToggles } from '@typer/featureToggles';
 import { Route, Routes } from 'react-router';
 import { describe, expect, type MockInstance } from 'vitest';
 
 import { Heading } from '@navikt/ds-react';
-import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 import { Behandlingsmeny } from './Behandlingsmeny';
 import { HenleggBehandlingModal } from './HenleggBehandling/HenleggBehandlingModal';
@@ -127,7 +124,7 @@ describe('Behandlingsmeny', () => {
         expect(screen.getByRole('menuitem', { name: 'A-Inntekt' })).toBeInTheDocument();
     });
 
-    test('skal vise "Endre søknadstidspunkt" i menyen for en søknadsbehandling på behandlingsresultat-siden når toggle er på', async () => {
+    test('skal vise "Endre søknadstidspunkt" i menyen for en søknadsbehandling på behandlingsresultat-siden', async () => {
         const { screen, user } = render(<Behandlingsmeny />, {
             wrapper: props => (
                 <Wrapper
@@ -175,36 +172,6 @@ describe('Behandlingsmeny', () => {
                         årsak: BehandlingÅrsak.NYE_OPPLYSNINGER,
                         steg: BehandlingSteg.REGISTRERE_SØKNAD,
                     })}
-                />
-            ),
-        });
-
-        await user.click(screen.getByRole('button', { name: 'Meny' }));
-
-        expect(screen.queryByRole('menuitem', { name: 'Endre søknadstidspunkt' })).not.toBeInTheDocument();
-    });
-
-    test('skal ikke vise "Endre søknadstidspunkt" i menyen når toggle er av', async () => {
-        const togglesMedSøknadstidspunktAv = {
-            ...skruPåAlleToggles(),
-            [FeatureToggle.kanRegistrereSøknadstidspunkt]: false,
-        };
-        // Overstyr både initialData (prop) og selve henteendepunktet, ellers henter React Query alle toggles på nytt.
-        server.use(
-            http.post('/familie-ba-sak/api/feature/er-toggler-enabled', () =>
-                HttpResponse.json(byggSuksessRessurs(togglesMedSøknadstidspunktAv))
-            )
-        );
-
-        const { screen, user } = render(<Behandlingsmeny />, {
-            wrapper: props => (
-                <Wrapper
-                    {...props}
-                    behandling={lagBehandling({
-                        årsak: BehandlingÅrsak.SØKNAD,
-                        steg: BehandlingSteg.BEHANDLINGSRESULTAT,
-                    })}
-                    featureToggles={togglesMedSøknadstidspunktAv}
                 />
             ),
         });

--- a/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Saklinje/Meny/Behandlingsmeny.tsx
@@ -1,10 +1,8 @@
 import { useState } from 'react';
 
 import { useBehandling } from '@hooks/useBehandling';
-import { useFeatureToggles } from '@hooks/useFeatureToggles';
 import { SideId, sider } from '@sider/Fagsak/Behandling/Sider/sider';
 import { BehandlingÅrsak, sjekkErBehandleneEnhetMidlertidig } from '@typer/behandling';
-import { FeatureToggle } from '@typer/featureToggles';
 import { useLocation } from 'react-router';
 
 import { ChevronDownIcon } from '@navikt/aksel-icons';
@@ -35,17 +33,13 @@ import { SendInformasjonsbrev } from './SendInformasjonsbrev/SendInformasjonsbre
 
 export function Behandlingsmeny() {
     const behandling = useBehandling();
-    const toggles = useFeatureToggles();
     const location = useLocation();
 
     const erBehandleneEnhetMidlertidig = sjekkErBehandleneEnhetMidlertidig(behandling);
     const erBehandlingPåVent = !!behandling.aktivSettPåVent;
 
     const erPåBehandlingsresultatside = location.pathname.includes(sider[SideId.BEHANDLINGRESULTAT].href);
-    const kanEndreSøknadstidspunkt =
-        toggles[FeatureToggle.kanRegistrereSøknadstidspunkt] &&
-        behandling.årsak === BehandlingÅrsak.SØKNAD &&
-        erPåBehandlingsresultatside;
+    const kanEndreSøknadstidspunkt = behandling.årsak === BehandlingÅrsak.SØKNAD && erPåBehandlingsresultatside;
 
     const [visOpprettBehandlingModal, settVisOpprettBehandlingModal] = useState(false);
     const [visTilbakekrevingsbehandlingOpprettetModal, settVisTilbakekrevingsbehandlingOpprettetModal] =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.test.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.test.tsx
@@ -107,7 +107,7 @@ describe('EndretUtbetalingAndelSkjema', () => {
         expect(screen.queryByRole('button', { name: 'Fjern periode' })).not.toBeInTheDocument();
     });
 
-    test('skal kun tillate sletting (ikke endring) for automatisk genererte andeler når toggle er på', () => {
+    test('skal kun tillate sletting (ikke endring) for automatisk genererte andeler', () => {
         function CustomWrapper({ children }: { children: ReactNode }) {
             return (
                 <Wrapper

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Behandlingsresultat/EndretUtbetaling/EndretUtbetalingAndelSkjema.tsx
@@ -1,8 +1,6 @@
 import { useErLesevisning } from '@hooks/useErLesevisning';
-import { useFeatureToggles } from '@hooks/useFeatureToggles';
 import { useOppdatererEndretUtbetalingAndelIsPending } from '@hooks/useOppdatererEndretUtbetalingAndelIsPending';
 import { useSletterEndretUtbetalingAndelIsPending } from '@hooks/useSletterEndretUtbetalingAndelIsPending';
-import { FeatureToggle } from '@typer/featureToggles';
 import { IEndretUtbetalingAndelÅrsak } from '@typer/utbetalingAndel';
 import { FormProvider, type SubmitHandler, type UseFormReturn } from 'react-hook-form';
 
@@ -29,13 +27,11 @@ export const EndretUtbetalingAndelSkjema = ({ form, onSubmit, lukkSkjema }: Endr
     const { endretUtbetalingAndel } = useEndretUtbetalingAndelContext();
 
     const erLesevisning = useErLesevisning();
-    const toggles = useFeatureToggles();
 
     const sletterEndretUtbetalingAndel = useSletterEndretUtbetalingAndelIsPending({ endretUtbetalingAndel });
     const oppdatererEndretUtbetalingAndel = useOppdatererEndretUtbetalingAndelIsPending({ endretUtbetalingAndel });
 
-    const erAutomatiskGenerert =
-        toggles[FeatureToggle.kanRegistrereSøknadstidspunkt] && !!endretUtbetalingAndel.erAutomatiskGenerert;
+    const erAutomatiskGenerert = !!endretUtbetalingAndel.erAutomatiskGenerert;
 
     const låsFelter =
         erLesevisning ||

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -14,5 +14,4 @@ export enum FeatureToggle {
     preutfyllingLovligOpphold = 'familie-ba-sak.preutfylling-lovlig-opphold',
     kanGenerereBarnasVilkar = 'familie-ba-sak.kan-generere-barnas-vilkar',
     nySlettVilkaarLogikk = 'familie-ba-sak.ny-slett-vilkaar-logikk',
-    kanRegistrereSøknadstidspunkt = 'familie-ba-sak.kan-registrere-soknadstidspunkt',
 }


### PR DESCRIPTION
### 📮 Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-30005

### 💰 Hva skal gjøres, og hvorfor?

Sletter featuretoggelen for registrering av søknadstidspunkt på person. Toggelen har vært på i prod, så oppførselen den ga beholdes som standard, og den gamle grenen slettes som død kode.

- `typer/featureToggles.ts` — toggle-definisjonen fjernet
- `Behandlingsmeny.tsx` — menyvalget for å registrere søknadstidspunkt vises alltid
- `EndretUtbetalingAndelSkjema.tsx` — automatisk genererte andeler er alltid låst for endring
- Toggle-spesifikke tester fjernet/forenklet

Tilhørende backend-PR: navikt/familie-ba-sak#6397

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?

Ingenting spesielt — rent opprydningsarbeid uten funksjonell endring for saksbehandler.

Selve toggelen må slettes manuelt i Unleash, men først etter at denne og backend-PR-en er deployet.