### PR TITLE
NAV-30016 Skriv tester for opprett behandling

### DIFF
--- a/src/frontend/api/opprettBehandling.test.ts
+++ b/src/frontend/api/opprettBehandling.test.ts
@@ -1,0 +1,129 @@
+import { apiClient } from '@api/client/apiClient';
+import { opprettBehandling } from '@api/opprettBehandling';
+import { lagBehandling } from '@testutils/testdata/behandlingTestdata';
+import { Behandlingstype, BehandlingÅrsak } from '@typer/behandling';
+import { BehandlingKategori, BehandlingUnderkategori } from '@typer/behandlingstema';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        post: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('opprettBehandling', () => {
+    test('skal sende forespørsel om opprettelse av behandling ved førstegangsbehandling', async () => {
+        const payload = {
+            kategori: BehandlingKategori.NASJONAL,
+            underkategori: BehandlingUnderkategori.ORDINÆR,
+            behandlingType: Behandlingstype.FØRSTEGANGSBEHANDLING,
+            behandlingÅrsak: BehandlingÅrsak.SØKNAD,
+            navIdent: 'Z123456',
+            nyMigreringsdato: undefined,
+            søknadMottattDato: '2026-08-04',
+            barnasIdenter: undefined,
+            fagsakId: 123,
+            begrunnelse: undefined,
+        };
+
+        const behandling = lagBehandling({
+            kategori: BehandlingKategori.NASJONAL,
+            underkategori: BehandlingUnderkategori.ORDINÆR,
+            type: Behandlingstype.FØRSTEGANGSBEHANDLING,
+            årsak: BehandlingÅrsak.SØKNAD,
+            endretAv: 'Z123456',
+            migreringsdato: undefined,
+            søknadMottattDato: '2026-08-04T00:00:00',
+        });
+
+        vi.mocked(apiClient.post).mockResolvedValueOnce(behandling);
+
+        const svar = await opprettBehandling(payload);
+
+        expect(apiClient.post).toHaveBeenCalledTimes(1);
+        expect(apiClient.post).toHaveBeenCalledWith({
+            data: payload,
+            url: '/familie-ba-sak/api/behandlinger',
+        });
+        expect(svar).toEqual(behandling);
+    });
+
+    test('skal sende forespørsel om opprettelse av behandling ved migrering fra Infotrygd', async () => {
+        const payload = {
+            behandlingType: Behandlingstype.MIGRERING_FRA_INFOTRYGD,
+            behandlingÅrsak: BehandlingÅrsak.HELMANUELL_MIGRERING,
+            fagsakId: 123,
+            kategori: BehandlingKategori.NASJONAL,
+            underkategori: BehandlingUnderkategori.UTVIDET,
+            navIdent: 'Z123456',
+            nyMigreringsdato: '2023-01-01',
+            barnasIdenter: ['15522483319'],
+        };
+        const behandling = lagBehandling({
+            type: Behandlingstype.MIGRERING_FRA_INFOTRYGD,
+            årsak: BehandlingÅrsak.HELMANUELL_MIGRERING,
+            kategori: BehandlingKategori.NASJONAL,
+            underkategori: BehandlingUnderkategori.UTVIDET,
+            endretAv: 'Z123456',
+            migreringsdato: '2023-01-02',
+        });
+
+        vi.mocked(apiClient.post).mockResolvedValueOnce(behandling);
+
+        const svar = await opprettBehandling(payload);
+
+        expect(apiClient.post).toHaveBeenCalledTimes(1);
+        expect(apiClient.post).toHaveBeenCalledWith({
+            data: payload,
+            url: '/familie-ba-sak/api/behandlinger',
+        });
+        expect(svar).toEqual(behandling);
+    });
+
+    test('skal sende forespørsel om opprettelse av behandling ved teknisk endring', async () => {
+        const payload = {
+            behandlingType: Behandlingstype.TEKNISK_ENDRING,
+            behandlingÅrsak: BehandlingÅrsak.TEKNISK_ENDRING,
+            fagsakId: 123,
+            kategori: BehandlingKategori.NASJONAL,
+            underkategori: BehandlingUnderkategori.UTVIDET,
+            navIdent: 'Z123456',
+        };
+        const behandling = lagBehandling({
+            type: Behandlingstype.TEKNISK_ENDRING,
+            årsak: BehandlingÅrsak.TEKNISK_ENDRING,
+            kategori: BehandlingKategori.NASJONAL,
+            underkategori: BehandlingUnderkategori.UTVIDET,
+            endretAv: 'Z123456',
+        });
+
+        vi.mocked(apiClient.post).mockResolvedValueOnce(behandling);
+
+        const svar = await opprettBehandling(payload);
+
+        expect(apiClient.post).toHaveBeenCalledTimes(1);
+        expect(apiClient.post).toHaveBeenCalledWith({
+            data: payload,
+            url: '/familie-ba-sak/api/behandlinger',
+        });
+        expect(svar).toEqual(behandling);
+    });
+
+    test('skal håndtere feil', async () => {
+        vi.mocked(apiClient.post).mockRejectedValue(new Error('Noe gikk galt'));
+
+        const payload = {
+            kategori: null,
+            underkategori: null,
+            behandlingType: Behandlingstype.FØRSTEGANGSBEHANDLING,
+            navIdent: 'Z123456',
+            fagsakId: 123,
+        };
+
+        await expect(opprettBehandling(payload)).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/opprettBehandling.test.ts
+++ b/src/frontend/api/opprettBehandling.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 describe('opprettBehandling', () => {
-    test('skal sende forespørsel om opprettelse av behandling ved førstegangsbehandling', async () => {
+    test('skal sende forespørsel om opprettelse av behandling', async () => {
         const payload = {
             kategori: BehandlingKategori.NASJONAL,
             underkategori: BehandlingUnderkategori.ORDINÆR,
@@ -31,74 +31,12 @@ describe('opprettBehandling', () => {
         };
 
         const behandling = lagBehandling({
-            kategori: BehandlingKategori.NASJONAL,
-            underkategori: BehandlingUnderkategori.ORDINÆR,
-            type: Behandlingstype.FØRSTEGANGSBEHANDLING,
-            årsak: BehandlingÅrsak.SØKNAD,
-            endretAv: 'Z123456',
-            migreringsdato: undefined,
+            kategori: payload.kategori,
+            underkategori: payload.underkategori,
+            type: payload.behandlingType,
+            årsak: payload.behandlingÅrsak,
+            endretAv: payload.navIdent,
             søknadMottattDato: '2026-08-04T00:00:00',
-        });
-
-        vi.mocked(apiClient.post).mockResolvedValueOnce(behandling);
-
-        const svar = await opprettBehandling(payload);
-
-        expect(apiClient.post).toHaveBeenCalledTimes(1);
-        expect(apiClient.post).toHaveBeenCalledWith({
-            data: payload,
-            url: '/familie-ba-sak/api/behandlinger',
-        });
-        expect(svar).toEqual(behandling);
-    });
-
-    test('skal sende forespørsel om opprettelse av behandling ved migrering fra Infotrygd', async () => {
-        const payload = {
-            behandlingType: Behandlingstype.MIGRERING_FRA_INFOTRYGD,
-            behandlingÅrsak: BehandlingÅrsak.HELMANUELL_MIGRERING,
-            fagsakId: 123,
-            kategori: BehandlingKategori.NASJONAL,
-            underkategori: BehandlingUnderkategori.UTVIDET,
-            navIdent: 'Z123456',
-            nyMigreringsdato: '2023-01-01',
-            barnasIdenter: ['15522483319'],
-        };
-        const behandling = lagBehandling({
-            type: Behandlingstype.MIGRERING_FRA_INFOTRYGD,
-            årsak: BehandlingÅrsak.HELMANUELL_MIGRERING,
-            kategori: BehandlingKategori.NASJONAL,
-            underkategori: BehandlingUnderkategori.UTVIDET,
-            endretAv: 'Z123456',
-            migreringsdato: '2023-01-02',
-        });
-
-        vi.mocked(apiClient.post).mockResolvedValueOnce(behandling);
-
-        const svar = await opprettBehandling(payload);
-
-        expect(apiClient.post).toHaveBeenCalledTimes(1);
-        expect(apiClient.post).toHaveBeenCalledWith({
-            data: payload,
-            url: '/familie-ba-sak/api/behandlinger',
-        });
-        expect(svar).toEqual(behandling);
-    });
-
-    test('skal sende forespørsel om opprettelse av behandling ved teknisk endring', async () => {
-        const payload = {
-            behandlingType: Behandlingstype.TEKNISK_ENDRING,
-            behandlingÅrsak: BehandlingÅrsak.TEKNISK_ENDRING,
-            fagsakId: 123,
-            kategori: BehandlingKategori.NASJONAL,
-            underkategori: BehandlingUnderkategori.UTVIDET,
-            navIdent: 'Z123456',
-        };
-        const behandling = lagBehandling({
-            type: Behandlingstype.TEKNISK_ENDRING,
-            årsak: BehandlingÅrsak.TEKNISK_ENDRING,
-            kategori: BehandlingKategori.NASJONAL,
-            underkategori: BehandlingUnderkategori.UTVIDET,
-            endretAv: 'Z123456',
         });
 
         vi.mocked(apiClient.post).mockResolvedValueOnce(behandling);

--- a/src/frontend/api/opprettKlagebehandling.test.ts
+++ b/src/frontend/api/opprettKlagebehandling.test.ts
@@ -1,0 +1,45 @@
+import { apiClient } from '@api/client/apiClient';
+import { opprettKlagebehandling } from '@api/opprettKlagebehandling';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        post: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('opprettKlagebehandling', () => {
+    test('skal sende forespørsel om opprettelse av klagebehandling', async () => {
+        const payload = {
+            klageMottattDato: '2026-08-05',
+        };
+
+        const fagsakId = 123;
+
+        vi.mocked(apiClient.post).mockResolvedValueOnce(fagsakId);
+
+        const svar = await opprettKlagebehandling(payload, fagsakId);
+
+        expect(apiClient.post).toHaveBeenCalledTimes(1);
+        expect(apiClient.post).toHaveBeenCalledWith({
+            data: payload,
+            url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
+        });
+        expect(svar).toEqual(fagsakId);
+    });
+
+    test('skal håndtere feil', async () => {
+        vi.mocked(apiClient.post).mockRejectedValue(new Error('Noe gikk galt'));
+
+        const payload = {
+            klageMottattDato: '2026-08-05',
+        };
+        const fagsakId = 123;
+
+        await expect(opprettKlagebehandling(payload, fagsakId)).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/opprettKlagebehandling.ts
+++ b/src/frontend/api/opprettKlagebehandling.ts
@@ -1,5 +1,4 @@
 import { apiClient } from '@api/client/apiClient';
-import type { IBehandling } from '@typer/behandling';
 import type { IsoDatoString } from '@utils/dato';
 
 export interface OpprettKlagebehandlingPayload {
@@ -7,7 +6,7 @@ export interface OpprettKlagebehandlingPayload {
 }
 
 export async function opprettKlagebehandling(payload: OpprettKlagebehandlingPayload, fagsakId: number) {
-    return apiClient.post<OpprettKlagebehandlingPayload, IBehandling>({
+    return apiClient.post<OpprettKlagebehandlingPayload, number>({
         data: payload,
         url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-klagebehandling`,
     });

--- a/src/frontend/api/opprettTilbakekreving.test.ts
+++ b/src/frontend/api/opprettTilbakekreving.test.ts
@@ -1,0 +1,35 @@
+import { apiClient } from '@api/client/apiClient';
+import { opprettTilbakekreving } from '@api/opprettTilbakekreving';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@api/client/apiClient', () => ({
+    apiClient: {
+        get: vi.fn(),
+    },
+}));
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('opprettTilbakekreving', () => {
+    test('skal sende forespørsel om opprettelse av tilbakekreving', async () => {
+        const fagsakId = 123;
+        vi.mocked(apiClient.get).mockResolvedValueOnce('Tilbakekreving opprettet');
+
+        const svar = await opprettTilbakekreving(fagsakId);
+
+        expect(apiClient.get).toHaveBeenCalledTimes(1);
+        expect(apiClient.get).toHaveBeenCalledWith({
+            url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,
+        });
+        expect(svar).toEqual('Tilbakekreving opprettet');
+    });
+
+    test('skal håndtere feil', async () => {
+        const fagsakId = 123;
+        vi.mocked(apiClient.get).mockRejectedValue(new Error('Noe gikk galt'));
+
+        await expect(opprettTilbakekreving(fagsakId)).rejects.toThrow('Noe gikk galt');
+    });
+});

--- a/src/frontend/api/opprettTilbakekreving.ts
+++ b/src/frontend/api/opprettTilbakekreving.ts
@@ -1,8 +1,7 @@
 import { apiClient } from '@api/client/apiClient';
-import type { IBehandling } from '@typer/behandling';
 
 export async function opprettTilbakekreving(fagsakId: number) {
-    return apiClient.get<void, IBehandling>({
+    return apiClient.get<void, string>({
         url: `/familie-ba-sak/api/fagsaker/${fagsakId}/opprett-tilbakekreving`,
     });
 }

--- a/src/frontend/hooks/useOpprettKlagebehandling.ts
+++ b/src/frontend/hooks/useOpprettKlagebehandling.ts
@@ -1,16 +1,15 @@
 import { opprettKlagebehandling, type OpprettKlagebehandlingPayload } from '@api/opprettKlagebehandling';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
 
 interface OpprettKlagebehandlingParameters extends OpprettKlagebehandlingPayload {
     fagsakId: number;
 }
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettKlagebehandlingParameters>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<number, DefaultError, OpprettKlagebehandlingParameters>, 'mutationFn'>;
 
 export function useOpprettKlagebehandling(options?: Options) {
-    return useMutation<IBehandling, Error, OpprettKlagebehandlingParameters>({
-        mutationFn: ({ klageMottattDato, fagsakId }: OpprettKlagebehandlingParameters): Promise<IBehandling> =>
+    return useMutation<number, Error, OpprettKlagebehandlingParameters>({
+        mutationFn: ({ klageMottattDato, fagsakId }: OpprettKlagebehandlingParameters): Promise<number> =>
             opprettKlagebehandling({ klageMottattDato }, fagsakId),
         ...options,
     });

--- a/src/frontend/hooks/useOpprettTilbakekreving.ts
+++ b/src/frontend/hooks/useOpprettTilbakekreving.ts
@@ -1,17 +1,15 @@
 import { opprettTilbakekreving } from '@api/opprettTilbakekreving';
 import { type DefaultError, useMutation, type UseMutationOptions } from '@tanstack/react-query';
-import type { IBehandling } from '@typer/behandling';
 
 interface OpprettTilbakekrevingParameters {
     fagsakId: number;
 }
 
-type Options = Omit<UseMutationOptions<IBehandling, DefaultError, OpprettTilbakekrevingParameters>, 'mutationFn'>;
+type Options = Omit<UseMutationOptions<string, DefaultError, OpprettTilbakekrevingParameters>, 'mutationFn'>;
 
 export function useOpprettTilbakekreving(options?: Options) {
-    return useMutation<IBehandling, Error, OpprettTilbakekrevingParameters>({
-        mutationFn: ({ fagsakId }: OpprettTilbakekrevingParameters): Promise<IBehandling> =>
-            opprettTilbakekreving(fagsakId),
+    return useMutation<string, Error, OpprettTilbakekrevingParameters>({
+        mutationFn: ({ fagsakId }: OpprettTilbakekrevingParameters): Promise<string> => opprettTilbakekreving(fagsakId),
         ...options,
     });
 }


### PR DESCRIPTION
### 📮 Favro: [NAV-30016](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-30016)

### 💰 Hva skal gjøres, og hvorfor?
Skriv tester for OpprettBehandling etter omskriving til React Hook Form og React Query. For å påse at funksjonaliteten fungerer som forventet, også ved senere endringer av koden.

Oppdaget at return-typene på kallene til `opprettKlagebehandling` og `opprettTilbakekreving` var feil, så har endret disse fra `IBehandling` til hhv. `number` og `string`.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester.


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_ Ingen visuelle endringer