### PR TITLE
NAV-29875: Refaktorer registrer soknad til RHF og RQ

### DIFF
--- a/src/frontend/api/registrerSøknad.ts
+++ b/src/frontend/api/registrerSøknad.ts
@@ -1,0 +1,30 @@
+import { apiClient } from '@api/client/apiClient';
+import type { IBehandling } from '@typer/behandling';
+import type { BehandlingUnderkategori } from '@typer/behandlingstema';
+import type { IBarnMedOpplysningerBackend, Målform } from '@typer/søknad';
+
+interface PathParams {
+    behandlingId: number;
+}
+
+export interface Payload {
+    søknad: {
+        underkategori: BehandlingUnderkategori;
+        søkerMedOpplysninger: {
+            ident: string;
+            målform: Målform | undefined;
+        };
+        barnaMedOpplysninger: IBarnMedOpplysningerBackend[];
+        endringAvOpplysningerBegrunnelse: string;
+        erAutomatiskRegistrert: boolean;
+    };
+    bekreftEndringerViaFrontend: boolean;
+}
+
+export async function registrerSøknad(pathParams: PathParams, payload: Payload): Promise<IBehandling> {
+    const { behandlingId } = pathParams;
+    return apiClient.post<Payload, IBehandling>({
+        data: payload,
+        url: `/familie-ba-sak/api/behandlinger/${behandlingId}/steg/registrer-søknad`,
+    });
+}

--- a/src/frontend/api/registrerSøknad.ts
+++ b/src/frontend/api/registrerSøknad.ts
@@ -12,7 +12,7 @@ export interface Payload {
         underkategori: BehandlingUnderkategori;
         søkerMedOpplysninger: {
             ident: string;
-            målform: Målform | undefined;
+            målform: Målform;
         };
         barnaMedOpplysninger: IBarnMedOpplysningerBackend[];
         endringAvOpplysningerBegrunnelse: string;

--- a/src/frontend/hooks/useRegistrerSøknad.ts
+++ b/src/frontend/hooks/useRegistrerSøknad.ts
@@ -1,0 +1,20 @@
+import type { ApiFeil } from '@api/client/apiClient';
+import { type Payload, registrerSøknad } from '@api/registrerSøknad';
+import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
+import type { IBehandling } from '@typer/behandling';
+
+interface Parameters extends Payload {
+    behandlingId: number;
+}
+
+type Options = Omit<UseMutationOptions<IBehandling, ApiFeil, Parameters>, 'mutationFn'>;
+
+export function useRegistrerSøknad(options?: Options) {
+    return useMutation<IBehandling, ApiFeil, Parameters>({
+        mutationFn: (parameters: Parameters): Promise<IBehandling> => {
+            const { behandlingId, ...payload } = parameters;
+            return registrerSøknad({ behandlingId }, payload);
+        },
+        ...options,
+    });
+}

--- a/src/frontend/hooks/useScrollOnMount.ts
+++ b/src/frontend/hooks/useScrollOnMount.ts
@@ -1,0 +1,14 @@
+import { useRef, useEffect } from 'react';
+
+export function useScrollOnMount<T extends HTMLElement = HTMLElement>(
+    options: ScrollIntoViewOptions = { block: 'start' }
+) {
+    const ref = useRef<T>(null);
+    const optionsRef = useRef(options);
+
+    useEffect(() => {
+        ref.current?.scrollIntoView(optionsRef.current);
+    }, []);
+
+    return ref;
+}

--- a/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/BehandlingRoutes.tsx
@@ -1,5 +1,6 @@
 import { NotFound } from '@komponenter/Error/NotFound';
 import { TidslinjeProvider } from '@komponenter/Tidslinje/TidslinjeContext';
+import { RegistrerSøknad } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/RegistrerSøknad';
 import { VedtakContainer } from '@sider/Fagsak/Behandling/Sider/Vedtak/VedtakContainer';
 import { VilkårsvurderingContainer } from '@sider/Fagsak/Behandling/Sider/Vilkårsvurdering/VilkårsvurderingContainer';
 import type { RouteObject } from 'react-router';
@@ -7,8 +8,6 @@ import type { RouteObject } from 'react-router';
 import Behandlingsresultat from './Sider/Behandlingsresultat/Behandlingsresultat';
 import Filtreringsregler from './Sider/FiltreringFødselshendelser/Filtreringsregler';
 import RegistrerInstitusjon from './Sider/RegistrerInstitusjon/RegistrerInstitusjon';
-import { RegistrerSøknad } from './Sider/RegistrerSøknad/RegistrerSøknad';
-import { SøknadProvider } from './Sider/RegistrerSøknad/SøknadContext';
 import Simulering from './Sider/Simulering/Simulering';
 import { SimuleringProvider } from './Sider/Simulering/SimuleringContext';
 import { Vedtak } from './Sider/Vedtak/Vedtak';
@@ -20,11 +19,7 @@ export const behandlingRoutes: RouteObject[] = [
     },
     {
         path: 'registrer-soknad',
-        element: (
-            <SøknadProvider>
-                <RegistrerSøknad />
-            </SøknadProvider>
-        ),
+        element: <RegistrerSøknad />,
     },
     {
         path: 'filtreringsregler',

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/RegistrerSøknad.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/RegistrerSøknad.tsx
@@ -1,0 +1,33 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFeatureToggles } from '@hooks/useFeatureToggles';
+import { RegistrerSøknad as RegistrerSøknadGammel } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknad/RegistrerSøknad';
+import { SøknadProvider } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknad/SøknadContext';
+import { BekreftEndringModalProvider } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext';
+import { RegistrerSøknadForm } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm';
+import { SøknadRegistrert } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/SøknadRegistrert';
+import { Steg } from '@sider/Fagsak/Behandling/Sider/Steg';
+import { FeatureToggle } from '@typer/featureToggles';
+
+export function RegistrerSøknad() {
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+    const toggles = useFeatureToggles();
+
+    if (toggles[FeatureToggle.brukNyRegistrerSøknad]) {
+        return (
+            <BekreftEndringModalProvider>
+                <Steg tittel={'Registrer opplysninger fra søknaden'} maxWidth={'60rem'}>
+                    {behandling.søknadsgrunnlag && !erLesevisning && <SøknadRegistrert />}
+                    <RegistrerSøknadForm />
+                </Steg>
+            </BekreftEndringModalProvider>
+        );
+    }
+
+    return (
+        <SøknadProvider>
+            <RegistrerSøknadGammel />
+        </SøknadProvider>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/SøknadRegistrert.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/SøknadRegistrert.tsx
@@ -1,0 +1,16 @@
+import { Box, LocalAlert } from '@navikt/ds-react';
+
+export function SøknadRegistrert() {
+    return (
+        <Box marginBlock={'space-28 space-12'}>
+            <LocalAlert status={'warning'}>
+                <LocalAlert.Header>
+                    <LocalAlert.Title>Søknad registrert</LocalAlert.Title>
+                </LocalAlert.Header>
+                <LocalAlert.Content>
+                    En søknad er allerede registrert på behandlingen. Vi har fylt ut søknaden i skjemaet.
+                </LocalAlert.Content>
+            </LocalAlert>
+        </Box>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BarnaFieldArrayContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BarnaFieldArrayContext.tsx
@@ -18,7 +18,7 @@ export interface BarnaFieldArray {
     slettBarn: (index: number) => void;
 }
 
-const BarnaFieldArrayContext = createContext<BarnaFieldArray | null>(null);
+const BarnaFieldArrayContext = createContext<BarnaFieldArray | undefined>(undefined);
 
 interface Props {
     control: Control<RegistrerSøknadFormValues, unknown, TransformedRegistrerSøknadFormValues>;
@@ -64,7 +64,7 @@ export function BarnaFieldArrayProvider({ control, children }: Props) {
 
 export function useBarnaFieldArray() {
     const barnaFieldArray = useContext(BarnaFieldArrayContext);
-    if (barnaFieldArray === null) {
+    if (barnaFieldArray === undefined) {
         throw new Error('useBarnaFieldArray må brukes innenfor en BarnaFieldArrayProvider');
     }
     return barnaFieldArray;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BarnaFieldArrayContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BarnaFieldArrayContext.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { useFagsak } from '@hooks/useFagsak';
+import {
+    RegistrerSøknadFormField,
+    type RegistrerSøknadFormValues,
+    type TransformedRegistrerSøknadFormValues,
+} from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { hentBarnMedLøpendeUtbetaling } from '@utils/fagsak';
+import { type Control, useFieldArray, useWatch } from 'react-hook-form';
+
+export type BarnField = IBarnMedOpplysninger & { id: string };
+
+export interface BarnaFieldArray {
+    fields: BarnField[];
+    leggTilBarn: (barn: IBarnMedOpplysninger) => void;
+    slettBarn: (index: number) => void;
+}
+
+const BarnaFieldArrayContext = createContext<BarnaFieldArray | null>(null);
+
+interface Props {
+    control: Control<RegistrerSøknadFormValues, unknown, TransformedRegistrerSøknadFormValues>;
+    children: React.ReactNode | ((barnaFieldArray: BarnaFieldArray) => React.ReactNode);
+}
+
+export function BarnaFieldArrayProvider({ control, children }: Props) {
+    const fagsak = useFagsak();
+
+    const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
+
+    const { fields, append, remove } = useFieldArray({
+        control,
+        name: RegistrerSøknadFormField.BARN,
+        rules: {
+            validate: barn => {
+                const merketBarn = barn.filter(b => b.merket);
+                if (merketBarn.length === 0 && barnMedLøpendeUtbetaling.size === 0) {
+                    return 'Minst et barn er påkrevd.';
+                }
+                return true;
+            },
+        },
+    });
+
+    const watchedBarn = useWatch({ control, name: RegistrerSøknadFormField.BARN });
+
+    const value = useMemo<BarnaFieldArray>(
+        () => ({
+            fields: fields.map((field, index) => ({ ...field, ...watchedBarn?.[index] })),
+            leggTilBarn: barn => append(barn, { shouldFocus: false }),
+            slettBarn: remove,
+        }),
+        [fields, watchedBarn, append, remove]
+    );
+
+    return (
+        <BarnaFieldArrayContext.Provider value={value}>
+            {typeof children === 'function' ? children(value) : children}
+        </BarnaFieldArrayContext.Provider>
+    );
+}
+
+export function useBarnaFieldArray() {
+    const barnaFieldArray = useContext(BarnaFieldArrayContext);
+    if (barnaFieldArray === null) {
+        throw new Error('useBarnaFieldArray må brukes innenfor en BarnaFieldArrayProvider');
+    }
+    return barnaFieldArray;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal.module.css
@@ -1,0 +1,3 @@
+.innhold {
+    white-space: pre-wrap;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react';
-
 import { useBekreftEndringModalContext } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext';
-import type {
-    RegistrerSøknadFormValues,
-    TransformedRegistrerSøknadFormValues,
+import {
+    type RegistrerSøknadFormValues,
+    type TransformedRegistrerSøknadFormValues,
 } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
 import { useFormContext } from 'react-hook-form';
 
@@ -16,32 +14,29 @@ interface Props {
 }
 
 export function BekreftEndringModal({ onSubmit }: Props) {
-    const { erBekreftEndringModalÅpen, lukkBekreftEndringModal } = useBekreftEndringModalContext();
+    const {
+        erBekreftEndringModalÅpen,
+        bekreftEndringFeilmelding,
+        settBekreftEndringFeilmelding,
+        lukkBekreftEndringModal,
+    } = useBekreftEndringModalContext();
 
     const {
         handleSubmit,
-        setError,
-        clearErrors,
-        formState: { isSubmitting, errors },
+        formState: { isSubmitting },
     } = useFormContext<RegistrerSøknadFormValues, unknown, TransformedRegistrerSøknadFormValues>();
-
-    const [lokalFeilmelding, settLokalFeilmelding] = useState<string | undefined>(undefined);
 
     async function bekreft() {
         try {
-            settLokalFeilmelding(errors.root?.message);
             await handleSubmit(data => onSubmit(data, 'bekreftet'))();
-            settLokalFeilmelding(undefined);
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : 'En ukjent feil oppstod.';
-            setError('root', { message });
-            settLokalFeilmelding(message);
+            settBekreftEndringFeilmelding(message);
         }
     }
 
     function avbryt() {
         lukkBekreftEndringModal();
-        clearErrors('root');
     }
 
     return (
@@ -52,7 +47,7 @@ export function BekreftEndringModal({ onSubmit }: Props) {
             width={'35rem'}
         >
             <Modal.Body>
-                <BodyShort className={Styles.innhold}>{lokalFeilmelding || errors.root?.message}</BodyShort>
+                <BodyShort className={Styles.innhold}>{bekreftEndringFeilmelding}</BodyShort>
             </Modal.Body>
             <Modal.Footer>
                 <Button type={'button'} variant={'primary'} onClick={bekreft} loading={isSubmitting}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+import { useBekreftEndringModalContext } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext';
+import type {
+    RegistrerSøknadFormValues,
+    TransformedRegistrerSøknadFormValues,
+} from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { useFormContext } from 'react-hook-form';
+
+import { BodyShort, Button, Modal } from '@navikt/ds-react';
+
+import Styles from './BekreftEndringModal.module.css';
+
+interface Props {
+    onSubmit: (values: TransformedRegistrerSøknadFormValues, modus: 'ubekreftet' | 'bekreftet') => Promise<void>;
+}
+
+export function BekreftEndringModal({ onSubmit }: Props) {
+    const { erBekreftEndringModalÅpen, lukkBekreftEndringModal } = useBekreftEndringModalContext();
+
+    const {
+        handleSubmit,
+        setError,
+        clearErrors,
+        formState: { isSubmitting, errors },
+    } = useFormContext<RegistrerSøknadFormValues, unknown, TransformedRegistrerSøknadFormValues>();
+
+    const [lokalFeilmelding, settLokalFeilmelding] = useState<string | undefined>(undefined);
+
+    async function bekreft() {
+        try {
+            settLokalFeilmelding(errors.root?.message);
+            await handleSubmit(data => onSubmit(data, 'bekreftet'))();
+            settLokalFeilmelding(undefined);
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : 'En ukjent feil oppstod.';
+            setError('root', { message });
+            settLokalFeilmelding(message);
+        }
+    }
+
+    function avbryt() {
+        lukkBekreftEndringModal();
+        clearErrors('root');
+    }
+
+    return (
+        <Modal
+            open={erBekreftEndringModalÅpen}
+            onClose={avbryt}
+            header={{ heading: 'Er du sikker på at du vil gå videre?' }}
+            width={'35rem'}
+        >
+            <Modal.Body>
+                <BodyShort className={Styles.innhold}>{lokalFeilmelding || errors.root?.message}</BodyShort>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button type={'button'} variant={'primary'} onClick={bekreft} loading={isSubmitting}>
+                    Ja
+                </Button>
+                <Button type={'button'} variant={'secondary'} onClick={avbryt} disabled={isSubmitting}>
+                    Nei
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext.tsx
@@ -40,7 +40,7 @@ export function BekreftEndringModalProvider({ children }: Props) {
 export function useBekreftEndringModalContext() {
     const context = useContext(Context);
     if (context === undefined) {
-        throw new Error('useBekreftEndringModalContext må brukes innenfor en BekreftModalProvider.');
+        throw new Error('useBekreftEndringModalContext må brukes innenfor en BekreftEndringModalProvider.');
     }
     return context;
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext.tsx
@@ -2,7 +2,9 @@ import { type ReactNode, useCallback, useMemo, useState, createContext, useConte
 
 interface BekreftEndringModalContext {
     erBekreftEndringModalÅpen: boolean;
-    åpneBekreftEndringModal: () => void;
+    bekreftEndringFeilmelding: string | undefined;
+    settBekreftEndringFeilmelding: (feilmelding: string) => void;
+    åpneBekreftEndringModal: (feilmelding: string) => void;
     lukkBekreftEndringModal: () => void;
 }
 
@@ -14,22 +16,33 @@ interface Props {
 
 export function BekreftEndringModalProvider({ children }: Props) {
     const [erBekreftEndringModalÅpen, settErBekreftEndringModalÅpen] = useState(false);
+    const [bekreftEndringFeilmelding, settBekreftEndringFeilmelding] = useState<string | undefined>(undefined);
 
-    const åpneBekreftEndringModal = useCallback(() => {
+    const åpneBekreftEndringModal = useCallback((feilmelding: string) => {
+        settBekreftEndringFeilmelding(feilmelding);
         settErBekreftEndringModalÅpen(true);
     }, []);
 
     const lukkBekreftEndringModal = useCallback(() => {
         settErBekreftEndringModalÅpen(false);
+        settBekreftEndringFeilmelding(undefined);
     }, []);
 
     const value = useMemo(
         () => ({
             erBekreftEndringModalÅpen,
+            bekreftEndringFeilmelding,
+            settBekreftEndringFeilmelding,
             åpneBekreftEndringModal,
             lukkBekreftEndringModal,
         }),
-        [erBekreftEndringModalÅpen, åpneBekreftEndringModal, lukkBekreftEndringModal]
+        [
+            erBekreftEndringModalÅpen,
+            bekreftEndringFeilmelding,
+            settBekreftEndringFeilmelding,
+            åpneBekreftEndringModal,
+            lukkBekreftEndringModal,
+        ]
     );
 
     return (

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext.tsx
@@ -1,0 +1,46 @@
+import { type ReactNode, useCallback, useMemo, useState, createContext, useContext } from 'react';
+
+interface BekreftEndringModalContext {
+    erBekreftEndringModalÅpen: boolean;
+    åpneBekreftEndringModal: () => void;
+    lukkBekreftEndringModal: () => void;
+}
+
+const Context = createContext<BekreftEndringModalContext | undefined>(undefined);
+
+interface Props {
+    children: ReactNode | ((context: BekreftEndringModalContext) => ReactNode);
+}
+
+export function BekreftEndringModalProvider({ children }: Props) {
+    const [erBekreftEndringModalÅpen, settErBekreftEndringModalÅpen] = useState(false);
+
+    const åpneBekreftEndringModal = useCallback(() => {
+        settErBekreftEndringModalÅpen(true);
+    }, []);
+
+    const lukkBekreftEndringModal = useCallback(() => {
+        settErBekreftEndringModalÅpen(false);
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            erBekreftEndringModalÅpen,
+            åpneBekreftEndringModal,
+            lukkBekreftEndringModal,
+        }),
+        [erBekreftEndringModalÅpen, åpneBekreftEndringModal, lukkBekreftEndringModal]
+    );
+
+    return (
+        <Context.Provider value={value}>{typeof children === 'function' ? children(value) : children}</Context.Provider>
+    );
+}
+
+export function useBekreftEndringModalContext() {
+    const context = useContext(Context);
+    if (context === undefined) {
+        throw new Error('useBekreftEndringModalContext må brukes innenfor en BekreftModalProvider.');
+    }
+    return context;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag.tsx
@@ -3,14 +3,21 @@ import { useFormState } from 'react-hook-form';
 
 import { Box, ErrorSummary } from '@navikt/ds-react';
 
-function hentFeilmelding(feil: unknown): string | undefined {
+interface Feil {
+    name: string;
+    message: string;
+}
+
+function flatUtFeil(feil: unknown, sti: string): Feil[] {
     if (!feil || typeof feil !== 'object') {
-        return undefined;
+        return [];
     }
-    if ('message' in feil && typeof feil.message === 'string') {
-        return feil.message;
+    if ('message' in feil && typeof feil.message === 'string' && feil.message.length > 0) {
+        return [{ name: sti, message: feil.message }];
     }
-    return undefined;
+    return Object.entries(feil)
+        .filter(([nøkkel]) => nøkkel !== 'ref' && nøkkel !== 'types')
+        .flatMap(([nøkkel, verdi]) => flatUtFeil(verdi, nøkkel === 'root' ? sti : `${sti}.${nøkkel}`));
 }
 
 export function Feilsammendrag() {
@@ -18,10 +25,7 @@ export function Feilsammendrag() {
 
     const feil = Object.entries(errors)
         .filter(([name]) => name !== 'root')
-        .flatMap(([name, error]) => {
-            const message = hentFeilmelding(error);
-            return message ? [{ name, message }] : [];
-        });
+        .flatMap(([navn, feil]) => flatUtFeil(feil, navn));
 
     if (feil.length === 0) {
         return null;

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag.tsx
@@ -1,0 +1,44 @@
+import type { RegistrerSøknadFormValues } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { useFormState } from 'react-hook-form';
+
+import { Box, ErrorSummary } from '@navikt/ds-react';
+
+function hentFeilmelding(feil: unknown): string | undefined {
+    if (!feil || typeof feil !== 'object') {
+        return undefined;
+    }
+    if ('message' in feil && typeof feil.message === 'string') {
+        return feil.message;
+    }
+    if ('root' in feil) {
+        return hentFeilmelding(feil.root);
+    }
+    return undefined;
+}
+
+export function Feilsammendrag() {
+    const { errors } = useFormState<RegistrerSøknadFormValues>();
+
+    const feil = Object.entries(errors)
+        .filter(([name]) => name !== 'root')
+        .flatMap(([name, error]) => {
+            const message = hentFeilmelding(error);
+            return message ? [{ name, message }] : [];
+        });
+
+    if (feil.length === 0) {
+        return null;
+    }
+
+    return (
+        <Box marginBlock={'space-0 space-20'} maxWidth={'50rem'}>
+            <ErrorSummary heading={'For å gå videre må du rette opp følgende feil:'} size={'small'}>
+                {feil.map(({ name, message }) => (
+                    <ErrorSummary.Item key={name} href={`#${name}`}>
+                        {message}
+                    </ErrorSummary.Item>
+                ))}
+            </ErrorSummary>
+        </Box>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag.tsx
@@ -10,9 +10,6 @@ function hentFeilmelding(feil: unknown): string | undefined {
     if ('message' in feil && typeof feil.message === 'string') {
         return feil.message;
     }
-    if ('root' in feil) {
-        return hentFeilmelding(feil.root);
-    }
     return undefined;
 }
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/LeggTilBarnKnapp.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/LeggTilBarnKnapp.tsx
@@ -1,0 +1,16 @@
+import { useLeggTilBarnModalContext } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
+
+import { PlusCircleIcon } from '@navikt/aksel-icons';
+import { Button } from '@navikt/ds-react';
+
+export function LeggTilBarnKnapp() {
+    const { åpneModal } = useLeggTilBarnModalContext();
+
+    return (
+        <div>
+            <Button type={'button'} variant={'tertiary'} size={'medium'} onClick={åpneModal} icon={<PlusCircleIcon />}>
+                Legg til barn
+            </Button>
+        </div>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.module.css
@@ -1,0 +1,3 @@
+.rootError {
+    white-space: pre-wrap;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.module.css
@@ -1,3 +1,0 @@
-.rootError {
-    white-space: pre-wrap;
-}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.tsx
@@ -22,7 +22,6 @@ import { useNavigate } from 'react-router';
 import { Button, Fieldset, VStack } from '@navikt/ds-react';
 
 import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
-import Styles from './RegistrerSøknadForm.module.css';
 
 export function RegistrerSøknadForm() {
     const navigate = useNavigate();
@@ -62,8 +61,6 @@ export function RegistrerSøknadForm() {
         return handleSubmit(data => onSubmit(data, 'ubekreftet'))(event);
     }
 
-    const rootError = errors.root ? <span className={Styles.rootError}>{errors.root?.message}</span> : undefined;
-
     return (
         <BarnaFieldArrayProvider control={control}>
             {({ leggTilBarn }) => (
@@ -77,7 +74,12 @@ export function RegistrerSøknadForm() {
                         <form id={id} onSubmit={submitEllerNaviger}>
                             {erBekreftEndringModalÅpen && <BekreftEndringModal onSubmit={onSubmit} />}
                             <VStack gap={'space-20'}>
-                                <Fieldset error={rootError} legend={'Registrer søknad'} hideLegend={true}>
+                                <Fieldset
+                                    error={errors.root?.message}
+                                    legend={'Registrer søknad'}
+                                    hideLegend={true}
+                                    errorPropagation={false}
+                                >
                                     <VStack gap={'space-20'} marginBlock={'space-20'}>
                                         {!gjelderInstitusjon && <UnderkategoriField />}
                                         <VStack gap={'space-0'}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.tsx
@@ -1,0 +1,95 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import { LeggTilBarnModal } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
+import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
+import { BekreftEndringModal } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal';
+import { useBekreftEndringModalContext } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext';
+import { Feilsammendrag } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag';
+import { BarnaField } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnaField';
+import { BegrunnelseField } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BegrunnelseField';
+import { MålformField } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/MålformField';
+import { UnderkategoriField } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/UnderkategoriField';
+import {
+    RegistrerSøknadFormField,
+    useRegistrerSøknadForm,
+} from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
+import { FormProvider } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+
+import { Button, Fieldset, VStack } from '@navikt/ds-react';
+
+import { LeggTilBarnKnapp } from './LeggTilBarnKnapp';
+import Styles from './RegistrerSøknadForm.module.css';
+
+export function RegistrerSøknadForm() {
+    const navigate = useNavigate();
+    const fagsak = useFagsak();
+    const behandling = useBehandling();
+    const erLesevisning = useErLesevisning();
+
+    const { erBekreftEndringModalÅpen } = useBekreftEndringModalContext();
+
+    const form = useRegistrerSøknadForm();
+
+    const {
+        id,
+        handleSubmit,
+        formState: { isSubmitting, errors },
+        watch,
+        fields,
+        actions: { onSubmit, leggTilBarn, slettBarn },
+    } = form;
+
+    const barn = watch(RegistrerSøknadFormField.BARN);
+
+    const gjelderInstitusjon = erFagsakAvTypeInstitusjon(fagsak);
+    const gjelderEnsligMindreårig = erFagsakAvTypeEnsligMindreårig(fagsak);
+    const gjelderSkjermetBarn = erFagsakAvTypeSkjermetBarn(fagsak);
+    const harBrevmottaker = behandling.brevmottakere.length > 0;
+
+    const erMuligÅLeggeTilBarn =
+        !erLesevisning && !gjelderInstitusjon && !gjelderEnsligMindreårig && !gjelderSkjermetBarn;
+
+    function submitEllerNaviger(event: React.FormEvent<HTMLFormElement>) {
+        if (erLesevisning) {
+            event.preventDefault();
+            navigate(`/fagsak/${fagsak.id}/${behandling.behandlingId}/vilkaarsvurdering`);
+            return;
+        }
+        return handleSubmit(data => onSubmit(data, 'ubekreftet'))(event);
+    }
+
+    const rootError = errors.root ? <span className={Styles.rootError}>{errors.root?.message}</span> : undefined;
+
+    return (
+        <LeggTilBarnModalContextProvider barn={barn} onLeggTilBarn={leggTilBarn} harBrevmottaker={harBrevmottaker}>
+            {erMuligÅLeggeTilBarn && <LeggTilBarnModal />}
+            <FormProvider {...form}>
+                <form id={id} onSubmit={submitEllerNaviger}>
+                    {erBekreftEndringModalÅpen && <BekreftEndringModal onSubmit={onSubmit} />}
+                    <VStack gap={'space-20'}>
+                        <Fieldset error={rootError} legend={'Registrer søknad'} hideLegend={true}>
+                            <VStack gap={'space-20'} marginBlock={'space-20'}>
+                                {!gjelderInstitusjon && <UnderkategoriField />}
+                                <VStack gap={'space-0'}>
+                                    <BarnaField fields={fields[RegistrerSøknadFormField.BARN]} slettBarn={slettBarn} />
+                                    {erMuligÅLeggeTilBarn && <LeggTilBarnKnapp />}
+                                </VStack>
+                                <MålformField />
+                                <BegrunnelseField />
+                            </VStack>
+                        </Fieldset>
+                        <Feilsammendrag />
+                        <div>
+                            <Button form={id} type={'submit'} variant={'primary'} loading={isSubmitting}>
+                                {erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
+                            </Button>
+                        </div>
+                    </VStack>
+                </form>
+            </FormProvider>
+        </LeggTilBarnModalContextProvider>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/RegistrerSøknadForm.tsx
@@ -3,6 +3,7 @@ import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
 import { LeggTilBarnModal } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModal';
 import { LeggTilBarnModalContextProvider } from '@komponenter/Modal/LeggTilBarn/LeggTilBarnModalContext';
+import { BarnaFieldArrayProvider } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BarnaFieldArrayContext';
 import { BekreftEndringModal } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModal';
 import { useBekreftEndringModalContext } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext';
 import { Feilsammendrag } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/Feilsammendrag';
@@ -35,11 +36,11 @@ export function RegistrerSøknadForm() {
 
     const {
         id,
+        control,
         handleSubmit,
         formState: { isSubmitting, errors },
         watch,
-        fields,
-        actions: { onSubmit, leggTilBarn, slettBarn },
+        onSubmit,
     } = form;
 
     const barn = watch(RegistrerSøknadFormField.BARN);
@@ -64,32 +65,40 @@ export function RegistrerSøknadForm() {
     const rootError = errors.root ? <span className={Styles.rootError}>{errors.root?.message}</span> : undefined;
 
     return (
-        <LeggTilBarnModalContextProvider barn={barn} onLeggTilBarn={leggTilBarn} harBrevmottaker={harBrevmottaker}>
-            {erMuligÅLeggeTilBarn && <LeggTilBarnModal />}
-            <FormProvider {...form}>
-                <form id={id} onSubmit={submitEllerNaviger}>
-                    {erBekreftEndringModalÅpen && <BekreftEndringModal onSubmit={onSubmit} />}
-                    <VStack gap={'space-20'}>
-                        <Fieldset error={rootError} legend={'Registrer søknad'} hideLegend={true}>
-                            <VStack gap={'space-20'} marginBlock={'space-20'}>
-                                {!gjelderInstitusjon && <UnderkategoriField />}
-                                <VStack gap={'space-0'}>
-                                    <BarnaField fields={fields[RegistrerSøknadFormField.BARN]} slettBarn={slettBarn} />
-                                    {erMuligÅLeggeTilBarn && <LeggTilBarnKnapp />}
-                                </VStack>
-                                <MålformField />
-                                <BegrunnelseField />
+        <BarnaFieldArrayProvider control={control}>
+            {({ leggTilBarn }) => (
+                <LeggTilBarnModalContextProvider
+                    barn={barn}
+                    onLeggTilBarn={leggTilBarn}
+                    harBrevmottaker={harBrevmottaker}
+                >
+                    {erMuligÅLeggeTilBarn && <LeggTilBarnModal />}
+                    <FormProvider {...form}>
+                        <form id={id} onSubmit={submitEllerNaviger}>
+                            {erBekreftEndringModalÅpen && <BekreftEndringModal onSubmit={onSubmit} />}
+                            <VStack gap={'space-20'}>
+                                <Fieldset error={rootError} legend={'Registrer søknad'} hideLegend={true}>
+                                    <VStack gap={'space-20'} marginBlock={'space-20'}>
+                                        {!gjelderInstitusjon && <UnderkategoriField />}
+                                        <VStack gap={'space-0'}>
+                                            <BarnaField />
+                                            {erMuligÅLeggeTilBarn && <LeggTilBarnKnapp />}
+                                        </VStack>
+                                        <MålformField />
+                                        <BegrunnelseField />
+                                    </VStack>
+                                </Fieldset>
+                                <Feilsammendrag />
+                                <div>
+                                    <Button form={id} type={'submit'} variant={'primary'} loading={isSubmitting}>
+                                        {erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
+                                    </Button>
+                                </div>
                             </VStack>
-                        </Fieldset>
-                        <Feilsammendrag />
-                        <div>
-                            <Button form={id} type={'submit'} variant={'primary'} loading={isSubmitting}>
-                                {erLesevisning ? 'Neste' : 'Bekreft og fortsett'}
-                            </Button>
-                        </div>
-                    </VStack>
-                </form>
-            </FormProvider>
-        </LeggTilBarnModalContextProvider>
+                        </form>
+                    </FormProvider>
+                </LeggTilBarnModalContextProvider>
+            )}
+        </BarnaFieldArrayProvider>
     );
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
+import { useBarnaFieldArray } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BarnaFieldArrayContext';
 import type { RegistrerSøknadFormValues } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
 import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
 import type { IBarnMedOpplysninger } from '@typer/søknad';
@@ -13,14 +14,15 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { BodyLong, BodyShort, Box, Button, Checkbox, Dialog, HStack } from '@navikt/ds-react';
 
 interface Props {
+    index: number;
     barn: IBarnMedOpplysninger & { id: string };
-    slettBarn: () => void;
 }
 
-export function BarnCheckbox({ barn, slettBarn }: Props) {
+export function BarnCheckbox({ index, barn }: Props) {
     const erLesevisning = useErLesevisning();
     const fagsak = useFagsak();
 
+    const { slettBarn } = useBarnaFieldArray();
     const { isSubmitting } = useFormState<RegistrerSøknadFormValues>();
 
     const [visBekreftSlettBarnModal, settVisBekreftSlettBarnModal] = useState(false);
@@ -57,7 +59,7 @@ export function BarnCheckbox({ barn, slettBarn }: Props) {
                         variant={'tertiary'}
                         size={'small'}
                         onClick={() => settVisBekreftSlettBarnModal(true)}
-                        icon={<TrashIcon />}
+                        icon={<TrashIcon fontSize={'1.3rem'} />}
                         disabled={isSubmitting}
                     >
                         Fjern barn
@@ -86,7 +88,7 @@ export function BarnCheckbox({ barn, slettBarn }: Props) {
                                         variant={'danger'}
                                         size={'medium'}
                                         icon={<TrashIcon />}
-                                        onClick={() => slettBarn()}
+                                        onClick={() => slettBarn(index)}
                                         disabled={isSubmitting}
                                     >
                                         Fjern

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import type { RegistrerSøknadFormValues } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { hentBarnMedLøpendeUtbetaling } from '@utils/fagsak';
+import { formaterIdent, hentAlderSomString } from '@utils/formatter';
+import { useFormState } from 'react-hook-form';
+
+import { TrashIcon } from '@navikt/aksel-icons';
+import { BodyLong, BodyShort, Box, Button, Checkbox, Dialog, HStack } from '@navikt/ds-react';
+
+interface Props {
+    barn: IBarnMedOpplysninger & { id: string };
+    slettBarn: () => void;
+}
+
+export function BarnCheckbox({ barn, slettBarn }: Props) {
+    const erLesevisning = useErLesevisning();
+    const fagsak = useFagsak();
+
+    const { isSubmitting } = useFormState<RegistrerSøknadFormValues>();
+
+    const [visBekreftSlettBarnModal, settVisBekreftSlettBarnModal] = useState(false);
+
+    const gjelderInstitusjon = erFagsakAvTypeInstitusjon(fagsak);
+    const gjelderEnsligMindreårig = erFagsakAvTypeEnsligMindreårig(fagsak);
+    const gjelderSkjermetBarn = erFagsakAvTypeSkjermetBarn(fagsak);
+
+    const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
+    const barnetHarLøpendeUtbetaling = barnMedLøpendeUtbetaling.has(barn.ident);
+
+    const navn = barn.navn ?? 'Navn ukjent';
+    const alder = hentAlderSomString(barn.fødselsdato);
+    const ident = formaterIdent(barn.ident);
+    const løpende = barnetHarLøpendeUtbetaling ? '(løpende)' : '';
+    const manueltRegistrert = barn.manueltRegistrert ? '| (manuelt registrert)' : '';
+    const navnOgIdentTekst = `${navn} (${alder}) | ${ident} ${løpende} ${manueltRegistrert}`;
+
+    const kanSletteBarn = barn.manueltRegistrert && !erLesevisning;
+
+    if (gjelderInstitusjon || gjelderEnsligMindreårig || gjelderSkjermetBarn) {
+        return <BodyShort title={navnOgIdentTekst}>{navnOgIdentTekst}</BodyShort>;
+    }
+
+    return (
+        <HStack gap={'space-16'}>
+            <Checkbox readOnly={erLesevisning} value={barn.id}>
+                {navnOgIdentTekst}
+            </Checkbox>
+            {kanSletteBarn && (
+                <>
+                    <Button
+                        type={'button'}
+                        variant={'tertiary'}
+                        size={'small'}
+                        onClick={() => settVisBekreftSlettBarnModal(true)}
+                        icon={<TrashIcon />}
+                        disabled={isSubmitting}
+                    >
+                        Fjern barn
+                    </Button>
+                    <Dialog open={visBekreftSlettBarnModal} onOpenChange={settVisBekreftSlettBarnModal}>
+                        <Dialog.Popup role={'alertdialog'} closeOnOutsideClick={false} position={'center'}>
+                            <Dialog.Header withClosebutton={false}>
+                                <Dialog.Title>Bekreft fjerning av barn</Dialog.Title>
+                            </Dialog.Header>
+                            <Dialog.Body>
+                                <Box paddingBlock={'space-12'}>
+                                    <BodyLong>
+                                        Er du sikker på at du vil fjerne {barn.navn} ({alder})? Denne handlingen kan
+                                        ikke angres.
+                                    </BodyLong>
+                                </Box>
+                            </Dialog.Body>
+                            <Dialog.Footer>
+                                <Dialog.CloseTrigger>
+                                    <Button variant={'secondary'} size={'medium'}>
+                                        Avbryt
+                                    </Button>
+                                </Dialog.CloseTrigger>
+                                <Dialog.CloseTrigger>
+                                    <Button
+                                        variant={'danger'}
+                                        size={'medium'}
+                                        icon={<TrashIcon />}
+                                        onClick={() => slettBarn()}
+                                        disabled={isSubmitting}
+                                    >
+                                        Fjern
+                                    </Button>
+                                </Dialog.CloseTrigger>
+                            </Dialog.Footer>
+                        </Dialog.Popup>
+                    </Dialog>
+                </>
+            )}
+        </HStack>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox.tsx
@@ -37,9 +37,12 @@ export function BarnCheckbox({ index, barn }: Props) {
     const navn = barn.navn ?? 'Navn ukjent';
     const alder = hentAlderSomString(barn.fødselsdato);
     const ident = formaterIdent(barn.ident);
-    const løpende = barnetHarLøpendeUtbetaling ? '(løpende)' : '';
-    const manueltRegistrert = barn.manueltRegistrert ? '| (manuelt registrert)' : '';
-    const navnOgIdentTekst = `${navn} (${alder}) | ${ident} ${løpende} ${manueltRegistrert}`;
+    const løpende = barnetHarLøpendeUtbetaling ? 'løpende' : undefined;
+    const manueltRegistrert = barn.manueltRegistrert ? 'manuelt registrert' : undefined;
+
+    const navnOgIdentTekst = [`${navn} (${alder})`, ident, løpende, manueltRegistrert]
+        .filter(value => value !== undefined)
+        .join(' | ');
 
     const kanSletteBarn = barn.manueltRegistrert && !erLesevisning;
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnaField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnaField.tsx
@@ -23,6 +23,7 @@ export function BarnaField() {
 
     const {
         setValue,
+        clearErrors,
         formState: { errors, isSubmitting },
     } = useFormContext<RegistrerSøknadFormValues>();
 
@@ -47,6 +48,7 @@ export function BarnaField() {
                 });
             }
         });
+        clearErrors(RegistrerSøknadFormField.BARN);
     }
 
     const description =

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnaField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnaField.tsx
@@ -2,6 +2,7 @@ import { useBruker } from '@hooks/useBruker';
 import { useErLesevisning } from '@hooks/useErLesevisning';
 import { useFagsak } from '@hooks/useFagsak';
 import StatusIkon, { Status } from '@ikoner/StatusIkon';
+import { useBarnaFieldArray } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BarnaFieldArrayContext';
 import { BarnCheckbox } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox';
 import { FieldLabel } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/FieldLabel';
 import {
@@ -10,30 +11,22 @@ import {
 } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
 import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
 import { adressebeskyttelsestyper, ForelderBarnRelasjonRolle } from '@typer/person';
-import { type FieldArrayWithId, useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import { InformationSquareIcon } from '@navikt/aksel-icons';
 import { BodyShort, CheckboxGroup, HStack, InfoCard, VStack } from '@navikt/ds-react';
 
-interface Props {
-    fields: FieldArrayWithId<RegistrerSøknadFormValues, RegistrerSøknadFormField.BARN>[];
-    slettBarn: (index: number) => void;
-}
-
-export function BarnaField({ fields, slettBarn }: Props) {
+export function BarnaField() {
     const fagsak = useFagsak();
     const bruker = useBruker();
     const erLesevisning = useErLesevisning();
 
     const {
-        control,
         setValue,
-        clearErrors,
         formState: { errors, isSubmitting },
     } = useFormContext<RegistrerSøknadFormValues>();
 
-    const watchedBarn = useWatch({ control, name: RegistrerSøknadFormField.BARN });
-    const barna = fields.map((field, index) => ({ ...field, ...watchedBarn?.[index] }));
+    const { fields } = useBarnaFieldArray();
 
     const gjelderInstitusjon = erFagsakAvTypeInstitusjon(fagsak);
     const gjelderEnsligMindreårig = erFagsakAvTypeEnsligMindreårig(fagsak);
@@ -44,16 +37,16 @@ export function BarnaField({ fields, slettBarn }: Props) {
     );
 
     function onBarnChecked(checkedIds: string[]) {
-        barna.forEach((barn, index) => {
+        fields.forEach((barn, index) => {
             const merket = checkedIds.includes(barn.id);
             if (merket !== barn.merket) {
                 setValue(`${RegistrerSøknadFormField.BARN}.${index}.merket`, merket as never, {
                     shouldDirty: true,
                     shouldTouch: true,
+                    shouldValidate: true,
                 });
             }
         });
-        clearErrors(RegistrerSøknadFormField.BARN);
     }
 
     const description =
@@ -76,15 +69,15 @@ export function BarnaField({ fields, slettBarn }: Props) {
                 id={RegistrerSøknadFormField.BARN}
                 legend={<FieldLabel label={'Opplysninger om barn'} />}
                 description={description}
-                value={barna.filter(barn => barn.merket).map(barn => barn.id)}
+                value={fields.filter(barn => barn.merket).map(barn => barn.id)}
                 onChange={onBarnChecked}
                 readOnly={erLesevisning || isSubmitting}
                 error={errors[RegistrerSøknadFormField.BARN]?.root?.message}
             >
-                {barna.map((barn, index) => (
-                    <BarnCheckbox key={barn.id} barn={barn} slettBarn={() => slettBarn(index)} />
+                {fields.map((barn, index) => (
+                    <BarnCheckbox key={barn.id} index={index} barn={barn} />
                 ))}
-                {barna.length === 0 && maskerteRelasjoner.length === 0 && (
+                {fields.length === 0 && maskerteRelasjoner.length === 0 && (
                     <VStack marginBlock={'space-0 space-20'}>
                         <InfoCard data-color={'info'}>
                             <InfoCard.Message icon={<InformationSquareIcon aria-hidden={true} />}>

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnaField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnaField.tsx
@@ -1,0 +1,99 @@
+import { useBruker } from '@hooks/useBruker';
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { useFagsak } from '@hooks/useFagsak';
+import StatusIkon, { Status } from '@ikoner/StatusIkon';
+import { BarnCheckbox } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BarnCheckbox';
+import { FieldLabel } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/FieldLabel';
+import {
+    RegistrerSøknadFormField,
+    type RegistrerSøknadFormValues,
+} from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
+import { adressebeskyttelsestyper, ForelderBarnRelasjonRolle } from '@typer/person';
+import { type FieldArrayWithId, useFormContext, useWatch } from 'react-hook-form';
+
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { BodyShort, CheckboxGroup, HStack, InfoCard, VStack } from '@navikt/ds-react';
+
+interface Props {
+    fields: FieldArrayWithId<RegistrerSøknadFormValues, RegistrerSøknadFormField.BARN>[];
+    slettBarn: (index: number) => void;
+}
+
+export function BarnaField({ fields, slettBarn }: Props) {
+    const fagsak = useFagsak();
+    const bruker = useBruker();
+    const erLesevisning = useErLesevisning();
+
+    const {
+        control,
+        setValue,
+        clearErrors,
+        formState: { errors, isSubmitting },
+    } = useFormContext<RegistrerSøknadFormValues>();
+
+    const watchedBarn = useWatch({ control, name: RegistrerSøknadFormField.BARN });
+    const barna = fields.map((field, index) => ({ ...field, ...watchedBarn?.[index] }));
+
+    const gjelderInstitusjon = erFagsakAvTypeInstitusjon(fagsak);
+    const gjelderEnsligMindreårig = erFagsakAvTypeEnsligMindreårig(fagsak);
+    const gjelderSkjermetBarn = erFagsakAvTypeSkjermetBarn(fagsak);
+
+    const maskerteRelasjoner = bruker.forelderBarnRelasjonMaskert.filter(
+        forelderBarnRelasjonMaskert => forelderBarnRelasjonMaskert.relasjonRolle === ForelderBarnRelasjonRolle.BARN
+    );
+
+    function onBarnChecked(checkedIds: string[]) {
+        barna.forEach((barn, index) => {
+            const merket = checkedIds.includes(barn.id);
+            if (merket !== barn.merket) {
+                setValue(`${RegistrerSøknadFormField.BARN}.${index}.merket`, merket as never, {
+                    shouldDirty: true,
+                    shouldTouch: true,
+                });
+            }
+        });
+        clearErrors(RegistrerSøknadFormField.BARN);
+    }
+
+    const description =
+        !erLesevisning && !gjelderInstitusjon && !gjelderEnsligMindreårig && !gjelderSkjermetBarn
+            ? 'Velg hvilke barn det er søkt om'
+            : 'Barn det er søkt om';
+
+    return (
+        <VStack marginBlock={'space-16'}>
+            {maskerteRelasjoner.map((relasjon, index) => {
+                const diskresjonskode = adressebeskyttelsestyper[relasjon.adressebeskyttelseGradering];
+                return (
+                    <HStack gap={'space-8'} margin={'space-8'} key={`${index}_${relasjon.relasjonRolle}`}>
+                        <StatusIkon status={Status.FEIL} />
+                        <BodyShort>{`Bruker har barn med diskresjonskode ${diskresjonskode ?? 'ukjent'}`}</BodyShort>
+                    </HStack>
+                );
+            })}
+            <CheckboxGroup
+                id={RegistrerSøknadFormField.BARN}
+                legend={<FieldLabel label={'Opplysninger om barn'} />}
+                description={description}
+                value={barna.filter(barn => barn.merket).map(barn => barn.id)}
+                onChange={onBarnChecked}
+                readOnly={erLesevisning || isSubmitting}
+                error={errors[RegistrerSøknadFormField.BARN]?.root?.message}
+            >
+                {barna.map((barn, index) => (
+                    <BarnCheckbox key={barn.id} barn={barn} slettBarn={() => slettBarn(index)} />
+                ))}
+                {barna.length === 0 && maskerteRelasjoner.length === 0 && (
+                    <VStack marginBlock={'space-0 space-20'}>
+                        <InfoCard data-color={'info'}>
+                            <InfoCard.Message icon={<InformationSquareIcon aria-hidden={true} />}>
+                                Folkeregisteret har ikke registrerte barn på denne søkeren
+                            </InfoCard.Message>
+                        </InfoCard>
+                    </VStack>
+                )}
+            </CheckboxGroup>
+        </VStack>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BegrunnelseField.module.css
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BegrunnelseField.module.css
@@ -1,0 +1,3 @@
+.felt {
+    max-width: 50rem;
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BegrunnelseField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/BegrunnelseField.tsx
@@ -1,0 +1,45 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { FieldLabel } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/FieldLabel';
+import {
+    RegistrerSøknadFormField,
+    type RegistrerSøknadFormValues,
+} from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Textarea } from '@navikt/ds-react';
+
+import Styles from './BegrunnelseField.module.css';
+
+export function BegrunnelseField() {
+    const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { name, value, onChange, onBlur },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFormField.BEGRUNNELSE,
+        control,
+        rules: {
+            maxLength: { value: 2000, message: 'Maks 2000 tegn.' },
+        },
+    });
+
+    return (
+        <Textarea
+            id={name}
+            name={name}
+            label={<FieldLabel label={'Annet'} />}
+            description={'Ved endring av opplysningene er begrunnelse obligatorisk'}
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            maxLength={2000}
+            error={error?.message}
+            readOnly={erLesevisning || isSubmitting}
+            className={Styles.felt}
+        />
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/FieldLabel.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/FieldLabel.tsx
@@ -1,0 +1,13 @@
+import { Heading } from '@navikt/ds-react';
+
+interface Props {
+    label: string;
+}
+
+export function FieldLabel({ label }: Props) {
+    return (
+        <Heading size={'medium'} align={'start'} level={'2'}>
+            {label}
+        </Heading>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/MålformField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/MålformField.tsx
@@ -1,0 +1,42 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { FieldLabel } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/FieldLabel';
+import {
+    RegistrerSøknadFormField,
+    type RegistrerSøknadFormValues,
+} from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { målform, Målform } from '@typer/søknad';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Radio, RadioGroup } from '@navikt/ds-react';
+
+export function MålformField() {
+    const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { name, value, onChange, onBlur },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFormField.MÅLFORM,
+        control,
+        rules: { required: 'Målform er påkrevd.' },
+    });
+
+    return (
+        <RadioGroup
+            id={name}
+            name={name}
+            legend={<FieldLabel label={'Målform'} />}
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            readOnly={erLesevisning || isSubmitting}
+            error={error?.message}
+        >
+            <Radio value={Målform.NB}>{målform[Målform.NB]}</Radio>
+            <Radio value={Målform.NN}>{målform[Målform.NN]}</Radio>
+        </RadioGroup>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/UnderkategoriField.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/UnderkategoriField.tsx
@@ -1,0 +1,46 @@
+import { useErLesevisning } from '@hooks/useErLesevisning';
+import { FieldLabel } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/field/FieldLabel';
+import {
+    RegistrerSøknadFormField,
+    type RegistrerSøknadFormValues,
+} from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm';
+import { behandlingUnderkategori, BehandlingUnderkategori } from '@typer/behandlingstema';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { Radio, RadioGroup } from '@navikt/ds-react';
+
+export function UnderkategoriField() {
+    const erLesevisning = useErLesevisning();
+
+    const { control } = useFormContext<RegistrerSøknadFormValues>();
+
+    const {
+        field: { name, value, onChange, onBlur },
+        fieldState: { error },
+        formState: { isSubmitting },
+    } = useController({
+        name: RegistrerSøknadFormField.UNDERKATEGORI,
+        control,
+        rules: { required: 'Kategori er påkrevd.' },
+    });
+
+    return (
+        <RadioGroup
+            id={name}
+            name={name}
+            legend={<FieldLabel label={'Hva har bruker søkt om?'} />}
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            readOnly={erLesevisning || isSubmitting}
+            error={error?.message}
+        >
+            <Radio value={BehandlingUnderkategori.ORDINÆR}>
+                {behandlingUnderkategori[BehandlingUnderkategori.ORDINÆR]}
+            </Radio>
+            <Radio value={BehandlingUnderkategori.UTVIDET}>
+                {behandlingUnderkategori[BehandlingUnderkategori.UTVIDET]}
+            </Radio>
+        </RadioGroup>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm.ts
@@ -1,0 +1,156 @@
+import { useId } from 'react';
+
+import { ApiFeil, RessursStatus } from '@api/client/apiClient';
+import { useConfirmBrowserRefresh } from '@hooks/useConfirmBrowserRefresh';
+import { useFagsak } from '@hooks/useFagsak';
+import { useOnFormSubmitSuccessful } from '@hooks/useOnFormSubmitSuccessful';
+import { useRegistrerSøknad } from '@hooks/useRegistrerSøknad';
+import { useBehandlingContext } from '@sider/Fagsak/Behandling/context/BehandlingContext';
+import { useBekreftEndringModalContext } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/BekreftEndringModalContext';
+import { useValgbareBarn } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useValgbareBarn';
+import type { BehandlingUnderkategori } from '@typer/behandlingstema';
+import type { IBarnMedOpplysninger, Målform } from '@typer/søknad';
+import { hentBarnMedLøpendeUtbetaling } from '@utils/fagsak';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+
+import { byggSuksessRessurs } from '@navikt/familie-typer';
+
+export enum RegistrerSøknadFormField {
+    UNDERKATEGORI = 'underkategori',
+    BARN = 'barn',
+    BEGRUNNELSE = 'begrunnelse',
+    MÅLFORM = 'målform',
+}
+
+export interface RegistrerSøknadFormValues {
+    [RegistrerSøknadFormField.UNDERKATEGORI]: BehandlingUnderkategori;
+    [RegistrerSøknadFormField.BARN]: IBarnMedOpplysninger[];
+    [RegistrerSøknadFormField.BEGRUNNELSE]: string;
+    [RegistrerSøknadFormField.MÅLFORM]: Målform | '';
+}
+
+export interface TransformedRegistrerSøknadFormValues {
+    [RegistrerSøknadFormField.UNDERKATEGORI]: BehandlingUnderkategori;
+    [RegistrerSøknadFormField.BARN]: IBarnMedOpplysninger[];
+    [RegistrerSøknadFormField.BEGRUNNELSE]: string;
+    [RegistrerSøknadFormField.MÅLFORM]: Målform;
+}
+
+export function useRegistrerSøknadForm() {
+    const id = useId();
+    const fagsak = useFagsak();
+    const navigate = useNavigate();
+
+    const { behandling, settÅpenBehandling } = useBehandlingContext();
+    const { åpneBekreftEndringModal, lukkBekreftEndringModal } = useBekreftEndringModalContext();
+
+    const { mutateAsync: registrerSøknad } = useRegistrerSøknad();
+
+    const søknadsgrunnlag = behandling.søknadsgrunnlag;
+
+    const valgbareBarn = useValgbareBarn();
+
+    const form = useForm<RegistrerSøknadFormValues, unknown, TransformedRegistrerSøknadFormValues>({
+        values: {
+            [RegistrerSøknadFormField.UNDERKATEGORI]: søknadsgrunnlag?.underkategori || behandling.underkategori,
+            [RegistrerSøknadFormField.BARN]: valgbareBarn,
+            [RegistrerSøknadFormField.BEGRUNNELSE]: søknadsgrunnlag?.endringAvOpplysningerBegrunnelse || '',
+            [RegistrerSøknadFormField.MÅLFORM]: søknadsgrunnlag?.søkerMedOpplysninger.målform || '',
+        },
+        resetOptions: {
+            keepErrors: true,
+            keepDirtyValues: true,
+            keepIsSubmitted: true,
+            keepTouched: true,
+            keepSubmitCount: true,
+        },
+    });
+
+    const {
+        control,
+        formState: { isDirty },
+        setError,
+        clearErrors,
+        reset,
+    } = form;
+
+    useConfirmBrowserRefresh({ enabled: isDirty });
+
+    useOnFormSubmitSuccessful(control, () => reset());
+
+    const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
+
+    const { fields, append, remove } = useFieldArray({
+        control: form.control,
+        name: RegistrerSøknadFormField.BARN,
+        rules: {
+            validate: barn => {
+                const merketBarn = barn.filter(b => b.merket);
+                if (merketBarn.length === 0 && barnMedLøpendeUtbetaling.size === 0) {
+                    return 'Minst et barn er påkrevd.';
+                }
+                return true;
+            },
+        },
+    });
+
+    function leggTilBarn(barn: IBarnMedOpplysninger) {
+        append(barn, { shouldFocus: false });
+        clearErrors(RegistrerSøknadFormField.BARN);
+    }
+
+    function slettBarn(index: number) {
+        remove(index);
+    }
+
+    async function onSubmit(
+        values: TransformedRegistrerSøknadFormValues,
+        modus: 'ubekreftet' | 'bekreftet' = 'ubekreftet'
+    ): Promise<void> {
+        const { underkategori, barn, målform, begrunnelse } = values;
+        try {
+            const oppdatertBehandling = await registrerSøknad({
+                behandlingId: behandling.behandlingId,
+                søknad: {
+                    underkategori: underkategori,
+                    søkerMedOpplysninger: {
+                        ident: fagsak.søkerFødselsnummer,
+                        målform: målform,
+                    },
+                    barnaMedOpplysninger: barn.map(barn => ({
+                        ...barn,
+                        inkludertISøknaden: barn.merket,
+                    })),
+                    endringAvOpplysningerBegrunnelse: begrunnelse,
+                    erAutomatiskRegistrert: false,
+                },
+                bekreftEndringerViaFrontend: modus === 'bekreftet',
+            });
+            settÅpenBehandling(byggSuksessRessurs(oppdatertBehandling));
+            navigate(`/fagsak/${fagsak.id}/${oppdatertBehandling.behandlingId}/vilkaarsvurdering`);
+            if (modus === 'bekreftet') {
+                lukkBekreftEndringModal();
+            }
+        } catch (error: unknown) {
+            if (error instanceof ApiFeil && error.ressursStatus === RessursStatus.FUNKSJONELL_FEIL) {
+                åpneBekreftEndringModal();
+            }
+            const message = error instanceof Error ? error.message : 'En ukjent feil oppstod.';
+            setError('root', { message });
+        }
+    }
+
+    return {
+        id,
+        ...form,
+        fields: {
+            [RegistrerSøknadFormField.BARN]: fields,
+        },
+        actions: {
+            onSubmit,
+            leggTilBarn,
+            slettBarn,
+        },
+    };
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm.ts
@@ -10,8 +10,7 @@ import { useBekreftEndringModalContext } from '@sider/Fagsak/Behandling/Sider/Re
 import { useValgbareBarn } from '@sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useValgbareBarn';
 import type { BehandlingUnderkategori } from '@typer/behandlingstema';
 import type { IBarnMedOpplysninger, Målform } from '@typer/søknad';
-import { hentBarnMedLøpendeUtbetaling } from '@utils/fagsak';
-import { useFieldArray, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
 import { byggSuksessRessurs } from '@navikt/familie-typer';
@@ -71,38 +70,12 @@ export function useRegistrerSøknadForm() {
         control,
         formState: { isDirty },
         setError,
-        clearErrors,
         reset,
     } = form;
 
     useConfirmBrowserRefresh({ enabled: isDirty });
 
     useOnFormSubmitSuccessful(control, () => reset());
-
-    const barnMedLøpendeUtbetaling = hentBarnMedLøpendeUtbetaling(fagsak);
-
-    const { fields, append, remove } = useFieldArray({
-        control: form.control,
-        name: RegistrerSøknadFormField.BARN,
-        rules: {
-            validate: barn => {
-                const merketBarn = barn.filter(b => b.merket);
-                if (merketBarn.length === 0 && barnMedLøpendeUtbetaling.size === 0) {
-                    return 'Minst et barn er påkrevd.';
-                }
-                return true;
-            },
-        },
-    });
-
-    function leggTilBarn(barn: IBarnMedOpplysninger) {
-        append(barn, { shouldFocus: false });
-        clearErrors(RegistrerSøknadFormField.BARN);
-    }
-
-    function slettBarn(index: number) {
-        remove(index);
-    }
 
     async function onSubmit(
         values: TransformedRegistrerSøknadFormValues,
@@ -144,13 +117,6 @@ export function useRegistrerSøknadForm() {
     return {
         id,
         ...form,
-        fields: {
-            [RegistrerSøknadFormField.BARN]: fields,
-        },
-        actions: {
-            onSubmit,
-            leggTilBarn,
-            slettBarn,
-        },
+        onSubmit,
     };
 }

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useRegistrerSøknadForm.ts
@@ -107,10 +107,12 @@ export function useRegistrerSøknadForm() {
             }
         } catch (error: unknown) {
             if (error instanceof ApiFeil && error.ressursStatus === RessursStatus.FUNKSJONELL_FEIL) {
-                åpneBekreftEndringModal();
+                const message = error instanceof Error ? error.message : 'En ukjent feil oppstod.';
+                åpneBekreftEndringModal(message);
+            } else {
+                const message = error instanceof Error ? error.message : 'En ukjent feil oppstod.';
+                setError('root', { message });
             }
-            const message = error instanceof Error ? error.message : 'En ukjent feil oppstod.';
-            setError('root', { message });
         }
     }
 

--- a/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useValgbareBarn.ts
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/RegistrerSøknadNy/form/useValgbareBarn.ts
@@ -1,0 +1,66 @@
+import { useBehandling } from '@hooks/useBehandling';
+import { useBruker } from '@hooks/useBruker';
+import { useFagsak } from '@hooks/useFagsak';
+import { erFagsakAvTypeEnsligMindreårig, erFagsakAvTypeInstitusjon, erFagsakAvTypeSkjermetBarn } from '@typer/fagsak';
+import { ForelderBarnRelasjonRolle } from '@typer/person';
+import type { IBarnMedOpplysninger } from '@typer/søknad';
+import { isoStringTilDate } from '@utils/dato';
+
+function sorterBarn(barn1: IBarnMedOpplysninger, barn2: IBarnMedOpplysninger) {
+    const barn1ManglerIdent = !barn1.ident;
+    const barn2ManglerIdent = !barn2.ident;
+
+    if (barn1ManglerIdent && barn2ManglerIdent) return 0;
+    if (barn1ManglerIdent) return 1;
+    if (barn2ManglerIdent) return -1;
+
+    if (!barn1.fødselsdato && !barn2.fødselsdato) return 0;
+    if (!barn1.fødselsdato) return 1;
+    if (!barn2.fødselsdato) return -1;
+
+    return isoStringTilDate(barn2.fødselsdato).getTime() - isoStringTilDate(barn1.fødselsdato).getTime();
+}
+
+export function useValgbareBarn(): IBarnMedOpplysninger[] {
+    const fagsak = useFagsak();
+    const bruker = useBruker();
+    const behandling = useBehandling();
+
+    const gjelderInstitusjon = erFagsakAvTypeInstitusjon(fagsak);
+    const gjelderEnsligMindreårig = erFagsakAvTypeEnsligMindreårig(fagsak);
+    const gjelderSkjermetBarn = erFagsakAvTypeSkjermetBarn(fagsak);
+
+    if (behandling.søknadsgrunnlag) {
+        return behandling.søknadsgrunnlag.barnaMedOpplysninger
+            .map(barn => ({
+                ...barn,
+                merket: barn.inkludertISøknaden,
+            }))
+            .toSorted(sorterBarn);
+    }
+
+    if (gjelderInstitusjon || gjelderEnsligMindreårig || gjelderSkjermetBarn) {
+        return [
+            {
+                merket: true,
+                ident: bruker.personIdent,
+                navn: bruker.navn,
+                fødselsdato: bruker.fødselsdato,
+                manueltRegistrert: false,
+                erFolkeregistrert: true,
+            },
+        ];
+    }
+
+    return bruker.forelderBarnRelasjon
+        .filter(relasjon => relasjon.relasjonRolle === ForelderBarnRelasjonRolle.BARN)
+        .map(relasjon => ({
+            merket: false,
+            ident: relasjon.personIdent,
+            navn: relasjon.navn,
+            fødselsdato: relasjon.fødselsdato,
+            manueltRegistrert: false,
+            erFolkeregistrert: true,
+        }))
+        .toSorted(sorterBarn);
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Steg.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Steg.tsx
@@ -1,0 +1,31 @@
+import type { PropsWithChildren } from 'react';
+
+import { useScrollOnMount } from '@hooks/useScrollOnMount';
+import { BehandlingPåVentAlert } from '@komponenter/Alert/BehandlingPåVentAlert';
+import { MidlertidigEnhetAlert } from '@komponenter/Alert/MidlertidigEnhetAlert';
+
+import { Box, type BoxProps, Heading, VStack } from '@navikt/ds-react';
+
+interface Props extends PropsWithChildren {
+    tittel: string;
+    maxWidth?: BoxProps['maxWidth'];
+}
+
+export function Steg({ tittel, maxWidth, children }: Props) {
+    const ref = useScrollOnMount<HTMLDivElement>();
+
+    return (
+        <Box ref={ref} marginBlock={'space-0 space-128'} maxWidth={maxWidth}>
+            <VStack paddingInline={'space-32'} paddingBlock={'space-24'} gap={'space-16'}>
+                <BehandlingPåVentAlert />
+                <MidlertidigEnhetAlert />
+                <Box position={'relative'} marginBlock={'space-8'}>
+                    <Heading size={'large'} level={'1'}>
+                        {tittel}
+                    </Heading>
+                    {children}
+                </Box>
+            </VStack>
+        </Box>
+    );
+}

--- a/src/frontend/sider/Fagsak/Behandling/Sider/Steg.tsx
+++ b/src/frontend/sider/Fagsak/Behandling/Sider/Steg.tsx
@@ -20,7 +20,7 @@ export function Steg({ tittel, maxWidth, children }: Props) {
                 <BehandlingPåVentAlert />
                 <MidlertidigEnhetAlert />
                 <Box position={'relative'} marginBlock={'space-8'}>
-                    <Heading size={'large'} level={'1'}>
+                    <Heading size={'large'} level={'1'} spacing={true}>
                         {tittel}
                     </Heading>
                     {children}

--- a/src/frontend/typer/featureToggles.ts
+++ b/src/frontend/typer/featureToggles.ts
@@ -14,4 +14,5 @@ export enum FeatureToggle {
     preutfyllingLovligOpphold = 'familie-ba-sak.preutfylling-lovlig-opphold',
     kanGenerereBarnasVilkar = 'familie-ba-sak.kan-generere-barnas-vilkar',
     nySlettVilkaarLogikk = 'familie-ba-sak.ny-slett-vilkaar-logikk',
+    brukNyRegistrerSøknad = 'familie-ba-sak.bruk-ny-registrer-soknad',
 }

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -1,5 +1,6 @@
+import type { IsoDatoString } from '@utils/dato';
+
 import type { BehandlingUnderkategori } from './behandlingstema';
-import type { IsoDatoString } from '../utils/dato';
 
 export interface IRestRegistrerSøknad {
     søknad: ISøknadDTO;


### PR DESCRIPTION
### 📮 Favro
NAV-29875

### 💰 Hva skal gjøres, og hvorfor?
Denne PR-en refaktorerer «registrer søknad»-steget ved å introdusere en ny implementasjon (RHF/RQ) bak en feature toggle, samtidig som eksisterende flyt beholdes som fallback.

**Endringer:**
- La til ny toggle `brukNyRegistrerSøknad` og en ny `RegistrerSøknad`-entry som bytter mellom ny/gammel implementasjon.
- Implementerte nytt «Registrer søknad»-skjema (React Hook Form) med tilhørende hjelpehooks/contexts og modaler.
- Tar i bruk API-klient + react-query hook for registrering av søknad, samt felles `Steg`-wrapper og `useScrollOnMount`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

### 👀 Screen shots
Ingen store visuelle endringer. 