### PR TITLE
Nav 22519 vis deployet branch i preprod

### DIFF
--- a/.github/workflows/manual-deploy-dev.yaml
+++ b/.github/workflows/manual-deploy-dev.yaml
@@ -31,7 +31,8 @@ jobs:
       contents: read
       id-token: write
     needs: [build]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
+    # TODO NAV-22519: sett tilbake til @main før merge
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@NAV-22519_eksponer_deployet_branch # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp

--- a/.github/workflows/manual-deploy-dev.yaml
+++ b/.github/workflows/manual-deploy-dev.yaml
@@ -31,8 +31,7 @@ jobs:
       contents: read
       id-token: write
     needs: [build]
-    # TODO NAV-22519: sett tilbake til @main før merge
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@NAV-22519_eksponer_deployet_branch # ratchet:exclude
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/deploy.yaml@main # ratchet:exclude
     with:
       image: ${{ needs.build.outputs.image }}
       cluster: dev-gcp

--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -53,7 +53,7 @@ spec:
     - name: APP_VERSION
       value: {{ VERSION }}
     - name: APP_BRANCH
-      value: {{ BRANCH }}
+      value: "{{ BRANCH }}"
     - name: ENV
       value: preprod
   valkey:

--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -52,6 +52,8 @@ spec:
   env:
     - name: APP_VERSION
       value: {{ VERSION }}
+    - name: APP_BRANCH
+      value: {{ BRANCH }}
     - name: ENV
       value: preprod
   valkey:

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -25,7 +25,13 @@ const redirectHvisInternUrlIPreprod = () => {
 export default async (authClient: Client, router: Router) => {
     router.get('/version', (_: Request, res: Response) => {
         res.status(200)
-            .send({ status: 'SUKSESS', data: envVar('APP_VERSION') })
+            .send({
+                status: 'SUKSESS',
+                data: {
+                    versjon: envVar('APP_VERSION'),
+                    branch: envVar('APP_BRANCH', false, 'ukjent'),
+                },
+            })
             .end();
     });
 

--- a/src/frontend/api/hentVersjonsinfo.ts
+++ b/src/frontend/api/hentVersjonsinfo.ts
@@ -1,0 +1,16 @@
+import { apiClient } from '@api/client/apiClient';
+
+export interface Versjonsinfo {
+    branch: string;
+    versjon: string;
+}
+
+export async function hentBackendVersjonsinfo() {
+    return apiClient.get<void, Versjonsinfo>({
+        url: '/familie-ba-sak/api/preprod/versjonsinfo',
+    });
+}
+
+export async function hentFrontendVersjonsinfo() {
+    return apiClient.get<void, Versjonsinfo>({ url: '/version' });
+}

--- a/src/frontend/hooks/useVersjonsinfo.ts
+++ b/src/frontend/hooks/useVersjonsinfo.ts
@@ -1,0 +1,32 @@
+import { hentBackendVersjonsinfo, hentFrontendVersjonsinfo } from '@api/hentVersjonsinfo';
+import { useQueries } from '@tanstack/react-query';
+import { erPreprod } from '@utils/miljø';
+
+export const VERSJONSINFO_QUERY_KEY_PREFIX = 'versjonsinfo';
+
+export function useVersjonsinfo() {
+    const skalHentes = erPreprod();
+
+    return useQueries({
+        queries: [
+            {
+                queryKey: [VERSJONSINFO_QUERY_KEY_PREFIX, 'frontend'],
+                queryFn: hentFrontendVersjonsinfo,
+                enabled: skalHentes,
+                staleTime: Infinity,
+                retry: false,
+            },
+            {
+                queryKey: [VERSJONSINFO_QUERY_KEY_PREFIX, 'backend'],
+                queryFn: hentBackendVersjonsinfo,
+                enabled: skalHentes,
+                staleTime: Infinity,
+                retry: false,
+            },
+        ],
+        combine: ([frontend, backend]) => ({
+            frontendBranch: frontend.data?.branch,
+            backendBranch: backend.data?.branch,
+        }),
+    });
+}

--- a/src/frontend/hooks/useVersjonsinfo.ts
+++ b/src/frontend/hooks/useVersjonsinfo.ts
@@ -25,6 +25,7 @@ export function useVersjonsinfo() {
             },
         ],
         combine: ([frontend, backend]) => ({
+            laster: frontend.isPending || backend.isPending,
             frontendBranch: frontend.data?.branch,
             backendBranch: backend.data?.branch,
         }),

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.module.css
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.module.css
@@ -1,0 +1,13 @@
+/*
+ * Header-en rendrer tittelen, en spacer med margin-left: auto og deretter children.
+ * For å plassere branch-informasjonen rett etter tittelen – uten å dytte søkefeltet
+ * ut av posisjon – flyttes tittel og branch foran spaceren med flex order.
+ */
+:global(.aksel-internalheader__title) {
+    order: -2;
+}
+
+.deployetBranch {
+    order: -1;
+    padding-inline: var(--ax-space-16);
+}

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
@@ -51,6 +51,19 @@ describe('DeployetBranch', () => {
         expect(await screen.findByText('Backend: min-backend-branch')).toBeInTheDocument();
     });
 
+    test('viser ingenting mens versjonsinfo hentes', () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(true);
+        hentFrontendVersjonsinfoMock.mockReturnValue(new Promise(() => {}));
+        hentBackendVersjonsinfoMock.mockReturnValue(new Promise(() => {}));
+
+        // Act
+        const { container } = render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(container).toBeEmptyDOMElement();
+    });
+
     test('viser ukjent når henting av versjonsinfo feiler', async () => {
         // Arrange
         erPreprodMock.mockReturnValue(true);

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
@@ -1,0 +1,53 @@
+import type { PropsWithChildren } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { DeployetBranch } from './DeployetBranch';
+
+const { erPreprodMock, hentFrontendVersjonsinfoMock, hentBackendVersjonsinfoMock } = vi.hoisted(() => ({
+    erPreprodMock: vi.fn(),
+    hentFrontendVersjonsinfoMock: vi.fn(),
+    hentBackendVersjonsinfoMock: vi.fn(),
+}));
+
+vi.mock('@utils/miljø', () => ({ erPreprod: erPreprodMock }));
+
+vi.mock('@api/hentVersjonsinfo', () => ({
+    hentFrontendVersjonsinfo: hentFrontendVersjonsinfoMock,
+    hentBackendVersjonsinfo: hentBackendVersjonsinfoMock,
+}));
+
+const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+);
+
+describe('DeployetBranch', () => {
+    test('viser ingenting utenfor preprod', () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(false);
+
+        // Act
+        const { container } = render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(container).toBeEmptyDOMElement();
+        expect(hentFrontendVersjonsinfoMock).not.toHaveBeenCalled();
+        expect(hentBackendVersjonsinfoMock).not.toHaveBeenCalled();
+    });
+
+    test('viser deployet branch for frontend og backend i preprod', async () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(true);
+        hentFrontendVersjonsinfoMock.mockResolvedValue({ branch: 'min-frontend-branch', versjon: 'fe:1' });
+        hentBackendVersjonsinfoMock.mockResolvedValue({ branch: 'min-backend-branch', versjon: 'be:1' });
+
+        // Act
+        render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(await screen.findByText('Frontend: min-frontend-branch')).toBeInTheDocument();
+        expect(await screen.findByText('Backend: min-backend-branch')).toBeInTheDocument();
+    });
+});

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.test.tsx
@@ -50,4 +50,18 @@ describe('DeployetBranch', () => {
         expect(await screen.findByText('Frontend: min-frontend-branch')).toBeInTheDocument();
         expect(await screen.findByText('Backend: min-backend-branch')).toBeInTheDocument();
     });
+
+    test('viser ukjent når henting av versjonsinfo feiler', async () => {
+        // Arrange
+        erPreprodMock.mockReturnValue(true);
+        hentFrontendVersjonsinfoMock.mockResolvedValue({ branch: 'min-frontend-branch', versjon: 'fe:1' });
+        hentBackendVersjonsinfoMock.mockRejectedValue(new Error('Backend er nede'));
+
+        // Act
+        render(<DeployetBranch />, { wrapper });
+
+        // Assert
+        expect(await screen.findByText('Frontend: min-frontend-branch')).toBeInTheDocument();
+        expect(await screen.findByText('Backend: ukjent')).toBeInTheDocument();
+    });
 });

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
@@ -6,9 +6,9 @@ import { Detail, HStack } from '@navikt/ds-react';
 import Styles from './DeployetBranch.module.css';
 
 export function DeployetBranch() {
-    const { frontendBranch, backendBranch } = useVersjonsinfo();
+    const { laster, frontendBranch, backendBranch } = useVersjonsinfo();
 
-    if (!erPreprod()) {
+    if (!erPreprod() || laster) {
         return null;
     }
 

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
@@ -1,0 +1,19 @@
+import { useVersjonsinfo } from '@hooks/useVersjonsinfo';
+import { erPreprod } from '@utils/miljø';
+
+import { Detail, HStack } from '@navikt/ds-react';
+
+export function DeployetBranch() {
+    const { frontendBranch, backendBranch } = useVersjonsinfo();
+
+    if (!erPreprod()) {
+        return null;
+    }
+
+    return (
+        <HStack gap="space-8" align="center" wrap={false}>
+            <Detail textColor="subtle">{`Frontend: ${frontendBranch ?? 'ukjent'}`}</Detail>
+            <Detail textColor="subtle">{`Backend: ${backendBranch ?? 'ukjent'}`}</Detail>
+        </HStack>
+    );
+}

--- a/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/DeployetBranch.tsx
@@ -3,6 +3,8 @@ import { erPreprod } from '@utils/miljø';
 
 import { Detail, HStack } from '@navikt/ds-react';
 
+import Styles from './DeployetBranch.module.css';
+
 export function DeployetBranch() {
     const { frontendBranch, backendBranch } = useVersjonsinfo();
 
@@ -11,7 +13,7 @@ export function DeployetBranch() {
     }
 
     return (
-        <HStack gap="space-8" align="center" wrap={false}>
+        <HStack gap="space-8" align="center" wrap={false} className={Styles.deployetBranch}>
             <Detail textColor="subtle">{`Frontend: ${frontendBranch ?? 'ukjent'}`}</Detail>
             <Detail textColor="subtle">{`Backend: ${backendBranch ?? 'ukjent'}`}</Detail>
         </HStack>

--- a/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
@@ -25,8 +25,8 @@ export function HeaderMedSøk() {
                 },
             ]}
         >
-            <FagsakDeltagerSøk />
             <DeployetBranch />
+            <FagsakDeltagerSøk />
         </Header>
     );
 }

--- a/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/komponenter/HeaderMedSøk/HeaderMedSøk.tsx
@@ -1,5 +1,6 @@
 import { Header } from '@navikt/familie-header';
 
+import { DeployetBranch } from './DeployetBranch';
 import FagsakDeltagerSøk from './FagsakDeltagerSøk';
 import { useSaksbehandler } from '../../hooks/useSaksbehandler';
 
@@ -25,6 +26,7 @@ export function HeaderMedSøk() {
             ]}
         >
             <FagsakDeltagerSøk />
+            <DeployetBranch />
         </Header>
     );
 }

--- a/src/frontend/testutils/mocks/handlers/versionHandlers.ts
+++ b/src/frontend/testutils/mocks/handlers/versionHandlers.ts
@@ -4,6 +4,6 @@ import { byggSuksessRessurs } from '@navikt/familie-typer';
 
 export const versionHandlers = [
     http.get('/version', () => {
-        return HttpResponse.json(byggSuksessRessurs('1'));
+        return HttpResponse.json(byggSuksessRessurs({ versjon: '1', branch: 'main' }));
     }),
 ];


### PR DESCRIPTION
### 📮 Favro: NAV-22519

### 💰 Hva skal gjøres, og hvorfor?
Viser deployet frontend- og backend-branch i headeren i preprod.

- `.nais/app-dev.yaml`: eksponerer `APP_BRANCH`.
- `src/backend/router.ts`: `/version` returnerer nå `{ versjon, branch }` i stedet
  for kun versjonsstrengen. Ingen andre konsumenter av endepunktet.
- Ny `useVersjonsinfo`-hook som henter begge kildene parallelt med `useQueries`,
  og ny `DeployetBranch`-komponent i headeren.

Alt er gated på `erPreprod()` — i prod rendrer komponenten `null` og gjør ingen kall.
`APP_BRANCH` er bevisst ikke satt i `app-prod.yaml`, så BFF-en faller tilbake på `ukjent`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
⚠️ **Merge-rekkefølge:** https://github.com/navikt/familie-baks-gha-workflows/pull/97 må merges først, deretter https://github.com/navikt/familie-ba-sak/pull/6399. `.nais/app-dev.yaml` refererer `{{ BRANCH }}`, og nais feiler på uløste variabler. Etterpå må `uses:`-refen i `manual-deploy-dev.yaml` settes tilbake til `@main` (merket `# TODO NAV-22519`) — den peker midlertidig på workflow-branchen for å kunne teste i preprod.

`Header` fra `@navikt/familie-header` rendrer `Tittel → spacer(margin-left:auto) →
children`, og har ingen slot før spaceren. For å få branch-teksten rett etter
tittelen — uten å dytte søkefeltet ut av posisjon — overstyrer
`DeployetBranch.module.css` flex-order på Aksel-klassen
`.aksel-internalheader__title`. Det er en intern klasse, så den kan brekke ved en
ds-css-oppgradering (konsekvensen er kun kosmetisk, og kun i preprod). Alternativet
er å legge en ekte slot i `familie-header` — si fra om dere heller vil det.

<img width="1197" height="294" alt="branchnavn" src="https://github.com/user-attachments/assets/886beb38-c9ad-4c4c-b117-a059b9d25ca6" />



